### PR TITLE
[jdbc] Update dependencies

### DIFF
--- a/bundles/org.openhab.persistence.jdbc/README.md
+++ b/bundles/org.openhab.persistence.jdbc/README.md
@@ -12,13 +12,13 @@ The following databases are currently supported and tested:
 | Database                                     | Tested Driver / Version                                                                                                                     |
 | -------------------------------------------- |---------------------------------------------------------------------------------------------------------------------------------------------|
 | [Apache Derby](https://db.apache.org/derby/) | [derby-10.17.1.0.jar](https://mvnrepository.com/artifact/org.apache.derby/derby)                                                            |
-| [H2](https://www.h2database.com/)            | [h2-2.2.224.jar](https://mvnrepository.com/artifact/com.h2database/h2)                                                                      |
-| [HSQLDB](http://hsqldb.org/)                 | [hsqldb-2.3.3.jar](https://mvnrepository.com/artifact/org.hsqldb/hsqldb)                                                                    |
-| [MariaDB](https://mariadb.org/)              | [mariadb-java-client-3.0.8.jar](https://mvnrepository.com/artifact/org.mariadb.jdbc/mariadb-java-client)                                    |
-| [MySQL](https://www.mysql.com/)              | [mysql-connector-j-9.2.0.jar](https://mvnrepository.com/artifact/com.mysql/mysql-connector-j)                                               |
-| [PostgreSQL](https://www.postgresql.org/)    | [postgresql-42.4.4.jar](https://mvnrepository.com/artifact/org.postgresql/postgresql)                                                       |
-| [SQLite](https://www.sqlite.org/)            | [sqlite-jdbc-3.42.0.0.jar](https://mvnrepository.com/artifact/org.xerial/sqlite-jdbc)                                                       |
-| [TimescaleDB](https://www.timescale.com/)    | [postgresql-42.4.4.jar](https://mvnrepository.com/artifact/org.postgresql/postgresql)                                                       |
+| [H2](https://www.h2database.com/)            | [h2-2.3.232.jar](https://mvnrepository.com/artifact/com.h2database/h2)                                                                      |
+| [HSQLDB](http://hsqldb.org/)                 | [hsqldb-2.7.4.jar](https://mvnrepository.com/artifact/org.hsqldb/hsqldb)                                                                    |
+| [MariaDB](https://mariadb.org/)              | [mariadb-java-client-3.5.5.jar](https://mvnrepository.com/artifact/org.mariadb.jdbc/mariadb-java-client)                                    |
+| [MySQL](https://www.mysql.com/)              | [mysql-connector-j-9.4.0.jar](https://mvnrepository.com/artifact/com.mysql/mysql-connector-j)                                               |
+| [PostgreSQL](https://www.postgresql.org/)    | [postgresql-42.7.7.jar](https://mvnrepository.com/artifact/org.postgresql/postgresql)                                                       |
+| [SQLite](https://www.sqlite.org/)            | [sqlite-jdbc-3.50.3.0.jar](https://mvnrepository.com/artifact/org.xerial/sqlite-jdbc)                                                       |
+| [TimescaleDB](https://www.timescale.com/)    | [postgresql-42.7.7.jar](https://mvnrepository.com/artifact/org.postgresql/postgresql)                                                       |
 | [OracleDB](https://www.oracle.com/database/) | [com.oracle.database.jdbc.ojdbc11-23.5.0.2407.jar](https://mvnrepository.com/artifact/org.openhab.osgiify/com.oracle.database.jdbc.ojdbc11) |
 
 ## Table of Contents

--- a/bundles/org.openhab.persistence.jdbc/pom.xml
+++ b/bundles/org.openhab.persistence.jdbc/pom.xml
@@ -29,7 +29,7 @@
     <h2.version>2.2.224</h2.version>
     <hsqldb.version>2.3.3</hsqldb.version>
     <mariadb.version>3.0.8</mariadb.version>
-    <mysql.version>9.2.0</mysql.version>
+    <mysql.version>9.4.0</mysql.version>
     <postgresql.version>42.4.4</postgresql.version>
     <sqlite.version>3.42.0.0</sqlite.version>
     <oracle.version>23.5.0.2407</oracle.version>

--- a/bundles/org.openhab.persistence.jdbc/pom.xml
+++ b/bundles/org.openhab.persistence.jdbc/pom.xml
@@ -32,7 +32,7 @@
     <mysql.version>9.4.0</mysql.version>
     <postgresql.version>42.7.7</postgresql.version>
     <sqlite.version>3.50.3.0</sqlite.version>
-    <oracle.version>23.5.0.2407</oracle.version>
+    <oracle.version>23.9.0.25.07</oracle.version>
   </properties>
 
   <dependencies>
@@ -101,7 +101,7 @@
     </dependency>
     <dependency>
       <groupId>org.openhab.osgiify</groupId>
-      <artifactId>com.oracle.database.jdbc.ojdbc11</artifactId>
+      <artifactId>com.oracle.database.jdbc.ojdbc17</artifactId>
       <version>${oracle.version}</version>
     </dependency>
   </dependencies>

--- a/bundles/org.openhab.persistence.jdbc/pom.xml
+++ b/bundles/org.openhab.persistence.jdbc/pom.xml
@@ -31,7 +31,7 @@
     <mariadb.version>3.5.5</mariadb.version>
     <mysql.version>9.4.0</mysql.version>
     <postgresql.version>42.7.7</postgresql.version>
-    <sqlite.version>3.42.0.0</sqlite.version>
+    <sqlite.version>3.50.3.0</sqlite.version>
     <oracle.version>23.5.0.2407</oracle.version>
   </properties>
 

--- a/bundles/org.openhab.persistence.jdbc/pom.xml
+++ b/bundles/org.openhab.persistence.jdbc/pom.xml
@@ -26,7 +26,7 @@
 
     <!-- JDBC database driver versions -->
     <derby.version>10.17.1.0</derby.version>
-    <h2.version>2.2.224</h2.version>
+    <h2.version>2.3.232</h2.version>
     <hsqldb.version>2.7.4</hsqldb.version>
     <mariadb.version>3.0.8</mariadb.version>
     <mysql.version>9.4.0</mysql.version>

--- a/bundles/org.openhab.persistence.jdbc/pom.xml
+++ b/bundles/org.openhab.persistence.jdbc/pom.xml
@@ -32,7 +32,7 @@
     <mysql.version>9.4.0</mysql.version>
     <postgresql.version>42.7.7</postgresql.version>
     <sqlite.version>3.50.3.0</sqlite.version>
-    <oracle.version>23.9.0.25.07</oracle.version>
+    <oracle.version>23.5.0.2407</oracle.version>
   </properties>
 
   <dependencies>
@@ -101,7 +101,7 @@
     </dependency>
     <dependency>
       <groupId>org.openhab.osgiify</groupId>
-      <artifactId>com.oracle.database.jdbc.ojdbc17</artifactId>
+      <artifactId>com.oracle.database.jdbc.ojdbc11</artifactId>
       <version>${oracle.version}</version>
     </dependency>
   </dependencies>

--- a/bundles/org.openhab.persistence.jdbc/pom.xml
+++ b/bundles/org.openhab.persistence.jdbc/pom.xml
@@ -27,7 +27,7 @@
     <!-- JDBC database driver versions -->
     <derby.version>10.17.1.0</derby.version>
     <h2.version>2.2.224</h2.version>
-    <hsqldb.version>2.3.3</hsqldb.version>
+    <hsqldb.version>2.7.4</hsqldb.version>
     <mariadb.version>3.0.8</mariadb.version>
     <mysql.version>9.4.0</mysql.version>
     <postgresql.version>42.4.4</postgresql.version>

--- a/bundles/org.openhab.persistence.jdbc/pom.xml
+++ b/bundles/org.openhab.persistence.jdbc/pom.xml
@@ -28,7 +28,7 @@
     <derby.version>10.17.1.0</derby.version>
     <h2.version>2.3.232</h2.version>
     <hsqldb.version>2.7.4</hsqldb.version>
-    <mariadb.version>3.0.8</mariadb.version>
+    <mariadb.version>3.5.5</mariadb.version>
     <mysql.version>9.4.0</mysql.version>
     <postgresql.version>42.4.4</postgresql.version>
     <sqlite.version>3.42.0.0</sqlite.version>

--- a/bundles/org.openhab.persistence.jdbc/pom.xml
+++ b/bundles/org.openhab.persistence.jdbc/pom.xml
@@ -30,7 +30,7 @@
     <hsqldb.version>2.7.4</hsqldb.version>
     <mariadb.version>3.5.5</mariadb.version>
     <mysql.version>9.4.0</mysql.version>
-    <postgresql.version>42.4.4</postgresql.version>
+    <postgresql.version>42.7.7</postgresql.version>
     <sqlite.version>3.42.0.0</sqlite.version>
     <oracle.version>23.5.0.2407</oracle.version>
   </properties>

--- a/bundles/org.openhab.persistence.jdbc/src/main/feature/feature.xml
+++ b/bundles/org.openhab.persistence.jdbc/src/main/feature/feature.xml
@@ -15,7 +15,7 @@
 	<feature name="openhab-persistence-jdbc-h2" description="JDBC Persistence H2" version="${project.version}">
 		<configfile finalname="${openhab.conf}/services/jdbc.cfg" override="false">mvn:org.openhab.addons.features.karaf/org.openhab.addons.features.karaf.openhab-addons-external/${project.version}/cfg/jdbc</configfile>
 		<feature prerequisite="false" dependency="false">openhab-runtime-base</feature>
-		<bundle start-level="80">mvn:com.h2database/h2/2.2.224</bundle>
+		<bundle start-level="80">mvn:com.h2database/h2/2.3.232</bundle>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.persistence.jdbc/${project.version}</bundle>
 	</feature>
 

--- a/bundles/org.openhab.persistence.jdbc/src/main/feature/feature.xml
+++ b/bundles/org.openhab.persistence.jdbc/src/main/feature/feature.xml
@@ -22,7 +22,7 @@
 	<feature name="openhab-persistence-jdbc-hsqldb" description="JDBC Persistence HSQLDB" version="${project.version}">
 		<configfile finalname="${openhab.conf}/services/jdbc.cfg" override="false">mvn:org.openhab.addons.features.karaf/org.openhab.addons.features.karaf.openhab-addons-external/${project.version}/cfg/jdbc</configfile>
 		<feature prerequisite="false" dependency="false">openhab-runtime-base</feature>
-		<bundle start-level="80">mvn:org.hsqldb/hsqldb/2.3.3</bundle>
+		<bundle start-level="80">mvn:org.hsqldb/hsqldb/2.7.4</bundle>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.persistence.jdbc/${project.version}</bundle>
 	</feature>
 

--- a/bundles/org.openhab.persistence.jdbc/src/main/feature/feature.xml
+++ b/bundles/org.openhab.persistence.jdbc/src/main/feature/feature.xml
@@ -57,7 +57,7 @@
 	<feature name="openhab-persistence-jdbc-oracle" description="JDBC Persistence Oracle" version="${project.version}">
 		<configfile finalname="${openhab.conf}/services/jdbc.cfg" override="false">mvn:org.openhab.addons.features.karaf/org.openhab.addons.features.karaf.openhab-addons-external/${project.version}/cfg/jdbc</configfile>
 		<feature prerequisite="false" dependency="false">openhab-runtime-base</feature>
-		<bundle start-level="80">mvn:org.openhab.osgiify/com.oracle.database.jdbc.ojdbc11/23.5.0.2407</bundle>
+		<bundle start-level="80">mvn:org.openhab.osgiify/com.oracle.database.jdbc.ojdbc17/23.9.0.25.07</bundle>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.persistence.jdbc/${project.version}</bundle>
 	</feature>
 </features>

--- a/bundles/org.openhab.persistence.jdbc/src/main/feature/feature.xml
+++ b/bundles/org.openhab.persistence.jdbc/src/main/feature/feature.xml
@@ -43,7 +43,7 @@
 	<feature name="openhab-persistence-jdbc-postgresql" description="JDBC Persistence PostgreSQL" version="${project.version}">
 		<configfile finalname="${openhab.conf}/services/jdbc.cfg" override="false">mvn:org.openhab.addons.features.karaf/org.openhab.addons.features.karaf.openhab-addons-external/${project.version}/cfg/jdbc</configfile>
 		<feature prerequisite="false" dependency="false">openhab-runtime-base</feature>
-		<bundle start-level="80">mvn:org.postgresql/postgresql/42.4.4</bundle>
+		<bundle start-level="80">mvn:org.postgresql/postgresql/42.7.7</bundle>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.persistence.jdbc/${project.version}</bundle>
 	</feature>
 

--- a/bundles/org.openhab.persistence.jdbc/src/main/feature/feature.xml
+++ b/bundles/org.openhab.persistence.jdbc/src/main/feature/feature.xml
@@ -57,7 +57,7 @@
 	<feature name="openhab-persistence-jdbc-oracle" description="JDBC Persistence Oracle" version="${project.version}">
 		<configfile finalname="${openhab.conf}/services/jdbc.cfg" override="false">mvn:org.openhab.addons.features.karaf/org.openhab.addons.features.karaf.openhab-addons-external/${project.version}/cfg/jdbc</configfile>
 		<feature prerequisite="false" dependency="false">openhab-runtime-base</feature>
-		<bundle start-level="80">mvn:org.openhab.osgiify/com.oracle.database.jdbc.ojdbc17/23.9.0.25.07</bundle>
+		<bundle start-level="80">mvn:org.openhab.osgiify/com.oracle.database.jdbc.ojdbc11/23.5.0.2407</bundle>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.persistence.jdbc/${project.version}</bundle>
 	</feature>
 </features>

--- a/bundles/org.openhab.persistence.jdbc/src/main/feature/feature.xml
+++ b/bundles/org.openhab.persistence.jdbc/src/main/feature/feature.xml
@@ -50,7 +50,7 @@
 	<feature name="openhab-persistence-jdbc-sqlite" description="JDBC Persistence SQLite" version="${project.version}">
 		<configfile finalname="${openhab.conf}/services/jdbc.cfg" override="false">mvn:org.openhab.addons.features.karaf/org.openhab.addons.features.karaf.openhab-addons-external/${project.version}/cfg/jdbc</configfile>
 		<feature prerequisite="false" dependency="false">openhab-runtime-base</feature>
-		<bundle start-level="80">mvn:org.xerial/sqlite-jdbc/3.42.0.0</bundle>
+		<bundle start-level="80">mvn:org.xerial/sqlite-jdbc/3.50.3.0</bundle>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.persistence.jdbc/${project.version}</bundle>
 	</feature>
 

--- a/bundles/org.openhab.persistence.jdbc/src/main/feature/feature.xml
+++ b/bundles/org.openhab.persistence.jdbc/src/main/feature/feature.xml
@@ -29,7 +29,7 @@
 	<feature name="openhab-persistence-jdbc-mariadb" description="JDBC Persistence MariaDB" version="${project.version}">
 		<configfile finalname="${openhab.conf}/services/jdbc.cfg" override="false">mvn:org.openhab.addons.features.karaf/org.openhab.addons.features.karaf.openhab-addons-external/${project.version}/cfg/jdbc</configfile>
 		<feature prerequisite="false" dependency="false">openhab-runtime-base</feature>
-		<bundle start-level="80">mvn:org.mariadb.jdbc/mariadb-java-client/3.0.8</bundle>
+		<bundle start-level="80">mvn:org.mariadb.jdbc/mariadb-java-client/3.5.5</bundle>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.persistence.jdbc/${project.version}</bundle>
 	</feature>
 

--- a/bundles/org.openhab.persistence.jdbc/src/main/feature/feature.xml
+++ b/bundles/org.openhab.persistence.jdbc/src/main/feature/feature.xml
@@ -36,7 +36,7 @@
 	<feature name="openhab-persistence-jdbc-mysql" description="JDBC Persistence MySQL" version="${project.version}">
 		<configfile finalname="${openhab.conf}/services/jdbc.cfg" override="false">mvn:org.openhab.addons.features.karaf/org.openhab.addons.features.karaf.openhab-addons-external/${project.version}/cfg/jdbc</configfile>
 		<feature prerequisite="false" dependency="false">openhab-runtime-base</feature>
-		<bundle start-level="80">mvn:com.mysql/mysql-connector-j/9.2.0</bundle>
+		<bundle start-level="80">mvn:com.mysql/mysql-connector-j/9.4.0</bundle>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.persistence.jdbc/${project.version}</bundle>
 	</feature>
 

--- a/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/internal/JdbcConfiguration.java
+++ b/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/internal/JdbcConfiguration.java
@@ -321,25 +321,25 @@ public class JdbcConfiguration {
             if (serviceName != null) {
                 switch (serviceName) {
                     case "derby":
-                        warn += "\tDerby:     version >= 10.14.2.0 from          https://mvnrepository.com/artifact/org.apache.derby/derby\n";
+                        warn += "\tDerby:     version >= 10.17.1.0 from          https://mvnrepository.com/artifact/org.apache.derby/derby\n";
                         break;
                     case "h2":
-                        warn += "\tH2:        version >= 2.2.224 from            https://mvnrepository.com/artifact/com.h2database/h2\n";
+                        warn += "\tH2:        version >= 2.3.232 from            https://mvnrepository.com/artifact/com.h2database/h2\n";
                         break;
                     case "hsqldb":
-                        warn += "\tHSQLDB:    version >= 2.3.3 from              https://mvnrepository.com/artifact/org.hsqldb/hsqldb\n";
+                        warn += "\tHSQLDB:    version >= 2.7.4 from              https://mvnrepository.com/artifact/org.hsqldb/hsqldb\n";
                         break;
                     case "mariadb":
-                        warn += "\tMariaDB:   version >= 3.0.8 from              https://mvnrepository.com/artifact/org.mariadb.jdbc/mariadb-java-client\n";
+                        warn += "\tMariaDB:   version >= 3.5.5 from              https://mvnrepository.com/artifact/org.mariadb.jdbc/mariadb-java-client\n";
                         break;
                     case "mysql":
-                        warn += "\tMySQL:     version >= 9.2.0 from              https://mvnrepository.com/artifact/com.mysql/mysql-connector-j\n";
+                        warn += "\tMySQL:     version >= 9.4.0 from              https://mvnrepository.com/artifact/com.mysql/mysql-connector-j\n";
                         break;
                     case "postgresql":
-                        warn += "\tPostgreSQL:version >= 42.4.4 from             https://mvnrepository.com/artifact/org.postgresql/postgresql\n";
+                        warn += "\tPostgreSQL:version >= 42.7.7 from             https://mvnrepository.com/artifact/org.postgresql/postgresql\n";
                         break;
                     case "sqlite":
-                        warn += "\tSQLite:    version >= 3.42.0.0 from           https://mvnrepository.com/artifact/org.xerial/sqlite-jdbc\n";
+                        warn += "\tSQLite:    version >= 3.50.3.0 from           https://mvnrepository.com/artifact/org.xerial/sqlite-jdbc\n";
                         break;
                     case "oracle":
                         warn += "\tOracle:    version >= 23.5.0.0 from           https://mvnrepository.com/artifact/org.openhab.osgiify/com.oracle.database.jdbc.ojdbc11\n";


### PR DESCRIPTION
Upgrade all jdbc persistence library's to the most recent.

Bump com.h2database:h2 from 2.2.224 from to 2.3.232

Bump org.hsqldb:hsqldb from 2.3.3 to 2.7.4

Bump org.mariadb.jdbc:mariadb-java-client from 3.0.8 to 3.5.5
- [Commits](https://github.com/mariadb-corporation/mariadb-connector-j/compare/3.0.8...3.5.5)

Bumps [com.mysql:mysql-connector-j](https://github.com/mysql/mysql-connector-j) from 9.2.0 to 9.4.0.
- [Changelog](https://github.com/mysql/mysql-connector-j/blob/release/9.x/CHANGES)
- [Commits](https://github.com/mysql/mysql-connector-j/compare/9.2.0...9.4.0)

Bump org.postgresql:postgresql from 42.4.4 to 42.7.7 3.0.8

Bump org.xerial:sqlite-jdbc 3.42.0.0 to 3.50.3.0

I also tried to upgrade com.oracle.database.jdbc.ojdbc11 from 23.5.0.2407 to 23.9.0.25.07 and upgrade to ojdbc17. But it seemed more difficult then expected due to the oracle lib needed to be osgified. Not sure if that is still the case. Hope @mherwege can have a look to update lib.

@florian-h05 i guess the files need to be uploaded to jfrog. Please wait before all is approved to prevent unneeded work.
