### PR TITLE
[amazoneechocontrol] Adapt to changed API

### DIFF
--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/connection/Connection.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/connection/Connection.java
@@ -1406,7 +1406,7 @@ public class Connection {
     public List<MusicProviderTO> getMusicProviders() {
         try {
             return requestBuilder.get(getAlexaServer() + "/api/behaviors/entities?skillId=amzn1.ask.1p.music")
-                    .withHeader("Routines-Version", "1.1.218665").syncSend(MusicProviderTO.LIST_TYPE_TOKEN);
+                    .withHeader("Routines-Version", "3.0.264101").syncSend(MusicProviderTO.LIST_TYPE_TOKEN);
         } catch (ConnectionException e) {
             logger.warn("Failed to get music providers: {}", e.getMessage());
         }

--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/dto/response/EndPointItemTO.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/dto/response/EndPointItemTO.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2010-2025 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.amazonechocontrol.internal.dto.response;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.amazonechocontrol.internal.dto.smarthome.JsonSmartHomeDevice;
+
+/**
+ * The {@link EndPointItemTO} encapsulate the GSON data of a smarthome graphql query
+ *
+ * @author Leo Siepel - Initial contribution
+ */
+@NonNullByDefault
+public class EndPointItemTO {
+    public @Nullable String endpointId;
+    public @Nullable String id;
+    public @Nullable String friendlyName;
+    public @Nullable JsonSmartHomeDevice legacyAppliance;
+    public @Nullable StringWrapper serialNumber;
+    public @Nullable String enablement;
+    public @Nullable StringWrapper model;
+    public @Nullable StringWrapper manufacturer;
+
+    public static class TextValue {
+        public @Nullable String text;
+    }
+
+    public static class StringWrapper {
+        public @Nullable TextValue value;
+    }
+}

--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/dto/response/SmartHomeTO.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/dto/response/SmartHomeTO.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2010-2025 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.amazonechocontrol.internal.dto.response;
+
+import java.util.List;
+
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.amazonechocontrol.internal.dto.smarthome.JsonSmartHomeDevice;
+
+/**
+ * The {@link SmartHomeTO} encapsulate the GSON data of a smarthome graphql query
+ *
+ * @author Leo Siepel - Initial contribution
+ */
+@NonNullByDefault
+public class SmartHomeTO {
+    public @Nullable Data data;
+
+    public static class Data {
+        public @Nullable Endpoints endpoints;
+    }
+
+    public static class Endpoints {
+        public @Nullable List<EndPointItemTO> items;
+    }
+
+    public List<JsonSmartHomeDevice> getLegacySmartHomeDevices() {
+        if (data instanceof Data data && data.endpoints != null && data.endpoints instanceof Endpoints endpoints
+                && endpoints.items instanceof List<EndPointItemTO> items) {
+
+            return items.stream().map(item -> item.legacyAppliance).filter(java.util.Objects::nonNull)
+                    .map(device -> (@NonNull JsonSmartHomeDevice) device).toList();
+        }
+        return List.of();
+    }
+}

--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/handler/AccountHandler.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/handler/AccountHandler.java
@@ -66,12 +66,12 @@ import org.openhab.binding.amazonechocontrol.internal.dto.response.BluetoothStat
 import org.openhab.binding.amazonechocontrol.internal.dto.response.CustomerHistoryRecordTO;
 import org.openhab.binding.amazonechocontrol.internal.dto.response.ListItemTO;
 import org.openhab.binding.amazonechocontrol.internal.dto.response.MusicProviderTO;
+import org.openhab.binding.amazonechocontrol.internal.dto.response.SmartHomeTO;
 import org.openhab.binding.amazonechocontrol.internal.dto.response.WakeWordTO;
 import org.openhab.binding.amazonechocontrol.internal.dto.smarthome.JsonSmartHomeDevice;
 import org.openhab.binding.amazonechocontrol.internal.dto.smarthome.JsonSmartHomeGroups;
 import org.openhab.binding.amazonechocontrol.internal.dto.smarthome.SmartHomeBaseDevice;
 import org.openhab.binding.amazonechocontrol.internal.push.PushConnection;
-import org.openhab.binding.amazonechocontrol.internal.smarthome.JsonNetworkDetails;
 import org.openhab.binding.amazonechocontrol.internal.smarthome.SmartHomeDeviceStateGroupUpdateCalculator;
 import org.openhab.binding.amazonechocontrol.internal.types.Notification;
 import org.openhab.core.library.types.OnOffType;
@@ -416,7 +416,7 @@ public class AccountHandler extends BaseBridgeHandler implements PushConnection.
         if (!connection.isLoggedIn()) {
             return;
         }
-
+        logger.debug("refresh notifications {}", getThing().getUID().getAsString());
         ZonedDateTime requestTime = ZonedDateTime.now();
         List<Notification> notifications = connection.getNotifications().stream()
                 .map(n -> map(n, requestTime, ZonedDateTime.now())).filter(Objects::nonNull)
@@ -709,28 +709,32 @@ public class AccountHandler extends BaseBridgeHandler implements PushConnection.
             return List.of();
         }
 
+        String jsonQuery = "{\"query\":\"query Endpoints{endpoints{items{endpointId id friendlyName displayCategories{primary{value}} legacyIdentifiers{dmsIdentifier{deviceType{type value{text}} deviceSerialNumber{type value{text}}}} legacyAppliance{applianceId applianceTypes endpointTypeId friendlyName friendlyDescription manufacturerName connectedVia modelName entityId actions mergedApplianceIds capabilities applianceNetworkState version isEnabled customerDefinedDeviceType customerPreference alexaDeviceIdentifierList aliases driverIdentity additionalApplianceDetails isConsentRequired applianceKey appliancePairs deduplicatedPairs entityPairs deduplicatedAliasesByEntityId relations} serialNumber{value{text}} enablement model{value{text}} manufacturer{value{text}} features{name operations{name}}}}}\"}";
+
         try {
             if (connection.isLoggedIn()) {
-                JsonNetworkDetails networkDetails = connection.getRequestBuilder()
-                        .get(connection.getAlexaServer() + "/api/phoenix").syncSend(JsonNetworkDetails.class);
-                Object jsonObject = gson.fromJson(networkDetails.networkDetail, Object.class);
-                List<SmartHomeBaseDevice> smartHomeDevices = new ArrayList<>();
-                searchSmartHomeDevicesRecursive(jsonObject, smartHomeDevices);
+                SmartHomeTO networkDetails = connection.getRequestBuilder()
+                        .post(connection.getAlexaServer() + "/nexus/v1/graphql").withContent(jsonQuery).withJson(true)
+                        .syncSend(SmartHomeTO.class);
 
-                // create new id map
+                List<JsonSmartHomeDevice> smartHomeDevices = (networkDetails != null)
+                        ? networkDetails.getLegacySmartHomeDevices()
+                        : List.of();
                 Map<String, SmartHomeBaseDevice> newJsonIdSmartHomeDeviceMapping = new HashMap<>();
-                for (SmartHomeBaseDevice smartHomeDevice : smartHomeDevices) {
+                for (JsonSmartHomeDevice smartHomeDevice : smartHomeDevices) {
                     String id = smartHomeDevice.findId();
                     if (id != null) {
                         newJsonIdSmartHomeDeviceMapping.put(id, smartHomeDevice);
                     }
                 }
+                // searchSmartHomeDevicesRecursive(jsonObject, smartHomeDevices);
+
                 jsonIdSmartHomeDeviceMapping = newJsonIdSmartHomeDeviceMapping;
 
                 // update handlers
                 smartHomeDeviceHandlers
                         .forEach(child -> child.setDeviceAndUpdateThingState(this, findSmartHomeDeviceJson(child)));
-                return smartHomeDevices;
+                return newJsonIdSmartHomeDeviceMapping.values().stream().toList();
             }
         } catch (ConnectionException e) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, e.getLocalizedMessage());

--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/handler/AccountHandler.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/handler/AccountHandler.java
@@ -727,7 +727,10 @@ public class AccountHandler extends BaseBridgeHandler implements PushConnection.
                         newJsonIdSmartHomeDeviceMapping.put(id, smartHomeDevice);
                     }
                 }
-                // searchSmartHomeDevicesRecursive(jsonObject, smartHomeDevices);
+                // TODO previously `searchSmartHomeDevicesRecursive` was called here. Due to changes in the JSON
+                // structure, this may need to be re-implemented.
+                // JsonSmartHomeDevice are now directly accessible from the response, JsonSmartHomeGroups.SmartHomeGroup
+                // seem to be missing
 
                 jsonIdSmartHomeDeviceMapping = newJsonIdSmartHomeDeviceMapping;
 

--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/util/HttpRequestBuilder.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/util/HttpRequestBuilder.java
@@ -15,7 +15,6 @@ package org.openhab.binding.amazonechocontrol.internal.util;
 import static org.eclipse.jetty.http.HttpHeader.*;
 import static org.eclipse.jetty.http.HttpMethod.*;
 import static org.eclipse.jetty.http.HttpStatus.*;
-import static org.eclipse.jetty.http.HttpStatus.BAD_REQUEST_400;
 import static org.eclipse.jetty.http.MimeTypes.Type.APPLICATION_JSON_UTF_8;
 import static org.eclipse.jetty.http.MimeTypes.Type.FORM_ENCODED;
 import static org.openhab.binding.amazonechocontrol.internal.AmazonEchoControlBindingConstants.API_VERSION;
@@ -259,7 +258,7 @@ public class HttpRequestBuilder {
                 try {
                     String contentType = response.headers.get(CONTENT_TYPE);
                     if (contentType == null) {
-                        throw new JsonParseException("Response Content-Type is not JSON: " + contentType);
+                        throw new JsonParseException("Response Content-Type header is missing");
                     }
                     T returnValue = gson.fromJson(response.content(), returnType);
                     // gson.fromJson is non-null if json is non-null and not empty

--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/resources/json/music_providers.json
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/resources/json/music_providers.json
@@ -1,0 +1,78 @@
+[
+    {
+        "id": "CLOUDPLAYER",
+        "displayName": "My Library",
+        "description": "Music provider",
+        "supportedProperties": [
+            "Alexa.Music.PlaySearchPhrase"
+        ],
+        "supportedTriggers": [],
+        "supportedOperations": [
+            "Alexa.Music.PlaySearchPhrase"
+        ],
+        "supportedConditions": [],
+        "availability": "AVAILABLE",
+        "icon": null,
+        "providerData": {
+            "isDefaultMusicProvider": false,
+            "isDefaultStationProvider": false
+        }
+    },
+    {
+        "id": "AMAZON_MUSIC",
+        "displayName": "Amazon Music",
+        "description": "Music provider",
+        "supportedProperties": [
+            "Alexa.Music.PlaySearchPhrase"
+        ],
+        "supportedTriggers": [],
+        "supportedOperations": [
+            "Alexa.Music.PlaySearchPhrase"
+        ],
+        "supportedConditions": [],
+        "availability": "AVAILABLE",
+        "icon": null,
+        "providerData": {
+            "isDefaultMusicProvider": true,
+            "isDefaultStationProvider": true
+        }
+    },
+    {
+        "id": "TUNEIN",
+        "displayName": "TuneIn",
+        "description": "Music provider",
+        "supportedProperties": [
+            "Alexa.Music.PlaySearchPhrase"
+        ],
+        "supportedTriggers": [],
+        "supportedOperations": [
+            "Alexa.Music.PlaySearchPhrase"
+        ],
+        "supportedConditions": [],
+        "availability": "AVAILABLE",
+        "icon": null,
+        "providerData": {
+            "isDefaultMusicProvider": false,
+            "isDefaultStationProvider": false
+        }
+    },
+    {
+        "id": "DEFAULT",
+        "displayName": "",
+        "description": "Default Music provider",
+        "supportedProperties": [
+            "Alexa.Music.PlaySearchPhrase"
+        ],
+        "supportedTriggers": [],
+        "supportedOperations": [
+            "Alexa.Music.PlaySearchPhrase"
+        ],
+        "supportedConditions": [],
+        "availability": "AVAILABLE",
+        "icon": null,
+        "providerData": {
+            "isDefaultMusicProvider": false,
+            "isDefaultStationProvider": false
+        }
+    }
+]

--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/resources/json/smarthomedevices.json
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/resources/json/smarthomedevices.json
@@ -1,0 +1,432 @@
+{
+    "data": {
+        "endpoints": {
+            "items": [
+                {
+                    "endpointId": "amzn1.alexa.endpoint.b5bfbc93-0794-42df-a679-cc7861d11e12",
+                    "id": "amzn1.alexa.endpoint.b5bfbc93-0794-42df-a679-cc7861d11e12",
+                    "friendlyName": "Leos Echo Dot",
+                    "displayCategories": {
+                        "primary": {
+                            "value": "ALEXA_VOICE_ENABLED"
+                        }
+                    },
+                    "legacyIdentifiers": {
+                        "dmsIdentifier": {
+                            "deviceType": {
+                                "type": "PLAIN",
+                                "value": {
+                                    "text": "A1RABVCI4QCIKC"
+                                }
+                            },
+                            "deviceSerialNumber": {
+                                "type": "PLAIN",
+                                "value": {
+                                    "text": "G090XG0901040Q8N"
+                                }
+                            }
+                        }
+                    },
+                    "legacyAppliance": {
+                        "applianceId": "AAA_SonarCloudService_b72d99bf-bf6c-3381-aaff-9a8a40b7eeab",
+                        "applianceTypes": [
+                            "ALEXA_VOICE_ENABLED"
+                        ],
+                        "endpointTypeId": "",
+                        "friendlyName": "Leos Echo Dot",
+                        "friendlyDescription": "Amazon smart device",
+                        "manufacturerName": "Amazon",
+                        "connectedVia": "Leos Echo Dot",
+                        "modelName": "",
+                        "entityId": "b5bfbc93-0794-42df-a679-cc7861d11e12",
+                        "actions": [],
+                        "mergedApplianceIds": [
+                            "AlexaBridge_G090XG0901040Q8N@A1RABVCI4QCIKC_G090XG0901040Q8N",
+                            "AAA_SonarCloudService_b72d99bf-bf6c-3381-aaff-9a8a40b7eeab"
+                        ],
+                        "capabilities": [
+                            {
+                                "capabilityType": "AVSInterfaceCapability",
+                                "type": "AlexaInterface",
+                                "version": "3",
+                                "properties": {
+                                    "supported": [
+                                        {
+                                            "name": "overallMode"
+                                        },
+                                        {
+                                            "name": "babyCryDetectionState"
+                                        },
+                                        {
+                                            "name": "carbonMonoxideSirenDetectionState"
+                                        },
+                                        {
+                                            "name": "snoreDetectionState"
+                                        },
+                                        {
+                                            "name": "waterSoundsDetectionState"
+                                        },
+                                        {
+                                            "name": "smokeAlarmDetectionState"
+                                        },
+                                        {
+                                            "name": "glassBreakDetectionState"
+                                        },
+                                        {
+                                            "name": "detectionModes"
+                                        },
+                                        {
+                                            "name": "runningWaterDetectionState"
+                                        },
+                                        {
+                                            "name": "coughDetectionState"
+                                        },
+                                        {
+                                            "name": "dogBarkDetectionState"
+                                        },
+                                        {
+                                            "name": "humanPresenceDetectionState"
+                                        },
+                                        {
+                                            "name": "smokeSirenDetectionState"
+                                        },
+                                        {
+                                            "name": "beepingApplianceDetectionState"
+                                        }
+                                    ],
+                                    "proactivelyReported": true,
+                                    "retrievable": true,
+                                    "readOnly": false
+                                },
+                                "configuration": {},
+                                "interfaceName": "Alexa.AcousticEventSensor"
+                            },
+                            {
+                                "type": "AlexaInterface",
+                                "version": "1.0",
+                                "properties": {
+                                    "supported": [
+                                        {
+                                            "name": "proactiveDetection"
+                                        }
+                                    ],
+                                    "proactivelyReported": false,
+                                    "retrievable": false
+                                },
+                                "capabilityType": "AlexaEndpointCapabilityInstance",
+                                "interfaceName": "Alexa.EndpointDetector"
+                            },
+                            {
+                                "capabilityType": "AVSInterfaceCapability",
+                                "type": "AlexaInterface",
+                                "version": "1.17",
+                                "properties": {
+                                    "supported": [
+                                        {
+                                            "name": "supportedFeatures"
+                                        },
+                                        {
+                                            "name": "LocalEngineState"
+                                        }
+                                    ],
+                                    "proactivelyReported": true,
+                                    "retrievable": true,
+                                    "readOnly": false
+                                },
+                                "interfaceName": "Alexa.LocalExecutionFlow"
+                            },
+                            {
+                                "type": "AlexaInterface",
+                                "version": "1.0",
+                                "configurations": {
+                                    "applicationProtocols": [
+                                        {
+                                            "type": "BLE_MESH",
+                                            "maxVersion": "1.0",
+                                            "commissioneeTypes": {
+                                                "displayCategories": [
+                                                    "FAN",
+                                                    "LIGHT",
+                                                    "OTHER",
+                                                    "REMOTE",
+                                                    "SMARTPLUG"
+                                                ]
+                                            }
+                                        },
+                                        {
+                                            "type": "OTHER",
+                                            "name": "LAP",
+                                            "maxVersion": "1.0",
+                                            "commissioneeTypes": {
+                                                "displayCategories": [
+                                                    "LIGHT",
+                                                    "SMARTPLUG",
+                                                    "SWITCH"
+                                                ]
+                                            }
+                                        },
+                                        {
+                                            "type": "MATTER",
+                                            "maxVersion": "1.3",
+                                            "transportProtocols": [
+                                                {
+                                                    "type": "WI-FI",
+                                                    "maxVersion": "5.0"
+                                                }
+                                            ],
+                                            "commissioneeTypes": {
+                                                "displayCategories": [
+                                                    "AIR_CONDITIONER",
+                                                    "AIR_PURIFIER",
+                                                    "AIR_QUALITY_MONITOR",
+                                                    "CARBON_MONOXIDE_SENSOR",
+                                                    "CONTACT_SENSOR",
+                                                    "COOLING_CABINET",
+                                                    "DISHWASHER",
+                                                    "FAN",
+                                                    "FREEZER",
+                                                    "HUB",
+                                                    "HUMIDITY_SENSOR",
+                                                    "INTERIOR_BLIND",
+                                                    "LIGHT",
+                                                    "LIGHT_SENSOR",
+                                                    "MOTION_SENSOR",
+                                                    "OTHER",
+                                                    "REFRIGERATOR",
+                                                    "REMOTE",
+                                                    "SMARTLOCK",
+                                                    "SMARTPLUG",
+                                                    "SMOKE_SENSOR",
+                                                    "SWITCH",
+                                                    "TEMPERATURE_SENSOR",
+                                                    "THERMOSTAT",
+                                                    "VACUUM_CLEANER"
+                                                ],
+                                                "deviceTypes": [
+                                                    "10",
+                                                    "14",
+                                                    "15",
+                                                    "19",
+                                                    "21",
+                                                    "22",
+                                                    "43",
+                                                    "44",
+                                                    "45",
+                                                    "112",
+                                                    "113",
+                                                    "114",
+                                                    "116",
+                                                    "117",
+                                                    "118",
+                                                    "256",
+                                                    "257",
+                                                    "262",
+                                                    "263",
+                                                    "266",
+                                                    "267",
+                                                    "268",
+                                                    "269",
+                                                    "514",
+                                                    "769",
+                                                    "770",
+                                                    "775"
+                                                ]
+                                            }
+                                        },
+                                        {
+                                            "type": "OTHER",
+                                            "name": "PHILIPS_BLE",
+                                            "maxVersion": "5.0",
+                                            "transportProtocols": [
+                                                {
+                                                    "type": "BLE",
+                                                    "maxVersion": "5.0"
+                                                }
+                                            ],
+                                            "commissioneeTypes": {
+                                                "displayCategories": [
+                                                    "LIGHT",
+                                                    "SMARTPLUG"
+                                                ]
+                                            }
+                                        },
+                                        {
+                                            "type": "PHILIPS_HUE",
+                                            "maxVersion": "1.0",
+                                            "transportProtocols": [
+                                                {
+                                                    "type": "WI-FI",
+                                                    "maxVersion": "5.0"
+                                                }
+                                            ],
+                                            "commissioneeTypes": {
+                                                "displayCategories": [
+                                                    "LIGHT"
+                                                ]
+                                            }
+                                        },
+                                        {
+                                            "type": "WEMO",
+                                            "maxVersion": "1.0",
+                                            "transportProtocols": [
+                                                {
+                                                    "type": "WI-FI",
+                                                    "maxVersion": "5.0"
+                                                }
+                                            ],
+                                            "commissioneeTypes": {
+                                                "displayCategories": [
+                                                    "SMARTPLUG",
+                                                    "SWITCH"
+                                                ]
+                                            }
+                                        },
+                                        {
+                                            "type": "IPP",
+                                            "maxVersion": "2.1",
+                                            "transportProtocols": [
+                                                {
+                                                    "type": "WI-FI",
+                                                    "maxVersion": "5.0"
+                                                }
+                                            ],
+                                            "commissioneeTypes": {
+                                                "displayCategories": [
+                                                    "PRINTER"
+                                                ]
+                                            }
+                                        }
+                                    ]
+                                },
+                                "capabilityType": "AlexaEndpointCapabilityInstance",
+                                "interfaceName": "Alexa.DeviceDiscovery.Hub"
+                            },
+                            {
+                                "type": "AlexaInterface",
+                                "version": "3.1",
+                                "properties": {
+                                    "supported": [
+                                        {
+                                            "name": "enablement"
+                                        },
+                                        {
+                                            "name": "illuminance"
+                                        }
+                                    ],
+                                    "proactivelyReported": true,
+                                    "retrievable": true
+                                },
+                                "capabilityType": "AlexaEndpointCapabilityInstance",
+                                "interfaceName": "Alexa.LightSensor"
+                            }
+                        ],
+                        "applianceNetworkState": {
+                            "reachability": "REACHABLE",
+                            "lastSeenAt": 1755420019855,
+                            "createdAt": 1755294328906,
+                            "lastSeenDiscoverySessionId": {
+                                "value": "5f458a21-d841-419b-8571-3535cb1232e8"
+                            }
+                        },
+                        "version": "0",
+                        "isEnabled": true,
+                        "customerDefinedDeviceType": "",
+                        "customerPreference": null,
+                        "alexaDeviceIdentifierList": [
+                            {
+                                "dmsDeviceSerialNumber": "G090XG0901040Q8N",
+                                "dmsDeviceTypeId": "A1RABVCI4QCIKC"
+                            }
+                        ],
+                        "aliases": [],
+                        "driverIdentity": {
+                            "namespace": "AAA",
+                            "identifier": "SonarCloudService"
+                        },
+                        "additionalApplianceDetails": {
+                            "additionalApplianceDetails": {}
+                        },
+                        "isConsentRequired": false,
+                        "applianceKey": "b5bfbc93-0794-42df-a679-cc7861d11e12",
+                        "appliancePairs": [
+                            "AlexaBridge_G090XG0901040Q8N@A1RABVCI4QCIKC_G090XG0901040Q8N",
+                            "AAA_SonarCloudService_b72d99bf-bf6c-3381-aaff-9a8a40b7eeab"
+                        ],
+                        "deduplicatedPairs": [
+                            {
+                                "applianceId": "AAA_SonarCloudService_b72d99bf-bf6c-3381-aaff-9a8a40b7eeab",
+                                "entityId": "b5bfbc93-0794-42df-a679-cc7861d11e12"
+                            },
+                            {
+                                "applianceId": "AlexaBridge_G090XG0901040Q8N@A1RABVCI4QCIKC_G090XG0901040Q8N",
+                                "entityId": "b5bfbc93-0794-42df-a679-cc7861d11e12"
+                            }
+                        ],
+                        "entityPairs": [
+                            "b5bfbc93-0794-42df-a679-cc7861d11e12"
+                        ],
+                        "deduplicatedAliasesByEntityId": {},
+                        "relations": [
+                            {
+                                "relatedEntityType": "PARENT",
+                                "relationshipEntity": {
+                                    "destination": {
+                                        "id": "G090XG0901040Q8N",
+                                        "entityType": "DMS_ENDPOINT",
+                                        "metadata": ""
+                                    },
+                                    "relationshipType": "IsComponentOf"
+                                }
+                            },
+                            {
+                                "relatedEntityType": "PARENT",
+                                "relationshipEntity": {
+                                    "destination": {
+                                        "id": "G090XG0901040Q8N",
+                                        "entityType": "DMS_ENDPOINT",
+                                        "metadata": ""
+                                    },
+                                    "relationshipType": "IsComponentOf"
+                                }
+                            }
+                        ]
+                    },
+                    "serialNumber": {
+                        "value": {
+                            "text": "G090XG0901040Q8N"
+                        }
+                    },
+                    "enablement": "ENABLED",
+                    "model": {
+                        "value": {
+                            "text": "Echo Dot (3rd generation)"
+                        }
+                    },
+                    "manufacturer": {
+                        "value": {
+                            "text": "Amazon"
+                        }
+                    },
+                    "features": [
+                        {
+                            "name": "speaker",
+                            "operations": null
+                        },
+                        {
+                            "name": "connectivity",
+                            "operations": null
+                        },
+                        {
+                            "name": "bluetooth",
+                            "operations": null
+                        }
+                    ]
+                }
+            ]
+        }
+    },
+    "extensions": {
+        "requestID": "1PPWV08RGFWVFSPWSPH0",
+        "duration": 58
+    }
+}


### PR DESCRIPTION
Amazon changed their API and that broke the openHAB binding. 
Two API calls needed to change including the dto/gsoin plumbing.

- call to get smarthomedevices (api/phoenix) leads to JsonParseException response is empty.
- call to get musicproviders leads to JsonParseException

Fixes: https://github.com/openhab/openhab-addons/issues/19084
Fixes: https://github.com/openhab/openhab-addons/issues/18899

Testable jar 5.0.x: https://1drv.ms/u/c/70ea7ac46bc61c73/EaBslrypz_lEnDVvwt562tEBKG6BjXu-IW-KGrls37m8BA?e=iZZGAc
(the zip file also contains 2 dependency's, drop all three files in your addons folder while the bundled binding is uninstalled)

Tested by me and by @sihui62 who provided me with an Echo dot to ease development and test this fix. A big thanks for his support!