### PR TITLE
[sungrow] Added configuration option for modbus read retries

### DIFF
--- a/bundles/org.openhab.binding.modbus.sungrow/src/main/java/org/openhab/binding/modbus/sungrow/internal/SungrowInverterConfiguration.java
+++ b/bundles/org.openhab.binding.modbus.sungrow/src/main/java/org/openhab/binding/modbus/sungrow/internal/SungrowInverterConfiguration.java
@@ -23,4 +23,5 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 public class SungrowInverterConfiguration {
 
     public int pollInterval;
+    public int maxTries;
 }

--- a/bundles/org.openhab.binding.modbus.sungrow/src/main/resources/OH-INF/config/config.xml
+++ b/bundles/org.openhab.binding.modbus.sungrow/src/main/resources/OH-INF/config/config.xml
@@ -10,6 +10,11 @@
 			<description>Time between polling the data in ms.</description>
 			<default>5000</default>
 		</parameter>
+		<parameter name="maxTries" type="integer" min="1">
+			<label>Maximum Tries When Reading</label>
+			<default>3</default>
+			<description>Number of tries when reading data, if some of the reading fail. For single try, enter 1.</description>
+		</parameter>
 	</config-description>
 
 </config-description:config-descriptions>


### PR DESCRIPTION
This PR adds a new configuration option for the sungrow binding, that allows the user to specify the amount of connection retries, when reading data from sungrow inverter.

fixes #19181 
