### PR TITLE
[zwavejs] Increase default message size

### DIFF
--- a/bundles/org.openhab.binding.zwavejs/README.md
+++ b/bundles/org.openhab.binding.zwavejs/README.md
@@ -38,12 +38,12 @@ The following discovery features are available:
 The `zwavejs` binding requires configuration of the bridge to connect to the Z-Wave JS Webservice.
 The configuration options include:
 
-| Name                  | Type    | Description                                          | Default | Required | Advanced |
-|-----------------------|---------|------------------------------------------------------|---------|----------|----------|
-| hostname              | text    | Hostname or IP address of the server                 | N/A     | yes      | no       |
-| port                  | number  | Port number to access the service                    | 3000    | yes      | no       |
-| maxMessageSize        | number  | Maximum size of messages in bytes                    | 2097152 | no       | yes      |
-| configurationChannels | boolean | Expose the command class 'configuration' as channels | false   | no       | yes      |
+| Name                  | Type    | Description                                          | Default  | Required | Advanced |
+|-----------------------|---------|------------------------------------------------------|----------|----------|----------|
+| hostname              | text    | Hostname or IP address of the server                 | N/A      | yes      | no       |
+| port                  | number  | Port number to access the service                    | 3000     | yes      | no       |
+| maxMessageSize        | number  | Maximum size of messages in bytes                    | 16777216 | no       | yes      |
+| configurationChannels | boolean | Expose the command class 'configuration' as channels | false    | no       | yes      |
 
 ## Thing Configuration
 

--- a/bundles/org.openhab.binding.zwavejs/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.zwavejs/src/main/resources/OH-INF/thing/thing-types.xml
@@ -32,7 +32,7 @@
 			<parameter name="maxMessageSize" type="integer" required="true" min="1048576" max="33554432" step="262144">
 				<label>Maximum Message Size</label>
 				<description>The maximum size of the message (in bytes) that the ZWave-JS server can send</description>
-				<default>2097152</default>
+				<default>16777216</default>
 				<advanced>true</advanced>
 			</parameter>
 		</config-description>


### PR DESCRIPTION
Users report `MessageTooLargeException`, so they have to adapt the `maxMessageSize`.
Raising the size to 16mb should make it work for 99% of users by default.

Fixes: https://github.com/openhab/openhab-addons/issues/19078