### PR TITLE
[ecovacs] Rename 'autoEmpty' state to 'emptying'

### DIFF
--- a/bundles/org.openhab.binding.ecovacs/README.md
+++ b/bundles/org.openhab.binding.ecovacs/README.md
@@ -93,7 +93,7 @@ In case a particular channel is not supported by a given device (see remarks), i
 Remarks:
 
 - [1] See [section below](#command-channel-actions)
-- [2] Possible states: `cleaning`, `pause`, `stop`, `autoEmpty`, `drying`, `washing`, `returning` and `charging` (where `autoEmpty`, `drying` and `washing` are only available on newer models with auto empty station)
+- [2] Possible states: `cleaning`, `pause`, `stop`, `emptying`, `drying`, `washing`, `returning` and `charging` (where `emptying`, `drying` and `washing` are only available on newer models with auto empty station)
 - [3] Possible states: `auto`, `edge`, `spot`, `spotArea`, `customArea`, `singleRoom`, and `sceneClean` (some of which depend on device capabilities)
 - [4] Current cleaning status is only valid if the device is currently cleaning
 - [5] Only valid for `spot`, `spotArea`, `customArea`, and `sceneClean` cleaning modes; value can be used for `spotArea`, `customArea`, or `sceneClean` commands (see below)

--- a/bundles/org.openhab.binding.ecovacs/src/main/java/org/openhab/binding/ecovacs/internal/EcovacsBindingConstants.java
+++ b/bundles/org.openhab.binding.ecovacs/src/main/java/org/openhab/binding/ecovacs/internal/EcovacsBindingConstants.java
@@ -97,9 +97,9 @@ public class EcovacsBindingConstants {
             new StateOptionEntry<>(CleanMode.SCENE_CLEAN, "sceneClean", DeviceCapability.SCENARIO_CLEANING),
             new StateOptionEntry<>(CleanMode.PAUSE, "pause"), //
             new StateOptionEntry<>(CleanMode.STOP, "stop"), //
-            new StateOptionEntry<>(CleanMode.AUTO_EMPTY, "autoEmpty"),
+            new StateOptionEntry<>(CleanMode.EMPTYING, "emptying"), //
             new StateOptionEntry<>(CleanMode.WASHING, "washing"), //
-            new StateOptionEntry<>(CleanMode.DRYING, "drying"),
+            new StateOptionEntry<>(CleanMode.DRYING, "drying"), //
             new StateOptionEntry<>(CleanMode.RETURNING, "returning"));
 
     public static final StateOptionMapping<MoppingWaterAmount> WATER_AMOUNT_MAPPING = StateOptionMapping.of(

--- a/bundles/org.openhab.binding.ecovacs/src/main/java/org/openhab/binding/ecovacs/internal/api/model/CleanMode.java
+++ b/bundles/org.openhab.binding.ecovacs/src/main/java/org/openhab/binding/ecovacs/internal/api/model/CleanMode.java
@@ -42,7 +42,7 @@ public enum CleanMode {
     @SerializedName(value = "going", alternate = { "goCharging" })
     RETURNING,
     @SerializedName("autoEmpty")
-    AUTO_EMPTY,
+    EMPTYING,
     @SerializedName("washing")
     WASHING,
     @SerializedName(value = "drying", alternate = { "spin-dry" })
@@ -56,6 +56,6 @@ public enum CleanMode {
     }
 
     public boolean isIdle() {
-        return this == IDLE || this == DRYING || this == WASHING || this == AUTO_EMPTY;
+        return this == IDLE || this == DRYING || this == WASHING || this == EMPTYING;
     }
 }

--- a/bundles/org.openhab.binding.ecovacs/src/main/java/org/openhab/binding/ecovacs/internal/handler/EcovacsVacuumHandler.java
+++ b/bundles/org.openhab.binding.ecovacs/src/main/java/org/openhab/binding/ecovacs/internal/handler/EcovacsVacuumHandler.java
@@ -676,7 +676,7 @@ public class EcovacsVacuumHandler extends BaseThingHandler implements EcovacsDev
             // charging in that case. The same applies for models with pad washing/drying station, as those states imply
             // the device being charging.
             if (cleanMode != CleanMode.RETURNING && cleanMode != CleanMode.WASHING && cleanMode != CleanMode.DRYING
-                    && cleanMode != CleanMode.AUTO_EMPTY) {
+                    && cleanMode != CleanMode.EMPTYING) {
                 return "charging";
             }
         }


### PR DESCRIPTION
Makes it consistent with 'drying', 'washing' and 'returning' states.
