### PR TITLE
[amazonechocontrol] Fix `IllegalArgumentException` for devices with humidity

### DIFF
--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/smarthome/Constants.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/smarthome/Constants.java
@@ -56,7 +56,8 @@ public class Constants {
     public static final ChannelTypeUID CHANNEL_TYPE_THERMOSTATMODE = new ChannelTypeUID(BINDING_ID, "thermostatMode");
     public static final ChannelTypeUID CHANNEL_TYPE_AIR_QUALITY_INDOOR_AIR_QUALITY = new ChannelTypeUID(BINDING_ID,
             "indoorAirQuality");
-    public static final ChannelTypeUID CHANNEL_TYPE_AIR_QUALITY_HUMIDITY = new ChannelTypeUID(BINDING_ID, "humidity");
+    public static final ChannelTypeUID CHANNEL_TYPE_AIR_QUALITY_HUMIDITY = new ChannelTypeUID(BINDING_ID,
+            "relativeHumidity");
     public static final ChannelTypeUID CHANNEL_TYPE_AIR_QUALITY_PM25 = new ChannelTypeUID(BINDING_ID, "pm25");
     public static final ChannelTypeUID CHANNEL_TYPE_AIR_QUALITY_CARBON_MONOXIDE = new ChannelTypeUID(BINDING_ID,
             "carbonMonoxide");


### PR DESCRIPTION
Discovered when porting to 4.3.x. 
Related thread here: https://community.openhab.org/t/amazon-echo-api-broken-again-u-s/165457/18
Only occurs if you have a humidity device. 

Regression of: https://github.com/openhab/openhab-addons/pull/17935

Should be backport to 5.0.x and 4.3.x (for 4.3.x it depends on https://github.com/openhab/openhab-addons/pull/19214)