### PR TITLE
Revert "Bump org.eclipse.jdt:ecj from 3.39.0 to 3.42.0 (#19180)"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -324,7 +324,7 @@ Import-Package: \\
             <dependency>
               <groupId>org.eclipse.jdt</groupId>
               <artifactId>ecj</artifactId>
-              <version>3.42.0</version>
+              <version>3.39.0</version>
             </dependency>
           </dependencies>
         </plugin>


### PR DESCRIPTION
https://github.com/openhab/openhab-addons/pull/19180 is causing the build to fail.
It was merged without a successful CI check.
This upgrade is also causing issues in the Core see https://github.com/openhab/openhab-core/pull/4960.   