### PR TITLE
[shelly] Improve error handling for Gen1 (CoAP/CoIoT)

### DIFF
--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api/ShellyDeviceProfile.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api/ShellyDeviceProfile.java
@@ -256,12 +256,13 @@ public class ShellyDeviceProfile {
     }
 
     public void updateFromStatus(ShellySettingsStatus status) {
+        if (status.input == null) {
+            return;
+        }
         if (hasRelays) {
             // Dimmer-2 doesn't report inputs under /settings, only on /status, we need to update that info after init
-            if (status.inputs != null) {
-                numInputs = status.inputs.size();
-            }
-        } else if (status.input != null) {
+            numInputs = status.inputs.size();
+        } else {
             // RGBW2
             numInputs = 1;
         }

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api/ShellyDeviceProfile.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api/ShellyDeviceProfile.java
@@ -256,13 +256,12 @@ public class ShellyDeviceProfile {
     }
 
     public void updateFromStatus(ShellySettingsStatus status) {
-        if (status.input == null) {
-            return;
-        }
         if (hasRelays) {
             // Dimmer-2 doesn't report inputs under /settings, only on /status, we need to update that info after init
-            numInputs = status.inputs.size();
-        } else {
+            if (status.inputs != null) {
+                numInputs = status.inputs.size();
+            }
+        } else if (status.input != null) {
             // RGBW2
             numInputs = 1;
         }

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api1/Shelly1CoIoTInterface.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api1/Shelly1CoIoTInterface.java
@@ -16,7 +16,6 @@ import java.util.List;
 import java.util.Map;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.shelly.internal.api1.Shelly1CoapJSonDTO.CoIotDescrBlk;
 import org.openhab.binding.shelly.internal.api1.Shelly1CoapJSonDTO.CoIotDescrSen;
 import org.openhab.binding.shelly.internal.api1.Shelly1CoapJSonDTO.CoIotSensor;
@@ -32,7 +31,7 @@ import org.openhab.core.types.State;
 public interface Shelly1CoIoTInterface {
     public int getVersion();
 
-    public CoIotDescrSen fixDescription(@Nullable CoIotDescrSen sen, Map<String, CoIotDescrBlk> blkMap);
+    public CoIotDescrSen fixDescription(CoIotDescrSen sen, Map<String, CoIotDescrBlk> blkMap);
 
     public void completeMissingSensorDefinition(Map<String, CoIotDescrSen> sensorMap);
 

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api1/Shelly1CoIoTProtocol.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api1/Shelly1CoIoTProtocol.java
@@ -20,7 +20,6 @@ import java.util.List;
 import java.util.Map;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.shelly.internal.api.ShellyApiInterface;
 import org.openhab.binding.shelly.internal.api.ShellyDeviceProfile;
 import org.openhab.binding.shelly.internal.api1.Shelly1CoapJSonDTO.CoIotDescrBlk;
@@ -257,7 +256,7 @@ public class Shelly1CoIoTProtocol {
             double brightness = -1.0;
             double power = -1.0;
             for (CoIotSensor update : allUpdates) {
-                CoIotDescrSen d = fixDescription(sensorMap.get(update.id), blkMap);
+                CoIotDescrSen d = sensorMap.getOrDefault(update.id, new CoIotDescrSen());
                 if (!checkL.isEmpty() && !d.links.equals(checkL)) {
                     // continue until we find the correct one
                     continue;
@@ -370,8 +369,8 @@ public class Shelly1CoIoTProtocol {
         return profile;
     }
 
-    public CoIotDescrSen fixDescription(@Nullable CoIotDescrSen sen, Map<String, CoIotDescrBlk> blkMap) {
-        return sen != null ? sen : new CoIotDescrSen();
+    public CoIotDescrSen fixDescription(CoIotDescrSen sen, Map<String, CoIotDescrBlk> blkMap) {
+        return sen;
     }
 
     public void completeMissingSensorDefinition(Map<String, CoIotDescrSen> sensorMap) {

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api1/Shelly1CoIoTProtocol.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api1/Shelly1CoIoTProtocol.java
@@ -257,7 +257,7 @@ public class Shelly1CoIoTProtocol {
             double power = -1.0;
             for (CoIotSensor update : allUpdates) {
                 CoIotDescrSen d = sensorMap.getOrDefault(update.id, new CoIotDescrSen());
-                if (!checkL.isEmpty() && !d.links.equals(checkL)) {
+                if (!checkL.isEmpty() && !checkL.equals(d.links)) {
                     // continue until we find the correct one
                     continue;
                 }

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api1/Shelly1CoIoTProtocol.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api1/Shelly1CoIoTProtocol.java
@@ -369,10 +369,6 @@ public class Shelly1CoIoTProtocol {
         return profile;
     }
 
-    public CoIotDescrSen fixDescription(CoIotDescrSen sen, Map<String, CoIotDescrBlk> blkMap) {
-        return sen;
-    }
-
     public void completeMissingSensorDefinition(Map<String, CoIotDescrSen> sensorMap) {
     }
 

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api1/Shelly1CoIoTVersion1.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api1/Shelly1CoIoTVersion1.java
@@ -20,7 +20,6 @@ import java.util.List;
 import java.util.Map;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.shelly.internal.api1.Shelly1CoapJSonDTO.CoIotDescrBlk;
 import org.openhab.binding.shelly.internal.api1.Shelly1CoapJSonDTO.CoIotDescrSen;
 import org.openhab.binding.shelly.internal.api1.Shelly1CoapJSonDTO.CoIotSensor;
@@ -240,7 +239,7 @@ public class Shelly1CoIoTVersion1 extends Shelly1CoIoTProtocol implements Shelly
      * @return fixed Sensor description (sen)
      */
     @Override
-    public CoIotDescrSen fixDescription(@Nullable CoIotDescrSen sen, Map<String, CoIotDescrBlk> blkMap) {
+    public CoIotDescrSen fixDescription(CoIotDescrSen sen, Map<String, CoIotDescrBlk> blkMap) {
         // Shelly1: reports null descr+type "Switch" -> map to S
         // Shelly1PM: reports null descr+type "Overtemp" -> map to O
         // Shelly1PM: reports null descr+type "W" -> add description
@@ -251,11 +250,11 @@ public class Shelly1CoIoTVersion1 extends Shelly1CoIoTProtocol implements Shelly
         // Shelly Sense: Motion is reported with Desc "battery", but type "H" instead of "B"
         // Shelly Bulb: Colors are coded with Type="Red" etc. rather than Type="S" and color as Descr
         // Shelly RGBW2 is reporting Brightness, Power, VSwitch for each channel, but all with L=0
-        if (sen == null) {
-            throw new IllegalArgumentException("sen should not be null!");
-        }
         if (sen.desc == null) {
             sen.desc = "";
+        }
+        if (sen.type == null) {
+            sen.type = "";
         }
         String desc = sen.desc.toLowerCase();
 

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api1/Shelly1CoIoTVersion2.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api1/Shelly1CoIoTVersion2.java
@@ -25,7 +25,6 @@ import java.util.List;
 import java.util.Map;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.shelly.internal.api1.Shelly1CoapJSonDTO.CoIotDescrBlk;
 import org.openhab.binding.shelly.internal.api1.Shelly1CoapJSonDTO.CoIotDescrSen;
 import org.openhab.binding.shelly.internal.api1.Shelly1CoapJSonDTO.CoIotSensor;
@@ -406,7 +405,7 @@ public class Shelly1CoIoTVersion2 extends Shelly1CoIoTProtocol implements Shelly
     }
 
     @Override
-    public CoIotDescrSen fixDescription(@Nullable CoIotDescrSen sen, Map<String, CoIotDescrBlk> blkMap) {
+    public CoIotDescrSen fixDescription(CoIotDescrSen sen, Map<String, CoIotDescrBlk> blkMap) {
         return super.fixDescription(sen, blkMap);
     }
 

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api1/Shelly1CoIoTVersion2.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api1/Shelly1CoIoTVersion2.java
@@ -406,7 +406,7 @@ public class Shelly1CoIoTVersion2 extends Shelly1CoIoTProtocol implements Shelly
 
     @Override
     public CoIotDescrSen fixDescription(CoIotDescrSen sen, Map<String, CoIotDescrBlk> blkMap) {
-        return super.fixDescription(sen, blkMap);
+        return sen;
     }
 
     private static final String ID_4101_DESCR = "{ \"I\":4101, \"T\":\"P\", \"D\":\"power\",  \"U\": \"W\",    \"R\":\"0/3500\", \"L\": 1}";

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api1/Shelly1CoapHandler.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api1/Shelly1CoapHandler.java
@@ -242,7 +242,7 @@ public class Shelly1CoapHandler implements Shelly1CoapListener {
                         return;
                     }
                     if (coiotBound && coiotVers != iVersion) {
-                        logger.debug("{}: CoIoT versopm has changed from {} to {}, maybe the firmware was upgraded",
+                        logger.debug("{}: CoIoT version has changed from {} to {}, maybe the firmware was upgraded",
                                 thingName, coiotVers, iVersion);
                         thingHandler.reinitializeThing();
                         coiotBound = false;
@@ -268,15 +268,15 @@ public class Shelly1CoapHandler implements Shelly1CoapListener {
                     serial = opt.getIntegerValue();
                     break;
                 default:
-                    logger.debug("{} ({}): COAP option {} with value {} skipped", thingName, devId, opt.getNumber(),
+                    logger.debug("{} ({}): CoAP option {} with value {} skipped", thingName, devId, opt.getNumber(),
                             opt.getValue());
             }
         }
 
         // Don't change state to online when thing is in status config error
-        // (e.g. auth failed, but device sends COAP packets via multicast)
+        // (e.g. auth failed, but device sends CoAP packets via multicast)
         if (thingHandler.getThingStatusDetail() == ThingStatusDetail.CONFIGURATION_ERROR) {
-            logger.debug("{}: The device is not configuired correctly, skip Coap packet", thingName);
+            logger.debug("{}: The device is not configured correctly, skip CoAP packet", thingName);
             return;
         }
 

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api1/Shelly1CoapHandler.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api1/Shelly1CoapHandler.java
@@ -237,7 +237,6 @@ public class Shelly1CoapHandler implements Shelly1CoapListener {
                             iVersion = Integer.parseInt(sVersion);
                         } catch (NumberFormatException e) {
                             logger.debug("{}: Unable to parse version in CoIoT message: {}", thingName, devId);
-                            resetSerial();
                             thingHandler.incProtErrors();
                             return;
                         }

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api1/Shelly1CoapJSonDTO.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api1/Shelly1CoapJSonDTO.java
@@ -101,7 +101,6 @@ public class Shelly1CoapJSonDTO {
     public static class CoIotDevDescription {
         public List<CoIotDescrBlk> blk;
         public List<CoIotDescrSen> sen;
-        // public List<CoIotDescrAct> act;
 
         public CoIotDevDescription() {
             blk = new ArrayList<>();

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/handler/ShellyBaseHandler.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/handler/ShellyBaseHandler.java
@@ -591,8 +591,6 @@ public abstract class ShellyBaseHandler extends BaseThingHandler
             // http call failed: go offline except for battery devices, which might be in
             // sleep mode. Once the next update is successful the device goes back online
             handleApiException(e);
-        } catch (NullPointerException | IllegalArgumentException e) {
-            logger.debug("{}: Unable to refresh status: {}", thingName, messages.get("statusupdate.failed"), e);
         } finally {
             if (scheduledUpdates > 0) {
                 --scheduledUpdates;
@@ -757,7 +755,7 @@ public abstract class ShellyBaseHandler extends BaseThingHandler
 
         // Update uptime and WiFi, internal temp
         ShellyComponents.updateDeviceStatus(this, status);
-        stats.wifiRssi = getInteger(status.wifiSta.rssi);
+        stats.wifiRssi = status.wifiSta != null && status.wifiSta.rssi != null ? status.wifiSta.rssi : 0;
 
         if (api.isInitialized()) {
             stats.timeoutErrors = api.getTimeoutErrors();
@@ -777,8 +775,8 @@ public abstract class ShellyBaseHandler extends BaseThingHandler
             alarm = ALARM_TYPE_LOADERR;
         }
         State internalTemp = getChannelValue(CHANNEL_GROUP_DEV_STATUS, CHANNEL_DEVST_ITEMP);
-        if (internalTemp != UnDefType.NULL) {
-            int temp = ((Number) internalTemp).intValue();
+        if (internalTemp instanceof Number number) {
+            int temp = number.intValue();
             if (temp > stats.maxInternalTemp) {
                 stats.maxInternalTemp = temp;
             }

--- a/bundles/org.openhab.binding.shelly/src/test/java/org/openhab/binding/shelly/internal/api/ShellyDeviceProfileTest.java
+++ b/bundles/org.openhab.binding.shelly/src/test/java/org/openhab/binding/shelly/internal/api/ShellyDeviceProfileTest.java
@@ -23,12 +23,15 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.openhab.binding.shelly.internal.api1.Shelly1ApiJsonDTO.ShellyInputState;
 import org.openhab.binding.shelly.internal.api1.Shelly1ApiJsonDTO.ShellySettingsDevice;
 import org.openhab.binding.shelly.internal.api1.Shelly1ApiJsonDTO.ShellySettingsGlobal;
 import org.openhab.binding.shelly.internal.api1.Shelly1ApiJsonDTO.ShellySettingsRgbwLight;
+import org.openhab.binding.shelly.internal.api1.Shelly1ApiJsonDTO.ShellySettingsStatus;
 import org.openhab.core.thing.ThingTypeUID;
 
 import com.google.gson.Gson;
@@ -194,5 +197,57 @@ public class ShellyDeviceProfileTest {
                 Arguments.of(THING_TYPE_SHELLYSENSE, "", 0, 0, 0, 5, CHANNEL_GROUP_SENSOR),
                 Arguments.of(THING_TYPE_SHELLYTRV, "", 0, 0, 0, 5, CHANNEL_GROUP_SENSOR),
                 Arguments.of(THING_TYPE_SHELLYPLUSWALLDISPLAY, "", 0, 0, 0, 5, CHANNEL_GROUP_SENSOR));
+    }
+
+    @Test
+    void updateFromStatusHasRelays() {
+        ShellyDeviceProfile deviceProfile = new ShellyDeviceProfile();
+        deviceProfile.hasRelays = true;
+        deviceProfile.numInputs = -1;
+
+        ShellySettingsStatus status = new ShellySettingsStatus();
+        status.inputs = new ArrayList<>();
+        status.inputs.add(new ShellyInputState());
+        status.inputs.add(new ShellyInputState());
+
+        deviceProfile.updateFromStatus(status);
+        assertThat(deviceProfile.numInputs, is(equalTo(2)));
+    }
+
+    @Test
+    void updateFromStatusHasRelaysNoInputs() {
+        ShellyDeviceProfile deviceProfile = new ShellyDeviceProfile();
+        deviceProfile.hasRelays = true;
+        deviceProfile.numInputs = -1;
+
+        ShellySettingsStatus status = new ShellySettingsStatus();
+
+        deviceProfile.updateFromStatus(status);
+        assertThat(deviceProfile.numInputs, is(equalTo(-1)));
+    }
+
+    @Test
+    void updateFromStatusInput() {
+        ShellyDeviceProfile deviceProfile = new ShellyDeviceProfile();
+        deviceProfile.hasRelays = false;
+        deviceProfile.numInputs = -1;
+
+        ShellySettingsStatus status = new ShellySettingsStatus();
+        status.input = 7;
+
+        deviceProfile.updateFromStatus(status);
+        assertThat(deviceProfile.numInputs, is(equalTo(1)));
+    }
+
+    @Test
+    void updateFromStatusNoInput() {
+        ShellyDeviceProfile deviceProfile = new ShellyDeviceProfile();
+        deviceProfile.hasRelays = false;
+        deviceProfile.numInputs = -1;
+
+        ShellySettingsStatus status = new ShellySettingsStatus();
+
+        deviceProfile.updateFromStatus(status);
+        assertThat(deviceProfile.numInputs, is(equalTo(-1)));
     }
 }


### PR DESCRIPTION
The goal of this PR is to prevent `NullPointerException` rather than catching it. A few `IllegalArgumentException` were prevented as well.

As principle for this PR, I have not changed behavior.