### PR TITLE
[tuya] Add Singapore Data Centre

### DIFF
--- a/bundles/org.openhab.binding.tuya/src/main/resources/OH-INF/i18n/tuya.properties
+++ b/bundles/org.openhab.binding.tuya/src/main/resources/OH-INF/i18n/tuya.properties
@@ -26,6 +26,7 @@ thing-type.config.tuya.project.dataCenter.option.https\://openapi-ueaz.tuyaus.co
 thing-type.config.tuya.project.dataCenter.option.https\://openapi.tuyaeu.com = Central Europe
 thing-type.config.tuya.project.dataCenter.option.https\://openapi-weaz.tuyaeu.com = Western Europe (Azure/MS)
 thing-type.config.tuya.project.dataCenter.option.https\://openapi.tuyain.com = India
+thing-type.config.tuya.project.dataCenter.option.https\://openapi-sg.iotbing.com = Singapore
 thing-type.config.tuya.project.password.label = Password
 thing-type.config.tuya.project.password.description = Password in Tuya Smart/Smart Life app.
 thing-type.config.tuya.project.schema.label = App Type
@@ -45,6 +46,7 @@ thing-type.config.tuya.tuyaDevice.protocol.label = Protocol Version
 thing-type.config.tuya.tuyaDevice.protocol.option.3.1 = 3.1
 thing-type.config.tuya.tuyaDevice.protocol.option.3.3 = 3.3
 thing-type.config.tuya.tuyaDevice.protocol.option.3.4 = 3.4
+thing-type.config.tuya.tuyaDevice.protocol.option.3.5 = 3.5
 
 # channel types
 
@@ -53,6 +55,7 @@ channel-type.tuya.dimmer.label = Dimmer
 channel-type.tuya.ir-code.label = IR Code
 channel-type.tuya.ir-code.description = Supported codes: tuya base64 codes diy mode, nec-format codes, samsung-format codes
 channel-type.tuya.number.label = Number
+channel-type.tuya.quantity.label = Number
 channel-type.tuya.string.label = String
 channel-type.tuya.switch.label = Switch
 
@@ -87,6 +90,11 @@ channel-type.config.tuya.number.max.label = Maximum
 channel-type.config.tuya.number.min.label = Minimum
 channel-type.config.tuya.number.sendAsString.label = Send As String
 channel-type.config.tuya.number.sendAsString.description = Send the value as string instead of number.
+channel-type.config.tuya.quantity.dp.label = DP
+channel-type.config.tuya.quantity.max.label = Maximum
+channel-type.config.tuya.quantity.min.label = Minimum
+channel-type.config.tuya.quantity.sendAsString.label = Send As String
+channel-type.config.tuya.quantity.sendAsString.description = Send the value as string instead of number.
 channel-type.config.tuya.string.dp.label = DP
 channel-type.config.tuya.string.range.label = Range
 channel-type.config.tuya.switch.dp.label = DP

--- a/bundles/org.openhab.binding.tuya/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.tuya/src/main/resources/OH-INF/thing/thing-types.xml
@@ -51,6 +51,7 @@
 					<option value="https://openapi.tuyaeu.com">Central Europe</option>
 					<option value="https://openapi-weaz.tuyaeu.com">Western Europe (Azure/MS)</option>
 					<option value="https://openapi.tuyain.com">India</option>
+					<option value="https://openapi-sg.iotbing.com">Singapore</option>
 				</options>
 				<limitToOptions>true</limitToOptions>
 			</parameter>


### PR DESCRIPTION
User reports on the forum that the Singapore data centre is missing (See https://community.openhab.org/t/singapore-data-center-not-available-in-tuya-binding/165907)

I found the URL for the data centre at https://github.com/jasonacox/tinytuya/blob/ad91c8eab9b64ec73e668f4e0236f38ed8bfedaf/tinytuya/Cloud.py#L136 and this PR adds it the Thing settings.
