### PR TITLE
[homematic] Reduce log level for homematic device type conversions to DEBUG

### DIFF
--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/misc/MiscUtils.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/misc/MiscUtils.java
@@ -32,7 +32,7 @@ public class MiscUtils {
         }
         String cleanedText = text.replaceAll("[^A-Za-z0-9_-]", replaceChar);
         if (!text.equals(cleanedText)) {
-            LOGGER.info("{} '{}' contains invalid characters, new {} '{}'", textType, text, textType, cleanedText);
+            LOGGER.debug("{} '{}' contains invalid characters, new {} '{}'", textType, text, textType, cleanedText);
         }
         return cleanedText;
     }


### PR DESCRIPTION
chore: reduce the log level for homematic device type conversions to DEBUG because this message is repeatedly logged and is therefore too noisy for the INFO level:

```
2025-08-23 12:50:52.703 [INFO ] [ng.homematic.internal.misc.MiscUtils] - Device type 'HmIP-eTRV-2 I9F' contains invalid characters, new Device type 'HmIP-eTRV-2-I9F'
2025-08-23 12:50:52.705 [INFO ] [ng.homematic.internal.misc.MiscUtils] - Device type 'HmIP-eTRV-2 I9F' contains invalid characters, new Device type 'HmIP-eTRV-2-I9F'
2025-08-23 12:50:53.291 [INFO ] [ng.homematic.internal.misc.MiscUtils] - Device type 'HmIP-eTRV-2 I9F' contains invalid characters, new Device type 'HmIP-eTRV-2-I9F'
2025-08-23 12:50:53.293 [INFO ] [ng.homematic.internal.misc.MiscUtils] - Device type 'HmIP-eTRV-2 I9F' contains invalid characters, new Device type 'HmIP-eTRV-2-I9F'
2025-08-23 12:50:53.295 [INFO ] [ng.homematic.internal.misc.MiscUtils] - Device type 'HmIP-eTRV-2 I9F' contains invalid characters, new Device type 'HmIP-eTRV-2-I9F'
2025-08-23 12:50:53.864 [INFO ] [ng.homematic.internal.misc.MiscUtils] - Device type 'HmIP-eTRV-2 I9F' contains invalid characters, new Device type 'HmIP-eTRV-2-I9F'
2025-08-23 12:50:53.867 [INFO ] [ng.homematic.internal.misc.MiscUtils] - Device type 'HmIP-eTRV-2 I9F' contains invalid characters, new Device type 'HmIP-eTRV-2-I9F'
2025-08-23 12:50:53.868 [INFO ] [ng.homematic.internal.misc.MiscUtils] - Device type 'HmIP-eTRV-2 I9F' contains invalid characters, new Device type 'HmIP-eTRV-2-I9F'
2025-08-23 12:50:54.634 [INFO ] [ng.homematic.internal.misc.MiscUtils] - Device type 'HmIP-eTRV-2 I9F' contains invalid characters, new Device type 'HmIP-eTRV-2-I9F'
2025-08-23 12:50:54.636 [INFO ] [ng.homematic.internal.misc.MiscUtils] - Device type 'HmIP-eTRV-2 I9F' contains invalid characters, new Device type 'HmIP-eTRV-2-I9F'
2025-08-23 12:50:54.638 [INFO ] [ng.homematic.internal.misc.MiscUtils] - Device type 'HmIP-eTRV-2 I9F' contains invalid characters, new Device type 'HmIP-eTRV-2-I9F'
2025-08-23 12:50:55.004 [INFO ] [ng.homematic.internal.misc.MiscUtils] - Device type 'HmIP-eTRV-2 I9F' contains invalid characters, new Device type 'HmIP-eTRV-2-I9F'
2025-08-23 12:50:55.004 [INFO ] [ng.homematic.internal.misc.MiscUtils] - Device type 'HmIP-eTRV-2 I9F' contains invalid characters, new Device type 'HmIP-eTRV-2-I9F'
2025-08-23 12:50:55.005 [INFO ] [ng.homematic.internal.misc.MiscUtils] - Device type 'HmIP-eTRV-2 I9F' contains invalid characters, new Device type 'HmIP-eTRV-2-I9F'
2025-08-23 12:50:55.272 [INFO ] [ng.homematic.internal.misc.MiscUtils] - Device type 'HmIP-eTRV-2 I9F' contains invalid characters, new Device type 'HmIP-eTRV-2-I9F'
2025-08-23 12:50:55.274 [INFO ] [ng.homematic.internal.misc.MiscUtils] - Device type 'HmIP-eTRV-2 I9F' contains invalid characters, new Device type 'HmIP-eTRV-2-I9F'
2025-08-23 12:50:55.276 [INFO ] [ng.homematic.internal.misc.MiscUtils] - Device type 'HmIP-eTRV-2 I9F' contains invalid characters, new Device type 'HmIP-eTRV-2-I9F'
2025-08-23 12:50:55.786 [INFO ] [ng.homematic.internal.misc.MiscUtils] - Device type 'HmIP-eTRV-2 I9F' contains invalid characters, new Device type 'HmIP-eTRV-2-I9F'
2025-08-23 12:50:55.788 [INFO ] [ng.homematic.internal.misc.MiscUtils] - Device type 'HmIP-eTRV-2 I9F' contains invalid characters, new Device type 'HmIP-eTRV-2-I9F'
2025-08-23 12:50:55.789 [INFO ] [ng.homematic.internal.misc.MiscUtils] - Device type 'HmIP-eTRV-2 I9F' contains invalid characters, new Device type 'HmIP-eTRV-2-I9F'
2025-08-23 12:50:56.078 [INFO ] [ng.homematic.internal.misc.MiscUtils] - Device type 'HmIP-eTRV-2 I9F' contains invalid characters, new Device type 'HmIP-eTRV-2-I9F'
2025-08-23 12:50:56.080 [INFO ] [ng.homematic.internal.misc.MiscUtils] - Device type 'HmIP-eTRV-2 I9F' contains invalid characters, new Device type 'HmIP-eTRV-2-I9F'
2025-08-23 12:50:56.082 [INFO ] [ng.homematic.internal.misc.MiscUtils] - Device type 'HmIP-eTRV-2 I9F' contains invalid characters, new Device type 'HmIP-eTRV-2-I9F'
2025-08-23 12:50:56.503 [INFO ] [ng.homematic.internal.misc.MiscUtils] - Device type 'HmIP-eTRV-2 I9F' contains invalid characters, new Device type 'HmIP-eTRV-2-I9F'
2025-08-23 12:50:56.506 [INFO ] [ng.homematic.internal.misc.MiscUtils] - Device type 'HmIP-eTRV-2 I9F' contains invalid characters, new Device type 'HmIP-eTRV-2-I9F'
2025-08-23 12:50:56.508 [INFO ] [ng.homematic.internal.misc.MiscUtils] - Device type 'HmIP-eTRV-2 I9F' contains invalid characters, new Device type 'HmIP-eTRV-2-I9F'
2025-08-23 12:50:56.807 [INFO ] [ng.homematic.internal.misc.MiscUtils] - Device type 'HmIP-eTRV-2 I9F' contains invalid characters, new Device type 'HmIP-eTRV-2-I9F'
2025-08-23 12:50:56.808 [INFO ] [ng.homematic.internal.misc.MiscUtils] - Device type 'HmIP-eTRV-2 I9F' contains invalid characters, new Device type 'HmIP-eTRV-2-I9F'
2025-08-23 12:50:56.809 [INFO ] [ng.homematic.internal.misc.MiscUtils] - Device type 'HmIP-eTRV-2 I9F' contains invalid characters, new Device type 'HmIP-eTRV-2-I9F'
2025-08-23 12:50:57.251 [INFO ] [ng.homematic.internal.misc.MiscUtils] - Device type 'HmIP-eTRV-2 I9F' contains invalid characters, new Device type 'HmIP-eTRV-2-I9F'
2025-08-23 12:50:57.253 [INFO ] [ng.homematic.internal.misc.MiscUtils] - Device type 'HmIP-eTRV-2 I9F' contains invalid characters, new Device type 'HmIP-eTRV-2-I9F'
2025-08-23 12:50:57.254 [INFO ] [ng.homematic.internal.misc.MiscUtils] - Device type 'HmIP-eTRV-2 I9F' contains invalid characters, new Device type 'HmIP-eTRV-2-I9F'
2025-08-23 12:50:57.865 [INFO ] [ng.homematic.internal.misc.MiscUtils] - Device type 'HmIP-eTRV-2 I9F' contains invalid characters, new Device type 'HmIP-eTRV-2-I9F'
2025-08-23 12:50:57.867 [INFO ] [ng.homematic.internal.misc.MiscUtils] - Device type 'HmIP-eTRV-2 I9F' contains invalid characters, new Device type 'HmIP-eTRV-2-I9F'
2025-08-23 12:50:57.868 [INFO ] [ng.homematic.internal.misc.MiscUtils] - Device type 'HmIP-eTRV-2 I9F' contains invalid characters, new Device type 'HmIP-eTRV-2-I9F'
2025-08-23 12:50:58.182 [INFO ] [ng.homematic.internal.misc.MiscUtils] - Device type 'HmIP-eTRV-2 I9F' contains invalid characters, new Device type 'HmIP-eTRV-2-I9F'
2025-08-23 12:50:58.183 [INFO ] [ng.homematic.internal.misc.MiscUtils] - Device type 'HmIP-eTRV-2 I9F' contains invalid characters, new Device type 'HmIP-eTRV-2-I9F'
2025-08-23 12:50:58.184 [INFO ] [ng.homematic.internal.misc.MiscUtils] - Device type 'HmIP-eTRV-2 I9F' contains invalid characters, new Device type 'HmIP-eTRV-2-I9F'
2025-08-23 12:50:58.450 [INFO ] [ng.homematic.internal.misc.MiscUtils] - Device type 'HmIP-eTRV-2 I9F' contains invalid characters, new Device type 'HmIP-eTRV-2-I9F'
2025-08-23 12:50:58.451 [INFO ] [ng.homematic.internal.misc.MiscUtils] - Device type 'HmIP-eTRV-2 I9F' contains invalid characters, new Device type 'HmIP-eTRV-2-I9F'
2025-08-23 12:50:58.451 [INFO ] [ng.homematic.internal.misc.MiscUtils] - Device type 'HmIP-eTRV-2 I9F' contains invalid characters, new Device type 'HmIP-eTRV-2-I9F'
```

<!--
Thanks for contributing to the openHAB project!
Please describe the goal and effect of your PR here.
Pay attention to the below notes and to *the guidelines* for this repository.
Feel free to delete any comment sections in the template (starting with "<!--").

ATTENTION: Don't use "git merge" when working with your pull request branch!
This can clutter your Git history and make your PR unusable.
Use "git rebase" instead. See this forum post for further details:
https://community.openhab.org/t/rebase-your-code-or-how-to-fix-your-git-history-before-requesting-a-pull/129358

All PRs should be created using the "main" branch as base.
Important bugfixes are cherry-picked by maintainers to the patch release branch after a PR has been merged.

Add one or more appropriate labels to make your PR show up in the release notes.
E.g. enhancement, bug, documentation, new binding
This can only be done by yourself if you already contributed to this repo.

If your PR's code is not backward compatible with previous releases (which
should be avoided), add a message to the release notes by filing another PR:
https://github.com/openhab/openhab-distro/blob/main/distributions/openhab/src/main/resources/bin/update.lst

# Title

Provide a short summary in the *Title* above. It will show up in the release notes.
For example:
- [homematic] Improve communication with weak signal devices
- [timemachine][WIP] Initial contribution

# Description

Please give a few sentences describing the overall goals of the pull request.
Give enough details to make the improvement and changes of the PR understandable
to both developers and tech-savy users.

Please keep the following in mind:
- What is the classification of the PR, e.g. Bugfix, Improvement, Novel Addition, ... ?
- Did you describe the PRs motivation and goal?
- Did you provide a link to any prior discussion, e.g. an issue or community forum thread?
- Did you describe new features for the end user?
- Did you describe any noteworthy changes in usage for the end user?
- Was the documentation updated accordingly, e.g. the add-on README?
- Does your contribution follow the coding guidelines:
  https://www.openhab.org/docs/developer/guidelines.html
- Did you check for any (relevant) issues from the static code analysis:
  https://www.openhab.org/docs/developer/bindings/#include-the-binding-in-the-build
- Did you sign-off your work:
  https://www.openhab.org/docs/developer/contributing.html#sign-your-work

# Testing

Your pull request will automatically be built and available under the following folder:
https://openhab.jfrog.io/ui/native/libs-pullrequest-local/org/openhab/addons/bundles/

It is a good practice to add a URL to your built JAR in this pull request description,
so it is easier for the community to test your Add-on.
If your pull request contains a new binding, it will likely take some time
before it is reviewed and processed by maintainers.
That said, consider submitting your Add-on in the Marketplace:
https://community.openhab.org/c/marketplace/69

Don't forget to submit a thread about your Add-on in the openHAB community:
https://community.openhab.org/c/add-ons 
-->
