### PR TITLE
[shelly] Improve Shelly Manager for offline devices

### DIFF
--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/manager/ShellyManagerOverviewPage.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/manager/ShellyManagerOverviewPage.java
@@ -75,7 +75,7 @@ public class ShellyManagerOverviewPage extends ShellyManagerPage {
         TreeMap<String, ShellyManagerInterface> sortedMap = new TreeMap<>();
         for (Map.Entry<String, ShellyManagerInterface> th : getThingHandlers().entrySet()) { // sort by Device Name
             ShellyManagerInterface handler = th.getValue();
-            sortedMap.put(getDisplayName(handler.getThing().getProperties()), handler);
+            sortedMap.put(getDisplayName(handler.getThing().getProperties(), handler.getThing()), handler);
         }
 
         html = loadHTML(HEADER_HTML, properties);
@@ -105,7 +105,7 @@ public class ShellyManagerOverviewPage extends ShellyManagerPage {
                     fillProperties(properties, uid, handler.getValue());
                     String deviceType = getDeviceType(properties);
 
-                    properties.put(ATTRIBUTE_DISPLAY_NAME, getDisplayName(properties));
+                    properties.put(ATTRIBUTE_DISPLAY_NAME, getDisplayName(properties, handler.getValue().getThing()));
                     properties.put(ATTRIBUTE_DEV_STATUS, fillDeviceStatus(warnings));
                     if (!warnings.isEmpty() && (status != ThingStatus.UNKNOWN)) {
                         properties.put(ATTRIBUTE_STATUS_ICON, ICON_ATTENTION);

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/manager/ShellyManagerPage.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/manager/ShellyManagerPage.java
@@ -558,13 +558,19 @@ public class ShellyManagerPage {
         return option.toString();
     }
 
-    protected static String getDisplayName(Map<String, String> properties) {
+    protected static String getDisplayName(Map<String, String> properties, Thing thing) {
         String name = getString(properties.get(PROPERTY_DEV_NAME));
         if (name.isEmpty()) {
             name = getString(properties.get(PROPERTY_SERVICE_NAME));
         }
         if (name.isEmpty()) {
             name = getString(properties.get(PROPERTY_MAC_ADDRESS));
+        }
+        if (name.isEmpty()) {
+            name = thing.getLabel();
+        }
+        if (name == null || name.isEmpty()) {
+            name = thing.getUID().getId();
         }
         return name;
     }


### PR DESCRIPTION
This pull requests implements a display name fallback for devices which was never online since the last openhab restart.

In my example only 1 of these 4 devices is visible. 3 of them are missing.

<img width="1597" height="360" alt="screenshot" src="https://github.com/user-attachments/assets/8525af56-167e-482b-9600-cec76b5a7d51" />

after this fix, it looks like below.

<img width="2203" height="339" alt="screenshot2" src="https://github.com/user-attachments/assets/cb796f06-a525-499d-8041-7c55bd9e9e92" />

e.g. 4 of my 9 shelly plug s devices are only used during Christmas time for light decorations. This means they are offline for 11 month.