### PR TITLE
[mqtt.homeassistant] Fix python packages path on Windows

### DIFF
--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/HomeAssistantPythonBridge.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/HomeAssistantPythonBridge.java
@@ -60,6 +60,14 @@ public class HomeAssistantPythonBridge {
 
         context.eval(PYTHON,
                 """
+                        # we need to set up the path just like it would have been set up on Linux, even if we're
+                        # on Windows
+                        import os
+                        import sys
+
+                        if os.sep != '/':
+                            sys.path.append(os.path.join(sys.prefix, "lib", "python%d.%d" % sys.version_info[:2], "site-packages"))
+
                         from homeassistant.helpers.template import Template
                         from homeassistant.components.mqtt.models import MqttCommandTemplate, MqttValueTemplate
                         from homeassistant.components.mqtt.discovery import process_discovery_config


### PR DESCRIPTION
Python builds the site packages path according to the OS path separator (see
https://github.com/oracle/graalpython/blob/7e69e05a7f07d3a4c23b416a7f3e95f9da20f129/graalpython/lib-python/3/site.py#L391 ), but openHAB is always built (for distribution) on *nix, so packages get installed with a *nix path into the venv that's embedded in the jar.

So explicitly add the *nix-style path to the syspath, so that even on Windows the installed packages can be found.

Fixes #19060.

I've tested this on both Windows and Ubuntu (with the same JAR -- compiled on Ubuntu -- used for both)/
