### PR TITLE
[evcc] Remove myself from CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -119,7 +119,7 @@
 /bundles/org.openhab.binding.ephemeris/ @clinique
 /bundles/org.openhab.binding.epsonprojector/ @mlobstein
 /bundles/org.openhab.binding.etherrain/ @dfad1469
-/bundles/org.openhab.binding.evcc/ @florian-h05 @marcelGoerentz
+/bundles/org.openhab.binding.evcc/ @marcelGoerentz
 /bundles/org.openhab.binding.evohome/ @Nebula83
 /bundles/org.openhab.binding.exec/ @kgoderis
 /bundles/org.openhab.binding.feed/ @openhab/add-ons-maintainers


### PR DESCRIPTION
As @marcelGoerentz reworked the binding and has been added as CODEOWNER, I am confident he will maintain the binding properly.
I therefore step back as evcc binding maintainer, having shifted focus from the evcc binding to other parts of openHAB for a while now.