### PR TITLE
[sonos] Remove unexpected XML tag added by backport of #19162 in 4.3.x

### DIFF
--- a/bundles/org.openhab.binding.sonos/src/main/resources/OH-INF/thing/ArcUltra.xml
+++ b/bundles/org.openhab.binding.sonos/src/main/resources/OH-INF/thing/ArcUltra.xml
@@ -8,7 +8,6 @@
 	<thing-type id="ArcUltra" listed="false">
 		<label>Arc Ultra</label>
 		<description>Represents SONOS Arc Ultra soundbar</description>
-		<semantic-equipment-tag>Speaker</semantic-equipment-tag>
 		<channels>
 			<channel id="add" typeId="add"/>
 			<channel id="alarm" typeId="alarm"/>


### PR DESCRIPTION
Related to #19162

XML tag semantic-equipment-tag was introduced in 5.0 and is not supported in 4.3.
