### PR TITLE
[automower] Implement individual Things for configuration dependent items

### DIFF
--- a/bundles/org.openhab.binding.automower/src/main/java/org/openhab/binding/automower/internal/AutomowerBindingConstants.java
+++ b/bundles/org.openhab.binding.automower/src/main/java/org/openhab/binding/automower/internal/AutomowerBindingConstants.java
@@ -125,13 +125,6 @@ public class AutomowerBindingConstants {
     public static final String GROUP_STAYOUTZONE = "stayoutzone#";
 
     public static final String CHANNEL_STAYOUTZONE_DIRTY = GROUP_STAYOUTZONE + "dirty";
-    public static final String CHANNEL_STAYOUTZONE_ENABLED = "zone-enabled";
-    public static final ArrayList<String> CHANNEL_STAYOUTZONE = new ArrayList<>(
-            List.of("zone-id", "zone-name", CHANNEL_STAYOUTZONE_ENABLED));
-
-    public static final ArrayList<ChannelTypeUID> CHANNEL_TYPE_STAYOUTZONE = new ArrayList<>(
-            List.of(new ChannelTypeUID(BINDING_ID, "zoneIdType"), new ChannelTypeUID(BINDING_ID, "zoneNameType"),
-                    new ChannelTypeUID(BINDING_ID, "zoneEnabledType")));
 
     // Work Areas Channel ids
     public static final String GROUP_WORKAREA = "workarea#";
@@ -193,6 +186,10 @@ public class AutomowerBindingConstants {
 
     public static final ChannelTypeUID CHANNEL_TYPE_STAYOUTZONES_DIRTY = new ChannelTypeUID(BINDING_ID,
             "zoneDirtyType");
+
+    // Stayout Zone Channel ids
+    public static final String CHANNEL_STAYOUTZONE_NAME = "name";
+    public static final String CHANNEL_STAYOUTZONE_ENABLED = "enabled";
 
     public static final Map<Integer, String> ERROR = new HashMap<>() {
         private static final long serialVersionUID = 1L;

--- a/bundles/org.openhab.binding.automower/src/main/java/org/openhab/binding/automower/internal/AutomowerBindingConstants.java
+++ b/bundles/org.openhab.binding.automower/src/main/java/org/openhab/binding/automower/internal/AutomowerBindingConstants.java
@@ -126,21 +126,6 @@ public class AutomowerBindingConstants {
 
     public static final String CHANNEL_STAYOUTZONE_DIRTY = GROUP_STAYOUTZONE + "dirty";
 
-    // Work Areas Channel ids
-    public static final String GROUP_WORKAREA = "workarea#";
-
-    public static final String CHANNEL_WORKAREA_CUTTING_HEIGHT = "area-cutting-height";
-    public static final String CHANNEL_WORKAREA_ENABLED = "area-enabled";
-    public static final ArrayList<String> CHANNEL_WORKAREA = new ArrayList<>(List.of("area-id", "area-name",
-            CHANNEL_WORKAREA_CUTTING_HEIGHT, CHANNEL_WORKAREA_ENABLED, "area-progress", "area-last-time-completed"));
-
-    public static final ArrayList<ChannelTypeUID> CHANNEL_TYPE_WORKAREA = new ArrayList<>(List.of(
-            new ChannelTypeUID(BINDING_ID, "workareaIdType"), new ChannelTypeUID(BINDING_ID, "workareaNameType"),
-            new ChannelTypeUID(BINDING_ID, "workareaCuttingHeightType"),
-            new ChannelTypeUID(BINDING_ID, "workareaEnabledType"),
-            new ChannelTypeUID(BINDING_ID, "workareaProgressType"),
-            new ChannelTypeUID(BINDING_ID, "workareaLastTimeCompletedType")));
-
     // Messages Channel ids
     public static final String GROUP_MESSAGE = "message#";
 
@@ -191,6 +176,14 @@ public class AutomowerBindingConstants {
     public static final String CHANNEL_STAYOUTZONE_NAME = "name";
     public static final String CHANNEL_STAYOUTZONE_ENABLED = "enabled";
 
+    // Work Area Channel ids
+    public static final String CHANNEL_WORKAREA_NAME = "name";
+    public static final String CHANNEL_WORKAREA_CUTTING_HEIGHT = "cutting-height";
+    public static final String CHANNEL_WORKAREA_ENABLED = "enabled";
+    public static final String CHANNEL_WORKAREA_PROGRESS = "progress";
+    public static final String CHANNEL_WORKAREA_LAST_TIME_COMPLETED = "last-time-completed";
+
+    // Error codes and messages
     public static final Map<Integer, String> ERROR = new HashMap<>() {
         private static final long serialVersionUID = 1L;
         {

--- a/bundles/org.openhab.binding.automower/src/main/java/org/openhab/binding/automower/internal/AutomowerBindingConstants.java
+++ b/bundles/org.openhab.binding.automower/src/main/java/org/openhab/binding/automower/internal/AutomowerBindingConstants.java
@@ -36,6 +36,8 @@ public class AutomowerBindingConstants {
 
     // generic thing types
     public static final ThingTypeUID THING_TYPE_AUTOMOWER = new ThingTypeUID(BINDING_ID, "automower");
+    public static final ThingTypeUID THING_TYPE_STAYOUTZONE = new ThingTypeUID(BINDING_ID, "stayoutzone");
+    public static final ThingTypeUID THING_TYPE_WORKAREA = new ThingTypeUID(BINDING_ID, "workarea");
 
     // List of all status Channel ids
     public static final String GROUP_STATUS = "status#";
@@ -168,6 +170,8 @@ public class AutomowerBindingConstants {
 
     // Automower properties
     public static final String AUTOMOWER_ID = "mowerId";
+    public static final String AUTOMOWER_STAYOUTZONE_ID = "stayoutzoneId";
+    public static final String AUTOMOWER_WORKAREA_ID = "workareaId";
     public static final String AUTOMOWER_NAME = "mowerName";
     public static final String AUTOMOWER_MODEL = "mowerModel";
     public static final String AUTOMOWER_SERIAL_NUMBER = "mowerSerialNumber";

--- a/bundles/org.openhab.binding.automower/src/main/java/org/openhab/binding/automower/internal/AutomowerHandlerFactory.java
+++ b/bundles/org.openhab.binding.automower/src/main/java/org/openhab/binding/automower/internal/AutomowerHandlerFactory.java
@@ -26,6 +26,7 @@ import org.openhab.binding.automower.internal.bridge.AutomowerBridgeHandler;
 import org.openhab.binding.automower.internal.discovery.AutomowerDiscoveryService;
 import org.openhab.binding.automower.internal.things.AutomowerHandler;
 import org.openhab.binding.automower.internal.things.AutomowerStayoutZoneHandler;
+import org.openhab.binding.automower.internal.things.AutomowerWorkAreaHandler;
 import org.openhab.core.auth.client.oauth2.OAuthFactory;
 import org.openhab.core.config.discovery.DiscoveryService;
 import org.openhab.core.i18n.TimeZoneProvider;
@@ -51,11 +52,11 @@ import org.osgi.service.component.annotations.Reference;
 @NonNullByDefault
 @Component(configurationPid = "binding.automower", service = ThingHandlerFactory.class)
 public class AutomowerHandlerFactory extends BaseThingHandlerFactory {
-    public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES = Collections
-            .unmodifiableSet(Stream.of(AutomowerBridgeHandler.SUPPORTED_THING_TYPES.stream(),
-                    AutomowerHandler.SUPPORTED_THING_TYPES.stream(), AutomowerStayoutZoneHandler.SUPPORTED_THING_TYPES
-                            .stream()/* , AutomowerWorkAreaHandler.SUPPORTED_THING_TYPES.stream() */)
-                    .flatMap(Function.identity()).collect(Collectors.toSet()));
+    public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES = Collections.unmodifiableSet(Stream
+            .of(AutomowerBridgeHandler.SUPPORTED_THING_TYPES.stream(), AutomowerHandler.SUPPORTED_THING_TYPES.stream(),
+                    AutomowerStayoutZoneHandler.SUPPORTED_THING_TYPES.stream(),
+                    AutomowerWorkAreaHandler.SUPPORTED_THING_TYPES.stream())
+            .flatMap(Function.identity()).collect(Collectors.toSet()));
 
     private final OAuthFactory oAuthFactory;
     protected final @NonNullByDefault({}) HttpClient httpClient;
@@ -84,20 +85,14 @@ public class AutomowerHandlerFactory extends BaseThingHandlerFactory {
                     webSocketFactory.getCommonWebSocketClient());
             registerAutomowerDiscoveryService(handler);
             return handler;
-        }
-
-        if (AutomowerHandler.SUPPORTED_THING_TYPES.contains(thing.getThingTypeUID())) {
+        } else if (AutomowerHandler.SUPPORTED_THING_TYPES.contains(thing.getThingTypeUID())) {
             return new AutomowerHandler(thing, timeZoneProvider);
+        } else if (AutomowerStayoutZoneHandler.SUPPORTED_THING_TYPES.contains(thing.getThingTypeUID())) {
+            return new AutomowerStayoutZoneHandler(thing);
+        } else if (AutomowerWorkAreaHandler.SUPPORTED_THING_TYPES.contains(thing.getThingTypeUID())) {
+            return new AutomowerWorkAreaHandler(thing);
         }
 
-        if (AutomowerStayoutZoneHandler.SUPPORTED_THING_TYPES.contains(thing.getThingTypeUID())) {
-            return new AutomowerStayoutZoneHandler(thing);
-        }
-        /*
-         * if (AutomowerWorkAreaHandler.SUPPORTED_THING_TYPES.contains(thing.getThingTypeUID())) {
-         * return new AutomowerWorkAreaHandler(thing, timeZoneProvider);
-         * }
-         */
         return null;
     }
 

--- a/bundles/org.openhab.binding.automower/src/main/java/org/openhab/binding/automower/internal/AutomowerHandlerFactory.java
+++ b/bundles/org.openhab.binding.automower/src/main/java/org/openhab/binding/automower/internal/AutomowerHandlerFactory.java
@@ -25,6 +25,7 @@ import org.eclipse.jetty.client.HttpClient;
 import org.openhab.binding.automower.internal.bridge.AutomowerBridgeHandler;
 import org.openhab.binding.automower.internal.discovery.AutomowerDiscoveryService;
 import org.openhab.binding.automower.internal.things.AutomowerHandler;
+import org.openhab.binding.automower.internal.things.AutomowerStayoutZoneHandler;
 import org.openhab.core.auth.client.oauth2.OAuthFactory;
 import org.openhab.core.config.discovery.DiscoveryService;
 import org.openhab.core.i18n.TimeZoneProvider;
@@ -50,9 +51,11 @@ import org.osgi.service.component.annotations.Reference;
 @NonNullByDefault
 @Component(configurationPid = "binding.automower", service = ThingHandlerFactory.class)
 public class AutomowerHandlerFactory extends BaseThingHandlerFactory {
-    public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES = Collections.unmodifiableSet(Stream
-            .of(AutomowerBridgeHandler.SUPPORTED_THING_TYPES.stream(), AutomowerHandler.SUPPORTED_THING_TYPES.stream())
-            .flatMap(Function.identity()).collect(Collectors.toSet()));
+    public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES = Collections
+            .unmodifiableSet(Stream.of(AutomowerBridgeHandler.SUPPORTED_THING_TYPES.stream(),
+                    AutomowerHandler.SUPPORTED_THING_TYPES.stream(), AutomowerStayoutZoneHandler.SUPPORTED_THING_TYPES
+                            .stream()/* , AutomowerWorkAreaHandler.SUPPORTED_THING_TYPES.stream() */)
+                    .flatMap(Function.identity()).collect(Collectors.toSet()));
 
     private final OAuthFactory oAuthFactory;
     protected final @NonNullByDefault({}) HttpClient httpClient;
@@ -87,6 +90,14 @@ public class AutomowerHandlerFactory extends BaseThingHandlerFactory {
             return new AutomowerHandler(thing, timeZoneProvider);
         }
 
+        if (AutomowerStayoutZoneHandler.SUPPORTED_THING_TYPES.contains(thing.getThingTypeUID())) {
+            return new AutomowerStayoutZoneHandler(thing);
+        }
+        /*
+         * if (AutomowerWorkAreaHandler.SUPPORTED_THING_TYPES.contains(thing.getThingTypeUID())) {
+         * return new AutomowerWorkAreaHandler(thing, timeZoneProvider);
+         * }
+         */
         return null;
     }
 

--- a/bundles/org.openhab.binding.automower/src/main/java/org/openhab/binding/automower/internal/discovery/AutomowerDiscoveryService.java
+++ b/bundles/org.openhab.binding.automower/src/main/java/org/openhab/binding/automower/internal/discovery/AutomowerDiscoveryService.java
@@ -87,14 +87,12 @@ public class AutomowerDiscoveryService extends AbstractDiscoveryService {
                     ThingTypeUID zoneThingTypeUID = THING_TYPE_STAYOUTZONE;
                     ThingUID zoneThingUid = new ThingUID(THING_TYPE_STAYOUTZONE, bridgeUID, stayOutZone.getId());
 
-                    Map<String, Object> stayoutZoneProperties = new HashMap<>();
-                    stayoutZoneProperties.put(AutomowerBindingConstants.AUTOMOWER_ID, mower.getId());
-                    stayoutZoneProperties.put(AutomowerBindingConstants.AUTOMOWER_STAYOUTZONE_ID, stayOutZone.getId());
-
-                    this.bridgeHandler.registerMowerIdForZoneId(stayOutZone.getId(), mower.getId());
+                    Map<String, Object> zoneProperties = new HashMap<>();
+                    zoneProperties.put(AutomowerBindingConstants.AUTOMOWER_ID, mower.getId());
+                    zoneProperties.put(AutomowerBindingConstants.AUTOMOWER_STAYOUTZONE_ID, stayOutZone.getId());
 
                     DiscoveryResult stayoutZoneDiscoveryResult = DiscoveryResultBuilder.create(zoneThingUid)
-                            .withThingType(zoneThingTypeUID).withProperties(stayoutZoneProperties).withBridge(bridgeUID)
+                            .withThingType(zoneThingTypeUID).withProperties(zoneProperties).withBridge(bridgeUID)
                             .withRepresentationProperty(AutomowerBindingConstants.AUTOMOWER_STAYOUTZONE_ID)
                             .withLabel(mower.getAttributes().getSystem().getName() + " - StayoutZone "
                                     + stayOutZone.getName())
@@ -112,12 +110,16 @@ public class AutomowerDiscoveryService extends AbstractDiscoveryService {
                     areaProperties.put(AutomowerBindingConstants.AUTOMOWER_ID, mower.getId());
                     areaProperties.put(AutomowerBindingConstants.AUTOMOWER_WORKAREA_ID, workArea.getWorkAreaId());
 
+                    String areaName;
+                    if (workArea.getWorkAreaId() == 0L && workArea.getName().isBlank()) {
+                        areaName = "main area";
+                    } else {
+                        areaName = workArea.getName();
+                    }
                     DiscoveryResult areaDiscoveryResult = DiscoveryResultBuilder.create(areaThingUid)
                             .withThingType(areaThingTypeUID).withProperties(areaProperties).withBridge(bridgeUID)
                             .withRepresentationProperty(AutomowerBindingConstants.AUTOMOWER_WORKAREA_ID)
-                            .withLabel(
-                                    mower.getAttributes().getSystem().getName() + " - WorkArea " + workArea.getName())
-                            .build();
+                            .withLabel(mower.getAttributes().getSystem().getName() + " - WorkArea " + areaName).build();
 
                     thingDiscovered(areaDiscoveryResult);
                 }

--- a/bundles/org.openhab.binding.automower/src/main/java/org/openhab/binding/automower/internal/discovery/AutomowerDiscoveryService.java
+++ b/bundles/org.openhab.binding.automower/src/main/java/org/openhab/binding/automower/internal/discovery/AutomowerDiscoveryService.java
@@ -13,6 +13,8 @@
 package org.openhab.binding.automower.internal.discovery;
 
 import static org.openhab.binding.automower.internal.AutomowerBindingConstants.THING_TYPE_AUTOMOWER;
+import static org.openhab.binding.automower.internal.AutomowerBindingConstants.THING_TYPE_STAYOUTZONE;
+import static org.openhab.binding.automower.internal.AutomowerBindingConstants.THING_TYPE_WORKAREA;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -24,6 +26,8 @@ import org.openhab.binding.automower.internal.AutomowerBindingConstants;
 import org.openhab.binding.automower.internal.bridge.AutomowerBridgeHandler;
 import org.openhab.binding.automower.internal.rest.api.automowerconnect.dto.Mower;
 import org.openhab.binding.automower.internal.rest.api.automowerconnect.dto.MowerListResult;
+import org.openhab.binding.automower.internal.rest.api.automowerconnect.dto.StayOutZone;
+import org.openhab.binding.automower.internal.rest.api.automowerconnect.dto.WorkArea;
 import org.openhab.core.config.discovery.AbstractDiscoveryService;
 import org.openhab.core.config.discovery.DiscoveryResult;
 import org.openhab.core.config.discovery.DiscoveryResultBuilder;
@@ -82,6 +86,45 @@ public class AutomowerDiscoveryService extends AbstractDiscoveryService {
                         .build();
 
                 thingDiscovered(discoveryResult);
+
+                for (StayOutZone stayOutZone : mower.getAttributes().getStayOutZones().getZones()) {
+                    ThingTypeUID zoneThingTypeUID = THING_TYPE_STAYOUTZONE;
+                    ThingUID zoneThingUid = new ThingUID(THING_TYPE_STAYOUTZONE, bridgeUID, stayOutZone.getId());
+
+                    Map<String, Object> stayoutZoneProperties = new HashMap<>();
+                    stayoutZoneProperties.put(AutomowerBindingConstants.AUTOMOWER_ID, mower.getId());
+                    stayoutZoneProperties.put(AutomowerBindingConstants.AUTOMOWER_STAYOUTZONE_ID, stayOutZone.getId());
+
+                    DiscoveryResult stayoutZoneDiscoveryResult = DiscoveryResultBuilder.create(zoneThingUid)
+                            .withThingType(zoneThingTypeUID).withProperties(stayoutZoneProperties).withBridge(bridgeUID)
+                            .withRepresentationProperty(AutomowerBindingConstants.AUTOMOWER_STAYOUTZONE_ID)
+                            .withLabel(mower.getAttributes().getSystem().getName() + " (Automower "
+                                    + mower.getAttributes().getSystem().getModel() + ") - StayOutZone "
+                                    + stayOutZone.getName())
+                            .build();
+
+                    thingDiscovered(stayoutZoneDiscoveryResult);
+                }
+
+                for (WorkArea workArea : mower.getAttributes().getWorkAreas()) {
+                    ThingTypeUID areaThingTypeUID = THING_TYPE_WORKAREA;
+                    ThingUID areaThingUid = new ThingUID(THING_TYPE_WORKAREA, bridgeUID,
+                            String.valueOf(workArea.getWorkAreaId()));
+
+                    Map<String, Object> areaProperties = new HashMap<>();
+                    areaProperties.put(AutomowerBindingConstants.AUTOMOWER_ID, mower.getId());
+                    areaProperties.put(AutomowerBindingConstants.AUTOMOWER_WORKAREA_ID, workArea.getWorkAreaId());
+
+                    DiscoveryResult areaDiscoveryResult = DiscoveryResultBuilder.create(areaThingUid)
+                            .withThingType(areaThingTypeUID).withProperties(areaProperties).withBridge(bridgeUID)
+                            .withRepresentationProperty(AutomowerBindingConstants.AUTOMOWER_WORKAREA_ID)
+                            .withLabel(mower.getAttributes().getSystem().getName() + " (Automower "
+                                    + mower.getAttributes().getSystem().getModel() + ") - WorkArea "
+                                    + String.valueOf(workArea.getWorkAreaId()))
+                            .build();
+
+                    thingDiscovered(areaDiscoveryResult);
+                }
             }
         });
     }

--- a/bundles/org.openhab.binding.automower/src/main/java/org/openhab/binding/automower/internal/discovery/AutomowerDiscoveryService.java
+++ b/bundles/org.openhab.binding.automower/src/main/java/org/openhab/binding/automower/internal/discovery/AutomowerDiscoveryService.java
@@ -12,9 +12,7 @@
  */
 package org.openhab.binding.automower.internal.discovery;
 
-import static org.openhab.binding.automower.internal.AutomowerBindingConstants.THING_TYPE_AUTOMOWER;
-import static org.openhab.binding.automower.internal.AutomowerBindingConstants.THING_TYPE_STAYOUTZONE;
-import static org.openhab.binding.automower.internal.AutomowerBindingConstants.THING_TYPE_WORKAREA;
+import static org.openhab.binding.automower.internal.AutomowerBindingConstants.*;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -81,9 +79,7 @@ public class AutomowerDiscoveryService extends AbstractDiscoveryService {
                 DiscoveryResult discoveryResult = DiscoveryResultBuilder.create(mowerThingUid)
                         .withThingType(thingTypeUID).withProperties(properties).withBridge(bridgeUID)
                         .withRepresentationProperty(AutomowerBindingConstants.AUTOMOWER_ID)
-                        .withLabel(mower.getAttributes().getSystem().getName() + " (Automower "
-                                + mower.getAttributes().getSystem().getModel() + ")")
-                        .build();
+                        .withLabel(mower.getAttributes().getSystem().getName()).build();
 
                 thingDiscovered(discoveryResult);
 
@@ -95,11 +91,12 @@ public class AutomowerDiscoveryService extends AbstractDiscoveryService {
                     stayoutZoneProperties.put(AutomowerBindingConstants.AUTOMOWER_ID, mower.getId());
                     stayoutZoneProperties.put(AutomowerBindingConstants.AUTOMOWER_STAYOUTZONE_ID, stayOutZone.getId());
 
+                    this.bridgeHandler.registerMowerIdForZoneId(stayOutZone.getId(), mower.getId());
+
                     DiscoveryResult stayoutZoneDiscoveryResult = DiscoveryResultBuilder.create(zoneThingUid)
                             .withThingType(zoneThingTypeUID).withProperties(stayoutZoneProperties).withBridge(bridgeUID)
                             .withRepresentationProperty(AutomowerBindingConstants.AUTOMOWER_STAYOUTZONE_ID)
-                            .withLabel(mower.getAttributes().getSystem().getName() + " (Automower "
-                                    + mower.getAttributes().getSystem().getModel() + ") - StayOutZone "
+                            .withLabel(mower.getAttributes().getSystem().getName() + " - StayoutZone "
                                     + stayOutZone.getName())
                             .build();
 
@@ -118,9 +115,8 @@ public class AutomowerDiscoveryService extends AbstractDiscoveryService {
                     DiscoveryResult areaDiscoveryResult = DiscoveryResultBuilder.create(areaThingUid)
                             .withThingType(areaThingTypeUID).withProperties(areaProperties).withBridge(bridgeUID)
                             .withRepresentationProperty(AutomowerBindingConstants.AUTOMOWER_WORKAREA_ID)
-                            .withLabel(mower.getAttributes().getSystem().getName() + " (Automower "
-                                    + mower.getAttributes().getSystem().getModel() + ") - WorkArea "
-                                    + String.valueOf(workArea.getWorkAreaId()))
+                            .withLabel(
+                                    mower.getAttributes().getSystem().getName() + " - WorkArea " + workArea.getName())
                             .build();
 
                     thingDiscovered(areaDiscoveryResult);

--- a/bundles/org.openhab.binding.automower/src/main/java/org/openhab/binding/automower/internal/things/AutomowerStayoutZoneHandler.java
+++ b/bundles/org.openhab.binding.automower/src/main/java/org/openhab/binding/automower/internal/things/AutomowerStayoutZoneHandler.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2010-2025 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.automower.internal.things;
+
+import static org.openhab.binding.automower.internal.AutomowerBindingConstants.*;
+
+import java.util.Set;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.automower.internal.bridge.AutomowerBridgeHandler;
+import org.openhab.binding.automower.internal.rest.api.automowerconnect.dto.StayOutZone;
+import org.openhab.core.library.types.OnOffType;
+import org.openhab.core.library.types.StringType;
+import org.openhab.core.thing.Bridge;
+import org.openhab.core.thing.ChannelUID;
+import org.openhab.core.thing.Thing;
+import org.openhab.core.thing.ThingStatus;
+import org.openhab.core.thing.ThingTypeUID;
+import org.openhab.core.thing.binding.BaseThingHandler;
+import org.openhab.core.thing.binding.ThingHandler;
+import org.openhab.core.types.Command;
+import org.openhab.core.types.RefreshType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link AutomowerStayoutZoneHandler} represents a StayoutZone of an automower as thing.
+ *
+ * @author MikeTheTux - Initial contribution
+ */
+@NonNullByDefault
+public class AutomowerStayoutZoneHandler extends BaseThingHandler {
+    public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES = Set.of(THING_TYPE_STAYOUTZONE);
+
+    private final Logger logger = LoggerFactory.getLogger(AutomowerStayoutZoneHandler.class);
+    private final String thingId;
+
+    public AutomowerStayoutZoneHandler(Thing thing) {
+        super(thing);
+        this.thingId = this.getThing().getUID().getId();
+
+        logger.trace("AutomowerStayoutZoneHandler created for thingId {}", this.thingId);
+    }
+
+    @Override
+    public synchronized void handleCommand(ChannelUID channelUID, Command command) {
+        // REFRESH is not implemented as it would causes >100 channel updates in a row during setup (performance, API
+        // rate limit)
+        if (RefreshType.REFRESH != command) {
+            if (CHANNEL_STAYOUTZONE_ENABLED.equals(channelUID.getIdWithoutGroup())) {
+                if (command instanceof OnOffType cmd) {
+                    AutomowerBridgeHandler automowerBridgeHandler = getAutomowerBridgeHandler();
+                    if (automowerBridgeHandler != null) {
+                        AutomowerHandler handler = automowerBridgeHandler
+                                .getAutomowerHandlerByStayoutZoneId(this.thingId);
+                        if (handler != null) {
+                            handler.sendAutomowerStayOutZone(this.thingId, ((cmd == OnOffType.ON) ? true : false));
+                        } else {
+                            logger.warn("No AutomowerHandler found for zoneId {}", this.thingId);
+                        }
+                    } else {
+                        logger.warn("No AutomowerBridgeHandler found for thingId {}", this.thingId);
+                    }
+                } else {
+                    logger.warn("Command {} not supported for channel {}", command, channelUID);
+                }
+            } else {
+                logger.warn("Command {} not supported for channel {}", command, channelUID);
+            }
+        }
+    }
+
+    @Override
+    public void initialize() {
+        // Adding handler to map of handlers
+        AutomowerBridgeHandler automowerBridgeHandler = getAutomowerBridgeHandler();
+        if (automowerBridgeHandler != null) {
+            automowerBridgeHandler.registerAutomowerStayoutZoneHandler(this.thingId, this);
+        } else {
+            logger.warn("No AutomowerBridgeHandler found for thingId {}", this.thingId);
+        }
+        updateStatus(ThingStatus.ONLINE);
+        logger.trace("AutomowerStayoutZoneHandler initialized for thingId {}", this.thingId);
+    }
+
+    @Nullable
+    private AutomowerBridgeHandler getAutomowerBridgeHandler() {
+        Bridge bridge = getBridge();
+        if (bridge != null) {
+            ThingHandler handler = bridge.getHandler();
+            if (handler instanceof AutomowerBridgeHandler bridgeHandler) {
+                return bridgeHandler;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public void dispose() {
+        AutomowerBridgeHandler automowerBridgeHandler = getAutomowerBridgeHandler();
+        if (automowerBridgeHandler != null) {
+            automowerBridgeHandler.unregisterAutomowerStayoutZoneHandler(this.thingId);
+        }
+    }
+
+    public void updateStayOutZoneChannels(StayOutZone stayOutZone) {
+        updateState(CHANNEL_STAYOUTZONE_NAME, new StringType(stayOutZone.getName()));
+        updateState(CHANNEL_STAYOUTZONE_ENABLED, OnOffType.from(stayOutZone.isEnabled()));
+    }
+}

--- a/bundles/org.openhab.binding.automower/src/main/java/org/openhab/binding/automower/internal/things/AutomowerWorkAreaHandler.java
+++ b/bundles/org.openhab.binding.automower/src/main/java/org/openhab/binding/automower/internal/things/AutomowerWorkAreaHandler.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 2010-2025 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.automower.internal.things;
+
+import static org.openhab.binding.automower.internal.AutomowerBindingConstants.*;
+
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.automower.internal.bridge.AutomowerBridgeHandler;
+import org.openhab.binding.automower.internal.rest.api.automowerconnect.dto.WorkArea;
+import org.openhab.core.library.types.DateTimeType;
+import org.openhab.core.library.types.DecimalType;
+import org.openhab.core.library.types.OnOffType;
+import org.openhab.core.library.types.QuantityType;
+import org.openhab.core.library.types.StringType;
+import org.openhab.core.library.unit.Units;
+import org.openhab.core.thing.Bridge;
+import org.openhab.core.thing.ChannelUID;
+import org.openhab.core.thing.Thing;
+import org.openhab.core.thing.ThingStatus;
+import org.openhab.core.thing.ThingTypeUID;
+import org.openhab.core.thing.binding.BaseThingHandler;
+import org.openhab.core.thing.binding.ThingHandler;
+import org.openhab.core.types.Command;
+import org.openhab.core.types.RefreshType;
+import org.openhab.core.types.UnDefType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link AutomowerWorkAreaHandler} represents a WorkArea of an automower as thing.
+ *
+ * @author MikeTheTux - Initial contribution
+ */
+@NonNullByDefault
+public class AutomowerWorkAreaHandler extends BaseThingHandler {
+    public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES = Set.of(THING_TYPE_WORKAREA);
+
+    private final Logger logger = LoggerFactory.getLogger(AutomowerWorkAreaHandler.class);
+    private final String thingId;
+
+    public AutomowerWorkAreaHandler(Thing thing) {
+        super(thing);
+        this.thingId = this.getThing().getUID().getId();
+
+        logger.trace("AutomowerWorkAreaHandler created for thingId {}", this.thingId);
+    }
+
+    @Override
+    public synchronized void handleCommand(ChannelUID channelUID, Command command) {
+        // REFRESH is not implemented as it would causes >100 channel updates in a row during setup (performance, API
+        // rate limit)
+        if (RefreshType.REFRESH != command) {
+            AutomowerBridgeHandler automowerBridgeHandler = getAutomowerBridgeHandler();
+            if (automowerBridgeHandler != null) {
+                AutomowerHandler handler = automowerBridgeHandler.getAutomowerHandlerByWorkAreaId(this.thingId);
+                if (handler != null) {
+                    if (CHANNEL_WORKAREA_ENABLED.equals(channelUID.getIdWithoutGroup())) {
+                        if (command instanceof OnOffType cmd) {
+                            handler.sendAutomowerWorkAreaEnable(this.thingId, ((cmd == OnOffType.ON) ? true : false));
+                        } else {
+                            logger.warn("Command {} not supported for channel {}", command, channelUID);
+                        }
+                    } else if (CHANNEL_WORKAREA_CUTTING_HEIGHT.equals(channelUID.getIdWithoutGroup())) {
+                        if (command instanceof QuantityType cmd) {
+                            cmd = cmd.toUnit("%");
+                            if (cmd != null) {
+                                handler.sendAutomowerWorkAreaCuttingHeight(this.thingId, cmd.byteValue());
+                            }
+                        } else if (command instanceof DecimalType cmd) {
+                            handler.sendAutomowerWorkAreaCuttingHeight(this.thingId, cmd.byteValue());
+                        } else {
+                            logger.warn("Command {} not supported for channel {}", command, channelUID);
+                        }
+                    }
+                } else {
+                    logger.warn("No AutomowerHandler found for areaId {}", this.thingId);
+                }
+            } else {
+                logger.warn("No AutomowerBridgeHandler found for thingId {}", this.thingId);
+            }
+        } else {
+            logger.warn("Command {} not supported for channel {}", command, channelUID);
+        }
+    }
+
+    @Override
+    public void initialize() {
+        // Adding handler to map of handlers
+        AutomowerBridgeHandler automowerBridgeHandler = getAutomowerBridgeHandler();
+        if (automowerBridgeHandler != null) {
+            automowerBridgeHandler.registerAutomowerWorkAreaHandler(this.thingId, this);
+        } else {
+            logger.warn("No AutomowerBridgeHandler found for thingId {}", this.thingId);
+        }
+        updateStatus(ThingStatus.ONLINE);
+        logger.trace("AutomowerWorkAreaHandler initialized for thingId {}", this.thingId);
+    }
+
+    @Nullable
+    private AutomowerBridgeHandler getAutomowerBridgeHandler() {
+        Bridge bridge = getBridge();
+        if (bridge != null) {
+            ThingHandler handler = bridge.getHandler();
+            if (handler instanceof AutomowerBridgeHandler bridgeHandler) {
+                return bridgeHandler;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public void dispose() {
+        AutomowerBridgeHandler automowerBridgeHandler = getAutomowerBridgeHandler();
+        if (automowerBridgeHandler != null) {
+            automowerBridgeHandler.unregisterAutomowerWorkAreaHandler(this.thingId);
+        }
+    }
+
+    public void updateWorkAreaChannels(WorkArea workArea, AutomowerHandler mowerHandler) {
+        if (workArea.getWorkAreaId() == 0L && workArea.getName().isBlank()) {
+            updateState(CHANNEL_WORKAREA_NAME, new StringType("main area"));
+        } else {
+            updateState(CHANNEL_WORKAREA_NAME, new StringType(workArea.getName()));
+        }
+        updateState(CHANNEL_WORKAREA_CUTTING_HEIGHT, new QuantityType<>(workArea.getCuttingHeight(), Units.PERCENT));
+        updateState(CHANNEL_WORKAREA_ENABLED, OnOffType.from(workArea.isEnabled()));
+        if (workArea.getProgress() != null) {
+            updateState(CHANNEL_WORKAREA_PROGRESS, new QuantityType<>(workArea.getProgress(), Units.PERCENT));
+        } else {
+            updateState(CHANNEL_WORKAREA_PROGRESS, UnDefType.NULL);
+        }
+
+        // lastTimeCompleted is in seconds, convert it to milliseconds
+        Long lastTimeCompleted = workArea.getLastTimeCompleted();
+        // If lastTimeCompleted is 0 it means the work area has never been completed
+        if (lastTimeCompleted != null && lastTimeCompleted != 0L) {
+            updateState(CHANNEL_WORKAREA_LAST_TIME_COMPLETED, new DateTimeType(mowerHandler
+                    .toZonedDateTime(TimeUnit.SECONDS.toMillis(lastTimeCompleted), mowerHandler.getMowerZoneId())));
+        } else {
+            updateState(CHANNEL_WORKAREA_LAST_TIME_COMPLETED, UnDefType.NULL);
+        }
+    }
+}

--- a/bundles/org.openhab.binding.automower/src/main/resources/OH-INF/i18n/automower.properties
+++ b/bundles/org.openhab.binding.automower/src/main/resources/OH-INF/i18n/automower.properties
@@ -9,6 +9,10 @@ thing-type.automower.automower.label = Automower®
 thing-type.automower.automower.description = An automatic lawn mower
 thing-type.automower.bridge.label = Automower® Connect Bridge
 thing-type.automower.bridge.description = The bridge to communicate with the Automower® Connect API
+thing-type.automower.stayoutzone.label = Automower® StayoutZone
+thing-type.automower.stayoutzone.description = An automatic lawn mower stay-out zone
+thing-type.automower.workarea.label = Automower® WorkArea
+thing-type.automower.workarea.description = An automatic lawn mower work-area
 
 # thing types config
 
@@ -32,7 +36,6 @@ channel-group-type.automower.settingsType.label = Settings
 channel-group-type.automower.statisticsType.label = Statistics
 channel-group-type.automower.statusType.label = Status
 channel-group-type.automower.stayoutZonesType.label = Stayout Zones
-channel-group-type.automower.workAreasType.label = Work Areas
 
 # channel types
 
@@ -198,24 +201,31 @@ channel-type.automower.workAreaType.label = Work Area Name
 channel-type.automower.workAreaType.description = Name of the active Work Area
 channel-type.automower.workareaCuttingHeightType.label = Cutting Height
 channel-type.automower.workareaCuttingHeightType.description = Cutting height of the Work Area, range: 0-100
-channel-type.automower.workareaEnabledType.label = Work Area Enabled
+channel-type.automower.workareaEnabledType.label = Enabled
 channel-type.automower.workareaEnabledType.description = If the Work Area is enabled or disabled
-channel-type.automower.workareaIdType.label = Work Area Id
-channel-type.automower.workareaIdType.description = Id of the Work Area
 channel-type.automower.workareaLastTimeCompletedType.label = Last Time Completed
 channel-type.automower.workareaLastTimeCompletedType.description = Timestamp when the Work Area was last completed. EPOS Automower® and systematic mowing Work Areas only
-channel-type.automower.workareaNameType.label = Work Area Name
+channel-type.automower.workareaNameType.label = Name
 channel-type.automower.workareaNameType.description = Name of the Work Area
-channel-type.automower.workareaProgressType.label = Work Area Progress
+channel-type.automower.workareaProgressType.label = Progress
 channel-type.automower.workareaProgressType.description = The progress on a Work Area. EPOS Automower® and systematic mowing Work Areas only
 channel-type.automower.zoneDirtyType.label = Stayout Zones Dirty Flag
 channel-type.automower.zoneDirtyType.description = If the stay-out zones are synchronized with the Husqvarna cloud. If the map is dirty you can not enable or disable a stay-out zone
-channel-type.automower.zoneEnabledType.label = Stayout Zone Enabled
+channel-type.automower.zoneEnabledType.label = Enabled
 channel-type.automower.zoneEnabledType.description = If the stay-out zone is enabled, the Automower® will not access the zone
+channel-type.automower.zoneNameType.label = Name
+channel-type.automower.zoneNameType.description = The name of the stay-out zone
+
+# channel group types
+
+channel-group-type.automower.workAreasType.label = Work Areas
+
+# channel types
+
+channel-type.automower.workareaIdType.label = Work Area Id
+channel-type.automower.workareaIdType.description = Id of the Work Area
 channel-type.automower.zoneIdType.label = Stayout Zone Id
 channel-type.automower.zoneIdType.description = Id of the stay-out zone
-channel-type.automower.zoneNameType.label = Stayout Zone Name
-channel-type.automower.zoneNameType.description = The name of the stay-out zone
 
 # channel types
 

--- a/bundles/org.openhab.binding.automower/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.automower/src/main/resources/OH-INF/thing/thing-types.xml
@@ -10,7 +10,6 @@
 		<description>The bridge to communicate with the Automower® Connect API</description>
 		<semantic-equipment-tag>WebService</semantic-equipment-tag>
 
-
 		<config-description>
 			<parameter name="appKey" type="text" required="true">
 				<label>Application Key</label>
@@ -93,9 +92,10 @@
 		<description>An automatic lawn mower stay-out zone</description>
 		<semantic-equipment-tag>LawnMower</semantic-equipment-tag>
 
-		<channel-groups>
-			<channel-group id="stayoutzone" typeId="stayoutZonesType"/>
-		</channel-groups>
+		<channels>
+			<channel id="name" typeId="zoneNameType"/>
+			<channel id="enabled" typeId="zoneEnabledType"/>
+		</channels>
 
 		<properties>
 			<property name="mowerId">N/A</property>
@@ -213,15 +213,9 @@
 		<!-- channels created on demand
 			<channels>
 			<channel id="dirty" typeId="zoneDirtyType"/>
-			<channel id="<xx>-id" typeId="zoneIdType"/>
-			<channel id="<xx>-name" typeId="zoneNameType"/>
-			<channel id="<xx>-enabled" typeId="zoneEnabledType"/>
-			...
 			</channels>
 		-->
-	</channel-group-type>
-
-	<!-- Work Areas -->
+	</channel-group-type>	<!-- Work Areas -->
 	<channel-group-type id="workAreasType">
 		<label>Work Areas</label>
 		<!-- channels created on demand
@@ -627,23 +621,16 @@
 		<state readOnly="true"/>
 	</channel-type>
 
-	<channel-type id="zoneIdType" advanced="true">
+	<channel-type id="zoneNameType" advanced="false">
 		<item-type>String</item-type>
-		<label>Stayout Zone Id</label>
-		<description>Id of the stay-out zone</description>
-		<state readOnly="true"/>
-	</channel-type>
-
-	<channel-type id="zoneNameType" advanced="true">
-		<item-type>String</item-type>
-		<label>Stayout Zone Name</label>
+		<label>Name</label>
 		<description>The name of the stay-out zone</description>
 		<state readOnly="true"/>
 	</channel-type>
 
-	<channel-type id="zoneEnabledType" advanced="true">
+	<channel-type id="zoneEnabledType" advanced="false">
 		<item-type>Switch</item-type>
-		<label>Stayout Zone Enabled</label>
+		<label>Enabled</label>
 		<description>If the stay-out zone is enabled, the Automower® will not access the zone</description>
 	</channel-type>
 

--- a/bundles/org.openhab.binding.automower/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.automower/src/main/resources/OH-INF/thing/thing-types.xml
@@ -113,9 +113,13 @@
 		<description>An automatic lawn mower work-area</description>
 		<semantic-equipment-tag>LawnMower</semantic-equipment-tag>
 
-		<channel-groups>
-			<channel-group id="workarea" typeId="workAreasType"/>
-		</channel-groups>
+		<channels>
+			<channel id="name" typeId="workareaNameType"/>
+			<channel id="cutting-height" typeId="workareaCuttingHeightType"/>
+			<channel id="enabled" typeId="workareaEnabledType"/>
+			<channel id="progress" typeId="workareaProgressType"/>
+			<channel id="last-time-completed" typeId="workareaLastTimeCompletedType"/>
+		</channels>
 
 		<properties>
 			<property name="mowerId">N/A</property>
@@ -213,20 +217,6 @@
 		<!-- channels created on demand
 			<channels>
 			<channel id="dirty" typeId="zoneDirtyType"/>
-			</channels>
-		-->
-	</channel-group-type>	<!-- Work Areas -->
-	<channel-group-type id="workAreasType">
-		<label>Work Areas</label>
-		<!-- channels created on demand
-			<channels>
-			<channel id="<xx>-id" typeId="workareaIdType"/>
-			<channel id="<xx>-name" typeId="workareaNameType"/>
-			<channel id="<xx>-cutting-height" typeId="workareaCuttingHeightType"/>
-			<channel id="<xx>-enabled" typeId="workareaEnabledType"/>
-			<channel id="<xx>-progress" typeId="workareaProgressType"/>
-			<channel id="<xx>-last-time-completed" typeId="workareaLastTimeCompletedType"/>
-			...
 			</channels>
 		-->
 	</channel-group-type>
@@ -635,36 +625,29 @@
 	</channel-type>
 
 	<!-- Work Areas -->
-	<channel-type id="workareaIdType" advanced="true">
-		<item-type>Number</item-type>
-		<label>Work Area Id</label>
-		<description>Id of the Work Area</description>
-		<state readOnly="true"/>
-	</channel-type>
-
-	<channel-type id="workareaNameType" advanced="true">
+	<channel-type id="workareaNameType" advanced="false">
 		<item-type>String</item-type>
-		<label>Work Area Name</label>
+		<label>Name</label>
 		<description>Name of the Work Area</description>
 		<state readOnly="true"/>
 	</channel-type>
 
-	<channel-type id="workareaCuttingHeightType" advanced="true">
+	<channel-type id="workareaCuttingHeightType" advanced="false">
 		<item-type>Number:Dimensionless</item-type>
 		<label>Cutting Height</label>
 		<description>Cutting height of the Work Area, range: 0-100</description>
 		<state pattern="%d %%"/>
 	</channel-type>
 
-	<channel-type id="workareaEnabledType" advanced="true">
+	<channel-type id="workareaEnabledType" advanced="false">
 		<item-type>Switch</item-type>
-		<label>Work Area Enabled</label>
+		<label>Enabled</label>
 		<description>If the Work Area is enabled or disabled</description>
 	</channel-type>
 
 	<channel-type id="workareaProgressType" advanced="true">
 		<item-type>Number:Dimensionless</item-type>
-		<label>Work Area Progress</label>
+		<label>Progress</label>
 		<description>The progress on a Work Area. EPOS Automower® and systematic mowing Work Areas only</description>
 		<state readOnly="true" pattern="%d %%"/>
 	</channel-type>

--- a/bundles/org.openhab.binding.automower/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.automower/src/main/resources/OH-INF/thing/thing-types.xml
@@ -83,6 +83,46 @@
 		</config-description>
 	</thing-type>
 
+	<!-- Automower StayoutZone Type -->
+	<thing-type id="stayoutzone" listed="false">
+		<supported-bridge-type-refs>
+			<bridge-type-ref id="bridge"/>
+		</supported-bridge-type-refs>
+
+		<label>Automower® StayoutZone</label>
+		<description>An automatic lawn mower stay-out zone</description>
+		<semantic-equipment-tag>LawnMower</semantic-equipment-tag>
+
+		<channel-groups>
+			<channel-group id="stayoutzone" typeId="stayoutZonesType"/>
+		</channel-groups>
+
+		<properties>
+			<property name="mowerId">N/A</property>
+			<property name="stayoutzoneId">N/A</property>
+		</properties>
+	</thing-type>
+
+	<!-- WorkArea Thing Type -->
+	<thing-type id="workarea" listed="false">
+		<supported-bridge-type-refs>
+			<bridge-type-ref id="bridge"/>
+		</supported-bridge-type-refs>
+
+		<label>Automower® WorkArea</label>
+		<description>An automatic lawn mower work-area</description>
+		<semantic-equipment-tag>LawnMower</semantic-equipment-tag>
+
+		<channel-groups>
+			<channel-group id="workarea" typeId="workAreasType"/>
+		</channel-groups>
+
+		<properties>
+			<property name="mowerId">N/A</property>
+			<property name="workareaId">N/A</property>
+		</properties>
+	</thing-type>
+
 	<channel-group-type id="statusType">
 		<label>Status</label>
 		<channels>


### PR DESCRIPTION
# [automower] Implement individual Things for configuration dependent items

This PR implements individual openHAB Things for configuration dependent Automower items like:

- WorkAreas (done)
- StayoutZones (done)
- CalenderTasks (todo)

The Thing UID is based on the unique Automower Id. This avoids the problem where changing the Automower configuration leads to a different ordering and thereby a shift in the consecutive channel naming in the old implementation.