### PR TITLE
[rfxcom] Added additional FirmwareType's

### DIFF
--- a/bundles/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComInterfaceMessage.java
+++ b/bundles/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComInterfaceMessage.java
@@ -125,7 +125,13 @@ public class RFXComInterfaceMessage extends RFXComBaseMessage {
         PRO1(0x05, "Pro1"),
         PRO2(0x06, "Pro2"),
         PROXL1(0x10, "ProXL1"),
-        PROXL2(0x12, "ProXL2"), // Discovered in the wild (not from RFXtrx SDK)
+        PROXL2_UN(0x12, "ProXL2"), // Discovered in the wild (not from RFXtrx SDK)
+        PROXL2(0x13, "ProXL2"),
+        RFX433(0x14, "RFX433"),
+        RFX868(0x15, "RFX868"),
+        PROXL95(0x16, "ProXL95"),
+        RFU(0x17, "RFU"),
+        RFX310(0x18, "RFX310 //RFXusb with 310MHz receiver"),
         UNKNOWN(0xFF, "Unknown");
 
         private final int type;


### PR DESCRIPTION
This adds additional firmware types as requested in https://github.com/openhab/openhab-addons/issues/13024

I provided a download:

https://download.martinvw.nl/org.openhab.binding.rfxcom-5.1.0-SNAPSHOT.13024.jar