### PR TITLE
[linky] Fix new url schema for getMeasures() related to September Enedis changes to WebAPI

### DIFF
--- a/bundles/org.openhab.binding.linky/src/main/java/org/openhab/binding/linky/internal/api/EnedisHttpApi.java
+++ b/bundles/org.openhab.binding.linky/src/main/java/org/openhab/binding/linky/internal/api/EnedisHttpApi.java
@@ -268,7 +268,7 @@ public class EnedisHttpApi {
             ResponseMeter meterResponse = getData(handler, url, ResponseMeter.class);
             return meterResponse.meterReading;
         } else {
-            String url = String.format(apiUrl, mps, prmId, dtStart, dtEnd);
+            String url = String.format(apiUrl, mps, prmId, "C5", dtStart, dtEnd);
             ConsumptionReport consomptionReport = getData(handler, url, ConsumptionReport.class);
             return MeterReading.convertFromComsumptionReport(consomptionReport);
         }

--- a/bundles/org.openhab.binding.linky/src/main/java/org/openhab/binding/linky/internal/api/EnedisHttpApi.java
+++ b/bundles/org.openhab.binding.linky/src/main/java/org/openhab/binding/linky/internal/api/EnedisHttpApi.java
@@ -259,7 +259,7 @@ public class EnedisHttpApi {
     }
 
     private MeterReading getMeasures(ThingLinkyRemoteHandler handler, String apiUrl, String mps, String prmId,
-            LocalDate from, LocalDate to) throws LinkyException {
+            String segment, LocalDate from, LocalDate to) throws LinkyException {
         String dtStart = from.format(linkyBridgeHandler.getApiDateFormat());
         String dtEnd = to.format(linkyBridgeHandler.getApiDateFormat());
 
@@ -274,19 +274,19 @@ public class EnedisHttpApi {
         }
     }
 
-    public MeterReading getEnergyData(ThingLinkyRemoteHandler handler, String mps, String prmId, LocalDate from,
-            LocalDate to) throws LinkyException {
-        return getMeasures(handler, linkyBridgeHandler.getDailyConsumptionUrl(), mps, prmId, from, to);
+    public MeterReading getEnergyData(ThingLinkyRemoteHandler handler, String mps, String prmId, String segment,
+            LocalDate from, LocalDate to) throws LinkyException {
+        return getMeasures(handler, linkyBridgeHandler.getDailyConsumptionUrl(), mps, prmId, segment, from, to);
     }
 
-    public MeterReading getLoadCurveData(ThingLinkyRemoteHandler handler, String mps, String prmId, LocalDate from,
-            LocalDate to) throws LinkyException {
-        return getMeasures(handler, linkyBridgeHandler.getLoadCurveUrl(), mps, prmId, from, to);
+    public MeterReading getLoadCurveData(ThingLinkyRemoteHandler handler, String mps, String prmId, String segment,
+            LocalDate from, LocalDate to) throws LinkyException {
+        return getMeasures(handler, linkyBridgeHandler.getLoadCurveUrl(), mps, prmId, segment, from, to);
     }
 
-    public MeterReading getPowerData(ThingLinkyRemoteHandler handler, String mps, String prmId, LocalDate from,
-            LocalDate to) throws LinkyException {
-        return getMeasures(handler, linkyBridgeHandler.getMaxPowerUrl(), mps, prmId, from, to);
+    public MeterReading getPowerData(ThingLinkyRemoteHandler handler, String mps, String prmId, String segment,
+            LocalDate from, LocalDate to) throws LinkyException {
+        return getMeasures(handler, linkyBridgeHandler.getMaxPowerUrl(), mps, prmId, segment, from, to);
     }
 
     public ResponseTempo getTempoData(ThingBaseRemoteHandler handler, LocalDate from, LocalDate to)

--- a/bundles/org.openhab.binding.linky/src/main/java/org/openhab/binding/linky/internal/api/EnedisHttpApi.java
+++ b/bundles/org.openhab.binding.linky/src/main/java/org/openhab/binding/linky/internal/api/EnedisHttpApi.java
@@ -268,7 +268,7 @@ public class EnedisHttpApi {
             ResponseMeter meterResponse = getData(handler, url, ResponseMeter.class);
             return meterResponse.meterReading;
         } else {
-            String url = String.format(apiUrl, mps, prmId, "C5", dtStart, dtEnd);
+            String url = String.format(apiUrl, mps, prmId, segment, dtStart, dtEnd);
             ConsumptionReport consomptionReport = getData(handler, url, ConsumptionReport.class);
             return MeterReading.convertFromComsumptionReport(consomptionReport);
         }

--- a/bundles/org.openhab.binding.linky/src/main/java/org/openhab/binding/linky/internal/handler/BridgeRemoteEnedisWebHandler.java
+++ b/bundles/org.openhab.binding.linky/src/main/java/org/openhab/binding/linky/internal/handler/BridgeRemoteEnedisWebHandler.java
@@ -67,17 +67,17 @@ public class BridgeRemoteEnedisWebHandler extends BridgeRemoteBaseHandler {
 
     private static final String USER_INFO_CONTRACT_URL = BASE_URL + "/mon-compte/api/private/v2/userinfos";
     private static final String USER_INFO_URL = BASE_URL + "/userinfos";
-    private static final String PRM_INFO_BASE_URL = BASE_URL + "/mes-mesures-prm/api/private/v1/personnes/";
+    private static final String PRM_INFO_BASE_URL = BASE_URL + "/mes-mesures-prm/api/private/v2/personnes/";
     private static final String PRM_INFO_URL = BASE_URL + "/mes-prms-part/api/private/v2/personnes/%s/prms";
 
     private static final String MEASURE_DAILY_CONSUMPTION_URL = PRM_INFO_BASE_URL
-            + "%s/prms/%s/donnees-energetiques?mesuresTypeCode=ENERGIE&mesuresCorrigees=false&typeDonnees=CONS";
+            + "%s/prms/%s/donnees-energetiques?mesuresTypeCode=ENERGIE&mesuresCorrigees=false&typeDonnees=CONS&segments=%s";
 
     private static final String MEASURE_MAX_POWER_URL = PRM_INFO_BASE_URL
-            + "%s/prms/%s/donnees-energetiques?mesuresTypeCode=PMAX&mesuresCorrigees=false&typeDonnees=CONS";
+            + "%s/prms/%s/donnees-energetiques?mesuresTypeCode=PMAX&mesuresCorrigees=false&typeDonnees=CONS&segments=%s";
 
     private static final String LOAD_CURVE_CONSUMPTION_URL = PRM_INFO_BASE_URL
-            + "%s/prms/%s/donnees-energetiques?mesuresTypeCode=COURBE&mesuresCorrigees=false&typeDonnees=CONS&dateDebut=%s";
+            + "%s/prms/%s/donnees-energetiques?mesuresTypeCode=COURBE&mesuresCorrigees=false&typeDonnees=CONS&segments=%s&dateDebut=%s";
 
     private static final DateTimeFormatter API_DATE_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd");
     private static final DateTimeFormatter API_DATE_FORMAT_YEAR_FIRST = DateTimeFormatter.ofPattern("yyyy-MM-dd");
@@ -86,6 +86,8 @@ public class BridgeRemoteEnedisWebHandler extends BridgeRemoteBaseHandler {
 
     private static final String BASE_MYELECT_URL = "https://www.myelectricaldata.fr/";
     private static final String TEMPO_URL = BASE_MYELECT_URL + "rte/tempo/%s/%s";
+
+    private String idPersonne = "";
 
     public BridgeRemoteEnedisWebHandler(Bridge bridge, final @Reference HttpClientFactory httpClientFactory,
             final @Reference OAuthFactory oAuthFactory, final @Reference HttpService httpService,
@@ -333,6 +335,7 @@ public class BridgeRemoteEnedisWebHandler extends BridgeRemoteBaseHandler {
 
             if (hashRes != null && hashRes.containsKey("cnAlex")) {
                 cookieKey = "personne_for_" + hashRes.get("cnAlex");
+                idPersonne = Objects.requireNonNull(hashRes.get("idPersonne"));
             } else {
                 throw new LinkyException("Connection failed step 5, missing cookieKey");
             }
@@ -354,5 +357,9 @@ public class BridgeRemoteEnedisWebHandler extends BridgeRemoteBaseHandler {
     @Override
     public boolean supportNewApiFormat() {
         return false;
+    }
+
+    public String getIdPersonne() {
+        return idPersonne;
     }
 }

--- a/bundles/org.openhab.binding.linky/src/main/java/org/openhab/binding/linky/internal/handler/ThingLinkyRemoteHandler.java
+++ b/bundles/org.openhab.binding.linky/src/main/java/org/openhab/binding/linky/internal/handler/ThingLinkyRemoteHandler.java
@@ -98,6 +98,7 @@ public class ThingLinkyRemoteHandler extends ThingBaseRemoteHandler {
     private double divider = 1.00;
 
     public String userId = "";
+    public String segment = "";
 
     private @Nullable ScheduledFuture<?> pollingJob = null;
 
@@ -290,7 +291,8 @@ public class ThingLinkyRemoteHandler extends ThingBaseRemoteHandler {
 
             addProps(props, PROPERTY_IDENTITY, title + " " + firstName + " " + lastName);
 
-            addProps(props, PROPERTY_CONTRACT_SEGMENT, values.contract.segment);
+            segment = values.contract.segment;
+            addProps(props, PROPERTY_CONTRACT_SEGMENT, segment);
             addProps(props, PROPERTY_CONTRACT_CONTRACT_STATUS, values.contract.contractStatus);
             addProps(props, PROPERTY_CONTRACT_CONTRACT_TYPE, values.contract.contractType);
             addProps(props, PROPERTY_CONTRACT_DISTRIBUTION_TARIFF, values.contract.distributionTariff);
@@ -612,7 +614,7 @@ public class ThingLinkyRemoteHandler extends ThingBaseRemoteHandler {
         EnedisHttpApi api = this.enedisApi;
         if (api != null) {
             try {
-                return api.getEnergyData(this, this.userId, config.prmId, from, to);
+                return api.getEnergyData(this, this.userId, config.prmId, segment, from, to);
             } catch (LinkyException e) {
                 logger.debug("Exception when getting consumption data for {} : {}", config.prmId, e.getMessage(), e);
                 updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.OFFLINE.COMMUNICATION_ERROR, e.getMessage());
@@ -629,7 +631,7 @@ public class ThingLinkyRemoteHandler extends ThingBaseRemoteHandler {
         EnedisHttpApi api = this.enedisApi;
         if (api != null) {
             try {
-                return api.getLoadCurveData(this, this.userId, config.prmId, from, to);
+                return api.getLoadCurveData(this, this.userId, config.prmId, segment, from, to);
             } catch (LinkyException e) {
                 logger.debug("Exception when getting consumption data: {}", e.getMessage(), e);
                 updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.OFFLINE.COMMUNICATION_ERROR, e.getMessage());
@@ -646,7 +648,7 @@ public class ThingLinkyRemoteHandler extends ThingBaseRemoteHandler {
         EnedisHttpApi api = this.enedisApi;
         if (api != null) {
             try {
-                return api.getPowerData(this, this.userId, config.prmId, from, to);
+                return api.getPowerData(this, this.userId, config.prmId, segment, from, to);
             } catch (LinkyException e) {
                 logger.debug("Exception when getting power data: {}", e.getMessage(), e);
                 updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.OFFLINE.COMMUNICATION_ERROR, e.getMessage());

--- a/bundles/org.openhab.binding.linky/src/main/java/org/openhab/binding/linky/internal/handler/ThingLinkyRemoteHandler.java
+++ b/bundles/org.openhab.binding.linky/src/main/java/org/openhab/binding/linky/internal/handler/ThingLinkyRemoteHandler.java
@@ -271,7 +271,18 @@ public class ThingLinkyRemoteHandler extends ThingBaseRemoteHandler {
             if (values.identity.internId == null) {
                 values.identity.internId = values.identity.firstname + " " + values.identity.lastname;
             }
+
             userId = values.identity.internId;
+
+            Bridge bridge = getBridge();
+            BridgeRemoteBaseHandler bridgeHandler = null;
+            if (bridge != null) {
+                bridgeHandler = (BridgeRemoteBaseHandler) bridge.getHandler();
+            }
+
+            if (bridgeHandler instanceof BridgeRemoteEnedisWebHandler) {
+                userId = ((BridgeRemoteEnedisWebHandler) bridgeHandler).getIdPersonne();
+            }
 
             addProps(props, USER_ID, userId);
 

--- a/bundles/org.openhab.binding.linky/src/main/java/org/openhab/binding/linky/internal/handler/ThingLinkyRemoteHandler.java
+++ b/bundles/org.openhab.binding.linky/src/main/java/org/openhab/binding/linky/internal/handler/ThingLinkyRemoteHandler.java
@@ -275,14 +275,9 @@ public class ThingLinkyRemoteHandler extends ThingBaseRemoteHandler {
 
             userId = values.identity.internId;
 
-            Bridge bridge = getBridge();
-            BridgeRemoteBaseHandler bridgeHandler = null;
-            if (bridge != null) {
-                bridgeHandler = (BridgeRemoteBaseHandler) bridge.getHandler();
-            }
-
-            if (bridgeHandler instanceof BridgeRemoteEnedisWebHandler) {
-                userId = ((BridgeRemoteEnedisWebHandler) bridgeHandler).getIdPersonne();
+            if (getBridge() instanceof Bridge bridge
+                    && bridge.getHandler() instanceof BridgeRemoteEnedisWebHandler bridgeHandler) {
+                userId = bridgeHandler.getIdPersonne();
             }
 
             addProps(props, USER_ID, userId);


### PR DESCRIPTION
Hello @lolodomo, @clinique, @isiepel,

This is a new patch to Linky addons that is due to somes new changes on Enedis Web API that occurs a few days ago.
The measure entry point move from the v1 api to v2 api.
There is also a few changes in the URL format : 

- The userId is now using the new idPersonne return by USER_INFO_CONTRACT_URL uri.
- The URL must contains the segment to work properly.


Laurent.


