### PR TITLE
[evcc] Fix bug where json parsing could throw an exception

### DIFF
--- a/bundles/org.openhab.binding.evcc/src/main/java/org/openhab/binding/evcc/internal/handler/EvccBaseThingHandler.java
+++ b/bundles/org.openhab.binding.evcc/src/main/java/org/openhab/binding/evcc/internal/handler/EvccBaseThingHandler.java
@@ -285,6 +285,7 @@ public abstract class EvccBaseThingHandler extends BaseThingHandler implements E
                 if (response.getStatus() == 200) {
                     logger.debug("Sending command was successful");
                 } else {
+                    updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR);
                     logger.debug("Sending command was unsuccessful, got this error:\n {}",
                             response.getContentAsString());
                 }


### PR DESCRIPTION
When sending commands to evcc it is possible that when the response is getting parsed an exception will be thrown.
New logic will simply write a debug message to the log.
