### PR TITLE
[tibber] Quarter-hourly prices

### DIFF
--- a/bundles/org.openhab.binding.tibber/src/main/resources/graphql/prices.graphql
+++ b/bundles/org.openhab.binding.tibber/src/main/resources/graphql/prices.graphql
@@ -2,7 +2,7 @@
   viewer {
     home(id: \"%s\") {
       currentSubscription {
-        priceInfo {
+        priceInfo(resolution: QUARTER_HOURLY) {
           tomorrow {
             startsAt
             total


### PR DESCRIPTION
October 1st Tibber is switching to quarter-hourly prices. 
[GraphQL query needs to be adapted to this resolution. ](https://developer.tibber.com/docs/changelog)
It's already possible to use it,  Tibber delivers 4 times the same price within an hour.
