### PR TITLE
[fronius] Fix config API authentication for firmware >= 1.38.6

### DIFF
--- a/bundles/org.openhab.binding.fronius/src/main/java/org/openhab/binding/fronius/internal/api/FroniusConfigAuthUtil.java
+++ b/bundles/org.openhab.binding.fronius/src/main/java/org/openhab/binding/fronius/internal/api/FroniusConfigAuthUtil.java
@@ -130,8 +130,8 @@ public class FroniusConfigAuthUtil {
         String response = hashAsHex(hashAlgorithm,
                 ha1 + ":" + nonce + ":" + String.format("%08x", nc) + ":" + cnonce + ":" + qop + ":" + ha2);
 
-        String algorithm = hashAlgorithm.equals("SHA-256") ? "SHA256" : "MD5"; // workaround Fronius expects wrong algo
-                                                                               // name
+        // Fronius expects "SHA256" as algorithm name instead of the standard "SHA-256"
+        String algorithm = hashAlgorithm.equals("SHA-256") ? "SHA256" : "MD5";
         return String.format(DIGEST_AUTH_HEADER_FORMAT, username, realm, nonce, algorithm, uri, response, qop, nc,
                 cnonce);
     }
@@ -142,7 +142,7 @@ public class FroniusConfigAuthUtil {
      * @param algorithm the hash algorithm to use
      * @param data the data to hash
      * @return the hashed data as a hex string
-     * @throws NoSuchAlgorithmException if the MD5 algorithm is not available
+     * @throws NoSuchAlgorithmException if the specified algorithm is not available
      */
     private static String hashAsHex(String algorithm, String data) throws NoSuchAlgorithmException {
         MessageDigest md = MessageDigest.getInstance(algorithm);

--- a/bundles/org.openhab.binding.fronius/src/main/java/org/openhab/binding/fronius/internal/handler/FroniusSymoInverterHandler.java
+++ b/bundles/org.openhab.binding.fronius/src/main/java/org/openhab/binding/fronius/internal/handler/FroniusSymoInverterHandler.java
@@ -107,7 +107,8 @@ public class FroniusSymoInverterHandler extends FroniusBaseThingHandler {
             String firmwareVersion = localInverterInfo.firmware();
             if (firmwareVersion != null) {
                 int hyphenIndex = firmwareVersion.indexOf('-');
-                SemverVersion version = SemverVersion.fromString(firmwareVersion.substring(0, hyphenIndex));
+                String versionString = (hyphenIndex > 0) ? firmwareVersion.substring(0, hyphenIndex) : firmwareVersion;
+                SemverVersion version = SemverVersion.fromString(versionString);
                 if (version.isGreaterThanOrEqualTo(SemverVersion.fromString("1.36.0"))) {
                     batteryControl = new FroniusBatteryControl(httpClient, version, scheme, hostname, username,
                             password);

--- a/bundles/org.openhab.binding.fronius/src/main/java/org/openhab/binding/fronius/internal/handler/FroniusSymoInverterHandler.java
+++ b/bundles/org.openhab.binding.fronius/src/main/java/org/openhab/binding/fronius/internal/handler/FroniusSymoInverterHandler.java
@@ -14,7 +14,6 @@ package org.openhab.binding.fronius.internal.handler;
 
 import static org.openhab.binding.fronius.internal.FroniusBindingConstants.API_TIMEOUT;
 
-import java.net.URI;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -45,6 +44,7 @@ import org.openhab.core.library.unit.Units;
 import org.openhab.core.thing.Bridge;
 import org.openhab.core.thing.Thing;
 import org.openhab.core.thing.binding.ThingHandlerService;
+import org.openhab.core.thing.firmware.types.SemverVersion;
 import org.openhab.core.types.State;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -96,29 +96,26 @@ public class FroniusSymoInverterHandler extends FroniusBaseThingHandler {
         updateChannels();
     }
 
-    private void initializeBatteryControl(String hostname, @Nullable String username, @Nullable String password) {
+    private void initializeBatteryControl(String scheme, String hostname, @Nullable String username,
+            @Nullable String password) {
         if (username == null || password == null) {
             return;
         }
 
-        String apiPrefix = "";
-
         InverterInfo localInverterInfo = inverterInfo;
         if (localInverterInfo != null) {
             String firmwareVersion = localInverterInfo.firmware();
-            int lastDotIndex = firmwareVersion.lastIndexOf('.');
-            float version = Float.parseFloat(firmwareVersion.substring(0, lastDotIndex));
-            if (version >= 1.36) {
-                apiPrefix = "/api";
-            } else {
-                logger.warn("Fronius Symo Inverter firmware version {} is not supported for battery control.",
-                        firmwareVersion);
-                return;
+            if (firmwareVersion != null) {
+                int hyphenIndex = firmwareVersion.indexOf('-');
+                SemverVersion version = SemverVersion.fromString(firmwareVersion.substring(0, hyphenIndex));
+                if (version.isGreaterThanOrEqualTo(SemverVersion.fromString("1.36.0"))) {
+                    batteryControl = new FroniusBatteryControl(httpClient, version, scheme, hostname, username,
+                            password);
+                    return;
+                }
             }
         }
-
-        batteryControl = new FroniusBatteryControl(httpClient, URI.create("http://" + hostname + apiPrefix), username,
-                password);
+        logger.warn("Your Fronius Symo Inverter firmware version is not supported by battery control.");
     }
 
     private void updateProperties() {
@@ -144,7 +141,8 @@ public class FroniusSymoInverterHandler extends FroniusBaseThingHandler {
             FroniusBridgeConfiguration bridgeConfig = bridge.getConfiguration().as(FroniusBridgeConfiguration.class);
             inverterInfo = getInverterInfo(bridgeConfig.scheme, bridgeConfig.hostname, config.deviceId);
             updateProperties();
-            initializeBatteryControl(bridgeConfig.hostname, bridgeConfig.username, bridgeConfig.password);
+            initializeBatteryControl(bridgeConfig.scheme, bridgeConfig.hostname, bridgeConfig.username,
+                    bridgeConfig.password);
         }
         super.initialize();
     }
@@ -163,7 +161,8 @@ public class FroniusSymoInverterHandler extends FroniusBaseThingHandler {
             FroniusBridgeConfiguration bridgeConfig = bridge.getConfiguration().as(FroniusBridgeConfiguration.class);
             inverterInfo = getInverterInfo(bridgeConfig.scheme, bridgeConfig.hostname, config.deviceId);
             updateProperties();
-            initializeBatteryControl(bridgeConfig.hostname, bridgeConfig.username, bridgeConfig.password);
+            initializeBatteryControl(bridgeConfig.scheme, bridgeConfig.hostname, bridgeConfig.username,
+                    bridgeConfig.password);
         }
     }
 


### PR DESCRIPTION
Fronius changed the digest hash algorithm for the config API endpoints from MD5 to SHA256 in firmware version 1.38.6-1.
This adjusts to this change and keeps backwards compatibility.

Reported on the community: https://community.openhab.org/t/fronius-binding-invalid-username-or-password-after-firmware-update/166188
I have tested the backwards compatibility by testing this PR against my Symo inverter before upgrading, and tested the new firmware afterwards.