### PR TITLE
[froniuswattpilot] Use camelCase for HTTP client name

### DIFF
--- a/bundles/org.openhab.binding.froniuswattpilot/src/main/java/org/openhab/binding/froniuswattpilot/internal/FroniusWattpilotHandlerFactory.java
+++ b/bundles/org.openhab.binding.froniuswattpilot/src/main/java/org/openhab/binding/froniuswattpilot/internal/FroniusWattpilotHandlerFactory.java
@@ -44,7 +44,7 @@ public class FroniusWattpilotHandlerFactory extends BaseThingHandlerFactory {
 
     @Activate
     public FroniusWattpilotHandlerFactory(@Reference final HttpClientFactory httpClientFactory) {
-        this.httpClient = httpClientFactory.createHttpClient("fronius-wattpilot");
+        this.httpClient = httpClientFactory.createHttpClient("froniusWattpilot");
     }
 
     @Override


### PR DESCRIPTION
Aligns with the naming scheme for thread pools in openHAB.