### PR TITLE
[fronius] Fix battery control actions unavailable if FW < 1.36.x

### DIFF
--- a/bundles/org.openhab.binding.fronius/README.md
+++ b/bundles/org.openhab.binding.fronius/README.md
@@ -150,6 +150,7 @@ Please note that user-specified time of use plans cannot be used together with b
 :::
 
 The `powerinverter` Thing provides actions to control the battery charging and discharging behaviour of hybrid inverters, such as Symo Gen24 Plus, if username and password are provided in the bridge configuration.
+The inverter must have the battery time of use plan settings available in the web interface.
 
 You can retrieve the actions as follows:
 

--- a/bundles/org.openhab.binding.fronius/src/main/java/org/openhab/binding/fronius/internal/api/FroniusBatteryControl.java
+++ b/bundles/org.openhab.binding.fronius/src/main/java/org/openhab/binding/fronius/internal/api/FroniusBatteryControl.java
@@ -95,7 +95,7 @@ public class FroniusBatteryControl {
 
     private static URI getBaseUri(SemverVersion firmwareVersion, String scheme, String hostname) {
         String apiPrefix = "";
-        if (firmwareVersion.isGreaterThanOrEqualTo(new SemverVersion(1, 36, 0))) {
+        if (firmwareVersion.isGreaterThanOrEqualTo(SemverVersion.fromString("1.36.0"))) {
             apiPrefix = "/api";
         }
         return URI.create(String.format("%s://%s%s", scheme, hostname, apiPrefix));

--- a/bundles/org.openhab.binding.fronius/src/main/java/org/openhab/binding/fronius/internal/handler/FroniusSymoInverterHandler.java
+++ b/bundles/org.openhab.binding.fronius/src/main/java/org/openhab/binding/fronius/internal/handler/FroniusSymoInverterHandler.java
@@ -109,14 +109,12 @@ public class FroniusSymoInverterHandler extends FroniusBaseThingHandler {
                 int hyphenIndex = firmwareVersion.indexOf('-');
                 String versionString = (hyphenIndex > 0) ? firmwareVersion.substring(0, hyphenIndex) : firmwareVersion;
                 SemverVersion version = SemverVersion.fromString(versionString);
-                if (version.isGreaterThanOrEqualTo(SemverVersion.fromString("1.36.0"))) {
-                    batteryControl = new FroniusBatteryControl(httpClient, version, scheme, hostname, username,
-                            password);
-                    return;
-                }
+                batteryControl = new FroniusBatteryControl(httpClient, version, scheme, hostname, username, password);
+                return;
             }
         }
-        logger.warn("Your Fronius Symo Inverter firmware version is not supported by battery control.");
+        logger.warn(
+                "The firmware version of the Fronius inverter could not be determined. Battery control is not available.");
     }
 
     private void updateProperties() {


### PR DESCRIPTION
#18872 introduced a badly designed if statement that completely disables battery control for firmware < 1.36.x. Since #18872 added support for FW >= 1.36.x, previous version must be still supported.