### PR TITLE
[freeboxos] Fix synchronization problems

### DIFF
--- a/bundles/org.openhab.binding.freeboxos/src/main/java/org/openhab/binding/freeboxos/internal/api/ApiHandler.java
+++ b/bundles/org.openhab.binding.freeboxos/src/main/java/org/openhab/binding/freeboxos/internal/api/ApiHandler.java
@@ -69,7 +69,7 @@ public class ApiHandler {
     private final HttpClient httpClient;
     private final Gson gson;
 
-    private long timeoutInMs = TimeUnit.SECONDS.toMillis(10);
+    private volatile long timeoutInMs = TimeUnit.SECONDS.toMillis(10);
 
     public ApiHandler(HttpClientFactory httpClientFactory, TimeZoneProvider timeZoneProvider) {
         this.gson = new GsonBuilder().setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
@@ -105,7 +105,7 @@ public class ApiHandler {
         }
     }
 
-    public synchronized <T> T executeUri(URI uri, HttpMethod method, Class<T> clazz, @Nullable String sessionToken,
+    public <T> T executeUri(URI uri, HttpMethod method, Class<T> clazz, @Nullable String sessionToken,
             @Nullable Object payload) throws FreeboxException, InterruptedException {
         logger.debug("executeUrl {}: {} ", method, uri);
 
@@ -171,6 +171,6 @@ public class ApiHandler {
 
     public void setTimeout(long millis) {
         timeoutInMs = millis;
-        logger.debug("Timeout set to {} ms", timeoutInMs);
+        logger.debug("Timeout set to {} ms", millis);
     }
 }


### PR DESCRIPTION
This PR came to be following the analysis of the thread dump posted in [this forum thread](https://community.openhab.org/t/jmdns-memory-leak/166318).

There's a multitude of problems going on for this user, so this isn't the only issue. But, it does contribute.

Basically, the binding makes blocking calls while holding a lock that "traps" other threads that have to wait for the blocking call to return or time out. Since I don't have a FreeboxOS device to test against, I can't know how long these calls can block, but it's clear from the thread dump that it's a significant problem, since it's blocking 6 threads from the `OH-thingHandler` pool, a pool that is already needed for so many other things and have no threads to spare.

The binding is written in a way that makes it very difficult to make thread-safe, in that there's a myriad of references between objects, some seem to be referencing each other circularly, which might prevent them from being GC'ed as well. Since I don't have a device myself, I can't debug and test what actually happens, so there's some guesswork involved, and I can't be 100% sure about how things play out in reality. Regardless, all the references, and they way objects are constructed (generalized, via reflection), makes it very hard to separate references and make them thread-safe.

Generally, you don't want to hold a lock while calling methods that might invoke other locks, so you need to be quite sure what the code that is called while holding the lock does. But, here, I have no choice but to create some objects while holding locks, without a good way to properly verify that no other locks are locked during creation. If I fully analyzed everything that goes on in the binding, I probably could be fairly certain, but that's far beyond the effort I am prepared to put into this problem.

So, what I can say is that the binding is still not thread-safe (but it hasn't been in the past either), but as is the case with a lot of thread-unsafe code, it often doesn't bite often or consistently enough to become a problem "that can be pointed out". I consider the most important issue here and now is to avoid it blocking the threads in the `OH-thingHandler` pool, and I *think* that I have achieved that.

I'm really unconfortable with submitting code that I haven't been able to test. Since I know that @lolodomo has such a device, I am hoping that maybe you would be willing to test this a bit before the PR moves forward?