### PR TITLE
[teslascope] Fix warnings

### DIFF
--- a/bundles/org.openhab.binding.teslascope/src/main/java/org/openhab/binding/teslascope/internal/TeslascopeAccountHandler.java
+++ b/bundles/org.openhab.binding.teslascope/src/main/java/org/openhab/binding/teslascope/internal/TeslascopeAccountHandler.java
@@ -62,10 +62,10 @@ public class TeslascopeAccountHandler extends BaseBridgeHandler {
     }
 
     public String getVehicleList() {
-        TeslascopeAccountConfiguration localConfig = config;
-        if (localConfig != null) {
+        TeslascopeAccountConfiguration config = this.config;
+        if (config != null) {
             try {
-                return webTargets.getVehicleList(localConfig.apiKey);
+                return webTargets.getVehicleList(config.apiKey);
             } catch (TeslascopeAuthenticationException e) {
                 updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
                         "Authentication problem: " + e.getMessage());
@@ -78,10 +78,10 @@ public class TeslascopeAccountHandler extends BaseBridgeHandler {
     }
 
     public String getDetailedInformation(String publicID) {
-        TeslascopeAccountConfiguration localConfig = config;
-        if (localConfig != null) {
+        TeslascopeAccountConfiguration config = this.config;
+        if (config != null) {
             try {
-                return webTargets.getDetailedInformation(publicID, localConfig.apiKey);
+                return webTargets.getDetailedInformation(publicID, config.apiKey);
             } catch (TeslascopeAuthenticationException e) {
                 updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
                         "Authentication problem: " + e.getMessage());
@@ -94,10 +94,10 @@ public class TeslascopeAccountHandler extends BaseBridgeHandler {
     }
 
     public void sendCommand(String publicID, String command) {
-        TeslascopeAccountConfiguration localConfig = config;
-        if (localConfig != null) {
+        TeslascopeAccountConfiguration config = this.config;
+        if (config != null) {
             try {
-                webTargets.sendCommand(publicID, localConfig.apiKey, command);
+                webTargets.sendCommand(publicID, config.apiKey, command);
             } catch (TeslascopeAuthenticationException e) {
                 updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
                         "Authentication problem: " + e.getMessage());
@@ -109,10 +109,10 @@ public class TeslascopeAccountHandler extends BaseBridgeHandler {
     }
 
     public void sendCommand(String publicID, String command, String params) {
-        TeslascopeAccountConfiguration localConfig = config;
-        if (localConfig != null) {
+        TeslascopeAccountConfiguration config = this.config;
+        if (config != null) {
             try {
-                webTargets.sendCommand(publicID, localConfig.apiKey, command, params);
+                webTargets.sendCommand(publicID, config.apiKey, command, params);
             } catch (TeslascopeAuthenticationException e) {
                 updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
                         "Authentication problem: " + e.getMessage());

--- a/bundles/org.openhab.binding.teslascope/src/main/java/org/openhab/binding/teslascope/internal/TeslascopeVehicleHandler.java
+++ b/bundles/org.openhab.binding.teslascope/src/main/java/org/openhab/binding/teslascope/internal/TeslascopeVehicleHandler.java
@@ -134,25 +134,25 @@ public class TeslascopeVehicleHandler extends BaseThingHandler {
                 }
                 break;
             case TeslascopeBindingConstants.CHANNEL_FLASH_LIGHTS:
-                if (command instanceof OnOffType onOffCommand) {
+                if (command instanceof OnOffType) {
                     flashLights();
                     return;
                 }
                 break;
             case TeslascopeBindingConstants.CHANNEL_FRONT_TRUNK:
-                if (command instanceof OnOffType onOffCommand) {
+                if (command instanceof OnOffType) {
                     openFrunk();
                     return;
                 }
                 break;
             case TeslascopeBindingConstants.CHANNEL_HONK_HORN:
-                if (command instanceof OnOffType onOffCommand) {
+                if (command instanceof OnOffType) {
                     honkHorn();
                     return;
                 }
                 break;
             case TeslascopeBindingConstants.CHANNEL_REAR_TRUNK:
-                if (command instanceof OnOffType onOffCommand) {
+                if (command instanceof OnOffType) {
                     openTrunk();
                     return;
                 }


### PR DESCRIPTION
This PR removes (almost) all the warnings when building the teslascope binding.

The remaining warnings are:
```
[WARNING] /home/psmedley/openhab-addons/bundles/org.openhab.binding.teslascope/src/main/java/org/openhab/binding/teslascope/internal/TeslascopeVehicleHandler.java:[137,50] The value of the local variable onOffCommand is not used
[WARNING] /home/psmedley/openhab-addons/bundles/org.openhab.binding.teslascope/src/main/java/org/openhab/binding/teslascope/internal/TeslascopeVehicleHandler.java:[143,50] The value of the local variable onOffCommand is not used
[WARNING] /home/psmedley/openhab-addons/bundles/org.openhab.binding.teslascope/src/main/java/org/openhab/binding/teslascope/internal/TeslascopeVehicleHandler.java:[149,50] The value of the local variable onOffCommand is not used
[WARNING] /home/psmedley/openhab-addons/bundles/org.openhab.binding.teslascope/src/main/java/org/openhab/binding/teslascope/internal/TeslascopeVehicleHandler.java:[155,50] The value of the local variable onOffCommand is not used

```
Which (I think) are safe to ignore.