### PR TITLE
[bluetooth] Remove unsupported thing type `connected`

### DIFF
--- a/bundles/org.openhab.binding.bluetooth/CONTRIBUTE.md
+++ b/bundles/org.openhab.binding.bluetooth/CONTRIBUTE.md
@@ -60,10 +60,11 @@ The beacon mode thing handler needs to handle the following functionality:
 
 ### Generic Bluetooth Device Support
 
-The core Bluetooth binding already includes generic "beacon" and "connected" Bluetooth thing types.
+The core Bluetooth binding already includes generic `beacon` Bluetooth thing type.
 All devices for which no discovery participant defines a specific thing type are added to the inbox as a beacon device.
 The corresponding handler implementation (`BeaconBluetoothHandler`) uses Beacon mode and merely defines a channel for RSSI for such devices.
 
-The "connected" thing type can be used by manually defining a thing.
-The corresponding handler implementation (`ConnectedBluetoothHandler`) uses Connected mode and thus immediately connects to the device and reads its services.
+The generic Bluetooth binding includes `generic` Bluetooth thing type.
+The `generic` thing type can be used by manually defining a thing.
+The corresponding handler implementation (`GenericBluetoothHandler`) uses Connected mode and thus immediately connects to the device and reads its services.
 Common services are added as channels (t.b.d.).

--- a/bundles/org.openhab.binding.bluetooth/src/main/java/org/openhab/binding/bluetooth/ConnectedBluetoothHandler.java
+++ b/bundles/org.openhab.binding.bluetooth/src/main/java/org/openhab/binding/bluetooth/ConnectedBluetoothHandler.java
@@ -42,7 +42,7 @@ import org.slf4j.LoggerFactory;
  * @author Kai Kreuzer - Initial contribution and API
  */
 @NonNullByDefault
-public class ConnectedBluetoothHandler extends BeaconBluetoothHandler {
+public abstract class ConnectedBluetoothHandler extends BeaconBluetoothHandler {
 
     private final Logger logger = LoggerFactory.getLogger(ConnectedBluetoothHandler.class);
     private @Nullable Future<?> reconnectJob;

--- a/bundles/org.openhab.binding.bluetooth/src/main/java/org/openhab/binding/bluetooth/internal/BluetoothHandlerFactory.java
+++ b/bundles/org.openhab.binding.bluetooth/src/main/java/org/openhab/binding/bluetooth/internal/BluetoothHandlerFactory.java
@@ -12,7 +12,6 @@
  */
 package org.openhab.binding.bluetooth.internal;
 
-import java.util.HashSet;
 import java.util.Set;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -35,10 +34,8 @@ import org.osgi.service.component.annotations.Component;
 @Component(service = ThingHandlerFactory.class, configurationPid = "binding.bluetooth")
 public class BluetoothHandlerFactory extends BaseThingHandlerFactory {
 
-    private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = new HashSet<>();
-    static {
-        SUPPORTED_THING_TYPES_UIDS.add(BluetoothBindingConstants.THING_TYPE_BEACON);
-    }
+    private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Set
+            .of(BluetoothBindingConstants.THING_TYPE_BEACON);
 
     @Override
     public boolean supportsThingType(ThingTypeUID thingTypeUID) {
@@ -49,7 +46,7 @@ public class BluetoothHandlerFactory extends BaseThingHandlerFactory {
     protected @Nullable ThingHandler createHandler(Thing thing) {
         ThingTypeUID thingTypeUID = thing.getThingTypeUID();
 
-        if (thingTypeUID.equals(BluetoothBindingConstants.THING_TYPE_BEACON)) {
+        if (BluetoothBindingConstants.THING_TYPE_BEACON.equals(thingTypeUID)) {
             return new BeaconBluetoothHandler(thing);
         }
         return null;

--- a/bundles/org.openhab.binding.bluetooth/src/main/resources/OH-INF/i18n/bluetooth.properties
+++ b/bundles/org.openhab.binding.bluetooth/src/main/resources/OH-INF/i18n/bluetooth.properties
@@ -7,15 +7,11 @@ addon.bluetooth.description = This binding supports the Bluetooth protocol.
 
 thing-type.bluetooth.beacon.label = Bluetooth Device
 thing-type.bluetooth.beacon.description = A generic Bluetooth device in beacon-mode
-thing-type.bluetooth.connected.label = Connected Bluetooth Device
-thing-type.bluetooth.connected.description = A generic Bluetooth device in connected-mode
 
 # thing types config
 
 thing-type.config.bluetooth.beacon.address.label = Address
 thing-type.config.bluetooth.beacon.address.description = The unique Bluetooth address of the device
-thing-type.config.bluetooth.connected.address.label = Address
-thing-type.config.bluetooth.connected.address.description = The unique Bluetooth address of the device
 
 # channel types
 

--- a/bundles/org.openhab.binding.bluetooth/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.bluetooth/src/main/resources/OH-INF/thing/thing-types.xml
@@ -29,22 +29,4 @@
 		</config-description>
 	</thing-type>
 
-	<thing-type id="connected">
-		<supported-bridge-type-refs>
-			<bridge-type-ref id="roaming"/>
-			<bridge-type-ref id="bluegiga"/>
-			<bridge-type-ref id="bluez"/>
-		</supported-bridge-type-refs>
-
-		<label>Connected Bluetooth Device</label>
-		<description>A generic Bluetooth device in connected-mode</description>
-
-		<config-description>
-			<parameter name="address" type="text">
-				<label>Address</label>
-				<description>The unique Bluetooth address of the device</description>
-			</parameter>
-		</config-description>
-	</thing-type>
-
 </thing:thing-descriptions>


### PR DESCRIPTION
Currently there are three generic Bluetooth thing types:

<img width="728" height="207" alt="image" src="https://github.com/user-attachments/assets/5ee17d0f-38e9-4876-9074-24a795725b48" />

Manually creating a Thing of type `connected` results in:
```text
2025-09-21 13:51:52.412 [INFO ] [ab.event.ThingStatusInfoChangedEvent] - Thing 'bluetooth:connected:90cf825ecd:50abc36f7f' changed from UNINITIALIZED to UNINITIALIZED (HANDLER_MISSING_ERROR): Handler factory not found
```

since `connected` is not a supported type.

I lost the track from [2019](https://github.com/openhab/openhab2-addons/commits/5a2b3a4d5d41a28dfa7daa5aa3735c8bcd9d688a/addons/binding/org.openhab.binding.bluetooth/src/main/java/org/openhab/binding/bluetooth/internal/BluetoothHandlerFactory.java?browsing_rename_history=true&new_path=bundles/org.openhab.binding.bluetooth/src/main/java/org/openhab/binding/bluetooth/internal/BluetoothHandlerFactory.java&original_branch=2.5.x), but it seems like this could be caused by the introduction of thing type `generic`:

https://github.com/openhab/openhab-addons/blob/c7dc1bac3b96f6049f7d5df287c4a69f85f04910/bundles/org.openhab.binding.bluetooth.generic/src/main/resources/OH-INF/thing/generic.xml#L7-L35

in the `generic` sub binding.

This is an implementation of a connected device:

https://github.com/openhab/openhab-addons/blob/c7dc1bac3b96f6049f7d5df287c4a69f85f04910/bundles/org.openhab.binding.bluetooth.generic/src/main/java/org/openhab/binding/bluetooth/generic/internal/GenericBluetoothHandler.java#L66

There are no occurrences of `new ConnectedBluetoothHandler` in the codebase.

Perhaps `connected` is a left-over from when `generic` was introduced.