### PR TITLE
Fix tests when having spaces in path

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -417,7 +417,7 @@ Import-Package: \\
           <configuration>
             <argLine>--add-opens java.base/java.lang=ALL-UNNAMED
               --add-opens java.base/java.util=ALL-UNNAMED
-              -javaagent:${settings.localRepository}/org/mockito/mockito-core/${mockito.version}/mockito-core-${mockito.version}.jar
+              -javaagent:"${settings.localRepository}/org/mockito/mockito-core/${mockito.version}/mockito-core-${mockito.version}.jar"
               -Xshare:off</argLine>
             <systemPropertyVariables>
               <junit.jupiter.execution.timeout.default>15 m</junit.jupiter.execution.timeout.default>


### PR DESCRIPTION
This fixes this error on `mvn clean install` from a path having spaces in it:
```text
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
Error opening zip file or JAR manifest missing : C:\Users\Jacob
[ERROR] Error occurred during initialization of VM
```

in this case on a Windows machine where path starts with "C:\Users\Jacob Laursen".

Regression of #19329