### PR TITLE
[shelly] Fix prefix in logging

### DIFF
--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/Shelly2ApiRpc.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/Shelly2ApiRpc.java
@@ -787,7 +787,7 @@ public class Shelly2ApiRpc extends Shelly2ApiClient implements ShellyApiInterfac
 
     @Override
     public void onError(Throwable cause) {
-        logger.debug("WebSocket error", cause);
+        logger.debug("{}: WebSocket error", thingName, cause);
         ShellyThingInterface thing = this.thing;
         if (thing != null && thing.getProfile().alwaysOn) {
             thingOffline("WebSocket error");


### PR DESCRIPTION
This will now log:
```text
2025-09-23 22:10:59.970 [DEBUG] [g.shelly.internal.api2.Shelly2ApiRpc] - shellypmmini-543204828114: WebSocket error
java.lang.IndexOutOfBoundsException: Index 10 out of bounds for length 1
	at jdk.internal.util.Preconditions.outOfBounds(Preconditions.java:100) ~[?:?]
	at jdk.internal.util.Preconditions.outOfBoundsCheckIndex(Preconditions.java:106) ~[?:?]
	at jdk.internal.util.Preconditions.checkIndex(Preconditions.java:302) ~[?:?]
	at java.util.Objects.checkIndex(Objects.java:385) ~[?:?]
	at java.util.ArrayList.get(ArrayList.java:427) ~[?:?]
	at org.openhab.binding.shelly.internal.api2.Shelly2ApiClient.updateRelayStatus(Shelly2ApiClient.java:322) ~[?:?]
	at org.openhab.binding.shelly.internal.api2.Shelly2ApiClient.fillDeviceStatus(Shelly2ApiClient.java:240) ~[?:?]
	at org.openhab.binding.shelly.internal.api2.Shelly2ApiRpc.onNotifyStatus(Shelly2ApiRpc.java:663) ~[?:?]
	at org.openhab.binding.shelly.internal.api2.Shelly2RpcSocket.onText(Shelly2RpcSocket.java:251) ~[?:?]
	at jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103) ~[?:?]
	at java.lang.reflect.Method.invoke(Method.java:580) ~[?:?]
	at org.eclipse.jetty.websocket.common.events.annotated.CallableMethod.call(CallableMethod.java:70) ~[?:?]
	at org.eclipse.jetty.websocket.common.events.annotated.OptionalSessionCallableMethod.call(OptionalSessionCallableMethod.java:68) ~[?:?]
	at org.eclipse.jetty.websocket.common.events.JettyAnnotatedEventDriver.onTextMessage(JettyAnnotatedEventDriver.java:301) ~[?:?]
	at org.eclipse.jetty.websocket.common.message.SimpleTextMessage.messageComplete(SimpleTextMessage.java:69) ~[?:?]
	at org.eclipse.jetty.websocket.common.events.AbstractEventDriver.appendMessage(AbstractEventDriver.java:67) ~[?:?]
	at org.eclipse.jetty.websocket.common.events.JettyAnnotatedEventDriver.onTextFrame(JettyAnnotatedEventDriver.java:287) ~[?:?]
	at org.eclipse.jetty.websocket.common.events.AbstractEventDriver.incomingFrame(AbstractEventDriver.java:152) ~[?:?]
	at org.eclipse.jetty.websocket.common.WebSocketSession.incomingFrame(WebSocketSession.java:326) ~[?:?]
	at org.eclipse.jetty.websocket.common.extensions.ExtensionStack.incomingFrame(ExtensionStack.java:202) ~[?:?]
	at org.eclipse.jetty.websocket.common.Parser.notifyFrame(Parser.java:225) ~[?:?]
	at org.eclipse.jetty.websocket.common.Parser.parseSingleFrame(Parser.java:259) ~[?:?]
	at org.eclipse.jetty.websocket.common.io.AbstractWebSocketConnection.onFillable(AbstractWebSocketConnection.java:459) ~[?:?]
	at org.eclipse.jetty.websocket.common.io.AbstractWebSocketConnection.onFillable(AbstractWebSocketConnection.java:440) ~[?:?]
	at org.eclipse.jetty.io.AbstractConnection$ReadCallback.succeeded(AbstractConnection.java:311) ~[?:?]
	at org.eclipse.jetty.io.FillInterest.fillable(FillInterest.java:105) ~[?:?]
	at org.eclipse.jetty.io.ChannelEndPoint$1.run(ChannelEndPoint.java:104) ~[?:?]
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.runTask(EatWhatYouKill.java:338) ~[?:?]
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.doProduce(EatWhatYouKill.java:315) ~[?:?]
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.tryProduce(EatWhatYouKill.java:173) ~[?:?]
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.run(EatWhatYouKill.java:131) ~[?:?]
	at org.eclipse.jetty.util.thread.ReservedThreadExecutor$ReservedThread.run(ReservedThreadExecutor.java:409) ~[?:?]
	at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:883) ~[?:?]
	at org.eclipse.jetty.util.thread.QueuedThreadPool$Runner.run(QueuedThreadPool.java:1034) ~[?:?]
	at java.lang.Thread.run(Thread.java:1583) [?:?]
2025-09-23 22:10:59.984 [DEBUG] [g.shelly.internal.api2.Shelly2ApiRpc] - shellypmmini-543204828114: Closing Rpc API (socket is connected, discovery=false)
```

Regression of #19363