### PR TITLE
[astro] Fix regression from #19310

### DIFF
--- a/bundles/org.openhab.binding.astro/src/main/java/org/openhab/binding/astro/internal/calc/SeasonCalc.java
+++ b/bundles/org.openhab.binding.astro/src/main/java/org/openhab/binding/astro/internal/calc/SeasonCalc.java
@@ -42,7 +42,7 @@ public class SeasonCalc {
         boolean isSouthernHemisphere = latitude < 0.0;
         Season season = currentSeason;
         if (currentYear != year) {
-            season = new Season();
+            season = new Season(zone, locale);
             if (!isSouthernHemisphere) {
                 season.setSpring(calcEquiSol(0, year, zone, locale));
                 season.setSummer(calcEquiSol(1, year, zone, locale));
@@ -82,7 +82,7 @@ public class SeasonCalc {
                     : getCurrentSeasonNameSouthern(calendar));
             return season;
         }
-        return new Season();
+        return new Season(zone, locale);
     }
 
     private void atMidnightOfFirstMonthDay(Calendar calendar) {

--- a/bundles/org.openhab.binding.astro/src/main/java/org/openhab/binding/astro/internal/job/DailyJobSun.java
+++ b/bundles/org.openhab.binding.astro/src/main/java/org/openhab/binding/astro/internal/job/DailyJobSun.java
@@ -129,7 +129,7 @@ public final class DailyJobSun extends AbstractJob {
             if (cal != null) {
                 schedulePublishPlanet(handler, cal, zone, locale);
             }
-            schedulePublishPlanet(handler, sun.getSeason().getNextSeason(zone, locale), zone, locale);
+            schedulePublishPlanet(handler, sun.getSeason().getNextSeason(), zone, locale);
 
             // schedule phase jobs
             cal = sun.getRise().getStart();

--- a/bundles/org.openhab.binding.astro/src/main/java/org/openhab/binding/astro/internal/model/Season.java
+++ b/bundles/org.openhab.binding.astro/src/main/java/org/openhab/binding/astro/internal/model/Season.java
@@ -40,6 +40,14 @@ public class Season {
 
     private @Nullable SeasonName name;
 
+    private TimeZone timeZone;
+    private Locale locale;
+
+    public Season(TimeZone timeZone, Locale locale) {
+        this.timeZone = timeZone;
+        this.locale = locale;
+    }
+
     /**
      * Returns the date of the beginning of spring.
      */
@@ -118,8 +126,8 @@ public class Season {
     /**
      * Returns the next season.
      */
-    public Calendar getNextSeason(TimeZone zone, Locale locale) {
-        return DateTimeUtils.getNextFromToday(zone, locale, spring, summer, autumn, winter);
+    public Calendar getNextSeason() {
+        return DateTimeUtils.getNextFromToday(timeZone, locale, spring, summer, autumn, winter);
     }
 
     /**
@@ -136,9 +144,9 @@ public class Season {
     /**
      * Returns the time left for current season
      */
-    public QuantityType<Time> getTimeLeft(TimeZone zone, Locale locale) {
-        final Calendar now = Calendar.getInstance(zone, locale);
-        final Calendar next = getNextSeason(zone, locale);
+    public QuantityType<Time> getTimeLeft() {
+        final Calendar now = Calendar.getInstance(timeZone, locale);
+        final Calendar next = getNextSeason();
         final Duration timeLeft = Duration.of(next.getTimeInMillis() - now.getTimeInMillis(), ChronoUnit.MILLIS);
 
         return new QuantityType<>(timeLeft.toDays(), Units.DAY);

--- a/bundles/org.openhab.binding.astro/src/main/java/org/openhab/binding/astro/internal/model/Sun.java
+++ b/bundles/org.openhab.binding.astro/src/main/java/org/openhab/binding/astro/internal/model/Sun.java
@@ -13,7 +13,9 @@
 package org.openhab.binding.astro.internal.model;
 
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
+import java.util.TimeZone;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
@@ -32,7 +34,7 @@ public class Sun extends RiseSet implements Planet {
 
     private @Nullable SunZodiac zodiac;
 
-    private Season season = new Season();
+    private Season season = new Season(TimeZone.getDefault(), Locale.getDefault());
 
     private Eclipse eclipse = new Eclipse(EclipseKind.PARTIAL, EclipseKind.TOTAL, EclipseKind.RING);
 


### PR DESCRIPTION
I discovered a regression from #19310. It turns out that Astro's `PropertyUtils` use reflection to retrieve values from "the model" when updating channels. The fact that some of the methods has changed signature due to time zone and locale parameters, makes this fail with "No such method". 

I've rearranged things a bit so that the methods invoked using reflection again are without parameters, instead of making `PropertyUtils` handle a much more complex situation that includes parameters.

The exception I was seeing is gone, this only applied to a few methods.