### PR TITLE
[serial] Fix test on Windows platform

### DIFF
--- a/bundles/org.openhab.binding.serial/src/test/java/org/openhab/binding/serial/internal/SerialBindingHandlerTest.java
+++ b/bundles/org.openhab.binding.serial/src/test/java/org/openhab/binding/serial/internal/SerialBindingHandlerTest.java
@@ -257,6 +257,6 @@ public class SerialBindingHandlerTest {
         bin.appendBuffer(new byte[] { 'T', 'E', 'S', 'T', '1', '\n', 'T', 'E', 'S', 'T', '2' });
         sb = new StringBuilder();
         handler.receiveAndProcess(sb, false);
-        assertEquals("54 45 53 54 31 0A\n54 45 53 54 32", sb.toString());
+        assertEquals("54 45 53 54 31 0A" + System.lineSeparator() + "54 45 53 54 32", sb.toString());
     }
 }


### PR DESCRIPTION
Fix line break issue on Windows due to hard coded `\n`.
I have changed the expected result, hope this is the intention.