### PR TITLE
Add ability to write to Solarman registers

### DIFF
--- a/bundles/org.openhab.binding.solarman/pom.xml
+++ b/bundles/org.openhab.binding.solarman/pom.xml
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
 

--- a/bundles/org.openhab.binding.solarman/src/main/java/org/openhab/binding/solarman/internal/channel/SolarmanChannelManager.java
+++ b/bundles/org.openhab.binding.solarman/src/main/java/org/openhab/binding/solarman/internal/channel/SolarmanChannelManager.java
@@ -87,6 +87,8 @@ public class SolarmanChannelManager {
             baseChannelConfig.rule = item.getRule();
         }
 
+        baseChannelConfig.readOnly = !Boolean.FALSE.equals(item.getIsReadOnly());
+
         baseChannelConfig.registers = convertRegisters(item.getRegisters());
         baseChannelConfig.uom = item.getUom();
 

--- a/bundles/org.openhab.binding.solarman/src/main/java/org/openhab/binding/solarman/internal/defmodel/ParameterItem.java
+++ b/bundles/org.openhab.binding.solarman/src/main/java/org/openhab/binding/solarman/internal/defmodel/ParameterItem.java
@@ -46,6 +46,8 @@ public class ParameterItem {
     private BigDecimal offset;
     @Nullable
     private Boolean isstr;
+    @Nullable
+    private Boolean isReadOnly;
     private List<Lookup> lookup = new ArrayList<>();
 
     public ParameterItem() {
@@ -54,18 +56,20 @@ public class ParameterItem {
     public ParameterItem(String name, @Nullable String itemClass, @Nullable String stateClass, @Nullable String uom,
             @Nullable BigDecimal scale, Integer rule, List<Integer> registers, @Nullable String icon,
             @Nullable Validation validation, @Nullable BigDecimal offset, @Nullable Boolean isstr,
-            @Nullable List<Lookup> lookup) {
+            @Nullable Boolean isReadOnly, @Nullable List<Lookup> lookup) {
         this.name = name;
         this.itemClass = itemClass;
         this.stateClass = stateClass;
         this.uom = uom;
         this.scale = scale;
         this.rule = rule;
-        this.registers = registers;
+        this.registers = new ArrayList<>(registers);
+        this.registers.sort(Integer::compareTo);
         this.icon = icon;
         this.validation = validation;
         this.offset = offset;
         this.isstr = isstr;
+        this.isReadOnly = isReadOnly;
         if (lookup != null) {
             this.lookup = lookup;
         }
@@ -149,6 +153,14 @@ public class ParameterItem {
 
     public void setIsstr(Boolean isstr) {
         this.isstr = isstr;
+    }
+
+    public @Nullable Boolean getIsReadOnly() {
+        return isReadOnly;
+    }
+
+    public void setIsReadOnly(Boolean isReadOnly) {
+        this.isReadOnly = isReadOnly;
     }
 
     public @Nullable String getItemClass() {

--- a/bundles/org.openhab.binding.solarman/src/main/java/org/openhab/binding/solarman/internal/enums/IntegerValueType.java
+++ b/bundles/org.openhab.binding.solarman/src/main/java/org/openhab/binding/solarman/internal/enums/IntegerValueType.java
@@ -10,22 +10,15 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-package org.openhab.binding.solarman.internal.channel;
-
-import java.math.BigDecimal;
+package org.openhab.binding.solarman.internal.enums;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.eclipse.jdt.annotation.Nullable;
 
 /**
- * @author Catalin Sanda - Initial contribution
+ * @author Oleksandr Mishchuk - Initial contribution
  */
 @NonNullByDefault
-public class BaseChannelConfig {
-    public @Nullable String uom;
-    public BigDecimal scale = BigDecimal.ONE;
-    public Integer rule = 1;
-    public BigDecimal offset = BigDecimal.ZERO;
-    public String registers = "";
-    public boolean readOnly = true;
+public enum IntegerValueType {
+    UNSIGNED,
+    SIGNED
 }

--- a/bundles/org.openhab.binding.solarman/src/main/java/org/openhab/binding/solarman/internal/modbus/SolarmanProtocol.java
+++ b/bundles/org.openhab.binding.solarman/src/main/java/org/openhab/binding/solarman/internal/modbus/SolarmanProtocol.java
@@ -22,7 +22,12 @@ import org.openhab.binding.solarman.internal.modbus.exception.SolarmanException;
  */
 @NonNullByDefault
 public interface SolarmanProtocol {
+    byte DEFAULT_SLAVE_ID = 0x01;
+    byte WRITE_REGISTERS_FUNCTION_CODE = 0x10;
 
     Map<Integer, byte[]> readRegisters(SolarmanLoggerConnection solarmanLoggerConnection, byte mbFunctionCode,
             int firstReg, int lastReg) throws SolarmanException;
+
+    boolean writeRegisters(SolarmanLoggerConnection solarmanLoggerConnection, int register, byte[] data)
+            throws SolarmanException;
 }

--- a/bundles/org.openhab.binding.solarman/src/main/java/org/openhab/binding/solarman/internal/typeprovider/ChannelUtils.java
+++ b/bundles/org.openhab.binding.solarman/src/main/java/org/openhab/binding/solarman/internal/typeprovider/ChannelUtils.java
@@ -59,6 +59,10 @@ public class ChannelUtils {
             uom = "UNKN";
         }
 
+        if (item.hasLookup() || Boolean.TRUE.equals(item.getIsstr())) {
+            return CoreItemFactory.STRING;
+        }
+
         return switch (rule) {
             case 5, 6, 7, 9 -> CoreItemFactory.STRING;
             case 8 -> CoreItemFactory.DATETIME;

--- a/bundles/org.openhab.binding.solarman/src/main/java/org/openhab/binding/solarman/internal/updater/SolarmanRegisterUpdater.java
+++ b/bundles/org.openhab.binding.solarman/src/main/java/org/openhab/binding/solarman/internal/updater/SolarmanRegisterUpdater.java
@@ -1,0 +1,230 @@
+/*
+ * Copyright (c) 2010-2025 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.solarman.internal.updater;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.solarman.internal.defmodel.Lookup;
+import org.openhab.binding.solarman.internal.defmodel.ParameterItem;
+import org.openhab.binding.solarman.internal.enums.IntegerValueType;
+import org.openhab.binding.solarman.internal.modbus.SolarmanLoggerConnection;
+import org.openhab.binding.solarman.internal.modbus.SolarmanLoggerConnector;
+import org.openhab.binding.solarman.internal.modbus.SolarmanProtocol;
+import org.openhab.binding.solarman.internal.modbus.exception.SolarmanConnectionException;
+import org.openhab.binding.solarman.internal.modbus.exception.SolarmanException;
+import org.openhab.core.library.types.DecimalType;
+import org.openhab.core.library.types.OnOffType;
+import org.openhab.core.library.types.StringType;
+import org.openhab.core.thing.ChannelUID;
+import org.openhab.core.types.Command;
+import org.openhab.core.util.HexUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link SolarmanRegisterUpdater} is responsible for updating registers from received commands
+ *
+ * @author Oleksandr Mishchuk - Initial contribution
+ */
+@NonNullByDefault
+public class SolarmanRegisterUpdater {
+    private static final Logger logger = LoggerFactory.getLogger(SolarmanRegisterUpdater.class);
+
+    private static final Pattern TIME_PATTERN = Pattern.compile("^([0-1][0-9])|(2[0-3]):[0-5][0-9]");
+
+    private final SolarmanLoggerConnector solarmanLoggerConnector;
+    private final SolarmanProtocol solarmanProtocol;
+    private final Map<ChannelUID, ParameterItem> writableChannels;
+
+    public SolarmanRegisterUpdater(Map<ParameterItem, ChannelUID> paramToChannelMapping,
+            SolarmanLoggerConnector solarmanLoggerConnector, SolarmanProtocol solarmanProtocol) {
+        this.solarmanProtocol = solarmanProtocol;
+        this.solarmanLoggerConnector = solarmanLoggerConnector;
+
+        writableChannels = paramToChannelMapping.entrySet().stream()
+                .filter(e -> Boolean.FALSE.equals(e.getKey().getIsReadOnly())).filter(e -> {
+                    final List<Integer> registers = e.getKey().getRegisters();
+                    if (registers.isEmpty()) {
+                        logger.warn("Writeable channel {} have no registers, skipping", e.getValue());
+                        return false;
+                    }
+
+                    final int firstRegister = registers.getFirst();
+                    int i = 0;
+                    while (i < registers.size() && registers.get(i) == firstRegister + i) {
+                        i++;
+                    }
+                    if (i != registers.size()) {
+                        logger.warn("Writeable channel {} should have consecutive registers, skipping", e.getValue());
+                        return false;
+                    }
+
+                    return true;
+                }).collect(Collectors.toMap(Map.Entry::getValue, Map.Entry::getKey));
+    }
+
+    public void updateLoggerRegisters(ChannelUID channelUID, Command command) {
+        final ParameterItem channelToUpdate = writableChannels.get(channelUID);
+        if (channelToUpdate == null) {
+            logger.warn("Channel '{}' is either read-only or doesn't exist", channelUID);
+            return;
+        }
+
+        switch (channelToUpdate.getRule()) {
+            case 1 -> updateIntRegisters(channelUID, channelToUpdate, command, Short.BYTES, IntegerValueType.UNSIGNED);
+            case 2 -> updateIntRegisters(channelUID, channelToUpdate, command, Short.BYTES, IntegerValueType.SIGNED);
+            case 3 ->
+                updateIntRegisters(channelUID, channelToUpdate, command, Integer.BYTES, IntegerValueType.UNSIGNED);
+            case 4 -> updateIntRegisters(channelUID, channelToUpdate, command, Integer.BYTES, IntegerValueType.SIGNED);
+            case 5 -> updateStringRegisters(channelUID, channelToUpdate, command);
+            case 6 -> updateRawRegisters(channelUID, channelToUpdate, command);
+            case 7 -> updateVersionRegisters(channelUID, channelToUpdate, command);
+            case 8 -> updateDateTimeRegisters(channelUID, channelToUpdate, command);
+            case 9 -> updateTimeRegisters(channelUID, channelToUpdate, command);
+        }
+    }
+
+    private void updateIntRegisters(ChannelUID channelUID, ParameterItem channelToUpdate, Command command, int size,
+            IntegerValueType integerValueType) {
+        final DecimalType decimalValue = switch (command) {
+            case DecimalType decimal -> decimal;
+            case OnOffType onOff -> onOff == OnOffType.ON ? new DecimalType(1) : DecimalType.ZERO;
+            case StringType stringType -> {
+                if (channelToUpdate.getLookup().isEmpty()) {
+                    logUnexpectedCommand(channelUID, command);
+                    yield null;
+                } else {
+                    final String lookupValue = stringType.toString();
+                    final Optional<Lookup> lookupOptional = channelToUpdate.getLookup().stream()
+                            .filter(l -> lookupValue.equals(l.getValue())).findFirst();
+                    if (lookupOptional.isPresent()) {
+                        yield new DecimalType(lookupOptional.get().getKey());
+                    } else {
+                        logUnexpectedCommand(channelUID, command);
+                        yield null;
+                    }
+                }
+            }
+            default -> {
+                logUnexpectedCommand(channelUID, command);
+                yield null;
+            }
+        };
+
+        if (decimalValue != null) {
+            long value = convertNumericValue(decimalValue, channelToUpdate.getOffset(), channelToUpdate.getScale())
+                    .longValue();
+            if (IntegerValueType.UNSIGNED == integerValueType) {
+                long mask = (1L << (size * 8)) - 1;
+                value = value & mask;
+            }
+            ByteBuffer buffer = ByteBuffer.allocate(size);
+            switch (size) {
+                case 2 -> buffer.putShort((short) value);
+                case 4 -> buffer.putInt((int) value);
+                case 8 -> buffer.putLong(value);
+            }
+            byte[] data = buffer.array();
+            writeRegisters(channelToUpdate.getRegisters().getFirst(), size / 2, data);
+        }
+    }
+
+    private void updateStringRegisters(ChannelUID channelUID, ParameterItem channelToUpdate, Command command) {
+        if (command instanceof StringType stringType) {
+            String string = stringType.toString();
+            int length = (string.length() + 1) / 2 * 2;
+            byte[] data = ByteBuffer.allocate(length).put(string.getBytes(StandardCharsets.UTF_8)).array();
+            writeRegisters(channelToUpdate.getRegisters().getFirst(), length / 2, data);
+        } else {
+            logUnexpectedCommand(channelUID, command);
+        }
+    }
+
+    private void updateRawRegisters(ChannelUID channelUID, ParameterItem channelToUpdate, Command command) {
+        logger.warn("Writing Raw to logger is not implemented yet");
+    }
+
+    private void updateVersionRegisters(ChannelUID channelUID, ParameterItem channelToUpdate, Command command) {
+        logger.warn("Writing Version to logger is not implemented yet");
+    }
+
+    private void updateDateTimeRegisters(ChannelUID channelUID, ParameterItem channelToUpdate, Command command) {
+        logger.warn("Writing DateTime to logger is not implemented yet");
+    }
+
+    private void updateTimeRegisters(ChannelUID channelUID, ParameterItem channelToUpdate, Command command) {
+        if (command instanceof StringType string) {
+            String timeString = string.toString();
+            final Matcher timeMatcher = TIME_PATTERN.matcher(timeString);
+            if (timeMatcher.matches()) {
+                final int hour = Integer.parseInt(timeString.substring(0, 2));
+                final int minute = Integer.parseInt(timeString.substring(3, 5));
+                final short value = (short) (hour * 100 + minute);
+                byte[] data = ByteBuffer.allocate(2).putShort(value).array();
+                writeRegisters(channelToUpdate.getRegisters().getFirst(), 1, data);
+            } else {
+                logger.warn("Received string '{}' is not correct time format 'HH:mm'", timeString);
+            }
+        } else {
+            logUnexpectedCommand(channelUID, command);
+        }
+    }
+
+    private BigDecimal convertNumericValue(DecimalType decimal, @Nullable BigDecimal offset,
+            @Nullable BigDecimal scale) {
+        return decimal.toBigDecimal().divide(scale != null ? scale : BigDecimal.ONE, RoundingMode.HALF_UP)
+                .add(offset != null ? offset : BigDecimal.ZERO);
+    }
+
+    private void writeRegisters(int firstRegister, int registerCount, byte[] data) {
+        if (data.length > registerCount * 2) {
+            logger.warn(
+                    "Data to be written ({}) is longer than the number of 2 byte registers declared for channel ({}). Data will be truncated!",
+                    data.length, registerCount);
+        }
+
+        data = ByteBuffer.wrap(data, 0, registerCount * 2).array();
+
+        try (SolarmanLoggerConnection solarmanLoggerConnection = solarmanLoggerConnector.createConnection()) {
+            logger.debug("Writing data {} to {} logger register(s) starting from 0x{}", HexUtils.bytesToHex(data),
+                    registerCount, String.format("%04X", firstRegister));
+
+            if (!solarmanLoggerConnection.isConnected()) {
+                throw new SolarmanConnectionException("Unable to connect to logger");
+            }
+
+            if (solarmanProtocol.writeRegisters(solarmanLoggerConnection, firstRegister, data)) {
+                logger.info("Successfully updated registers");
+            } else {
+                logger.error("Failed to update registers");
+            }
+        } catch (SolarmanException e) {
+            logger.error("Failed to communicate with logger", e);
+        }
+    }
+
+    private void logUnexpectedCommand(ChannelUID uid, Command command) {
+        logger.warn("Received unexpected command {} in channel {}", command, uid);
+    }
+}

--- a/bundles/org.openhab.binding.solarman/src/main/java/org/openhab/binding/solarman/internal/util/ParserUtils.java
+++ b/bundles/org.openhab.binding.solarman/src/main/java/org/openhab/binding/solarman/internal/util/ParserUtils.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2010-2025 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.solarman.internal.util;
+
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * The {@link ParserUtils} contains different utility methods for parsing
+ *
+ * @author Oleksandr Mishchuk - Initial contribution
+ */
+@NonNullByDefault
+public class ParserUtils {
+    private static final Pattern REGISTER_PATTERN = Pattern.compile("\\s*(0x[\\da-fA-F]+|[\\d]+)\\s*");
+
+    public static List<Integer> parseRegisters(String registers) {
+        String[] tokens = registers.split(",");
+        return Stream.of(tokens).map(REGISTER_PATTERN::matcher).filter(Matcher::find).map(matcher -> matcher.group(1))
+                .map(ParserUtils::parseNumber).toList();
+    }
+
+    public static int parseNumber(String number) {
+        return number.startsWith("0x") ? Integer.parseInt(number.substring(2), 16) : Integer.parseInt(number);
+    }
+}

--- a/bundles/org.openhab.binding.solarman/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.solarman/src/main/resources/OH-INF/thing/thing-types.xml
@@ -32,6 +32,7 @@
 					<option value="deye_4mppt">DEYE Microinverter with 4 MPPT Trackers (deye_4mppt)</option>
 					<option value="deye_hybrid">Generic DEYE/Sunsynk/SolArk Hybrid inverters (deye_hybrid)</option>
 					<option value="deye_sg04lp3">DEYE/Sunsynk/SolArk Hybrid 8/12K-SG04LP3 (deye_sg04lp3)</option>
+					<option value="deye_sg01hp3">DEYE/Sunsynk/SolArk Hybrid 30K-SG01HP3 (deye_sg01hp3)</option>
 					<option value="deye_string">Generic DEYE/Sunsynk/SolArk String inverters (deye_string)</option>
 					<option value="kstar_hybrid">KSTAR Hybrid Inverter (kstar_hybrid)</option>
 					<option value="sofar_g3hyd">SOFAR Hybrid Three-Phase Inverter (sofar_g3hyd)</option>

--- a/bundles/org.openhab.binding.solarman/src/main/resources/definitions/deye_sg01hp3.yaml
+++ b/bundles/org.openhab.binding.solarman/src/main/resources/definitions/deye_sg01hp3.yaml
@@ -1,0 +1,1043 @@
+# SUN-302K-SG01HP3-EU | 30KW | Three Phase | 3 MPPT | Hybrid Inverter | High Voltage Battery
+
+requests:
+  - start: 0x0003
+    end: 0x0059
+    mb_functioncode: 0x03
+  - start: 0x0063
+    end: 0x006D
+    mb_functioncode: 0x03
+  - start: 0x0085
+    end: 0x0085
+    mb_functioncode: 0x03
+  - start: 0x00A6
+    end: 0x00B1
+    mb_functioncode: 0x03
+  - start: 0x0094
+    end: 0x009F
+    mb_functioncode: 0x03
+  - start: 0x0202
+    end: 0x022E
+    mb_functioncode: 0x03
+  - start: 0x0218
+    end: 0x021A
+    mb_functioncode: 0x03
+  - start: 0x024A
+    end: 0x024F
+    mb_functioncode: 0x03
+  - start: 0x0256
+    end: 0x027C
+    mb_functioncode: 0x03
+  - start: 0x0284
+    end: 0x028D
+    mb_functioncode: 0x03
+  - start: 0x0295
+    end: 0x029F
+    mb_functioncode: 0x03
+  - start: 0x02A0
+    end: 0x02A8
+    mb_functioncode: 0x03
+
+parameters:
+  - group: solar
+    items:
+      - name: "PV1 Power"
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        scale: 1
+        rule: 1
+        registers: [0x02A0]
+        icon: "mdi:solar-power"
+
+      - name: "PV2 Power"
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        scale: 1
+        rule: 1
+        registers: [0x02A1]
+        icon: "mdi:solar-power"
+
+      - name: "PV3 Power"
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        scale: 1
+        rule: 1
+        registers: [ 0x02A2 ]
+        icon: "mdi:solar-power"
+
+      - name: "PV1 Voltage"
+        class: "voltage"
+        state_class: "measurement"
+        uom: "V"
+        scale: 0.1
+        rule: 1
+        registers: [0x02A4]
+        icon: "mdi:solar-power"
+
+      - name: "PV2 Voltage"
+        class: "voltage"
+        state_class: "measurement"
+        uom: "V"
+        scale: 0.1
+        rule: 1
+        registers: [0x02A6]
+        icon: "mdi:solar-power"
+
+      - name: "PV3 Voltage"
+        class: "voltage"
+        state_class: "measurement"
+        uom: "V"
+        scale: 0.1
+        rule: 1
+        registers: [ 0x02A7 ]
+        icon: "mdi:solar-power"
+
+      - name: "PV1 Current"
+        class: "current"
+        state_class: "measurement"
+        uom: "A"
+        scale: 0.1
+        rule: 1
+        registers: [0x02A5]
+        icon: "mdi:solar-power"
+
+      - name: "PV2 Current"
+        class: "current"
+        state_class: "measurement"
+        uom: "A"
+        scale: 0.1
+        rule: 1
+        registers: [0x02A7]
+        icon: "mdi:solar-power"
+
+      - name: "PV3 Current"
+        class: "current"
+        state_class: "measurement"
+        uom: "A"
+        scale: 0.1
+        rule: 1
+        registers: [ 0x02A8 ]
+        icon: "mdi:solar-power"
+
+      - name: "Daily Production"
+        class: "energy"
+        state_class: "total_increasing"
+        uom: "kWh"
+        scale: 0.1
+        rule: 1
+        registers: [0x0211]
+        icon: "mdi:solar-power"
+        validation:
+          max: 100
+          invalidate_all:
+
+      - name: "Total Production"
+        class: "energy"
+        state_class: "total_increasing"
+        uom: "kWh"
+        scale: 0.1
+        rule: 3
+        registers: [0x0216, 0x0217]
+        icon: "mdi:solar-power"
+
+  - group: Battery
+    items:
+      - name: "Battery Equalization V"
+        class: "voltage"
+        state_class: "measurement"
+        uom: "V"
+        scale: 0.01
+        rule: 1
+        registers: [0x0063]
+        icon: "mdi:battery"
+
+      - name: "Battery Absorption V"
+        class: "voltage"
+        state_class: "measurement"
+        uom: "V"
+        scale: 0.01
+        rule: 1
+        registers: [0x0064]
+        icon: "mdi:battery"
+
+      - name: "Battery Float V"
+        class: "voltage"
+        state_class: "measurement"
+        uom: "V"
+        scale: 0.01
+        rule: 1
+        registers: [0x0065]
+        icon: "mdi:battery"
+
+      - name: "Battery Capacity"
+        class: "battery"
+        state_class: "measurement"
+        uom: "Ah"
+        scale: 1
+        rule: 1
+        registers: [0x0066]
+        icon: "mdi:battery"
+
+      - name: "Battery Empty V"
+        class: "voltage"
+        state_class: "measurement"
+        uom: "V"
+        scale: 0.01
+        rule: 1
+        registers: [0x0066]
+        icon: "mdi:battery"
+
+      - name: "Battery Max A Charge"
+        class: "current"
+        state_class: "measurement"
+        uom: "A"
+        scale: 1
+        rule: 1
+        registers: [0x006C]
+        icon: "mdi:battery"
+
+      - name: "Battery Max A Discharge"
+        class: "current"
+        state_class: "measurement"
+        uom: "A"
+        scale: 1
+        rule: 1
+        registers: [0x006D]
+        icon: "mdi:battery"
+
+      - name: "Daily Battery Charge"
+        class: "energy"
+        state_class: "total_increasing"
+        uom: "kWh"
+        scale: 0.1
+        rule: 1
+        registers: [0x0202]
+        icon: "mdi:battery-plus"
+
+      - name: "Daily Battery Discharge"
+        class: "energy"
+        state_class: "total_increasing"
+        uom: "kWh"
+        scale: 0.1
+        rule: 1
+        registers: [0x0203]
+        icon: "mdi:battery-plus"
+
+      - name: "Total Battery Charge"
+        class: "energy"
+        state_class: "total_increasing"
+        uom: "kWh"
+        scale: 0.1
+        rule: 3
+        registers: [0x0204, 0x0205]
+        icon: "mdi:battery-plus"
+
+      - name: "Total Battery Discharge"
+        class: "energy"
+        state_class: "total_increasing"
+        uom: "kWh"
+        scale: 0.1
+        rule: 3
+        registers: [0x0206, 0x0207]
+        icon: "mdi:battery-minus"
+
+      - name: "Battery Power"
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        scale: 1
+        rule: 2
+        registers: [0x024E]
+        icon: "mdi:battery"
+
+      - name: "Battery Voltage"
+        class: "voltage"
+        state_class: "measurement"
+        uom: "V"
+        scale: 0.01
+        rule: 1
+        registers: [0x024B]
+        icon: "mdi:battery"
+
+      - name: "Battery SOC"
+        class: "battery"
+        state_class: "measurement"
+        uom: "%"
+        scale: 1
+        rule: 1
+        registers: [0x024C]
+        icon: "mdi:battery"
+        validation:
+          min: 0
+          max: 101
+
+      - name: "Battery Current"
+        class: "current"
+        state_class: "measurement"
+        uom: "A"
+        scale: 0.01
+        rule: 2
+        registers: [0x024F]
+        icon: "mdi:battery"
+
+      - name: "Battery Temperature"
+        class: "temperature"
+        state_class: "measurement"
+        uom: "°C"
+        scale: 0.1
+        rule: 1
+        offset: 1000
+        registers: [0x024A]
+        icon: "mdi:battery"
+        validation:
+          min: 1
+          max: 99
+
+  - group: Grid
+    items:
+      - name: "Total Grid Power"
+        class: "measurement"
+        state_class: "measurement"
+        uom: "W"
+        scale: 1
+        rule: 2
+        registers: [0x0271]
+        icon: "mdi:transmission-tower"
+
+      - name: "Grid Voltage L1"
+        class: "voltage"
+        state_class: "measurement"
+        uom: "V"
+        scale: 0.1
+        rule: 1
+        registers: [0x0256]
+        icon: "mdi:transmission-tower"
+
+      - name: "Grid Voltage L2"
+        class: "voltage"
+        state_class: "measurement"
+        uom: "V"
+        scale: 0.1
+        rule: 1
+        registers: [0x0257]
+        icon: "mdi:transmission-tower"
+
+      - name: "Grid Voltage L3"
+        class: "voltage"
+        state_class: "measurement"
+        uom: "V"
+        scale: 0.1
+        rule: 1
+        registers: [0x0258]
+        icon: "mdi:transmission-tower"
+
+      - name: "Internal CT L1 Power"
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        scale: 1
+        rule: 2
+        registers: [0x025C]
+        icon: "mdi:transmission-tower"
+
+      - name: "Internal CT L2 Power"
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        scale: 1
+        rule: 2
+        registers: [0x025D]
+        icon: "mdi:transmission-tower"
+
+      - name: "Internal CT L3 Power"
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        scale: 1
+        rule: 2
+        registers: [0x025E]
+        icon: "mdi:transmission-tower"
+
+      - name: "External CT L1 Power"
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        scale: 1
+        rule: 2
+        registers: [0x0268]
+        icon: "mdi:transmission-tower"
+
+      - name: "External CT L2 Power"
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        scale: 1
+        rule: 2
+        registers: [0x0269]
+        icon: "mdi:transmission-tower"
+
+      - name: "External CT L3 Power"
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        scale: 1
+        rule: 2
+        registers: [0x026A]
+        icon: "mdi:transmission-tower"
+
+      - name: "Daily Energy Bought"
+        class: "energy"
+        state_class: "total_increasing"
+        uom: "kWh"
+        scale: 0.1
+        rule: 1
+        registers: [0x0208]
+        icon: "mdi:transmission-tower-export"
+
+      - name: "Total Energy Bought"
+        class: "energy"
+        state_class: "total_increasing"
+        uom: "kWh"
+        scale: 0.1
+        rule: 1
+        registers: [0x020A, 0x020B]
+        icon: "mdi:transmission-tower-export"
+
+      - name: "Daily Energy Sold"
+        class: "energy"
+        state_class: "total_increasing"
+        uom: "kWh"
+        scale: 0.1
+        rule: 1
+        registers: [0x0209]
+        icon: "mdi:transmission-tower-import"
+
+      - name: "Total Energy Sold"
+        class: "energy"
+        state_class: "total_increasing"
+        uom: "kWh"
+        scale: 0.1
+        rule: 3
+        registers: [0x020C, 0x020D]
+        icon: "mdi:transmission-tower-import"
+
+      - name: "Total Grid Production"
+        class: "energy"
+        state_class: "total_increasing"
+        uom: "kWh"
+        scale: 0.1
+        rule: 4
+        registers: [0x020C, 0x020D]
+        icon: "mdi:transmission-tower"
+
+  - group: Upload
+    items:
+      - name: "Total Load Power"
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        scale: 1
+        rule: 1
+        registers: [0x028D]
+        icon: "mdi:lightning-bolt-outline"
+
+      - name: "Load L1 Power"
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        scale: 1
+        rule: 1
+        registers: [0x028A]
+        icon: "mdi:lightning-bolt-outline"
+
+      - name: "Load L2 Power"
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        scale: 1
+        rule: 1
+        registers: [0x028B]
+        icon: "mdi:lightning-bolt-outline"
+
+      - name: "Load L3 Power"
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        scale: 1
+        rule: 1
+        registers: [0x028C]
+        icon: "mdi:lightning-bolt-outline"
+
+      - name: "Load Voltage L1"
+        class: "voltage"
+        state_class: "measurement"
+        uom: "V"
+        scale: 0.1
+        rule: 1
+        registers: [0x0284]
+        icon: "mdi:lightning-bolt-outline"
+
+      - name: "Load Voltage L2"
+        class: "voltage"
+        state_class: "measurement"
+        uom: "V"
+        scale: 0.1
+        rule: 1
+        registers: [0x0285]
+        icon: "mdi:lightning-bolt-outline"
+
+      - name: "Load Voltage L3"
+        class: "voltage"
+        state_class: "measurement"
+        uom: "V"
+        scale: 0.1
+        rule: 1
+        registers: [0x0286]
+        icon: "mdi:lightning-bolt-outline"
+
+      - name: "Daily Load Consumption"
+        class: "energy"
+        state_class: "total_increasing"
+        uom: "kWh"
+        scale: 0.1
+        rule: 1
+        registers: [0x020E]
+        icon: "mdi:lightning-bolt-outline"
+
+      - name: "Total Load Consumption"
+        class: "energy"
+        state_class: "total_increasing"
+        uom: "kWh"
+        scale: 0.1
+        rule: 3
+        registers: [0x020F, 0x0210]
+        icon: "mdi:lightning-bolt-outline"
+
+  - group: Inverter
+    items:
+      - name: "Current L1"
+        class: "current"
+        state_class: "measurement"
+        uom: "A"
+        scale: 0.01
+        rule: 2
+        registers: [0x0276]
+        icon: "mdi:home-lightning-bolt"
+
+      - name: "Current L2"
+        class: "current"
+        state_class: "measurement"
+        uom: "A"
+        scale: 0.01
+        rule: 2
+        registers: [0x0277]
+        icon: "mdi:home-lightning-bolt"
+
+      - name: "Current L3"
+        class: "current"
+        uom: "A"
+        scale: 0.01
+        rule: 2
+        registers: [0x0278]
+        icon: "mdi:home-lightning-bolt"
+
+      - name: "Inverter L1 Power"
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        scale: 1
+        rule: 2
+        registers: [0x0279]
+        icon: "mdi:home-lightning-bolt"
+
+      - name: "Inverter L2 Power"
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        scale: 1
+        rule: 2
+        registers: [0x027A]
+        icon: "mdi:home-lightning-bolt"
+
+      - name: "Inverter L3 Power"
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        scale: 1
+        rule: 2
+        registers: [0x027B]
+        icon: "mdi:home-lightning-bolt"
+
+      - name: "DC Temperature"
+        class: "temperature"
+        state_class: "measurement"
+        uom: "°C"
+        scale: 0.1
+        rule: 2
+        offset: 1000
+        registers: [0x021C]
+        icon: "mdi:thermometer"
+
+      - name: "AC Temperature"
+        class: "temperature"
+        state_class: "measurement"
+        uom: "°C"
+        scale: 0.1
+        rule: 2
+        offset: 1000
+        registers: [0x021D]
+        icon: "mdi:thermometer"
+
+      - name: "Inverter ID"
+        class: ""
+        state_class: ""
+        uom: ""
+        scale: 1
+        rule: 5
+        registers: [0x0003, 0x0004, 0x0005, 0x0006, 0x0007]
+        isstr: true
+
+      - name: "Communication Board Version No."
+        class: ""
+        state_class: ""
+        uom: ""
+        scale: 1
+        rule: 1
+        registers: [0x0011]
+        isstr: true
+
+      - name: "Control Board Version No."
+        class: ""
+        state_class: ""
+        uom: ""
+        scale: 1
+        rule: 1
+        registers: [0x000D]
+        isstr: true
+
+  - group: SmartLoad
+    items:
+      - name: "SmartLoad Enable Status"
+        class: ""
+        state_class: ""
+        uom: ""
+        scale: 1
+        rule: 1
+        registers: [0x0085]
+        isstr: true
+        lookup:
+          - key: 0
+            value: "GEN Use"
+          - key: 1
+            value: "SMART Load output"
+          - key: 2
+            value: "Microinverter"
+        icon: "mdi:lightning-bolt-outline"
+
+      - name: "Phase voltage of Gen port A"
+        class: "voltage"
+        state_class: "measurement"
+        uom: "V"
+        scale: 0.1
+        rule: 1
+        registers: [0x0295]
+        icon: "mdi:home-lightning-bolt"
+
+      - name: "Phase voltage of Gen port B"
+        class: "voltage"
+        state_class: "measurement"
+        uom: "V"
+        scale: 0.1
+        rule: 1
+        registers: [0x0296]
+        icon: "mdi:home-lightning-bolt"
+
+      - name: "Phase voltage of Gen port C"
+        class: "voltage"
+        state_class: "measurement"
+        uom: "V"
+        scale: 0.1
+        rule: 1
+        registers: [0x0297]
+        icon: "mdi:home-lightning-bolt"
+
+      - name: "Phase power of Gen port A"
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        scale: 1
+        rule: 1
+        registers: [0x0298]
+        icon: "mdi:home-lightning-bolt"
+        validation:
+          min: 0
+          max: 30000
+
+      - name: "Phase power of Gen port B"
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        scale: 1
+        rule: 1
+        registers: [0x0299]
+        icon: "mdi:home-lightning-bolt"
+        validation:
+          min: 0
+          max: 30000
+
+      - name: "Phase power of Gen port C"
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        scale: 1
+        rule: 1
+        registers: [0x029A]
+        icon: "mdi:home-lightning-bolt"
+        validation:
+          min: 0
+          max: 30000
+
+      - name: "Total Power of Gen port"
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        scale: 1
+        rule: 1
+        registers: [0x029B]
+        icon: "mdi:home-l1ghtning-bolt"
+        validation:
+          min: 0
+          max: 30000
+
+      - name: "Generator daily power generation"
+        class: "energy"
+        state_class: "total_increasing"
+        uom: "kWh"
+        scale: 0.1
+        rule: 1
+        registers: [0x0218]
+        icon: "mdi:transmission-tower-import"
+
+      - name: "Generator total power generation"
+        class: "energy"
+        state_class: "total_increasing"
+        uom: "kWh"
+        scale: 0.1
+        rule: 3
+        registers: [0x0219, 0x021A]
+        icon: "mdi:transmission-tower-import"
+
+  - group: Alert
+    items:
+      - name: "Alert"
+        class: ""
+        state_class: ""
+        uom: ""
+        scale: 1
+        rule: 6
+        registers: [0x0229, 0x022A, 0x22B, 0x022C, 0x022D, 0x022E]
+
+  - group: Time Of Use
+    items:
+      - name: "TOU Time 1"
+        class: ""
+        state_class: ""
+        uom: ""
+        scale: 1
+        rule: 9
+        isReadOnly: false
+        registers: [0x0094]
+
+      - name: "TOU Time 2"
+        class: ""
+        state_class: ""
+        uom: ""
+        scale: 1
+        rule: 9
+        isReadOnly: false
+        registers: [0x0095]
+
+      - name: "TOU Time 3"
+        class: ""
+        state_class: ""
+        uom: ""
+        scale: 1
+        rule: 9
+        isReadOnly: false
+        registers: [0x0096]
+
+      - name: "TOU Time 4"
+        class: ""
+        state_class: ""
+        uom: ""
+        scale: 1
+        rule: 9
+        isReadOnly: false
+        registers: [0x0097]
+
+      - name: "TOU Time 5"
+        class: ""
+        state_class: ""
+        uom: ""
+        scale: 1
+        rule: 9
+        isReadOnly: false
+        registers: [0x0098]
+
+      - name: "TOU Time 6"
+        class: ""
+        state_class: ""
+        uom: ""
+        scale: 1
+        rule: 9
+        isReadOnly: false
+        registers: [0x0099]
+
+      - name: "TOU Power 1"
+        class: "energy"
+        state_class: "measurement"
+        uom: "W"
+        scale: 10
+        rule: 1
+        isReadOnly: false
+        registers: [0x009A]
+
+      - name: "TOU Power 2"
+        class: "energy"
+        state_class: "measurement"
+        uom: "W"
+        scale: 10
+        rule: 1
+        isReadOnly: false
+        registers: [0x009B]
+
+      - name: "TOU Power 3"
+        class: "energy"
+        state_class: "measurement"
+        uom: "W"
+        scale: 10
+        rule: 1
+        isReadOnly: false
+        registers: [0x009C]
+
+      - name: "TOU Power 4"
+        class: "energy"
+        state_class: "measurement"
+        uom: "W"
+        scale: 10
+        rule: 1
+        isReadOnly: false
+        registers: [0x009D]
+
+      - name: "TOU Power 5"
+        class: "energy"
+        state_class: "measurement"
+        uom: "W"
+        scale: 10
+        rule: 1
+        isReadOnly: false
+        registers: [0x009E]
+
+      - name: "TOU Power 6"
+        class: "energy"
+        state_class: "measurement"
+        uom: "W"
+        scale: 10
+        rule: 1
+        isReadOnly: false
+        registers: [0x009F]
+
+      - name: "TOU Battery SOC 1"
+        class: "battery"
+        state_class: "measurement"
+        uom: "%"
+        scale: 1
+        rule: 1
+        isReadOnly: false
+        registers: [0x00A6]
+        icon: "mdi:battery"
+        validation:
+          min: 0
+          max: 100
+
+      - name: "TOU Battery SOC 2"
+        class: "battery"
+        state_class: "measurement"
+        uom: "%"
+        scale: 1
+        rule: 1
+        isReadOnly: false
+        registers: [0x00A7]
+        icon: "mdi:battery"
+        validation:
+          min: 0
+          max: 100
+
+      - name: "TOU Battery SOC 3"
+        class: "battery"
+        state_class: "measurement"
+        uom: "%"
+        scale: 1
+        rule: 1
+        isReadOnly: false
+        registers: [0x00A8]
+        icon: "mdi:battery"
+        validation:
+          min: 0
+          max: 100
+
+      - name: "TOU Battery SOC 4"
+        class: "battery"
+        state_class: "measurement"
+        uom: "%"
+        scale: 1
+        rule: 1
+        isReadOnly: false
+        registers: [0x00A9]
+        icon: "mdi:battery"
+        validation:
+          min: 0
+          max: 100
+
+      - name: "TOU Battery SOC 5"
+        class: "battery"
+        state_class: "measurement"
+        uom: "%"
+        scale: 1
+        rule: 1
+        isReadOnly: false
+        registers: [0x00AA]
+        icon: "mdi:battery"
+        validation:
+          min: 0
+          max: 100
+
+      - name: "TOU Battery SOC 6"
+        class: "battery"
+        state_class: "measurement"
+        uom: "%"
+        scale: 1
+        rule: 1
+        isReadOnly: false
+        registers: [0x00AB]
+        icon: "mdi:battery"
+        validation:
+          min: 0
+          max: 100
+
+      - name: "TOU Charge Enable 1"
+        class: ""
+        state_class: ""
+        uom: ""
+        scale: 1
+        rule: 1
+        registers: [0x00AC]
+        isReadOnly: false
+        isstr: true
+        lookup:
+          - key: 0
+            value: "Charge disabled"
+          - key: 1
+            value: "Grid charge"
+          - key: 2
+            value: "Generator charge"
+          - key: 3
+            value: "Grid charge + Generator charge"
+
+      - name: "TOU Charge Enable 2"
+        class: ""
+        state_class: ""
+        uom: ""
+        scale: 1
+        rule: 1
+        registers: [ 0x00AD ]
+        isReadOnly: false
+        isstr: true
+        lookup:
+          - key: 0
+            value: "Charge disabled"
+          - key: 1
+            value: "Grid charge"
+          - key: 2
+            value: "Generator charge"
+          - key: 3
+            value: "Grid charge + Generator charge"
+
+      - name: "TOU Charge Enable 3"
+        class: ""
+        state_class: ""
+        uom: ""
+        scale: 1
+        rule: 1
+        registers: [ 0x00AE ]
+        isReadOnly: false
+        isstr: true
+        lookup:
+          - key: 0
+            value: "Charge disabled"
+          - key: 1
+            value: "Grid charge"
+          - key: 2
+            value: "Generator charge"
+          - key: 3
+            value: "Grid charge + Generator charge"
+
+      - name: "TOU Charge Enable 4"
+        class: ""
+        state_class: ""
+        uom: ""
+        scale: 1
+        rule: 1
+        registers: [ 0x00AF ]
+        isReadOnly: false
+        isstr: true
+        lookup:
+          - key: 0
+            value: "Charge disabled"
+          - key: 1
+            value: "Grid charge"
+          - key: 2
+            value: "Generator charge"
+          - key: 3
+            value: "Grid charge + Generator charge"
+
+      - name: "TOU Charge Enable 5"
+        class: ""
+        state_class: ""
+        uom: ""
+        scale: 1
+        rule: 1
+        registers: [ 0x00B0 ]
+        isReadOnly: false
+        isstr: true
+        lookup:
+          - key: 0
+            value: "Charge disabled"
+          - key: 1
+            value: "Grid charge"
+          - key: 2
+            value: "Generator charge"
+          - key: 3
+            value: "Grid charge + Generator charge"
+
+      - name: "TOU Charge Enable 6"
+        class: ""
+        state_class: ""
+        uom: ""
+        scale: 1
+        rule: 1
+        registers: [ 0x00B1 ]
+        isReadOnly: false
+        isstr: true
+        lookup:
+          - key: 0
+            value: "Charge disabled"
+          - key: 1
+            value: "Grid charge"
+          - key: 2
+            value: "Generator charge"
+          - key: 3
+            value: "Grid charge + Generator charge"

--- a/bundles/org.openhab.binding.solarman/src/test/java/org/openhab/binding/solarman/internal/modbus/SolarmanRawProtocolTest.java
+++ b/bundles/org.openhab.binding.solarman/src/test/java/org/openhab/binding/solarman/internal/modbus/SolarmanRawProtocolTest.java
@@ -45,8 +45,8 @@ class SolarmanRawProtocolTest {
     private SolarmanRawProtocol solarmanRawProtocol = new SolarmanRawProtocol(loggerConfiguration);
 
     @Test
-    void testbuildSolarmanRawFrame() {
-        byte[] requestFrame = solarmanRawProtocol.buildSolarmanRawFrame((byte) 0x03, 0x0063, 0x006D);
+    void testbuildSolarmanRawReadFrame() {
+        byte[] requestFrame = solarmanRawProtocol.buildSolarmanRawReadFrame((byte) 0x03, 0x0063, 11);
         byte[] expectedFrame = { (byte) 0x03, (byte) 0xE8, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x08,
                 (byte) 0x01, (byte) 0x03, (byte) 0x00, (byte) 0x63, (byte) 0x00, (byte) 0x0B, (byte) 0xF4,
                 (byte) 0x13 };

--- a/bundles/org.openhab.binding.solarman/src/test/java/org/openhab/binding/solarman/internal/modbus/SolarmanV5ProtocolTest.java
+++ b/bundles/org.openhab.binding.solarman/src/test/java/org/openhab/binding/solarman/internal/modbus/SolarmanV5ProtocolTest.java
@@ -45,8 +45,19 @@ class SolarmanV5ProtocolTest {
     private SolarmanV5Protocol solarmanV5Protocol = new SolarmanV5Protocol(loggerConfiguration);
 
     @Test
+    void tesBuildModbusReadHoldingRegistersFrame() {
+        byte[] modbusFrame = solarmanV5Protocol.buildModbusReadHoldingRegistersFrame((byte) 0x01, (byte) 0x03, 0x0000,
+                0x0021);
+        byte[] expectedFrame = { (byte) 0x01, (byte) 0x03, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x21,
+                (byte) 0x85, (byte) 0xD2 };
+        assertArrayEquals(modbusFrame, expectedFrame);
+    }
+
+    @Test
     void testbuildSolarmanV5Frame() {
-        byte[] requestFrame = solarmanV5Protocol.buildSolarmanV5Frame((byte) 0x03, 0x0000, 0x0020);
+        byte[] modbusFrame = solarmanV5Protocol.buildModbusReadHoldingRegistersFrame((byte) 0x01, (byte) 0x03, 0x0000,
+                0x0021);
+        byte[] requestFrame = solarmanV5Protocol.buildSolarmanV5Frame(modbusFrame);
 
         byte[] expectedFrame = { (byte) 0xA5, (byte) 0x17, (byte) 0x00, (byte) 0x10, (byte) 0x45, (byte) 0x00,
                 (byte) 0x00, (byte) 0xD2, (byte) 0x02, (byte) 0x96, (byte) 0x49, (byte) 0x02, (byte) 0x00, (byte) 0x00,


### PR DESCRIPTION
# [solarman] Add ability to write to Solarman registers

# Description

Current binding implementation doesn't allow to change data in invertor - only reads data from it. At the same time there are sets of registers that can safely be manipulated to automate eletricity usage, etc. 
By default all registers are treated as read-only unless other is directly stated in channel configuration, which should avoid any accidental writes. 
To make channel writable you should add `readOnly=false` to channel configuration. I have also added one new invertor definition `deye_sg01hp3` for Deye 30KWh High Volatage inverter, where this was tested. New channels introduced there are connected to Time Of Use functionality, including time periods, battery SOC, charge enabled.

# Testing

Existing unit tests were adapted to refactored code.
To test updated binding you can download built jar here: https://mega.nz/file/jjAlAT4D#mFLoSH1T8NP36iZzJKroslgVaMFkOTtW1ve7hfJ7KnY

