### PR TITLE
[frenchgovtenergydata] Fix `IllegalArgumentException` for thing type `tempo`

### DIFF
--- a/bundles/org.openhab.binding.frenchgovtenergydata/src/main/java/org/openhab/binding/frenchgovtenergydata/internal/dto/BaseTariff.java
+++ b/bundles/org.openhab.binding.frenchgovtenergydata/src/main/java/org/openhab/binding/frenchgovtenergydata/internal/dto/BaseTariff.java
@@ -24,8 +24,10 @@ public class BaseTariff extends Tariff {
     public final double variableHT;
     public final double variableTTC;
 
+    public static final int LEN_CONTROL = 7;
+
     public BaseTariff(String line) {
-        super(line, 7);
+        super(line, LEN_CONTROL);
         try {
             this.variableHT = parseDouble(values[5]);
             this.variableTTC = parseDouble(values[6]);

--- a/bundles/org.openhab.binding.frenchgovtenergydata/src/main/java/org/openhab/binding/frenchgovtenergydata/internal/dto/HpHcTariff.java
+++ b/bundles/org.openhab.binding.frenchgovtenergydata/src/main/java/org/openhab/binding/frenchgovtenergydata/internal/dto/HpHcTariff.java
@@ -26,8 +26,10 @@ public class HpHcTariff extends Tariff {
     public final double hpHT;
     public final double hpTTC;
 
+    public static final int LEN_CONTROL = 9;
+
     public HpHcTariff(String line) {
-        super(line, 9);
+        super(line, LEN_CONTROL);
         try {
             this.hcHT = parseDouble(values[5]);
             this.hcTTC = parseDouble(values[6]);

--- a/bundles/org.openhab.binding.frenchgovtenergydata/src/main/java/org/openhab/binding/frenchgovtenergydata/internal/dto/TempoTariff.java
+++ b/bundles/org.openhab.binding.frenchgovtenergydata/src/main/java/org/openhab/binding/frenchgovtenergydata/internal/dto/TempoTariff.java
@@ -36,8 +36,10 @@ public class TempoTariff extends Tariff {
     public final double redHpHT;
     public final double redHpTTC;
 
+    public static final int LEN_CONTROL = 17;
+
     public TempoTariff(String line) {
-        super(line, 17);
+        super(line, LEN_CONTROL);
         try {
             this.blueHcHT = parseDouble(values[5]);
             this.blueHcTTC = parseDouble(values[6]);

--- a/bundles/org.openhab.binding.frenchgovtenergydata/src/main/java/org/openhab/binding/frenchgovtenergydata/internal/handler/BaseTariffHandler.java
+++ b/bundles/org.openhab.binding.frenchgovtenergydata/src/main/java/org/openhab/binding/frenchgovtenergydata/internal/handler/BaseTariffHandler.java
@@ -32,6 +32,7 @@ import org.openhab.core.thing.Thing;
 @NonNullByDefault
 public class BaseTariffHandler extends TariffHandler<BaseTariff> {
     private static final String DATASET_ID = "c13d05e5-9e55-4d03-bf7e-042a2ade7e49";
+    private static final String EMPTY_LINE = ";".repeat(BaseTariff.LEN_CONTROL - 1);
 
     public BaseTariffHandler(Thing thing) {
         super(thing, DATASET_ID);
@@ -39,7 +40,7 @@ public class BaseTariffHandler extends TariffHandler<BaseTariff> {
 
     @Override
     protected Stream<BaseTariff> interpretLines(List<String> lines) {
-        return lines.stream().map(BaseTariff::new);
+        return lines.stream().filter(line -> !line.equals(EMPTY_LINE)).map(BaseTariff::new);
     }
 
     @Override

--- a/bundles/org.openhab.binding.frenchgovtenergydata/src/main/java/org/openhab/binding/frenchgovtenergydata/internal/handler/HpHcTariffHandler.java
+++ b/bundles/org.openhab.binding.frenchgovtenergydata/src/main/java/org/openhab/binding/frenchgovtenergydata/internal/handler/HpHcTariffHandler.java
@@ -31,8 +31,8 @@ import org.openhab.core.thing.Thing;
  */
 @NonNullByDefault
 public class HpHcTariffHandler extends TariffHandler<HpHcTariff> {
-    private static final String EMPTY_LINE = ";;;;;;;;";
     private static final String DATASET_ID = "f7303b3a-93c7-4242-813d-84919034c416";
+    private static final String EMPTY_LINE = ";".repeat(HpHcTariff.LEN_CONTROL - 1);
 
     public HpHcTariffHandler(Thing thing) {
         super(thing, DATASET_ID);

--- a/bundles/org.openhab.binding.frenchgovtenergydata/src/main/java/org/openhab/binding/frenchgovtenergydata/internal/handler/TempoTariffHandler.java
+++ b/bundles/org.openhab.binding.frenchgovtenergydata/src/main/java/org/openhab/binding/frenchgovtenergydata/internal/handler/TempoTariffHandler.java
@@ -31,8 +31,8 @@ import org.openhab.core.thing.Thing;
  */
 @NonNullByDefault
 public class TempoTariffHandler extends TariffHandler<TempoTariff> {
-    private static final String EMPTY_LINE = ";;;;;;;;;;;;;;;;";
     private static final String DATASET_ID = "0c3d1d36-c412-4620-8566-e5cbb4fa2b5a";
+    private static final String EMPTY_LINE = ";".repeat(TempoTariff.LEN_CONTROL - 1);
 
     public TempoTariffHandler(Thing thing) {
         super(thing, DATASET_ID);

--- a/bundles/org.openhab.binding.frenchgovtenergydata/src/main/java/org/openhab/binding/frenchgovtenergydata/internal/handler/TempoTariffHandler.java
+++ b/bundles/org.openhab.binding.frenchgovtenergydata/src/main/java/org/openhab/binding/frenchgovtenergydata/internal/handler/TempoTariffHandler.java
@@ -31,7 +31,7 @@ import org.openhab.core.thing.Thing;
  */
 @NonNullByDefault
 public class TempoTariffHandler extends TariffHandler<TempoTariff> {
-    private static final String EMPTY_LINE = ";;;;;;;;";
+    private static final String EMPTY_LINE = ";;;;;;;;;;;;;;;;";
     private static final String DATASET_ID = "0c3d1d36-c412-4620-8566-e5cbb4fa2b5a";
 
     public TempoTariffHandler(Thing thing) {


### PR DESCRIPTION
# Fixes for tempo tariff Handler in Frenchgovtenergydata

The was an error in 5.0 in the format of EMPTY_LINE for tempo tariff.
This 1 line fix correct the issue.
Without it, the thing never come online :(

