### PR TITLE
[energidataservice] Update tariff filter for Cerius

### DIFF
--- a/bundles/org.openhab.binding.energidataservice/src/main/resources/filters/grid_tariffs.yaml
+++ b/bundles/org.openhab.binding.energidataservice/src/main/resources/filters/grid_tariffs.yaml
@@ -11,6 +11,7 @@
   chargeTypeCodes:
     - "30TR_C_ET"
   notes:
+    - "Nettarif C"
     - "Nettarif C time"
 # Dinel
 - gln: "5790000610099"

--- a/bundles/org.openhab.binding.energidataservice/src/test/java/org/openhab/binding/energidataservice/internal/api/filter/DatahubTariffFilterFactoryTest.java
+++ b/bundles/org.openhab.binding.energidataservice/src/test/java/org/openhab/binding/energidataservice/internal/api/filter/DatahubTariffFilterFactoryTest.java
@@ -106,7 +106,7 @@ public class DatahubTariffFilterFactoryTest {
                 Arguments.of("5790001095451", DateQueryParameter.of(DateQueryParameterType.START_OF_DAY),
                         List.of("AAL-NT-05", "AAL-NTR05"), List.of("Nettarif C time")), //
                 Arguments.of("5790000705184", DateQueryParameter.EMPTY, List.of("30TR_C_ET"),
-                        List.of("Nettarif C time")), //
+                        List.of("Nettarif C", "Nettarif C time")), //
                 Arguments.of("5790000682102", DateQueryParameter.of(LocalDate.of(2022, 10, 1)), List.of("IEV-NT-01"),
                         List.of("Nettarif C time")), //
                 Arguments.of("5790001089030", DateQueryParameter.of(LocalDate.of(2023, 1, 1)), List.of("CD", "CD R"),


### PR DESCRIPTION
Cerius has made a change in the "notes" field for [published prices](https://energidataservice.dk/tso-electricity/DatahubPricelist):

<img width="1503" height="1049" alt="image" src="https://github.com/user-attachments/assets/bda23f8b-a428-428e-97ba-37a3dcd84bc3" />
