### PR TITLE
[jsscripting] Wrapper: Always enable for actions, configurable for conditions

### DIFF
--- a/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/GraalJSScriptEngineConfiguration.java
+++ b/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/GraalJSScriptEngineConfiguration.java
@@ -40,7 +40,7 @@ public class GraalJSScriptEngineConfiguration {
 
     private int injectionEnabled = INJECTION_ENABLED_FOR_ALL_SCRIPTS;
     private boolean injectionCachingEnabled = true;
-    private boolean scriptConditionWrapperEnabled = true;
+    private boolean scriptConditionWrapperEnabled = false;
     private boolean eventConversionEnabled = true;
     private boolean dependencyTrackingEnabled = true;
 

--- a/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/GraalJSScriptEngineConfiguration.java
+++ b/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/GraalJSScriptEngineConfiguration.java
@@ -30,7 +30,7 @@ public class GraalJSScriptEngineConfiguration {
 
     private static final String CFG_INJECTION_ENABLED = "injectionEnabledV2";
     private static final String CFG_INJECTION_CACHING_ENABLED = "injectionCachingEnabled";
-    private static final String CFG_WRAPPER_ENABLED = "wrapperEnabled";
+    private static final String CFG_SCRIPT_CONDITION_WRAPPER_ENABLED = "scriptConditionWrapperEnabled";
     private static final String CFG_EVENT_CONVERSION_ENABLED = "eventConversionEnabled";
     private static final String CFG_DEPENDENCY_TRACKING_ENABLED = "dependencyTrackingEnabled";
 
@@ -40,7 +40,7 @@ public class GraalJSScriptEngineConfiguration {
 
     private int injectionEnabled = INJECTION_ENABLED_FOR_ALL_SCRIPTS;
     private boolean injectionCachingEnabled = true;
-    private boolean wrapperEnabled = true;
+    private boolean scriptConditionWrapperEnabled = true;
     private boolean eventConversionEnabled = true;
     private boolean dependencyTrackingEnabled = true;
 
@@ -61,7 +61,7 @@ public class GraalJSScriptEngineConfiguration {
     void modified(Map<String, ?> config) {
         boolean oldInjectionEnabledForUiBasedScript = isInjectionEnabledForUiBasedScript();
         boolean oldDependencyTrackingEnabled = dependencyTrackingEnabled;
-        boolean oldWrapperEnabled = wrapperEnabled;
+        boolean oldScriptConditionWrapperEnabled = scriptConditionWrapperEnabled;
         boolean oldEventConversionEnabled = eventConversionEnabled;
 
         this.update(config);
@@ -76,10 +76,10 @@ public class GraalJSScriptEngineConfiguration {
                     "{} dependency tracking for JavaScript Scripting. Please resave your scripts to apply this change.",
                     dependencyTrackingEnabled ? "Enabled" : "Disabled");
         }
-        if (oldWrapperEnabled != wrapperEnabled) {
+        if (oldScriptConditionWrapperEnabled != scriptConditionWrapperEnabled) {
             logger.info(
-                    "{} wrapper for JavaScript Scripting. Please resave your UI-based scripts to apply this change.",
-                    wrapperEnabled ? "Enabled" : "Disabled");
+                    "{} script condition wrapper for JavaScript Scripting. Please resave your rules with JavaScript script conditions to apply this change.",
+                    scriptConditionWrapperEnabled ? "Enabled" : "Disabled");
         }
         if (oldEventConversionEnabled != eventConversionEnabled) {
             if (eventConversionEnabled && !isInjectionEnabledForUiBasedScript()) {
@@ -105,7 +105,8 @@ public class GraalJSScriptEngineConfiguration {
                 INJECTION_ENABLED_FOR_UI_BASED_SCRIPTS_ONLY);
         injectionCachingEnabled = ConfigParser.valueAsOrElse(config.get(CFG_INJECTION_CACHING_ENABLED), Boolean.class,
                 true);
-        wrapperEnabled = ConfigParser.valueAsOrElse(config.get(CFG_WRAPPER_ENABLED), Boolean.class, true);
+        scriptConditionWrapperEnabled = ConfigParser.valueAsOrElse(config.get(CFG_SCRIPT_CONDITION_WRAPPER_ENABLED),
+                Boolean.class, true);
         eventConversionEnabled = ConfigParser.valueAsOrElse(config.get(CFG_EVENT_CONVERSION_ENABLED), Boolean.class,
                 true);
         dependencyTrackingEnabled = ConfigParser.valueAsOrElse(config.get(CFG_DEPENDENCY_TRACKING_ENABLED),
@@ -128,8 +129,8 @@ public class GraalJSScriptEngineConfiguration {
         return injectionCachingEnabled;
     }
 
-    public boolean isWrapperEnabled() {
-        return wrapperEnabled;
+    public boolean isScriptConditionWrapperEnabled() {
+        return scriptConditionWrapperEnabled;
     }
 
     public boolean isEventConversionEnabled() {

--- a/bundles/org.openhab.automation.jsscripting/src/main/resources/OH-INF/config/config.xml
+++ b/bundles/org.openhab.automation.jsscripting/src/main/resources/OH-INF/config/config.xml
@@ -36,7 +36,7 @@
 			as well as the use of <code>function</code> and <code>class</code> declarations.<br>
 			With this option enabled, you need to use <code>return</code> statements in your script condition to return true or false.
 			]]></description>
-			<default>true</default>
+			<default>false</default>
 			<advanced>true</advanced>
 		</parameter>
 		<parameter name="eventConversionEnabled" type="boolean" required="true" groupName="environment">

--- a/bundles/org.openhab.automation.jsscripting/src/main/resources/OH-INF/config/config.xml
+++ b/bundles/org.openhab.automation.jsscripting/src/main/resources/OH-INF/config/config.xml
@@ -29,12 +29,12 @@
 			</options>
 			<default>3</default>
 		</parameter>
-		<parameter name="wrapperEnabled" type="boolean" required="true" groupName="environment">
-			<label>Wrap UI-based scripts in Self-Executing Function</label>
+		<parameter name="scriptConditionWrapperEnabled" type="boolean" required="true" groupName="environment">
+			<label>Wrap Script Conditions in Self-Executing Function</label>
 			<description><![CDATA[
-			Wrapping UI-based scripts in a self-executing function allows the use of the <code>let</code> and <code>const</code> variable declarations,
+			Wrapping script conditions in a self-executing function allows the use of the <code>let</code> and <code>const</code> variable declarations,
 			as well as the use of <code>function</code> and <code>class</code> declarations.<br>
-			With this option enabled, you can also use <code>return</code> statements in your scripts to abort execution at any point.
+			With this option enabled, you need to use <code>return</code> statements in your script condition to return true or false.
 			]]></description>
 			<default>true</default>
 			<advanced>true</advanced>

--- a/bundles/org.openhab.automation.jsscripting/src/main/resources/OH-INF/i18n/jsscripting.properties
+++ b/bundles/org.openhab.automation.jsscripting/src/main/resources/OH-INF/i18n/jsscripting.properties
@@ -21,5 +21,5 @@ automation.config.jsscripting.injectionEnabledV2.option.3 = Auto injection for a
 automation.config.jsscripting.injectionEnabledV2.option.2 = Auto injection for UI-based scripts and transformations
 automation.config.jsscripting.injectionEnabledV2.option.1 = Auto injection only for UI-based scripts (recommended)
 automation.config.jsscripting.injectionEnabledV2.option.0 = Disable auto-injection and import manually instead
-automation.config.jsscripting.wrapperEnabled.label = Wrap UI-based scripts in Self-Executing Function
-automation.config.jsscripting.wrapperEnabled.description = Wrapping UI-based scripts in a self-executing function allows the use of the <code>let</code> and <code>const</code> variable declarations, as well as the use of <code>function</code> and <code>class</code> declarations.<br> With this option enabled, you can also use <code>return</code> statements in your scripts to abort execution at any point.
+automation.config.jsscripting.scriptConditionWrapperEnabled.label = Wrap Script Conditions in Self-Executing Function
+automation.config.jsscripting.scriptConditionWrapperEnabled.description = Wrapping script conditions in a self-executing function allows the use of the <code>let</code> and <code>const</code> variable declarations, as well as the use of <code>function</code> and <code>class</code> declarations.<br> With this option enabled, you need to use <code>return</code> statements in your script condition to return true or false.


### PR DESCRIPTION
Follow up for #19019.

- This enables the wrapper that allows the use of `let`, `const`, `class`, `function`, `return` etc. always for script actions.
- The wrapper is only configurable for conditions anymore, and the option defaults to false to avoid breaking existing conditions.
- To allow disabling/enabling the script condition wrapper per condition, a directive is introduced: `"use wrapper"`
  - `"use wrapper"` & `"use wrapper=true"` enables the wrapper
  - `"use wrapper=false"` disables the wrapper