### PR TITLE
[heos] Fix bridge player channels

### DIFF
--- a/bundles/org.openhab.binding.heos/src/main/java/org/openhab/binding/heos/internal/HeosBindingConstants.java
+++ b/bundles/org.openhab.binding.heos/src/main/java/org/openhab/binding/heos/internal/HeosBindingConstants.java
@@ -39,7 +39,7 @@ public class HeosBindingConstants extends HeosConstants {
     public static final ThingTypeUID THING_TYPE_PLAYER = new ThingTypeUID(BINDING_ID, "player");
     public static final ThingTypeUID THING_TYPE_GROUP = new ThingTypeUID(BINDING_ID, "group");
 
-    // List off all Channel Types
+    // List of all Channel Types
     public static final ChannelTypeUID CH_TYPE_PLAYER = new ChannelTypeUID(BINDING_ID, "chPlayer");
 
     // List of all Channel IDs

--- a/bundles/org.openhab.binding.heos/src/main/java/org/openhab/binding/heos/internal/handler/HeosBridgeHandler.java
+++ b/bundles/org.openhab.binding.heos/src/main/java/org/openhab/binding/heos/internal/handler/HeosBridgeHandler.java
@@ -55,6 +55,7 @@ import org.openhab.binding.heos.internal.resources.HeosEventListener;
 import org.openhab.binding.heos.internal.resources.HeosMediaEventListener;
 import org.openhab.binding.heos.internal.resources.Telnet;
 import org.openhab.binding.heos.internal.resources.Telnet.ReadException;
+import org.openhab.core.library.CoreItemFactory;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.thing.Bridge;
 import org.openhab.core.thing.Channel;
@@ -378,8 +379,8 @@ public class HeosBridgeHandler extends BaseBridgeHandler implements HeosEventLis
             properties.put(PROP_NAME, playerName);
             properties.put(PID, pid);
 
-            Channel channel = ChannelBuilder.create(channelUID, "Switch").withLabel(playerName).withType(CH_TYPE_PLAYER)
-                    .withProperties(properties).build();
+            Channel channel = ChannelBuilder.create(channelUID, CoreItemFactory.SWITCH).withLabel(playerName)
+                    .withType(CH_TYPE_PLAYER).withProperties(properties).build();
             updateThingChannels(channelManager.addSingleChannel(channel));
         } catch (HeosNotFoundException e) {
             logger.debug("Group is not yet initialized fully");

--- a/bundles/org.openhab.binding.heos/src/main/resources/OH-INF/i18n/heos.properties
+++ b/bundles/org.openhab.binding.heos/src/main/resources/OH-INF/i18n/heos.properties
@@ -31,6 +31,7 @@ thing-type.config.heos.player.pid.description = The internal Player ID
 
 channel-type.heos.album.label = Album
 channel-type.heos.buildGroup.label = Make Group
+channel-type.heos.chPlayer.label = Player
 channel-type.heos.clearQueue.label = Clear Queue
 channel-type.heos.cover.label = Cover
 channel-type.heos.currentPosition.label = Track Position

--- a/bundles/org.openhab.binding.heos/src/main/resources/OH-INF/thing/Channels.xml
+++ b/bundles/org.openhab.binding.heos/src/main/resources/OH-INF/thing/Channels.xml
@@ -34,6 +34,10 @@
 			<tag>Mode</tag>
 		</tags>
 	</channel-type>
+	<channel-type id="chPlayer">
+		<item-type>Switch</item-type>
+		<label>Player</label>
+	</channel-type>
 	<channel-type id="playlists" advanced="true">
 		<item-type>String</item-type>
 		<label>Playlists</label>


### PR DESCRIPTION
This fixes an issue with creating dynamic channels for a channel type that doesn't exist. It is not created dynamically using `ChannelTypeBuilder` and it's not defined statically in the XML either. This leads to warnings like this:
```text
[WARN ] [core.thing.internal.ThingManagerImpl] - Failed to normalize configuration for new thing during update 'heos:bridge:denon': {thing/channel=Type description heos:chPlayer for heos:bridge:denon:Pdenon not found, although we checked the presence before.}
```

and the dynamic channels not being added to the `bridge` thing at all. It seems this goes all the way back to #6099.