### PR TITLE
[fronius] Fix bad float comparison causing battery control failure

### DIFF
--- a/bundles/org.openhab.binding.fronius/src/main/java/org/openhab/binding/fronius/internal/api/FroniusConfigAuthUtil.java
+++ b/bundles/org.openhab.binding.fronius/src/main/java/org/openhab/binding/fronius/internal/api/FroniusConfigAuthUtil.java
@@ -212,7 +212,7 @@ public class FroniusConfigAuthUtil {
     public static synchronized String login(HttpClient httpClient, float firmwareVersion, URI baseUri, String username,
             String password, HttpMethod method, String relativeUrl, int timeout)
             throws FroniusCommunicationException, FroniusUnauthorizedException {
-        final String hashAlgorithm = firmwareVersion >= 1.38 ? "SHA-256" : "MD5";
+        final String hashAlgorithm = firmwareVersion > 1.37 ? "SHA-256" : "MD5";
         final URI loginUri = URI.create(baseUri + LOGIN_ENDPOINT + "?user=" + username);
         final String relativeLoginUrl = loginUri.getPath();
 


### PR DESCRIPTION
... for inverter FW >= 1.37

This is a fix for a set of backported Fronius PRs and therefore has to go to 4.3.x. This fix is not required for 5.0.x and newer, as there we use the SemverVersion for handling the version.