### PR TITLE
[matter] Fix image links

### DIFF
--- a/bundles/org.openhab.binding.matter/README.md
+++ b/bundles/org.openhab.binding.matter/README.md
@@ -375,7 +375,7 @@ There are two ways in which to configure the Matter bridge:
 1. Using the "Matter Bridge Configuration" settings page (Main UI -> Settings -> Add-on Settings -> Matter Binding) for bridge status, general configuration and pairing 3rd party clients.
 1. Adding Matter metadata tags to Groups and Items either through the Main UI or through item files.
 
-<img src="./doc/bridge-settings.png" alt="Bridge Settings" width="500"/>
+<img src="doc/bridge-settings.png" alt="Bridge Settings" width="500"/>
 
 The openHAB matter bridge uses metadata tags with the key "matter", similar to the Alexa, Google Assistant and Apple Homekit integrations.
 Matter Metadata tag values generally follow the Matter "Device Type" and "Cluster" specification as much as possible.
@@ -412,7 +412,7 @@ Pairing codes and other options can be found in the MainUI under "Settings -> Ad
 
 When the matter bridge starts, if no 3rd party clients are paired, it will automatically open the "Commissioning Window", meaning you can use the QR code or manual pair code found in the bridge settings page to pair a new client like Alexa, Google Home or Apple Home.
 
-<img src="./doc/bridge-settings-pair.png" alt="Commissioning Window" width="500"/>
+<img src="doc/bridge-settings-pair.png" alt="Commissioning Window" width="500"/>
 
 Once a client is paired, the bridge will default to having its "Commissioning Window" closed and can not be paired with until the window is opened again in the settings.
 


### PR DESCRIPTION
This is an attempt to fix images in the [Matter documentation](https://next.openhab.org/addons/bindings/matter/).

There are four image files: https://github.com/openhab/openhab-addons/tree/main/bundles/org.openhab.binding.matter/doc

These images work:
- `<img src="./doc/bridge-settings.png" alt="Bridge Settings" width="500"/>` becomes `<img src="/assets/img/bridge-settings.e0306381.png" alt="Bridge Settings" width="500">`
- `<img src="./doc/bridge-settings-pair.png" alt="Commissioning Window" width="500"/>` becomes `<img src="/assets/img/bridge-settings-pair.d4048767.png" alt="Commissioning Window" width="500">`

And these do not:
- `<img src="doc/thing-discovery.png" alt="Thing Discovery" width="600"/>` becomes `<img src="doc/thing-discovery.png" alt="Thing Discovery" width="600">`
- `<img src="doc/pairing.png" alt="Matter Pairing" width="600"/>` becomes `<img src="doc/pairing.png" alt="Matter Pairing" width="600">`

The only difference seems to be the current directory reference in two of them: `./`. Those two happens to be working, but I'm not sure that's the reason. Could it be that they all need to be either with or without? For example, the MyBMW binding doesn't use `./` and all images seem to work.

It could also be a completely different issue that I have missed. In any case, it probably won't hurt to make these links consistent.