### PR TITLE
[matter] Send a source with all commands to items

### DIFF
--- a/bundles/org.openhab.binding.matter/src/main/java/org/openhab/binding/matter/internal/bridge/devices/BaseDevice.java
+++ b/bundles/org.openhab.binding.matter/src/main/java/org/openhab/binding/matter/internal/bridge/devices/BaseDevice.java
@@ -41,6 +41,9 @@ import org.slf4j.LoggerFactory;
  */
 @NonNullByDefault
 public abstract class BaseDevice implements StateChangeListener {
+    // The "source" sent with command events so rules can identify them as coming from Matter
+    public static final String MATTER_SOURCE = "org.openhab.binding.matter";
+
     protected final Logger logger = LoggerFactory.getLogger(getClass());
 
     protected final GenericItem primaryItem;

--- a/bundles/org.openhab.binding.matter/src/main/java/org/openhab/binding/matter/internal/bridge/devices/ColorDevice.java
+++ b/bundles/org.openhab.binding.matter/src/main/java/org/openhab/binding/matter/internal/bridge/devices/ColorDevice.java
@@ -155,7 +155,7 @@ public class ColorDevice extends BaseDevice {
     private void updateBrightness(PercentType brightness) {
         if (primaryItem instanceof ColorItem colorItem) {
             lastB = brightness;
-            colorItem.send(brightness);
+            colorItem.send(brightness, MATTER_SOURCE);
         }
     }
 
@@ -176,7 +176,7 @@ public class ColorDevice extends BaseDevice {
                     }
                 });
             }
-            colorItem.send(OnOffType.from(onOff));
+            colorItem.send(OnOffType.from(onOff), MATTER_SOURCE);
         }
     }
 
@@ -212,7 +212,7 @@ public class ColorDevice extends BaseDevice {
             if (b.intValue() == 0) {
                 b = new PercentType(100);
             }
-            colorItem.send(new HSBType(h, s, b));
+            colorItem.send(new HSBType(h, s, b), MATTER_SOURCE);
         }
         this.lastH = null;
         this.lastS = null;

--- a/bundles/org.openhab.binding.matter/src/main/java/org/openhab/binding/matter/internal/bridge/devices/DimmableLightDevice.java
+++ b/bundles/org.openhab.binding.matter/src/main/java/org/openhab/binding/matter/internal/bridge/devices/DimmableLightDevice.java
@@ -120,17 +120,17 @@ public class DimmableLightDevice extends BaseDevice {
     private void updateOnOff(OnOffType onOffType) {
         lastOnOffState = onOffType;
         if (primaryItem instanceof GroupItem groupItem) {
-            groupItem.send(onOffType);
+            groupItem.send(onOffType, MATTER_SOURCE);
         } else {
-            ((SwitchItem) primaryItem).send(onOffType);
+            ((SwitchItem) primaryItem).send(onOffType, MATTER_SOURCE);
         }
     }
 
     private void updateLevel(PercentType level) {
         if (primaryItem instanceof GroupItem groupItem) {
-            groupItem.send(level);
+            groupItem.send(level, MATTER_SOURCE);
         } else {
-            ((DimmerItem) primaryItem).send(level);
+            ((DimmerItem) primaryItem).send(level, MATTER_SOURCE);
         }
     }
 }

--- a/bundles/org.openhab.binding.matter/src/main/java/org/openhab/binding/matter/internal/bridge/devices/DoorLockDevice.java
+++ b/bundles/org.openhab.binding.matter/src/main/java/org/openhab/binding/matter/internal/bridge/devices/DoorLockDevice.java
@@ -50,9 +50,9 @@ public class DoorLockDevice extends BaseDevice {
                 int lockInt = ((Double) data).intValue();
                 boolean locked = DoorLockCluster.LockStateEnum.LOCKED.getValue() == lockInt;
                 if (primaryItem instanceof GroupItem groupItem) {
-                    groupItem.send(OnOffType.from(locked));
+                    groupItem.send(OnOffType.from(locked), MATTER_SOURCE);
                 } else {
-                    ((SwitchItem) primaryItem).send(OnOffType.from(locked));
+                    ((SwitchItem) primaryItem).send(OnOffType.from(locked), MATTER_SOURCE);
                 }
             }
             default:

--- a/bundles/org.openhab.binding.matter/src/main/java/org/openhab/binding/matter/internal/bridge/devices/FanDevice.java
+++ b/bundles/org.openhab.binding.matter/src/main/java/org/openhab/binding/matter/internal/bridge/devices/FanDevice.java
@@ -77,11 +77,11 @@ public class FanDevice extends BaseDevice {
                         int mode = ((Double) data).intValue();
                         String mappedMode = fanModeMapper.toCustomValue(mode);
                         if (item instanceof NumberItem numberItem) {
-                            numberItem.send(new DecimalType(mappedMode));
+                            numberItem.send(new DecimalType(mappedMode), MATTER_SOURCE);
                         } else if (item instanceof StringItem stringItem) {
-                            stringItem.send(new StringType(mappedMode));
+                            stringItem.send(new StringType(mappedMode), MATTER_SOURCE);
                         } else if (item instanceof SwitchItem switchItem) {
-                            switchItem.send(mode > 0 ? OnOffType.ON : OnOffType.OFF);
+                            switchItem.send(mode > 0 ? OnOffType.ON : OnOffType.OFF, MATTER_SOURCE);
                         }
                     } catch (FanModeMappingException e) {
                         logger.debug("Could not convert {} to custom value", data);
@@ -90,15 +90,15 @@ public class FanDevice extends BaseDevice {
                 case FanControlCluster.ATTRIBUTE_PERCENT_SETTING:
                     int level = ((Double) data).intValue();
                     if (item instanceof GroupItem groupItem) {
-                        groupItem.send(new PercentType(level));
+                        groupItem.send(new PercentType(level), MATTER_SOURCE);
                     } else if (item instanceof DimmerItem dimmerItem) {
-                        dimmerItem.send(new PercentType(level));
+                        dimmerItem.send(new PercentType(level), MATTER_SOURCE);
                     }
                     break;
                 case OnOffCluster.ATTRIBUTE_ON_OFF:
                     if (item instanceof SwitchItem switchItem) {
                         OnOffType onOff = OnOffType.from((Boolean) data);
-                        switchItem.send(onOff);
+                        switchItem.send(onOff, MATTER_SOURCE);
                         lastOnOff = onOff;
                     }
                     break;
@@ -114,7 +114,7 @@ public class FanDevice extends BaseDevice {
                     GenericItem genericItem = itemForAttribute(OnOffCluster.CLUSTER_PREFIX,
                             OnOffCluster.ATTRIBUTE_ON_OFF);
                     if (genericItem instanceof SwitchItem switchItem) {
-                        switchItem.send(OnOffType.from(level > 0));
+                        switchItem.send(OnOffType.from(level > 0), MATTER_SOURCE);
                     }
                     // try and update the fan mode if set
                     genericItem = itemForAttribute(FanControlCluster.CLUSTER_PREFIX,
@@ -124,11 +124,11 @@ public class FanDevice extends BaseDevice {
                                 .toCustomValue(level > 0 ? FanControlCluster.FanModeEnum.ON.getValue()
                                         : FanControlCluster.FanModeEnum.OFF.getValue());
                         if (genericItem instanceof NumberItem numberItem) {
-                            numberItem.send(new DecimalType(mappedMode));
+                            numberItem.send(new DecimalType(mappedMode), MATTER_SOURCE);
                         } else if (genericItem instanceof StringItem stringItem) {
-                            stringItem.send(new StringType(mappedMode));
+                            stringItem.send(new StringType(mappedMode), MATTER_SOURCE);
                         } else if (genericItem instanceof SwitchItem switchItem) {
-                            switchItem.send(OnOffType.from(level > 0));
+                            switchItem.send(OnOffType.from(level > 0), MATTER_SOURCE);
                         }
                     } catch (FanModeMappingException e) {
                         logger.debug("Could not convert {} to custom value", data);
@@ -141,14 +141,14 @@ public class FanDevice extends BaseDevice {
                             FanControlCluster.ATTRIBUTE_PERCENT_SETTING);
                     PercentType level = mode > 0 ? PercentType.HUNDRED : PercentType.ZERO;
                     if (genericItem instanceof GroupItem groupItem) {
-                        groupItem.send(level);
+                        groupItem.send(level, MATTER_SOURCE);
                     } else if (genericItem instanceof DimmerItem dimmerItem) {
-                        dimmerItem.send(level);
+                        dimmerItem.send(level, MATTER_SOURCE);
                     }
                     // try and update the on/off state if set
                     genericItem = itemForAttribute(OnOffCluster.CLUSTER_PREFIX, OnOffCluster.ATTRIBUTE_ON_OFF);
                     if (genericItem instanceof SwitchItem switchItem) {
-                        switchItem.send(OnOffType.from(mode > 0));
+                        switchItem.send(OnOffType.from(mode > 0), MATTER_SOURCE);
                     }
                 }
                     break;

--- a/bundles/org.openhab.binding.matter/src/main/java/org/openhab/binding/matter/internal/bridge/devices/ModeSelectDevice.java
+++ b/bundles/org.openhab.binding.matter/src/main/java/org/openhab/binding/matter/internal/bridge/devices/ModeSelectDevice.java
@@ -173,26 +173,26 @@ public class ModeSelectDevice extends BaseDevice {
         String value = modeMappings.get(mode);
         if (value != null) {
             if (primaryItem instanceof GroupItem groupItem) {
-                groupItem.send(new StringType(value));
+                groupItem.send(new StringType(value), MATTER_SOURCE);
             } else if (primaryItem instanceof StringItem stringItem) {
-                stringItem.send(new StringType(value));
+                stringItem.send(new StringType(value), MATTER_SOURCE);
             } else if (primaryItem instanceof NumberItem numberItem) {
-                numberItem.send(new DecimalType(value));
+                numberItem.send(new DecimalType(value), MATTER_SOURCE);
             } else if (primaryItem instanceof SwitchItem switchItem) {
-                switchItem.send(OnOffType.from(value));
+                switchItem.send(OnOffType.from(value), MATTER_SOURCE);
             } else if (primaryItem instanceof RollershutterItem rollershutterItem) {
                 switch (value.toUpperCase()) {
                     case "UP":
                     case "DOWN":
-                        rollershutterItem.send(UpDownType.valueOf(value.toUpperCase()));
+                        rollershutterItem.send(UpDownType.valueOf(value.toUpperCase()), MATTER_SOURCE);
                         break;
                     case "STOP":
                     case "MOVE":
-                        rollershutterItem.send(StopMoveType.valueOf(value.toUpperCase()));
+                        rollershutterItem.send(StopMoveType.valueOf(value.toUpperCase()), MATTER_SOURCE);
                         break;
                     default:
                         try {
-                            rollershutterItem.send(new PercentType(Integer.parseInt(value)));
+                            rollershutterItem.send(new PercentType(Integer.parseInt(value)), MATTER_SOURCE);
                         } catch (NumberFormatException ignored) {
                         }
                         break;

--- a/bundles/org.openhab.binding.matter/src/main/java/org/openhab/binding/matter/internal/bridge/devices/OnOffLightDevice.java
+++ b/bundles/org.openhab.binding.matter/src/main/java/org/openhab/binding/matter/internal/bridge/devices/OnOffLightDevice.java
@@ -51,18 +51,18 @@ public class OnOffLightDevice extends BaseDevice {
         switch (attributeName) {
             case OnOffCluster.ATTRIBUTE_ON_OFF: {
                 if (primaryItem instanceof GroupItem groupItem) {
-                    groupItem.send(OnOffType.from(Boolean.valueOf(data.toString())));
+                    groupItem.send(OnOffType.from(Boolean.valueOf(data.toString())), MATTER_SOURCE);
                 } else if (primaryItem instanceof SwitchItem switchItem) {
-                    switchItem.send(OnOffType.from(Boolean.valueOf(data.toString())));
+                    switchItem.send(OnOffType.from(Boolean.valueOf(data.toString())), MATTER_SOURCE);
                 }
             }
                 break;
             case LevelControlCluster.ATTRIBUTE_CURRENT_LEVEL: {
                 OnOffType onOff = OnOffType.from(((Double) data).intValue() > 0);
                 if (primaryItem instanceof GroupItem groupItem) {
-                    groupItem.send(onOff);
+                    groupItem.send(onOff, MATTER_SOURCE);
                 } else if (primaryItem instanceof SwitchItem switchItem) {
-                    switchItem.send(onOff);
+                    switchItem.send(onOff, MATTER_SOURCE);
                 }
             }
                 break;

--- a/bundles/org.openhab.binding.matter/src/main/java/org/openhab/binding/matter/internal/bridge/devices/ThermostatDevice.java
+++ b/bundles/org.openhab.binding.matter/src/main/java/org/openhab/binding/matter/internal/bridge/devices/ThermostatDevice.java
@@ -68,7 +68,7 @@ public class ThermostatDevice extends BaseDevice {
                         if (item instanceof NumberItem numberItem) {
                             QuantityType<Temperature> t = ValueUtils
                                     .valueToTemperature(Float.valueOf(data.toString()).intValue());
-                            numberItem.send(t);
+                            numberItem.send(t, MATTER_SOURCE);
                         }
                         break;
                     case ThermostatCluster.ATTRIBUTE_SYSTEM_MODE:
@@ -76,11 +76,11 @@ public class ThermostatDevice extends BaseDevice {
                             int mode = ((Double) data).intValue();
                             String mappedMode = systemModeMapper.toCustomValue(mode);
                             if (item instanceof NumberItem numberItem) {
-                                numberItem.send(new DecimalType(mappedMode));
+                                numberItem.send(new DecimalType(mappedMode), MATTER_SOURCE);
                             } else if (item instanceof StringItem stringItem) {
-                                stringItem.send(new StringType(mappedMode));
+                                stringItem.send(new StringType(mappedMode), MATTER_SOURCE);
                             } else if (item instanceof SwitchItem switchItem) {
-                                switchItem.send(OnOffType.from(mode > 0));
+                                switchItem.send(OnOffType.from(mode > 0), MATTER_SOURCE);
                             }
                         } catch (SystemModeMappingException e) {
                             logger.debug("Could not convert {} to custom value", data);

--- a/bundles/org.openhab.binding.matter/src/main/java/org/openhab/binding/matter/internal/bridge/devices/WindowCoveringDevice.java
+++ b/bundles/org.openhab.binding.matter/src/main/java/org/openhab/binding/matter/internal/bridge/devices/WindowCoveringDevice.java
@@ -98,16 +98,16 @@ public class WindowCoveringDevice extends BaseDevice {
                 int targetPercent = percentType.intValue();
                 Metadata primaryItemMetadata = this.primaryItemMetadata;
                 if (primaryItem instanceof GroupItem groupItem) {
-                    groupItem.send(percentType);
+                    groupItem.send(percentType, MATTER_SOURCE);
                 } else if (primaryItem instanceof DimmerItem dimmerItem) {
-                    dimmerItem.send(percentType);
+                    dimmerItem.send(percentType, MATTER_SOURCE);
                 } else if (primaryItem instanceof RollershutterItem rollerShutterItem) {
                     if (targetPercent == 100) {
-                        rollerShutterItem.send(UpDownType.DOWN);
+                        rollerShutterItem.send(UpDownType.DOWN, MATTER_SOURCE);
                     } else if (targetPercent == 0) {
-                        rollerShutterItem.send(UpDownType.UP);
+                        rollerShutterItem.send(UpDownType.UP, MATTER_SOURCE);
                     } else {
-                        rollerShutterItem.send(percentType);
+                        rollerShutterItem.send(percentType, MATTER_SOURCE);
                     }
                 } else if (primaryItem instanceof SwitchItem switchItem) {
                     // anything > 0 is considered partially open and ON , otherwise completely open and OFF (unless
@@ -116,13 +116,13 @@ public class WindowCoveringDevice extends BaseDevice {
                     if (invert) {
                         isOn = !isOn;
                     }
-                    switchItem.send(isOn ? OnOffType.ON : OnOffType.OFF);
+                    switchItem.send(isOn ? OnOffType.ON : OnOffType.OFF, MATTER_SOURCE);
                 } else if (primaryItem instanceof StringItem stringItem) {
                     Object value = targetPercent == 0 ? "OPEN" : "CLOSED";
                     if (primaryItemMetadata != null) {
                         value = primaryItemMetadata.getConfiguration().getOrDefault(value, value);
                     }
-                    stringItem.send(new StringType(value.toString()));
+                    stringItem.send(new StringType(value.toString()), MATTER_SOURCE);
                 }
                 lastTargetPercent = targetPercent;
                 break;
@@ -133,7 +133,7 @@ public class WindowCoveringDevice extends BaseDevice {
                     if (map.get("global") instanceof Integer value) {
                         if (WindowCoveringCluster.MovementStatus.STOPPED.getValue().equals(value)
                                 && primaryItem instanceof RollershutterItem rollerShutterItem) {
-                            rollerShutterItem.send(StopMoveType.STOP);
+                            rollerShutterItem.send(StopMoveType.STOP, MATTER_SOURCE);
                             cancelTimer();
                         }
                     }

--- a/bundles/org.openhab.binding.matter/src/test/java/org/openhab/binding/matter/internal/bridge/devices/ColorDeviceTest.java
+++ b/bundles/org.openhab.binding.matter/src/test/java/org/openhab/binding/matter/internal/bridge/devices/ColorDeviceTest.java
@@ -19,6 +19,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.openhab.binding.matter.internal.bridge.devices.BaseDevice.MATTER_SOURCE;
 
 import java.util.List;
 import java.util.Map;
@@ -89,29 +90,30 @@ class ColorDeviceTest {
     @Test
     void testHandleMatterEventOnOff() {
         device.handleMatterEvent("onOff", "onOff", true);
-        verify(colorItem).send(OnOffType.ON);
+        verify(colorItem).send(OnOffType.ON, MATTER_SOURCE);
 
         device.handleMatterEvent("onOff", "onOff", false);
-        verify(colorItem).send(OnOffType.OFF);
+        verify(colorItem).send(OnOffType.OFF, MATTER_SOURCE);
     }
 
     @Test
     void testHandleMatterEventColor() {
         // Turn device on first and wait for future completion
         device.handleMatterEvent("onOff", "onOff", true);
-        verify(colorItem).send(OnOffType.ON);
+        verify(colorItem).send(OnOffType.ON, MATTER_SOURCE);
         device.updateState(colorItem, initialHSBState);
 
         device.handleMatterEvent("colorControl", "currentHue", Double.valueOf(127));
         device.handleMatterEvent("colorControl", "currentSaturation", Double.valueOf(127));
 
-        verify(colorItem).send(new HSBType(new DecimalType(180), new PercentType(50), new PercentType(50)));
+        verify(colorItem).send(new HSBType(new DecimalType(180), new PercentType(50), new PercentType(50)),
+                MATTER_SOURCE);
     }
 
     @Test
     void testHandleMatterEventLevel() {
         device.handleMatterEvent("levelControl", "currentLevel", Double.valueOf(127));
-        verify(colorItem).send(new PercentType(50));
+        verify(colorItem).send(new PercentType(50), MATTER_SOURCE);
     }
 
     @Test

--- a/bundles/org.openhab.binding.matter/src/test/java/org/openhab/binding/matter/internal/bridge/devices/DimmableLightDeviceTest.java
+++ b/bundles/org.openhab.binding.matter/src/test/java/org/openhab/binding/matter/internal/bridge/devices/DimmableLightDeviceTest.java
@@ -19,6 +19,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.openhab.binding.matter.internal.bridge.devices.BaseDevice.MATTER_SOURCE;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -105,41 +106,41 @@ class DimmableLightDeviceTest {
     @Test
     void testHandleMatterEventOnOff() {
         dimmerDevice.handleMatterEvent("onOff", "onOff", true);
-        verify(dimmerItem).send(OnOffType.ON);
+        verify(dimmerItem).send(OnOffType.ON, MATTER_SOURCE);
 
         dimmerDevice.handleMatterEvent("onOff", "onOff", false);
-        verify(dimmerItem).send(OnOffType.OFF);
+        verify(dimmerItem).send(OnOffType.OFF, MATTER_SOURCE);
     }
 
     @Test
     void testHandleMatterEventOnOffGroup() {
         groupDevice.handleMatterEvent("onOff", "onOff", true);
-        verify(groupItem).send(OnOffType.ON);
+        verify(groupItem).send(OnOffType.ON, MATTER_SOURCE);
 
         groupDevice.handleMatterEvent("onOff", "onOff", false);
-        verify(groupItem).send(OnOffType.OFF);
+        verify(groupItem).send(OnOffType.OFF, MATTER_SOURCE);
     }
 
     @Test
     void testHandleMatterEventLevel() {
         dimmerDevice.handleMatterEvent("onOff", "onOff", true);
-        verify(dimmerItem).send(OnOffType.ON);
+        verify(dimmerItem).send(OnOffType.ON, MATTER_SOURCE);
 
         dimmerDevice.handleMatterEvent("levelControl", "currentLevel", Double.valueOf(254));
-        verify(dimmerItem).send(new PercentType(100));
+        verify(dimmerItem).send(new PercentType(100), MATTER_SOURCE);
 
         dimmerDevice.handleMatterEvent("levelControl", "currentLevel", Double.valueOf(127));
-        verify(dimmerItem).send(new PercentType(50));
+        verify(dimmerItem).send(new PercentType(50), MATTER_SOURCE);
     }
 
     @Test
     void testHandleMatterEventLevelGroup() {
         groupDevice.handleMatterEvent("onOff", "onOff", true);
         groupDevice.handleMatterEvent("levelControl", "currentLevel", Double.valueOf(254));
-        verify(groupItem).send(new PercentType(100));
+        verify(groupItem).send(new PercentType(100), MATTER_SOURCE);
 
         groupDevice.handleMatterEvent("levelControl", "currentLevel", Double.valueOf(127));
-        verify(groupItem).send(new PercentType(50));
+        verify(groupItem).send(new PercentType(50), MATTER_SOURCE);
     }
 
     @Test

--- a/bundles/org.openhab.binding.matter/src/test/java/org/openhab/binding/matter/internal/bridge/devices/DoorLockDeviceTest.java
+++ b/bundles/org.openhab.binding.matter/src/test/java/org/openhab/binding/matter/internal/bridge/devices/DoorLockDeviceTest.java
@@ -18,6 +18,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.openhab.binding.matter.internal.bridge.devices.BaseDevice.MATTER_SOURCE;
 
 import java.util.Map;
 
@@ -87,22 +88,22 @@ class DoorLockDeviceTest {
     void testHandleMatterEventLockState() {
         switchDevice.handleMatterEvent("doorLock", "lockState",
                 Double.valueOf(DoorLockCluster.LockStateEnum.LOCKED.getValue()));
-        verify(switchItem).send(OnOffType.ON);
+        verify(switchItem).send(OnOffType.ON, MATTER_SOURCE);
 
         switchDevice.handleMatterEvent("doorLock", "lockState",
                 Double.valueOf(DoorLockCluster.LockStateEnum.UNLOCKED.getValue()));
-        verify(switchItem).send(OnOffType.OFF);
+        verify(switchItem).send(OnOffType.OFF, MATTER_SOURCE);
     }
 
     @Test
     void testHandleMatterEventLockStateGroup() {
         groupDevice.handleMatterEvent("doorLock", "lockState",
                 Double.valueOf(DoorLockCluster.LockStateEnum.LOCKED.getValue()));
-        verify(groupItem).send(OnOffType.ON);
+        verify(groupItem).send(OnOffType.ON, MATTER_SOURCE);
 
         groupDevice.handleMatterEvent("doorLock", "lockState",
                 Double.valueOf(DoorLockCluster.LockStateEnum.UNLOCKED.getValue()));
-        verify(groupItem).send(OnOffType.OFF);
+        verify(groupItem).send(OnOffType.OFF, MATTER_SOURCE);
     }
 
     @Test

--- a/bundles/org.openhab.binding.matter/src/test/java/org/openhab/binding/matter/internal/bridge/devices/OnOffLightDeviceTest.java
+++ b/bundles/org.openhab.binding.matter/src/test/java/org/openhab/binding/matter/internal/bridge/devices/OnOffLightDeviceTest.java
@@ -19,6 +19,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.openhab.binding.matter.internal.bridge.devices.BaseDevice.MATTER_SOURCE;
 
 import java.util.Map;
 
@@ -86,19 +87,19 @@ class OnOffLightDeviceTest {
     @Test
     void testHandleMatterEventOnOff() {
         device.handleMatterEvent("onOff", "onOff", true);
-        verify(switchItem).send(OnOffType.ON);
+        verify(switchItem).send(OnOffType.ON, MATTER_SOURCE);
 
         device.handleMatterEvent("onOff", "onOff", false);
-        verify(switchItem).send(OnOffType.OFF);
+        verify(switchItem).send(OnOffType.OFF, MATTER_SOURCE);
     }
 
     @Test
     void testHandleMatterEventOnOffGroup() {
         groupDevice.handleMatterEvent("onOff", "onOff", true);
-        verify(groupItem).send(OnOffType.ON);
+        verify(groupItem).send(OnOffType.ON, MATTER_SOURCE);
 
         groupDevice.handleMatterEvent("onOff", "onOff", false);
-        verify(groupItem).send(OnOffType.OFF);
+        verify(groupItem).send(OnOffType.OFF, MATTER_SOURCE);
     }
 
     @Test

--- a/bundles/org.openhab.binding.matter/src/test/java/org/openhab/binding/matter/internal/bridge/devices/WindowCoveringDeviceTest.java
+++ b/bundles/org.openhab.binding.matter/src/test/java/org/openhab/binding/matter/internal/bridge/devices/WindowCoveringDeviceTest.java
@@ -18,6 +18,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.openhab.binding.matter.internal.bridge.devices.BaseDevice.MATTER_SOURCE;
 
 import java.util.AbstractMap;
 import java.util.LinkedHashMap;
@@ -114,7 +115,7 @@ class WindowCoveringDeviceTest {
     @Test
     void testHandleMatterEventPosition() {
         shutterDevice.handleMatterEvent("windowCovering", "targetPositionLiftPercent100ths", 5000.0);
-        verify(rollershutterItem).send(new PercentType(50));
+        verify(rollershutterItem).send(new PercentType(50), MATTER_SOURCE);
     }
 
     @Test
@@ -123,7 +124,7 @@ class WindowCoveringDeviceTest {
         stoppedStatus.put("global", WindowCoveringCluster.MovementStatus.STOPPED.getValue());
 
         shutterDevice.handleMatterEvent("windowCovering", "operationalStatus", stoppedStatus);
-        verify(rollershutterItem).send(StopMoveType.STOP);
+        verify(rollershutterItem).send(StopMoveType.STOP, MATTER_SOURCE);
     }
 
     @Test
@@ -148,52 +149,52 @@ class WindowCoveringDeviceTest {
     void testHandleMatterEventWithDimmer() {
         // Test 50% position
         dimmerDevice.handleMatterEvent("windowCovering", "targetPositionLiftPercent100ths", 5000.0);
-        verify(dimmerItem).send(new PercentType(50));
+        verify(dimmerItem).send(new PercentType(50), MATTER_SOURCE);
 
         // Test fully open
         dimmerDevice.handleMatterEvent("windowCovering", "targetPositionLiftPercent100ths", 0.0);
-        verify(dimmerItem).send(new PercentType(0));
+        verify(dimmerItem).send(new PercentType(0), MATTER_SOURCE);
 
         // Test fully closed
         dimmerDevice.handleMatterEvent("windowCovering", "targetPositionLiftPercent100ths", 10000.0);
-        verify(dimmerItem).send(new PercentType(100));
+        verify(dimmerItem).send(new PercentType(100), MATTER_SOURCE);
     }
 
     @Test
     void testHandleMatterEventWithRollershutter() {
         // Test fully closed
         shutterDevice.handleMatterEvent("windowCovering", "targetPositionLiftPercent100ths", 10000.0);
-        verify(rollershutterItem).send(UpDownType.DOWN);
+        verify(rollershutterItem).send(UpDownType.DOWN, MATTER_SOURCE);
 
         // Test fully open
         shutterDevice.handleMatterEvent("windowCovering", "targetPositionLiftPercent100ths", 0.0);
-        verify(rollershutterItem).send(UpDownType.UP);
+        verify(rollershutterItem).send(UpDownType.UP, MATTER_SOURCE);
 
         // Test 50% position
         shutterDevice.handleMatterEvent("windowCovering", "targetPositionLiftPercent100ths", 5000.0);
-        verify(rollershutterItem).send(new PercentType(50));
+        verify(rollershutterItem).send(new PercentType(50), MATTER_SOURCE);
     }
 
     @Test
     void testHandleMatterEventWithSwitch() {
         // Test fully closed
         switchDevice.handleMatterEvent("windowCovering", "targetPositionLiftPercent100ths", 10000.0);
-        verify(switchItem).send(OnOffType.ON);
+        verify(switchItem).send(OnOffType.ON, MATTER_SOURCE);
 
         // Test fully open
         switchDevice.handleMatterEvent("windowCovering", "targetPositionLiftPercent100ths", 0.0);
-        verify(switchItem).send(OnOffType.OFF);
+        verify(switchItem).send(OnOffType.OFF, MATTER_SOURCE);
     }
 
     @Test
     void testHandleMatterEventWithString() {
         // Test fully open
         stringDevice.handleMatterEvent("windowCovering", "targetPositionLiftPercent100ths", 0.0);
-        verify(stringItem).send(new StringType("UP"));
+        verify(stringItem).send(new StringType("UP"), MATTER_SOURCE);
 
         // Test fully closed
         stringDevice.handleMatterEvent("windowCovering", "targetPositionLiftPercent100ths", 10000.0);
-        verify(stringItem).send(new StringType("DOWN"));
+        verify(stringItem).send(new StringType("DOWN"), MATTER_SOURCE);
     }
 
     @Test
@@ -241,11 +242,11 @@ class WindowCoveringDeviceTest {
         invertedSwitchDevice.activate();
         // Test fully closed (100%) - should result in OFF for inverted switch
         invertedSwitchDevice.handleMatterEvent("windowCovering", "targetPositionLiftPercent100ths", 10000.0);
-        verify(invertedSwitchItem).send(OnOffType.OFF);
+        verify(invertedSwitchItem).send(OnOffType.OFF, MATTER_SOURCE);
 
         // Test fully open (0%) - should result in ON for inverted switch
         invertedSwitchDevice.handleMatterEvent("windowCovering", "targetPositionLiftPercent100ths", 0.0);
-        verify(invertedSwitchItem).send(OnOffType.ON);
+        verify(invertedSwitchItem).send(OnOffType.ON, MATTER_SOURCE);
 
         // Test state updates from switch to position
         invertedSwitchDevice.updateState(invertedSwitchItem, OnOffType.ON);
@@ -261,11 +262,11 @@ class WindowCoveringDeviceTest {
     void testSwitchItemWithNormalLogic() {
         // Test fully closed (100%) - should result in ON for normal switch
         switchDevice.handleMatterEvent("windowCovering", "targetPositionLiftPercent100ths", 10000.0);
-        verify(switchItem).send(OnOffType.ON);
+        verify(switchItem).send(OnOffType.ON, MATTER_SOURCE);
 
         // Test fully open (0%) - should result in OFF for normal switch
         switchDevice.handleMatterEvent("windowCovering", "targetPositionLiftPercent100ths", 0.0);
-        verify(switchItem).send(OnOffType.OFF);
+        verify(switchItem).send(OnOffType.OFF, MATTER_SOURCE);
 
         // Test state updates from switch to position
         switchDevice.updateState(switchItem, OnOffType.ON);


### PR DESCRIPTION
I'm not seeing a clear way to get any sort of identifier for what user/connection sent a message in MatterBridge.java, so this only emits the package name without any actor information.