### PR TITLE
[upnpcontrol] Missing TrackMetaData keys in onValueReceived switch case

### DIFF
--- a/bundles/org.openhab.binding.upnpcontrol/src/main/java/org/openhab/binding/upnpcontrol/internal/handler/UpnpRendererHandler.java
+++ b/bundles/org.openhab.binding.upnpcontrol/src/main/java/org/openhab/binding/upnpcontrol/internal/handler/UpnpRendererHandler.java
@@ -1086,7 +1086,8 @@ public class UpnpRendererHandler extends UpnpHandler {
                     break;
                 case "CurrentTrackMetaData":
                 case "CurrentURIMetaData":
-                case "TrackMetaData": // Some (non-compliant) renderers emit TrackMetaData instead of CurrentTrackMetaData/CurrentURIMetaData
+                case "TrackMetaData": // Some (non-compliant) renderers emit TrackMetaData instead of
+                                      // CurrentTrackMetaData/CurrentURIMetaData
                     onValueReceivedCurrentMetaData(value);
                     break;
                 case "NextAVTransportURIMetaData":


### PR DESCRIPTION
# Missing TrackMetaData keys in onValueReceived switch case

We are missing the TrackMetaData keys in onValueReceived function.
In some case, it prevent Openhab to synchronise current playing song metadata because some devices use this key.

Fixed: https://github.com/openhab/openhab-addons/issues/19486
