### PR TITLE
[homeassistant] Fix re-connection after connection loss

### DIFF
--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/handler/HomeAssistantThingHandler.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/handler/HomeAssistantThingHandler.java
@@ -201,6 +201,7 @@ public class HomeAssistantThingHandler extends AbstractMQTTThingHandler
 
     @Override
     public void dispose() {
+        discoveryHomeAssistantIDs.clear();
         removeStateDescriptions();
         // super.dispose() calls stop()
         super.dispose();
@@ -251,7 +252,6 @@ public class HomeAssistantThingHandler extends AbstractMQTTThingHandler
             haComponentsByUniqueId.clear();
             haComponentsByHaId.clear();
             channelStates.clear();
-            discoveryHomeAssistantIDs.clear();
             updateComponent = null;
             started = false;
         }


### PR DESCRIPTION
A connection loss only goes through a `stop`/start cycle, not a `dispose`/`initialize` cycle. `discoveryHomeAssistantIDs` (the list of discovery topics to subscribe to) only gets populated in `initialize`, so don't clear it in `stop` -- only in `dispose`.

This means that after a reconnect, it had forgetten which topics it needed to subscribe to.

Fixes #19431 