### PR TITLE
[matter] Bumps matter.js to latest v15

### DIFF
--- a/bundles/org.openhab.binding.matter/code-gen/package-lock.json
+++ b/bundles/org.openhab.binding.matter/code-gen/package-lock.json
@@ -8,7 +8,7 @@
             "name": "code-gen",
             "version": "0.1.0",
             "dependencies": {
-                "@matter/main": "v0.15.2",
+                "@matter/main": "v0.15.6",
                 "handlebars": "^4.7.8"
             },
             "devDependencies": {
@@ -124,85 +124,85 @@
             }
         },
         "node_modules/@matter/general": {
-            "version": "0.15.2",
-            "resolved": "https://registry.npmjs.org/@matter/general/-/general-0.15.2.tgz",
-            "integrity": "sha512-b160CG9ucZRWJD8KCQj6Tylqy73Z6wYloP+6mzSX1u6pwHeISbhSRKJBXSm9gsFPFsFVQgSLP1wMk3KtJ0sy7g==",
+            "version": "0.15.6",
+            "resolved": "https://registry.npmjs.org/@matter/general/-/general-0.15.6.tgz",
+            "integrity": "sha512-KhFUKNCD1F55Q1uvJbLpYAFHpAO5P24MWys8gWdNetm5UuzDoUIWhVMBxxHd+sAFFYIaNr8HlXdxJSKQSLC+ww==",
             "dependencies": {
-                "@noble/curves": "^1.9.4"
+                "@noble/curves": "^1.9.5"
             }
         },
         "node_modules/@matter/main": {
-            "version": "0.15.2",
-            "resolved": "https://registry.npmjs.org/@matter/main/-/main-0.15.2.tgz",
-            "integrity": "sha512-93Mqr0DmHO7QNAD2NdZFULFTYS0s1GFtPS3q0V5JKtzJ/W1LJzHYcQNPegD6sZJgCbouuzztWmDeyRsFXB06Rw==",
+            "version": "0.15.6",
+            "resolved": "https://registry.npmjs.org/@matter/main/-/main-0.15.6.tgz",
+            "integrity": "sha512-V9d8SMBJd66JLIGYCG695st2Q1eCwdzkkVwGwqnv2Fi/T4lovtWuKtRb2r5gvYj+cZ9vuLPmNSOWtAAXrTNJ1w==",
             "dependencies": {
-                "@matter/general": "0.15.2",
-                "@matter/model": "0.15.2",
-                "@matter/node": "0.15.2",
-                "@matter/protocol": "0.15.2",
-                "@matter/types": "0.15.2"
+                "@matter/general": "0.15.6",
+                "@matter/model": "0.15.6",
+                "@matter/node": "0.15.6",
+                "@matter/protocol": "0.15.6",
+                "@matter/types": "0.15.6"
             },
             "optionalDependencies": {
-                "@matter/nodejs": "0.15.2"
+                "@matter/nodejs": "0.15.6"
             }
         },
         "node_modules/@matter/model": {
-            "version": "0.15.2",
-            "resolved": "https://registry.npmjs.org/@matter/model/-/model-0.15.2.tgz",
-            "integrity": "sha512-8h47ks+hnyySal/70cuHXWk+xeYKLJdmcTLPRuJIegm5MoeH36hP4yhW3AH92Ej4tHTMiyHf1F9qShZq9/7Z0A==",
+            "version": "0.15.6",
+            "resolved": "https://registry.npmjs.org/@matter/model/-/model-0.15.6.tgz",
+            "integrity": "sha512-WrbQE1EBgITpG64zEjTtTeyA4VEtFEbZyKpjKiKKJ2+1Z5cABTYO7xAOAjO1QsiZn9O1nlsL479weVfBiehByg==",
             "dependencies": {
-                "@matter/general": "0.15.2"
+                "@matter/general": "0.15.6"
             }
         },
         "node_modules/@matter/node": {
-            "version": "0.15.2",
-            "resolved": "https://registry.npmjs.org/@matter/node/-/node-0.15.2.tgz",
-            "integrity": "sha512-4ZmRNE4SU+aj/DXV8xN2ypZXr/9hVJE8Yj52byQVBdTj7Uh/eRVLoPN19egIBc+VXdrD0uHVaHRhS0yInVBogQ==",
+            "version": "0.15.6",
+            "resolved": "https://registry.npmjs.org/@matter/node/-/node-0.15.6.tgz",
+            "integrity": "sha512-AtGbcBoNKlV3lYo3xg08zkn5uIvAjwoASulEfP8ZjKKLn6H6a3OLN8NPQGX+MeAWyVRgw5lqHwW4SPcBF8YAVQ==",
             "dependencies": {
-                "@matter/general": "0.15.2",
-                "@matter/model": "0.15.2",
-                "@matter/protocol": "0.15.2",
-                "@matter/types": "0.15.2"
+                "@matter/general": "0.15.6",
+                "@matter/model": "0.15.6",
+                "@matter/protocol": "0.15.6",
+                "@matter/types": "0.15.6"
             }
         },
         "node_modules/@matter/nodejs": {
-            "version": "0.15.2",
-            "resolved": "https://registry.npmjs.org/@matter/nodejs/-/nodejs-0.15.2.tgz",
-            "integrity": "sha512-Lgsv1Uvejq0/e2mdUmlXiabopw7xIshybIZWkWtYXT1egyXKNfRev69XiH+fCRzjxDbkKRweMFOHSpv9PQ2YKg==",
+            "version": "0.15.6",
+            "resolved": "https://registry.npmjs.org/@matter/nodejs/-/nodejs-0.15.6.tgz",
+            "integrity": "sha512-qkmnWRVLgj4dvYC6B3AxTR3TOylptZKc6cPhJix3m7VrxmI0mSv4mQ1iU8wCecpMeTi03RINDyA94ZA4UFDvtw==",
             "optional": true,
             "dependencies": {
-                "@matter/general": "0.15.2",
-                "@matter/node": "0.15.2",
-                "@matter/protocol": "0.15.2",
-                "@matter/types": "0.15.2"
+                "@matter/general": "0.15.6",
+                "@matter/node": "0.15.6",
+                "@matter/protocol": "0.15.6",
+                "@matter/types": "0.15.6"
             },
             "engines": {
                 "node": ">=18.0.0"
             }
         },
         "node_modules/@matter/protocol": {
-            "version": "0.15.2",
-            "resolved": "https://registry.npmjs.org/@matter/protocol/-/protocol-0.15.2.tgz",
-            "integrity": "sha512-7hycAbst9Laoc9w986nhEB6t9JoYYtiIQndMdVe5Qjq/BeOlDa0iEtJKTDVMKN2T4ML19Nq+m1tUGAoFBz1qHQ==",
+            "version": "0.15.6",
+            "resolved": "https://registry.npmjs.org/@matter/protocol/-/protocol-0.15.6.tgz",
+            "integrity": "sha512-oU+6zBMZuRf7f7srDT769G6hBS1Wvwa30VUNTXJvh1+vf4Apl9Ys6vealJLjU61SwE6ucarxZ+P5U2pDnK6RDw==",
             "dependencies": {
-                "@matter/general": "0.15.2",
-                "@matter/model": "0.15.2",
-                "@matter/types": "0.15.2"
+                "@matter/general": "0.15.6",
+                "@matter/model": "0.15.6",
+                "@matter/types": "0.15.6"
             }
         },
         "node_modules/@matter/types": {
-            "version": "0.15.2",
-            "resolved": "https://registry.npmjs.org/@matter/types/-/types-0.15.2.tgz",
-            "integrity": "sha512-70vPowfi+1GEAZ5F+ZI7I3WjX0dw0o9b8i+dt5sVt0D7CirxJkPY0XsLTWJHLKBGmSpLxY9J3XeQDUqva6sLmA==",
+            "version": "0.15.6",
+            "resolved": "https://registry.npmjs.org/@matter/types/-/types-0.15.6.tgz",
+            "integrity": "sha512-vjVBKCTui4+v0hRF+jN+el6HU5hpxsRiChQaXaLFqxKthzn3ec7tamyfJjNKRKzWPUcpZGdcBJ+yTD2K0P423g==",
             "dependencies": {
-                "@matter/general": "0.15.2",
-                "@matter/model": "0.15.2"
+                "@matter/general": "0.15.6",
+                "@matter/model": "0.15.6"
             }
         },
         "node_modules/@noble/curves": {
-            "version": "1.9.4",
-            "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.4.tgz",
-            "integrity": "sha512-2bKONnuM53lINoDrSmK8qP8W271ms7pygDhZt4SiLOoLwBtoHqeCFi6RG42V8zd3mLHuJFhU/Bmaqo4nX0/kBw==",
+            "version": "1.9.7",
+            "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
+            "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
             "dependencies": {
                 "@noble/hashes": "1.8.0"
             },

--- a/bundles/org.openhab.binding.matter/code-gen/package.json
+++ b/bundles/org.openhab.binding.matter/code-gen/package.json
@@ -18,7 +18,7 @@
         "prettier-plugin-organize-imports": "^4.1.0"
     },
     "dependencies": {
-        "@matter/main": "v0.15.2",
+        "@matter/main": "v0.15.6",
         "handlebars": "^4.7.8"
     },
     "files": [

--- a/bundles/org.openhab.binding.matter/matter-server/package-lock.json
+++ b/bundles/org.openhab.binding.matter/matter-server/package-lock.json
@@ -8,9 +8,9 @@
             "name": "matter-server",
             "version": "0.1.0",
             "dependencies": {
-                "@matter/main": "v0.15.2",
-                "@matter/node": "v0.15.2",
-                "@project-chip/matter.js": "v0.15.2",
+                "@matter/main": "v0.15.6",
+                "@matter/node": "v0.15.6",
+                "@project-chip/matter.js": "v0.15.6",
                 "uuid": "^9.0.1",
                 "ws": "^8.18.0",
                 "yargs": "^17.7.2"
@@ -424,85 +424,85 @@
             }
         },
         "node_modules/@matter/general": {
-            "version": "0.15.2",
-            "resolved": "https://registry.npmjs.org/@matter/general/-/general-0.15.2.tgz",
-            "integrity": "sha512-b160CG9ucZRWJD8KCQj6Tylqy73Z6wYloP+6mzSX1u6pwHeISbhSRKJBXSm9gsFPFsFVQgSLP1wMk3KtJ0sy7g==",
+            "version": "0.15.6",
+            "resolved": "https://registry.npmjs.org/@matter/general/-/general-0.15.6.tgz",
+            "integrity": "sha512-KhFUKNCD1F55Q1uvJbLpYAFHpAO5P24MWys8gWdNetm5UuzDoUIWhVMBxxHd+sAFFYIaNr8HlXdxJSKQSLC+ww==",
             "dependencies": {
-                "@noble/curves": "^1.9.4"
+                "@noble/curves": "^1.9.5"
             }
         },
         "node_modules/@matter/main": {
-            "version": "0.15.2",
-            "resolved": "https://registry.npmjs.org/@matter/main/-/main-0.15.2.tgz",
-            "integrity": "sha512-93Mqr0DmHO7QNAD2NdZFULFTYS0s1GFtPS3q0V5JKtzJ/W1LJzHYcQNPegD6sZJgCbouuzztWmDeyRsFXB06Rw==",
+            "version": "0.15.6",
+            "resolved": "https://registry.npmjs.org/@matter/main/-/main-0.15.6.tgz",
+            "integrity": "sha512-V9d8SMBJd66JLIGYCG695st2Q1eCwdzkkVwGwqnv2Fi/T4lovtWuKtRb2r5gvYj+cZ9vuLPmNSOWtAAXrTNJ1w==",
             "dependencies": {
-                "@matter/general": "0.15.2",
-                "@matter/model": "0.15.2",
-                "@matter/node": "0.15.2",
-                "@matter/protocol": "0.15.2",
-                "@matter/types": "0.15.2"
+                "@matter/general": "0.15.6",
+                "@matter/model": "0.15.6",
+                "@matter/node": "0.15.6",
+                "@matter/protocol": "0.15.6",
+                "@matter/types": "0.15.6"
             },
             "optionalDependencies": {
-                "@matter/nodejs": "0.15.2"
+                "@matter/nodejs": "0.15.6"
             }
         },
         "node_modules/@matter/model": {
-            "version": "0.15.2",
-            "resolved": "https://registry.npmjs.org/@matter/model/-/model-0.15.2.tgz",
-            "integrity": "sha512-8h47ks+hnyySal/70cuHXWk+xeYKLJdmcTLPRuJIegm5MoeH36hP4yhW3AH92Ej4tHTMiyHf1F9qShZq9/7Z0A==",
+            "version": "0.15.6",
+            "resolved": "https://registry.npmjs.org/@matter/model/-/model-0.15.6.tgz",
+            "integrity": "sha512-WrbQE1EBgITpG64zEjTtTeyA4VEtFEbZyKpjKiKKJ2+1Z5cABTYO7xAOAjO1QsiZn9O1nlsL479weVfBiehByg==",
             "dependencies": {
-                "@matter/general": "0.15.2"
+                "@matter/general": "0.15.6"
             }
         },
         "node_modules/@matter/node": {
-            "version": "0.15.2",
-            "resolved": "https://registry.npmjs.org/@matter/node/-/node-0.15.2.tgz",
-            "integrity": "sha512-4ZmRNE4SU+aj/DXV8xN2ypZXr/9hVJE8Yj52byQVBdTj7Uh/eRVLoPN19egIBc+VXdrD0uHVaHRhS0yInVBogQ==",
+            "version": "0.15.6",
+            "resolved": "https://registry.npmjs.org/@matter/node/-/node-0.15.6.tgz",
+            "integrity": "sha512-AtGbcBoNKlV3lYo3xg08zkn5uIvAjwoASulEfP8ZjKKLn6H6a3OLN8NPQGX+MeAWyVRgw5lqHwW4SPcBF8YAVQ==",
             "dependencies": {
-                "@matter/general": "0.15.2",
-                "@matter/model": "0.15.2",
-                "@matter/protocol": "0.15.2",
-                "@matter/types": "0.15.2"
+                "@matter/general": "0.15.6",
+                "@matter/model": "0.15.6",
+                "@matter/protocol": "0.15.6",
+                "@matter/types": "0.15.6"
             }
         },
         "node_modules/@matter/nodejs": {
-            "version": "0.15.2",
-            "resolved": "https://registry.npmjs.org/@matter/nodejs/-/nodejs-0.15.2.tgz",
-            "integrity": "sha512-Lgsv1Uvejq0/e2mdUmlXiabopw7xIshybIZWkWtYXT1egyXKNfRev69XiH+fCRzjxDbkKRweMFOHSpv9PQ2YKg==",
+            "version": "0.15.6",
+            "resolved": "https://registry.npmjs.org/@matter/nodejs/-/nodejs-0.15.6.tgz",
+            "integrity": "sha512-qkmnWRVLgj4dvYC6B3AxTR3TOylptZKc6cPhJix3m7VrxmI0mSv4mQ1iU8wCecpMeTi03RINDyA94ZA4UFDvtw==",
             "optional": true,
             "dependencies": {
-                "@matter/general": "0.15.2",
-                "@matter/node": "0.15.2",
-                "@matter/protocol": "0.15.2",
-                "@matter/types": "0.15.2"
+                "@matter/general": "0.15.6",
+                "@matter/node": "0.15.6",
+                "@matter/protocol": "0.15.6",
+                "@matter/types": "0.15.6"
             },
             "engines": {
                 "node": ">=18.0.0"
             }
         },
         "node_modules/@matter/protocol": {
-            "version": "0.15.2",
-            "resolved": "https://registry.npmjs.org/@matter/protocol/-/protocol-0.15.2.tgz",
-            "integrity": "sha512-7hycAbst9Laoc9w986nhEB6t9JoYYtiIQndMdVe5Qjq/BeOlDa0iEtJKTDVMKN2T4ML19Nq+m1tUGAoFBz1qHQ==",
+            "version": "0.15.6",
+            "resolved": "https://registry.npmjs.org/@matter/protocol/-/protocol-0.15.6.tgz",
+            "integrity": "sha512-oU+6zBMZuRf7f7srDT769G6hBS1Wvwa30VUNTXJvh1+vf4Apl9Ys6vealJLjU61SwE6ucarxZ+P5U2pDnK6RDw==",
             "dependencies": {
-                "@matter/general": "0.15.2",
-                "@matter/model": "0.15.2",
-                "@matter/types": "0.15.2"
+                "@matter/general": "0.15.6",
+                "@matter/model": "0.15.6",
+                "@matter/types": "0.15.6"
             }
         },
         "node_modules/@matter/types": {
-            "version": "0.15.2",
-            "resolved": "https://registry.npmjs.org/@matter/types/-/types-0.15.2.tgz",
-            "integrity": "sha512-70vPowfi+1GEAZ5F+ZI7I3WjX0dw0o9b8i+dt5sVt0D7CirxJkPY0XsLTWJHLKBGmSpLxY9J3XeQDUqva6sLmA==",
+            "version": "0.15.6",
+            "resolved": "https://registry.npmjs.org/@matter/types/-/types-0.15.6.tgz",
+            "integrity": "sha512-vjVBKCTui4+v0hRF+jN+el6HU5hpxsRiChQaXaLFqxKthzn3ec7tamyfJjNKRKzWPUcpZGdcBJ+yTD2K0P423g==",
             "dependencies": {
-                "@matter/general": "0.15.2",
-                "@matter/model": "0.15.2"
+                "@matter/general": "0.15.6",
+                "@matter/model": "0.15.6"
             }
         },
         "node_modules/@noble/curves": {
-            "version": "1.9.4",
-            "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.4.tgz",
-            "integrity": "sha512-2bKONnuM53lINoDrSmK8qP8W271ms7pygDhZt4SiLOoLwBtoHqeCFi6RG42V8zd3mLHuJFhU/Bmaqo4nX0/kBw==",
+            "version": "1.9.7",
+            "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
+            "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
             "dependencies": {
                 "@noble/hashes": "1.8.0"
             },
@@ -563,15 +563,15 @@
             }
         },
         "node_modules/@project-chip/matter.js": {
-            "version": "0.15.2",
-            "resolved": "https://registry.npmjs.org/@project-chip/matter.js/-/matter.js-0.15.2.tgz",
-            "integrity": "sha512-6yabHm8edoiBDyOlaITjgszf8nhIfHsjcyt600urPfV6fkuFAKo9DkFJrXyklO5TEZemQw2qD5BIm/LUBL3QIw==",
+            "version": "0.15.6",
+            "resolved": "https://registry.npmjs.org/@project-chip/matter.js/-/matter.js-0.15.6.tgz",
+            "integrity": "sha512-b0aPzhaF2Mgq8iuGfELP1XeaofkmrVC9y/LlQ5Y9bGDvbkZwcGuhX6Mh8VzQVuFLkCbrVXVDUBW6hRnEf8HJkQ==",
             "dependencies": {
-                "@matter/general": "0.15.2",
-                "@matter/model": "0.15.2",
-                "@matter/node": "0.15.2",
-                "@matter/protocol": "0.15.2",
-                "@matter/types": "0.15.2"
+                "@matter/general": "0.15.6",
+                "@matter/model": "0.15.6",
+                "@matter/node": "0.15.6",
+                "@matter/protocol": "0.15.6",
+                "@matter/types": "0.15.6"
             }
         },
         "node_modules/@tsconfig/node10": {

--- a/bundles/org.openhab.binding.matter/matter-server/package.json
+++ b/bundles/org.openhab.binding.matter/matter-server/package.json
@@ -38,9 +38,9 @@
         "webpack-cli": "^5.1.4"
     },
     "dependencies": {
-        "@matter/main": "v0.15.2",
-        "@matter/node": "v0.15.2",
-        "@project-chip/matter.js": "v0.15.2",
+        "@matter/main": "v0.15.6",
+        "@matter/node": "v0.15.6",
+        "@project-chip/matter.js": "v0.15.6",
         "uuid": "^9.0.1",
         "ws": "^8.18.0",
         "yargs": "^17.7.2"

--- a/bundles/org.openhab.binding.matter/matter-server/src/client/ControllerNode.ts
+++ b/bundles/org.openhab.binding.matter/matter-server/src/client/ControllerNode.ts
@@ -66,7 +66,7 @@ export class ControllerNode {
         });
         await this.commissioningController.initializeControllerStore();
 
-        const controllerStore = this.environment.get(ControllerStore);
+        const controllerStore = this.commissioningController.env.get(ControllerStore);
         // TODO: Implement resetStorage
         // if (resetStorage) {
         //     await controllerStore.erase();


### PR DESCRIPTION
This is also a candidate to backport, v0.15.6 has many bug fixes and is likely the last v0.15.x release