### PR TITLE
[ecotouch] Fix initial install of binding ecotouch

### DIFF
--- a/bundles/org.openhab.binding.ecotouch/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.ecotouch/src/main/resources/OH-INF/thing/thing-types.xml
@@ -126,6 +126,10 @@
 			<channel id="ecovent_mode" typeId="ecovent_mode"/>
 		</channels>
 
+		<properties>
+			<property name="thingTypeVersion">2</property>
+		</properties>
+
 		<config-description>
 			<parameter name="ip" type="text" required="true">
 				<context>network-address</context>
@@ -278,6 +282,10 @@
 			<channel id="ecovent_output_y1" typeId="ecovent_output_y1"/>
 			<channel id="ecovent_mode" typeId="ecovent_mode"/>
 		</channels>
+
+		<properties>
+			<property name="thingTypeVersion">2</property>
+		</properties>
 
 		<config-description>
 			<parameter name="ip" type="text" required="true">

--- a/bundles/org.openhab.binding.ecotouch/src/main/resources/OH-INF/update/instructions.xml
+++ b/bundles/org.openhab.binding.ecotouch/src/main/resources/OH-INF/update/instructions.xml
@@ -4,9 +4,6 @@
 	xsi:schemaLocation="https://openhab.org/schemas/update-description/v1.0.0 https://openhab.org/schemas/update-description-1.0.0.xsd">
 
 	<thing-type uid="ecotouch:geo">
-		<properties>
-			<property name="thingTypeVersion">2</property>
-		</properties>
 		<instruction-set targetVersion="1">
 			<add-channel id="percent_water_limit_min">
 				<type>ecotouch:percent_water_limit_min</type>
@@ -29,9 +26,6 @@
 	</thing-type>
 
 	<thing-type uid="ecotouch:air">
-		<properties>
-			<property name="thingTypeVersion">2</property>
-		</properties>
 		<instruction-set targetVersion="1">
 			<add-channel id="percent_water_limit_min">
 				<type>ecotouch:percent_water_limit_min</type>


### PR DESCRIPTION
Fixes #19502

On a new installation, the binding will be installed with thingTypeVersion == 0 (because it is missing in `thing-types.xml`). Openhab then tries to apply the update `instructions.xml` and will fail eventually.

