### PR TITLE
[siemenshvac] Fix sanetization of channel type UID

### DIFF
--- a/bundles/org.openhab.binding.siemenshvac/src/main/java/org/openhab/binding/siemenshvac/internal/type/UidUtils.java
+++ b/bundles/org.openhab.binding.siemenshvac/src/main/java/org/openhab/binding/siemenshvac/internal/type/UidUtils.java
@@ -40,7 +40,7 @@ public class UidUtils {
      * @param label
      * @return the label without invalid character
      */
-    private static String sanetizeId(String label) {
+    public static String sanetizeId(String label) {
         String result = label;
 
         if (!Normalizer.isNormalized(label, Normalizer.Form.NFKD)) {
@@ -68,7 +68,7 @@ public class UidUtils {
      * @param descriptor
      * @return
      */
-    public static String normalizeDescriptor(String descriptor) {
+    private static String normalizeDescriptor(String descriptor) {
         String result = descriptor.trim();
 
         if (result.indexOf("CC") >= 0 || result.indexOf("HC") >= 0) {


### PR DESCRIPTION
# Fix sanetization of channel type UID

This PR is related to issue #19505. 
Channel type UID are not properly sanetize.
If the sort descriptor contains specials character like "°", we end up with an exception.

