### PR TITLE
[tuya] Things should be online/waiting as soon as we know the IP

### DIFF
--- a/bundles/org.openhab.binding.tuya/src/main/java/org/openhab/binding/tuya/internal/handler/TuyaDeviceHandler.java
+++ b/bundles/org.openhab.binding.tuya/src/main/java/org/openhab/binding/tuya/internal/handler/TuyaDeviceHandler.java
@@ -601,6 +601,8 @@ public class TuyaDeviceHandler extends BaseThingHandler implements DeviceInfoSub
                 configuration.ip = deviceInfo.ip;
                 configuration.protocol = deviceInfo.protocolVersion;
 
+                updateStatus(ThingStatus.ONLINE, ThingStatusDetail.NONE, "@text/online.wait-for-device");
+
                 this.tuyaDevice = new TuyaDevice(gson, this, eventLoopGroup, configuration.deviceId,
                         configuration.localKey.getBytes(StandardCharsets.UTF_8), configuration.ip,
                         configuration.protocol);


### PR DESCRIPTION
All Tuya Things should be online and waiting for the device to send updates. They are only offline if we can't possibly talk to them for some reason (no IP, no/bad auth token, ...)