### PR TITLE
[meross] Fix cloud fallback not being called

### DIFF
--- a/bundles/org.openhab.binding.meross/src/main/java/org/openhab/binding/meross/internal/api/MerossManager.java
+++ b/bundles/org.openhab.binding.meross/src/main/java/org/openhab/binding/meross/internal/api/MerossManager.java
@@ -162,15 +162,15 @@ public class MerossManager implements MqttMessageSubscriber {
 
     private synchronized void publishMessage(String topic, byte[] message) throws MqttException, InterruptedException {
         try {
-            if (!publishMessageLocal(topic, message)) {
-                logger.trace("Publishing to mqtt...");
-                mqttConnector.publishMqttMessage(topic, message);
+            if (publishMessageLocal(topic, message)) {
+                return;
             }
         } catch (IOException e) {
-            logger.debug("Error communicating to device with IP address {} in LAN, trying cloud",
-                    callback.getIpAddress());
             logger.trace("Error: ", e);
         }
+        logger.debug("Failed communicating to device with IP address {} in LAN, trying cloud", callback.getIpAddress());
+        logger.trace("Publishing to mqtt...");
+        mqttConnector.publishMqttMessage(topic, message);
     }
 
     private boolean publishMessageLocal(String topic, byte[] message) throws IOException {


### PR DESCRIPTION
Fixes https://github.com/openhab/openhab-addons/issues/19501

When local communication fails handling a command, the binding should fall back to the cloud mqtt broker connection. This was never happening.

 @fabgio Please have a look.