### PR TITLE
[enocean] add category “QualityOfService” for RSSI channel

### DIFF
--- a/bundles/org.openhab.binding.enocean/src/main/resources/OH-INF/thing/channels.xml
+++ b/bundles/org.openhab.binding.enocean/src/main/resources/OH-INF/thing/channels.xml
@@ -444,6 +444,7 @@
 		<item-type>Number</item-type>
 		<label>RSSI</label>
 		<description>Received Signal Strength Indication</description>
+		<category>QualityOfService</category>
 		<tags>
 			<tag>Measurement</tag>
 			<tag>RSSI</tag>


### PR DESCRIPTION
This does not alter the icon (category) dynamically, based on the signal strength (which would work for values 0-4), but still makes things look nicer.