### PR TITLE
[enocean] D2-50 change units of supply and exhaust air fan flow rate

### DIFF
--- a/bundles/org.openhab.binding.enocean/src/main/java/org/openhab/binding/enocean/internal/eep/D2_50/D2_50.java
+++ b/bundles/org.openhab.binding.enocean/src/main/java/org/openhab/binding/enocean/internal/eep/D2_50/D2_50.java
@@ -152,9 +152,9 @@ public class D2_50 extends _VLDMessage {
                 return new QuantityType<>(-63 + ((bytes[8] & 0xff) >>> 4) + ((bytes[7] & 0b111) << 4), SIUnits.CELSIUS);
             case CHANNEL_SUPPLYAIRFANAIRFLOWRATE:
                 return new QuantityType<>(((bytes[9] & 0xff) >>> 2) + ((bytes[8] & 0b1111) << 6),
-                        Units.CUBICMETRE_PER_MINUTE);
+                        Units.CUBICMETRE_PER_HOUR);
             case CHANNEL_EXHAUSTAIRFANAIRFLOWRATE:
-                return new QuantityType<>((bytes[10] & 0xff) + ((bytes[9] & 0b11) << 8), Units.CUBICMETRE_PER_MINUTE);
+                return new QuantityType<>((bytes[10] & 0xff) + ((bytes[9] & 0b11) << 8), Units.CUBICMETRE_PER_HOUR);
             case CHANNEL_SUPPLYFANSPEED:
                 return new DecimalType(((bytes[12] & 0xff) >>> 4) + (bytes[11] << 4));
             case CHANNEL_EXHAUSTFANSPEED:


### PR DESCRIPTION
# Description

Change the units of the Supply and Exhaust Air Fan Flow Rate from m^3/m to m^3/h
Here is a screen shot of the [documentation](https://tools.enocean-alliance.org/EEPViewer/profiles/D2/50/00/D2-50-00.pdf):
<img width="1662" height="298" alt="Screenshot from 2025-10-27 09-53-59" src="https://github.com/user-attachments/assets/8774f657-dfa8-49c4-a5f4-290a9515ccbd" />

Something to keep in mind for someone with such device - using different item types could show the values differently like:
Before the change:
- with item type `Number:VolumetricFlowRate`  the value was in `l/h` but it was using `l/min` suffix - which was incorrect.
- with item type `Number` the value was correct and the workaround is to add `[%.2f m³/h]` to the label to show the units correctly.

After the change:
- with item type `Number:VolumetricFlowRate` has the correct value in `l/min` and if you have to change the suffix you coulld use `[%.2f m³/h]` in the label.
- with item type `Number` the value is also correct and you could add `[%.2f m³/h]` to the label and `unit="m³/h"` in the `bindingconfig` section in order to show the units.

# Testing
Here is a jar file for [4.x.x](https://drive.google.com/file/d/1UAyoluf6lBSC5LXtSfCWQnyQmJ7oM9Vi/view?usp=sharing) to test and for [5](https://drive.google.com/file/d/16rc8VCHLfSbTUg1KsMVV_hxs0Wb51-iT/view?usp=sharing)
