### PR TITLE
[samsungtv] Additional hint for environment variable when using in docker container

### DIFF
--- a/bundles/org.openhab.binding.samsungtv/README.md
+++ b/bundles/org.openhab.binding.samsungtv/README.md
@@ -677,7 +677,7 @@ If you have more than one network interface on your openHAB machine, you may hav
   - enable/disable `Enable multicast enhancement (IGMPv3)` if you have it (sometimes this helps).
   - Try to connect your openHAB machine or TV via Ethernet instead of WiFi (AP's can filter Multicasts).
   - Make sure you don't have any firewall rules blocking multicast.
-  - if you are using a Docker container, ensure you use the `--net=host` setting, as Docker filters multicast broadcasts by default. (if you still have problems, consider the usage of some jupnp environment variables as discussed at https://community.openhab.org/t/upnp-based-discovery-does-not-work-on-host-networked-docker-container/144360/21)
+  - if you are using a Docker container, ensure you use the `--net=host` setting, as Docker filters multicast broadcasts by default. If device discovery still does not work, try other jupnp environment variables as described in [openHAB Docker documentation](https://www.openhab.org/docs/installation/docker.html#universal-plug-and-play-upnp)
 
 ### I see the messages, but something else is not working properly
 


### PR DESCRIPTION
…in docker container

<!--

# Configuration hint when using in docker container


# Description

Broadcasts can get an issue when running the plugin in a docker container. Additionally to the (already existing hint) to run as host, there is an additional hint, which could help. Adding two additional jupnp envirionmen variables. 

Is is just a hint in the documentation.

Please give a few sentences describing the overall goals of the pull request.
Give enough details to make the improvement and changes of the PR understandable
to both developers and tech-savy users.


# Testing

Worked on my side and i found several posts (e.g. the linked one) where this helped.

-->
