### PR TITLE
[groovyscripting] For enum values do `import static`

### DIFF
--- a/bundles/org.openhab.automation.groovyscripting/src/main/java/org/openhab/automation/groovyscripting/internal/GroovyScriptEngineFactory.java
+++ b/bundles/org.openhab.automation.groovyscripting/src/main/java/org/openhab/automation/groovyscripting/internal/GroovyScriptEngineFactory.java
@@ -60,6 +60,9 @@ public class GroovyScriptEngineFactory extends AbstractScriptEngineFactory {
                 } catch (ClassNotFoundException e) {
                     logger.debug("Unable to add import for {} as {}", entry.getKey(), canonicalName, e);
                 }
+            } else if (entry.getValue() instanceof Enum<?> e) {
+                importCustomizer.addStaticImport(entry.getKey(), e.getDeclaringClass().getCanonicalName(), e.name());
+                logger.debug("Added static import for {}", e);
             } else {
                 scriptEngine.put(entry.getKey(), entry.getValue());
             }


### PR DESCRIPTION
Before this change
```groovy
@groovy.transform.CompileStatic
def isOn(Object o) {
  return o == ON
}
```
caused:
```
[INFO ] [ort.loader.AbstractScriptFileWatcher] - (Re-)Loading script '/etc/openhab/automation/jsr223/t.groovy'
[ERROR] [ipt.internal.ScriptEngineManagerImpl] - Error during evaluation of script '/etc/openhab/automation/jsr223/t.groovy': org.codehaus.groovy.control.MultipleCompilationErrorsException: startup failed:
/etc/openhab/automation/jsr223/t.groovy: 3: [Static type checking] - The variable [ON] is undeclared.
 @ line 3, column 15.
     return o == ON
                 ^

1 error

[WARN ] [ort.loader.AbstractScriptFileWatcher] - Script loading error, ignoring file '/etc/openhab/automation/jsr223/t.groovy'
```
With the change, it prints:
```
[INFO ] [ort.loader.AbstractScriptFileWatcher] - (Re-)Loading script '/etc/openhab/automation/jsr223/t.groovy'
[DEBUG] [g.internal.GroovyScriptEngineFactory] - Added static import for DOWN
[DEBUG] [g.internal.GroovyScriptEngineFactory] - Added static import for PLAY
[DEBUG] [g.internal.GroovyScriptEngineFactory] - Added static import for ON
…
```