### PR TITLE
[hueemulation] Fix `NullPointerException`s

### DIFF
--- a/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/ConfigStore.java
+++ b/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/ConfigStore.java
@@ -191,8 +191,9 @@ public class ConfigStore {
         InetAddress configuredAddress = null;
         int networkPrefixLength = 24; // Default for most networks: 255.255.255.0
 
-        if (config.discoveryIp != null) {
-            discoveryIps = Collections.unmodifiableSet(Stream.of(config.discoveryIp.split(",")).map(String::trim)
+        String discoveryIp = config.discoveryIp;
+        if (discoveryIp != null) {
+            discoveryIps = Collections.unmodifiableSet(Stream.of(discoveryIp.split(",")).map(String::trim)
                     .map(this::byName).filter(e -> e != null).collect(Collectors.toSet()));
         } else {
             discoveryIps = new LinkedHashSet<>();

--- a/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/DeviceType.java
+++ b/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/DeviceType.java
@@ -12,6 +12,8 @@
  */
 package org.openhab.io.hueemulation.internal;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
 /**
  * The pure item type is not enough to decide how we expose an item.
  * We need to consider the assigned tags and category as well. This
@@ -19,6 +21,7 @@ package org.openhab.io.hueemulation.internal;
  *
  * @author David Graeff - Initial contribution
  */
+@NonNullByDefault
 public enum DeviceType {
     SwitchType,
     WhiteType,

--- a/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/HueEmulationService.java
+++ b/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/HueEmulationService.java
@@ -47,7 +47,6 @@ import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicyOption;
 import org.osgi.service.event.Event;
-import org.osgi.service.event.EventAdmin;
 import org.osgi.service.event.EventConstants;
 import org.osgi.service.event.EventHandler;
 import org.osgi.service.jaxrs.whiteboard.JaxrsWhiteboardConstants;
@@ -194,7 +193,7 @@ public class HueEmulationService implements EventHandler {
     /**
      * We have a hard dependency on the {@link ConfigStore} and that it has initialized the Hue DataStore config
      * completely. That initialization happens asynchronously and therefore we cannot rely on OSGi activate/modified
-     * state changes. Instead the {@link EventAdmin} is used and we listen for the
+     * state changes. Instead the {@link org.osgi.service.event.EventAdmin} is used and we listen for the
      * {@link ConfigStore#EVENT_ADDRESS_CHANGED} event that is fired as soon as the config is ready.
      */
     @Override

--- a/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/RuleUtils.java
+++ b/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/RuleUtils.java
@@ -86,7 +86,6 @@ public class RuleUtils {
      *            {@code "/api/<username>/lights/1/state"}
      * @throws IllegalStateException Thrown if address is invalid
      */
-    @SuppressWarnings({ "unused", "null" })
     public static void validateHueHttpAddress(HueDataStore ds, String address) throws IllegalStateException {
         String[] validation = address.split("/");
         if (validation.length < 6 || !validation[0].isEmpty() || !"api".equals(validation[1])) {
@@ -113,7 +112,6 @@ public class RuleUtils {
         public String body = "";
     }
 
-    @SuppressWarnings({ "unused", "null" })
     public static @Nullable HueCommand httpActionToHueCommand(HueDataStore ds, Action a, @Nullable String ruleName) {
         ConfigHttpAction config = a.getConfiguration().as(ConfigHttpAction.class);
 

--- a/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/StateUtils.java
+++ b/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/StateUtils.java
@@ -430,30 +430,29 @@ public class StateUtils {
 
         if (lastCommand != null && lastHueChange != null) {
             if (lastCommand instanceof HSBType) {
-                if (hueState instanceof HueStateColorBulb && itemState.as(HSBType.class).equals(lastCommand)) {
-                    HueStateColorBulb c = (HueStateColorBulb) hueState;
-
+                if (hueState instanceof HueStateColorBulb hueStateColorBulb
+                        && lastCommand.equals(itemState.as(HSBType.class))) {
                     if (lastHueChange.bri != null) {
-                        c.bri = lastHueChange.bri;
+                        hueStateColorBulb.bri = lastHueChange.bri;
                     }
                     if (lastHueChange.hue != null) {
-                        c.hue = lastHueChange.hue;
+                        hueStateColorBulb.hue = lastHueChange.hue;
                     }
                     if (lastHueChange.sat != null) {
-                        c.sat = lastHueChange.sat;
+                        hueStateColorBulb.sat = lastHueChange.sat;
                     }
                     // Although we can't set a colour temperature in OH
                     // this keeps Alexa happy when asking to turn a light
                     // to white.
                     if (lastHueChange.ct != null) {
-                        c.ct = lastHueChange.ct;
+                        hueStateColorBulb.ct = lastHueChange.ct;
                     }
                 }
             } else if (lastCommand instanceof PercentType) {
-                if (hueState instanceof HueStateBulb && itemState != null
+                if (hueState instanceof HueStateBulb hueStateBulb
                         && lastCommand.equals(itemState.as(PercentType.class))) {
                     if (lastHueChange.bri != null) {
-                        ((HueStateBulb) hueState).bri = lastHueChange.bri;
+                        hueStateBulb.bri = lastHueChange.bri;
                     }
                 }
             }

--- a/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/automation/HttpActionHandler.java
+++ b/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/automation/HttpActionHandler.java
@@ -14,6 +14,7 @@ package org.openhab.io.hueemulation.internal.automation;
 
 import java.net.URI;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -74,7 +75,8 @@ public class HttpActionHandler extends BaseModuleHandler<Action> implements Acti
         // convert relative path to absolute one
         String url = config.url;
         if (url.startsWith("/")) {
-            config.url = "http://localhost:" + Integer.getInteger("org.osgi.service.http.port", 8080).toString() + url;
+            config.url = "http://localhost:"
+                    + Objects.requireNonNull(Integer.getInteger("org.osgi.service.http.port", 8080)).toString() + url;
         }
 
         httpClient = httpFactory.createHttpClient("HttpActionHandler_" + module.getId());

--- a/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/automation/HueRuleConditionHandler.java
+++ b/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/automation/HueRuleConditionHandler.java
@@ -16,8 +16,6 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoField;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 import java.util.function.Predicate;
 import java.util.regex.Matcher;
@@ -72,7 +70,6 @@ public class HueRuleConditionHandler extends BaseModuleHandler<Condition> implem
     // weekdays range from Monday to Sunday (1-7). The first entry is not used
     private final boolean[] weekDaysAllowed = { false, false, false, false, false, false, false, false };
 
-    @SuppressWarnings({ "null", "unused" })
     public HueRuleConditionHandler(Condition module, HueDataStore ds) {
         super(module);
         config = module.getConfiguration().as(HueRuleEntry.Condition.class);
@@ -103,10 +100,6 @@ public class HueRuleConditionHandler extends BaseModuleHandler<Condition> implem
             // Item not used
             itemUID = "";
         } else {
-            throw new IllegalStateException("Can only handle groups and lights");
-        }
-
-        if (itemUID == null) {
             throw new IllegalStateException("Can only handle groups and lights");
         }
 
@@ -174,7 +167,6 @@ public class HueRuleConditionHandler extends BaseModuleHandler<Condition> implem
 
                 // Monday = 64, Tuesday = 32, Wednesday = 16, Thursday = 8, Friday = 4, Saturday = 2, Sunday = 1
                 int weekdaysBinaryEncoded = Integer.valueOf(m.group(1));
-                List<String> cronWeekdays = new ArrayList<>();
                 for (int bin = 64, c = 1; bin > 0; bin /= 2, c += 1) {
                     if (weekdaysBinaryEncoded / bin == 1) {
                         weekdaysBinaryEncoded = weekdaysBinaryEncoded % bin;

--- a/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/automation/RemoveRuleActionHandler.java
+++ b/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/automation/RemoveRuleActionHandler.java
@@ -40,7 +40,6 @@ public class RemoveRuleActionHandler extends BaseModuleHandler<Action> implement
 
     private RuleRegistry ruleRegistry;
 
-    @SuppressWarnings({ "null", "unused" })
     public RemoveRuleActionHandler(final Action module, RuleRegistry ruleRegistry) {
         super(module);
         this.ruleRegistry = ruleRegistry;
@@ -49,10 +48,11 @@ public class RemoveRuleActionHandler extends BaseModuleHandler<Action> implement
             throw new IllegalArgumentException("'Configuration' can not be empty.");
         }
 
-        ruleUID = (String) config.get(CFG_REMOVE_UID);
+        String ruleUID = (String) config.get(CFG_REMOVE_UID);
         if (ruleUID == null) {
             throw new IllegalArgumentException("'ruleUIDs' property must not be null.");
         }
+        this.ruleUID = ruleUID;
     }
 
     @Override

--- a/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/automation/TimerTriggerHandler.java
+++ b/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/automation/TimerTriggerHandler.java
@@ -115,7 +115,9 @@ public class TimerTriggerHandler extends BaseTriggerModuleHandler implements Cal
 
     @Override
     public Duration call() {
-        ((TriggerHandlerCallback) callback).triggered(module, Map.of());
+        if (callback instanceof TriggerHandlerCallback triggerHandlerCallback) {
+            triggerHandlerCallback.triggered(module, Map.of());
+        }
         config.repeat -= 1;
         if (config.repeat == 0) {
             schedule = null;

--- a/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/rest/ConfigurationAccess.java
+++ b/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/rest/ConfigurationAccess.java
@@ -109,8 +109,10 @@ public class ConfigurationAccess {
         if (!userManagement.authorizeUser(username)) {
             return NetworkUtils.singleError(cs.gson, uri, HueResponse.UNAUTHORIZED, "Not Authorized");
         }
-        final HueChangeRequest changes;
-        changes = cs.gson.fromJson(body, HueChangeRequest.class);
+        final HueChangeRequest changes = cs.gson.fromJson(body, HueChangeRequest.class);
+        if (changes == null) {
+            return NetworkUtils.singleError(cs.gson, uri, HueResponse.INVALID_JSON, "Empty body");
+        }
         String devicename = changes.devicename;
         if (devicename != null) {
             cs.ds.config.devicename = devicename;

--- a/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/rest/Rules.java
+++ b/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/rest/Rules.java
@@ -292,6 +292,10 @@ public class Rules implements RegistryChangeListener<Rule> {
 
         final HueRuleEntry changeRequest = cs.gson.fromJson(body, HueRuleEntry.class);
 
+        if (changeRequest == null) {
+            return NetworkUtils.singleError(cs.gson, uri, HueResponse.INVALID_JSON, "Empty body");
+        }
+
         Rule rule = ruleRegistry.remove(id);
         if (rule == null) {
             return NetworkUtils.singleError(cs.gson, uri, HueResponse.NOT_AVAILABLE, "Rule does not exist!");
@@ -333,7 +337,6 @@ public class Rules implements RegistryChangeListener<Rule> {
         ));
     }
 
-    @SuppressWarnings({ "null" })
     @POST
     @Path("{username}/rules")
     @Operation(summary = "Create a new rule", responses = { @ApiResponse(responseCode = "200", description = "OK") })
@@ -353,10 +356,7 @@ public class Rules implements RegistryChangeListener<Rule> {
         String uid = UUID.randomUUID().toString();
         RuleBuilder builder = RuleBuilder.create(uid).withName(newRuleData.name);
 
-        String description = newRuleData.description;
-        if (description != null) {
-            builder.withDescription(description);
-        }
+        builder.withDescription(newRuleData.description);
 
         try {
             builder.withActions(createActions(uid, newRuleData.actions, Collections.emptyList(), username));

--- a/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/rest/Schedules.java
+++ b/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/rest/Schedules.java
@@ -313,7 +313,6 @@ public class Schedules implements RegistryChangeListener<Rule> {
         ));
     }
 
-    @SuppressWarnings({ "null" })
     @POST
     @Path("{username}/schedules")
     @Operation(summary = "Create a new schedule", responses = {
@@ -325,7 +324,13 @@ public class Schedules implements RegistryChangeListener<Rule> {
         }
 
         HueScheduleEntry newScheduleData = cs.gson.fromJson(body, HueScheduleEntry.class);
-        if (newScheduleData == null || newScheduleData.name.isEmpty() || newScheduleData.localtime.isEmpty()) {
+        if (newScheduleData == null) {
+            return NetworkUtils.singleError(cs.gson, uri, HueResponse.INVALID_JSON, "Empty body");
+        }
+
+        String name = newScheduleData.name;
+        String localtime = newScheduleData.localtime;
+        if (name == null || name.isEmpty() || localtime == null || localtime.isEmpty()) {
             return NetworkUtils.singleError(cs.gson, uri, HueResponse.INVALID_JSON,
                     "Invalid request: No name or localtime!");
         }

--- a/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/rest/Sensors.java
+++ b/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/rest/Sensors.java
@@ -197,7 +197,6 @@ public class Sensors implements RegistryChangeListener<Item> {
         return Response.ok(cs.gson.toJson(cs.ds.sensors.get(id))).build();
     }
 
-    @SuppressWarnings({ "null", "unused" })
     @GET
     @Path("{username}/sensors/{id}/config")
     @Operation(summary = "Return a sensor config. Always empty", responses = {
@@ -217,7 +216,6 @@ public class Sensors implements RegistryChangeListener<Item> {
         return Response.ok(cs.gson.toJson(sensor.config)).build();
     }
 
-    @SuppressWarnings({ "null", "unused" })
     @DELETE
     @Path("{username}/sensors/{id}")
     @Operation(summary = "Deletes the sensor that is represented by this id", responses = {
@@ -242,7 +240,6 @@ public class Sensors implements RegistryChangeListener<Item> {
         }
     }
 
-    @SuppressWarnings({ "null", "unused" })
     @PUT
     @Path("{username}/sensors/{id}")
     @Operation(summary = "Rename a sensor", responses = { @ApiResponse(responseCode = "200", description = "OK") })
@@ -258,6 +255,10 @@ public class Sensors implements RegistryChangeListener<Item> {
         }
 
         final HueChangeRequest changeRequest = cs.gson.fromJson(body, HueChangeRequest.class);
+
+        if (changeRequest == null) {
+            return NetworkUtils.singleError(cs.gson, uri, HueResponse.INVALID_JSON, "Empty body");
+        }
 
         String name = changeRequest.name;
         if (name == null || name.isEmpty()) {

--- a/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/rest/UserManagement.java
+++ b/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/rest/UserManagement.java
@@ -91,7 +91,6 @@ public class UserManagement extends DefaultAbstractManagedProvider<HueUserAuthWi
     /**
      * Checks if the username exists in the whitelist
      */
-    @SuppressWarnings("null")
     public boolean authorizeUser(String userName) {
         HueUserAuth userAuth = cs.ds.config.whitelist.get(userName);
 
@@ -127,7 +126,6 @@ public class UserManagement extends DefaultAbstractManagedProvider<HueUserAuthWi
         add(hueUserAuth);
     }
 
-    @SuppressWarnings("null")
     private synchronized void removeUser(String apiKey) {
         HueUserAuth userAuth = cs.ds.config.whitelist.remove(apiKey);
         if (userAuth != null) {
@@ -161,8 +159,12 @@ public class UserManagement extends DefaultAbstractManagedProvider<HueUserAuthWi
                     "link button not pressed");
         }
 
-        final HueCreateUser userRequest;
-        userRequest = cs.gson.fromJson(body, HueCreateUser.class);
+        final HueCreateUser userRequest = cs.gson.fromJson(body, HueCreateUser.class);
+
+        if (userRequest == null) {
+            return NetworkUtils.singleError(cs.gson, uri, HueResponse.INVALID_JSON, "Empty body");
+        }
+
         if (userRequest.devicetype.isEmpty()) {
             return NetworkUtils.singleError(cs.gson, uri, HueResponse.INVALID_JSON,
                     "Invalid request: No devicetype set");

--- a/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/upnp/HueEmulationConfigWithRuntime.java
+++ b/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/upnp/HueEmulationConfigWithRuntime.java
@@ -17,6 +17,7 @@ import java.net.Inet6Address;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.nio.channels.Selector;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 
@@ -34,7 +35,7 @@ import org.slf4j.LoggerFactory;
  * @author David Graeff - Initial contribution
  */
 @NonNullByDefault
-class HueEmulationConfigWithRuntime extends Thread implements Runnable {
+class HueEmulationConfigWithRuntime extends Thread {
 
     private final Logger logger = LoggerFactory.getLogger(HueEmulationConfigWithRuntime.class);
 
@@ -66,7 +67,8 @@ class HueEmulationConfigWithRuntime extends Thread implements Runnable {
             multicastAddress = MULTI_ADDR_IPV4;
         }
 
-        port = config.discoveryHttpPort == 0 ? Integer.getInteger("org.osgi.service.http.port", 8080)
+        port = config.discoveryHttpPort == 0
+                ? Objects.requireNonNull(Integer.getInteger("org.osgi.service.http.port", 8080))
                 : config.discoveryHttpPort;
     }
 

--- a/bundles/org.openhab.io.hueemulation/src/test/java/org/openhab/io/hueemulation/internal/rest/ItemUIDtoHueIDMappingTests.java
+++ b/bundles/org.openhab.io.hueemulation/src/test/java/org/openhab/io/hueemulation/internal/rest/ItemUIDtoHueIDMappingTests.java
@@ -14,6 +14,7 @@ package org.openhab.io.hueemulation.internal.rest;
 
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.mock;
 
 import java.io.IOException;
@@ -91,6 +92,7 @@ public class ItemUIDtoHueIDMappingTests {
         assertThat(hueID, CoreMatchers.is("2"));
 
         HueLightEntry device = cs.ds.lights.get(hueID);
+        assertNotNull(device);
         assertThat(device.item, is(item));
         assertThat(device.state, is(instanceOf(HueStatePlug.class)));
 
@@ -111,6 +113,7 @@ public class ItemUIDtoHueIDMappingTests {
         assertThat(hueID, CoreMatchers.is("10"));
 
         HueLightEntry device = cs.ds.lights.get(hueID);
+        assertNotNull(device);
         assertThat(device.item, is(item));
         assertThat(device.state, is(instanceOf(HueStatePlug.class)));
 
@@ -131,6 +134,7 @@ public class ItemUIDtoHueIDMappingTests {
         assertThat(hueID, CoreMatchers.is("255"));
 
         HueLightEntry device = cs.ds.lights.get(hueID);
+        assertNotNull(device);
         assertThat(device.item, is(item));
         assertThat(device.state, is(instanceOf(HueStatePlug.class)));
         assertThat(device.uniqueid, CoreMatchers.is("00:00:ff:00:00:ff:00:00-ff"));
@@ -144,6 +148,7 @@ public class ItemUIDtoHueIDMappingTests {
         assertThat(hueID, CoreMatchers.is("256000"));
 
         device = cs.ds.lights.get(hueID);
+        assertNotNull(device);
         assertThat(device.item, is(item));
         assertThat(device.state, is(instanceOf(HueStatePlug.class)));
         assertThat(device.uniqueid, CoreMatchers.is("03:e8:00:03:e8:00:03:e8-00"));

--- a/bundles/org.openhab.io.hueemulation/src/test/java/org/openhab/io/hueemulation/internal/rest/LightsAndGroupsTests.java
+++ b/bundles/org.openhab.io.hueemulation/src/test/java/org/openhab/io/hueemulation/internal/rest/LightsAndGroupsTests.java
@@ -14,7 +14,8 @@ package org.openhab.io.hueemulation.internal.rest;
 
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.verify;
 
@@ -92,6 +93,7 @@ public class LightsAndGroupsTests {
         item.setCategory("Light");
         itemRegistry.add(item);
         HueLightEntry device = cs.ds.lights.get(cs.mapItemUIDtoHueID(item));
+        assertNotNull(device);
         assertThat(device.item, is(item));
         assertThat(device.state, is(instanceOf(HueStatePlug.class)));
     }
@@ -102,6 +104,7 @@ public class LightsAndGroupsTests {
         item.addTag("Switchable");
         itemRegistry.add(item);
         HueLightEntry device = cs.ds.lights.get(cs.mapItemUIDtoHueID(item));
+        assertNotNull(device);
         assertThat(device.item, is(item));
         assertThat(device.state, is(instanceOf(HueStatePlug.class)));
     }
@@ -121,6 +124,7 @@ public class LightsAndGroupsTests {
         item.addTag("Switchable");
         itemRegistry.add(item);
         HueGroupEntry device = cs.ds.groups.get(cs.mapItemUIDtoHueID(item));
+        assertNotNull(device);
         assertThat(device.groupItem, is(item));
         assertThat(device.action, is(instanceOf(HueStatePlug.class)));
     }
@@ -132,6 +136,7 @@ public class LightsAndGroupsTests {
         item.addTag("Huelight");
         itemRegistry.add(item);
         HueLightEntry device = cs.ds.lights.get(cs.mapItemUIDtoHueID(item));
+        assertNotNull(device);
         assertThat(device.item, is(item));
         assertThat(device.state, is(instanceOf(HueStatePlug.class)));
     }
@@ -144,9 +149,10 @@ public class LightsAndGroupsTests {
         itemRegistry.add(item);
 
         HueGroupEntry device = cs.ds.groups.get(cs.mapItemUIDtoHueID(item));
+        assertNotNull(device);
         assertThat(device.groupItem, is(item));
         assertThat(device.action, is(instanceOf(HueStatePlug.class)));
-        assertThat(cs.ds.groups.get(cs.mapItemUIDtoHueID(item)).groupItem, is(item));
+        assertThat(device.groupItem, is(item));
     }
 
     @Test
@@ -187,6 +193,7 @@ public class LightsAndGroupsTests {
         itemRegistry.add(item);
         String hueID = cs.mapItemUIDtoHueID(item);
         HueLightEntry device = cs.ds.lights.get(hueID);
+        assertNotNull(device);
         assertThat(device.item, is(item));
         assertThat(device.state, is(instanceOf(HueStatePlug.class)));
         assertThat(device.name, is("labelOld"));
@@ -196,6 +203,7 @@ public class LightsAndGroupsTests {
         newitem.addTag("Switchable");
         subject.updated(item, newitem);
         device = cs.ds.lights.get(hueID);
+        assertNotNull(device);
         assertThat(device.item, is(newitem));
         assertThat(device.state, is(instanceOf(HueStatePlug.class)));
         assertThat(device.name, is("labelNew"));
@@ -209,6 +217,7 @@ public class LightsAndGroupsTests {
         itemRegistry.add(item);
         String hueID = cs.mapItemUIDtoHueID(item);
         HueLightEntry device = cs.ds.lights.get(hueID);
+        assertNotNull(device);
         assertThat(device.item, is(item));
         assertThat(device.state, is(instanceOf(HueStatePlug.class)));
         assertThat(device.name, is("labelOld"));
@@ -230,6 +239,7 @@ public class LightsAndGroupsTests {
         itemRegistry.add(item);
         String hueID = cs.mapItemUIDtoHueID(item);
         HueLightEntry device = cs.ds.lights.get(hueID);
+        assertNotNull(device);
         assertThat(device.item, is(item));
         assertThat(device.state, is(instanceOf(HueStatePlug.class)));
         assertThat(device.name, is("label"));
@@ -245,13 +255,19 @@ public class LightsAndGroupsTests {
 
     @Test
     public void changeSwitchState() throws Exception {
-        assertThat(((HueStatePlug) cs.ds.lights.get("1").state).on, is(false));
+        HueLightEntry hueLightEntry = cs.ds.lights.get("1");
+        assertNotNull(hueLightEntry);
+        HueStatePlug statePlug = assertInstanceOf(HueStatePlug.class, hueLightEntry.state);
+        assertThat(statePlug.on, is(false));
 
         String body = "{'on':true}";
         ContentResponse response = commonSetup.sendPut("/testuser/lights/1/state", body);
-        assertEquals(200, response.getStatus());
+        assertThat(response.getStatus(), is(200));
         assertThat(response.getContentAsString(), containsString("success"));
-        assertThat(((HueStatePlug) cs.ds.lights.get("1").state).on, is(true));
+        hueLightEntry = cs.ds.lights.get("1");
+        assertNotNull(hueLightEntry);
+        statePlug = assertInstanceOf(HueStatePlug.class, hueLightEntry.state);
+        assertThat(statePlug.on, is(true));
         verify(commonSetup.eventPublisher).post(argThat((Event t) -> {
             assertThat(t.getPayload(), is("{\"type\":\"OnOff\",\"value\":\"ON\"}"));
             return true;
@@ -260,13 +276,19 @@ public class LightsAndGroupsTests {
 
     @Test
     public void changeGroupItemSwitchState() throws Exception {
-        assertThat(((HueStatePlug) cs.ds.groups.get("10").action).on, is(false));
+        HueGroupEntry hueGroupEntry = cs.ds.groups.get("10");
+        assertNotNull(hueGroupEntry);
+        HueStatePlug statePlug = assertInstanceOf(HueStatePlug.class, hueGroupEntry.action);
+        assertThat(statePlug.on, is(false));
 
         String body = "{'on':true}";
         ContentResponse response = commonSetup.sendPut("/testuser/groups/10/action", body);
-        assertEquals(200, response.getStatus());
+        assertThat(response.getStatus(), is(200));
         assertThat(response.getContentAsString(), containsString("success"));
-        assertThat(((HueStatePlug) cs.ds.groups.get("10").action).on, is(true));
+        hueGroupEntry = cs.ds.groups.get("10");
+        assertNotNull(hueGroupEntry);
+        statePlug = assertInstanceOf(HueStatePlug.class, hueGroupEntry.action);
+        assertThat(statePlug.on, is(true));
         verify(commonSetup.eventPublisher).post(argThat((Event t) -> {
             assertThat(t.getPayload(), is("{\"type\":\"OnOff\",\"value\":\"ON\"}"));
             return true;
@@ -275,42 +297,58 @@ public class LightsAndGroupsTests {
 
     @Test
     public void changeOnValue() throws Exception {
-        assertThat(((HueStateColorBulb) cs.ds.lights.get("2").state).on, is(false));
+        HueLightEntry hueLightEntry = cs.ds.lights.get("2");
+        assertNotNull(hueLightEntry);
+        HueStateColorBulb stateColorBulb = assertInstanceOf(HueStateColorBulb.class, hueLightEntry.state);
+        assertThat(stateColorBulb.on, is(false));
 
         String body = "{'on':true}";
         ContentResponse response = commonSetup.sendPut("/testuser/lights/2/state", body);
-        assertEquals(200, response.getStatus());
+        assertThat(response.getStatus(), is(200));
         String entity = response.getContentAsString();
         assertThat(entity, is("[{\"success\":{\"/lights/2/state/on\":true}}]"));
-        assertThat(((HueStateColorBulb) cs.ds.lights.get("2").state).on, is(true));
+        hueLightEntry = cs.ds.lights.get("2");
+        assertNotNull(hueLightEntry);
+        stateColorBulb = assertInstanceOf(HueStateColorBulb.class, hueLightEntry.state);
+        assertThat(stateColorBulb.on, is(true));
     }
 
     @Test
     public void changeOnAndBriValues() throws Exception {
-        assertThat(((HueStateColorBulb) cs.ds.lights.get("2").state).on, is(false));
-        assertThat(((HueStateColorBulb) cs.ds.lights.get("2").state).bri, is(1));
+        HueLightEntry hueLightEntry = cs.ds.lights.get("2");
+        assertNotNull(hueLightEntry);
+        HueStateColorBulb stateColorBulb = assertInstanceOf(HueStateColorBulb.class, hueLightEntry.state);
+        assertThat(stateColorBulb.on, is(false));
+        assertThat(stateColorBulb.bri, is(1));
 
         String body = "{'on':true,'bri':200}";
         ContentResponse response = commonSetup.sendPut("/testuser/lights/2/state", body);
-        assertEquals(200, response.getStatus());
+        assertThat(response.getStatus(), is(200));
         assertThat(response.getContentAsString(), containsString("success"));
-        assertThat(((HueStateColorBulb) cs.ds.lights.get("2").state).on, is(true));
-        assertThat(((HueStateColorBulb) cs.ds.lights.get("2").state).bri, is(200));
+        hueLightEntry = cs.ds.lights.get("2");
+        assertNotNull(hueLightEntry);
+        stateColorBulb = assertInstanceOf(HueStateColorBulb.class, hueLightEntry.state);
+        assertThat(stateColorBulb.on, is(true));
+        assertThat(stateColorBulb.bri, is(200));
     }
 
     @Test
     public void changeHueSatValues() throws Exception {
-        HueLightEntry hueDevice = cs.ds.lights.get("2");
-        hueDevice.item.setState(OnOffType.ON);
-        hueDevice.state.as(HueStateColorBulb.class).on = true;
+        HueLightEntry hueLightEntry = cs.ds.lights.get("2");
+        assertNotNull(hueLightEntry);
+        hueLightEntry.item.setState(OnOffType.ON);
+        hueLightEntry.state.as(HueStateColorBulb.class).on = true;
 
         String body = "{'hue':1000,'sat':50}";
         ContentResponse response = commonSetup.sendPut("/testuser/lights/2/state", body);
-        assertEquals(200, response.getStatus());
+        assertThat(response.getStatus(), is(200));
         assertThat(response.getContentAsString(), containsString("success"));
-        assertThat(((HueStateColorBulb) cs.ds.lights.get("2").state).on, is(true));
-        assertThat(((HueStateColorBulb) cs.ds.lights.get("2").state).hue, is(1000));
-        assertThat(((HueStateColorBulb) cs.ds.lights.get("2").state).sat, is(50));
+        hueLightEntry = cs.ds.lights.get("2");
+        assertNotNull(hueLightEntry);
+        HueStateColorBulb stateColorBulb = assertInstanceOf(HueStateColorBulb.class, hueLightEntry.state);
+        assertThat(stateColorBulb.on, is(true));
+        assertThat(stateColorBulb.hue, is(1000));
+        assertThat(stateColorBulb.sat, is(50));
 
         verify(commonSetup.eventPublisher).post(argThat(ce -> assertHueValue((ItemCommandEvent) ce, 1000)));
     }
@@ -320,19 +358,23 @@ public class LightsAndGroupsTests {
      */
     @Test
     public void changeCtValue() throws Exception {
-        HueLightEntry hueDevice = cs.ds.lights.get("2");
-        hueDevice.item.setState(OnOffType.ON);
-        hueDevice.state.as(HueStateColorBulb.class).on = true;
+        HueLightEntry hueLightEntry = cs.ds.lights.get("2");
+        assertNotNull(hueLightEntry);
+        hueLightEntry.item.setState(OnOffType.ON);
+        hueLightEntry.state.as(HueStateColorBulb.class).on = true;
 
         String body = "{'ct':500}";
         ContentResponse response = commonSetup.sendPut("/testuser/lights/2/state", body);
-        assertEquals(200, response.getStatus());
+        assertThat(response.getStatus(), is(200));
         body = response.getContentAsString();
         assertThat(body, containsString("success"));
         assertThat(body, containsString("ct"));
-        assertThat(((HueStateColorBulb) cs.ds.lights.get("2").state).on, is(true));
-        assertThat(((HueStateColorBulb) cs.ds.lights.get("2").state).ct, is(500));
-        assertThat(((HueStateColorBulb) cs.ds.lights.get("2").state).sat, is(0));
+        hueLightEntry = cs.ds.lights.get("2");
+        assertNotNull(hueLightEntry);
+        HueStateColorBulb stateColorBulb = assertInstanceOf(HueStateColorBulb.class, hueLightEntry.state);
+        assertThat(stateColorBulb.on, is(true));
+        assertThat(stateColorBulb.ct, is(500));
+        assertThat(stateColorBulb.sat, is(0));
 
         // Saturation is expected to be 0 -> white light
         verify(commonSetup.eventPublisher).post(argThat(ce -> assertSatValue((ItemCommandEvent) ce, 0)));
@@ -340,29 +382,34 @@ public class LightsAndGroupsTests {
 
     @Test
     public void switchOnWithXY() throws Exception {
-        assertThat(((HueStateColorBulb) cs.ds.lights.get("2").state).on, is(false));
-        assertThat(((HueStateColorBulb) cs.ds.lights.get("2").state).bri, is(1));
+        HueLightEntry hueLightEntry = cs.ds.lights.get("2");
+        assertNotNull(hueLightEntry);
+        HueStateColorBulb stateColorBulb = assertInstanceOf(HueStateColorBulb.class, hueLightEntry.state);
+        assertThat(stateColorBulb.on, is(false));
+        assertThat(stateColorBulb.bri, is(1));
 
         String body = "{'on':true,'bri':200,'xy':[0.5119,0.4147]}";
         ContentResponse response = commonSetup.sendPut("/testuser/lights/2/state", body);
-        assertEquals(200, response.getStatus());
+        assertThat(response.getStatus(), is(200));
         assertThat(response.getContentAsString(), containsString("success"));
         assertThat(response.getContentAsString(), containsString("xy"));
-        assertThat(((HueStateColorBulb) cs.ds.lights.get("2").state).on, is(true));
-        assertThat(((HueStateColorBulb) cs.ds.lights.get("2").state).bri, is(200));
-        assertThat(((HueStateColorBulb) cs.ds.lights.get("2").state).xy[0], is(0.5119));
-        assertThat(((HueStateColorBulb) cs.ds.lights.get("2").state).xy[1], is(0.4147));
-        assertThat(((HueStateColorBulb) cs.ds.lights.get("2").state).colormode, is(HueStateColorBulb.ColorMode.xy));
-        assertThat(((HueStateColorBulb) cs.ds.lights.get("2").state).toHSBType().getHue().intValue(),
-                is((int) 27.47722590981918));
-        assertThat(((HueStateColorBulb) cs.ds.lights.get("2").state).toHSBType().getSaturation().intValue(), is(88));
-        assertThat(((HueStateColorBulb) cs.ds.lights.get("2").state).toHSBType().getBrightness().intValue(), is(78));
+        hueLightEntry = cs.ds.lights.get("2");
+        assertNotNull(hueLightEntry);
+        stateColorBulb = assertInstanceOf(HueStateColorBulb.class, hueLightEntry.state);
+        assertThat(stateColorBulb.on, is(true));
+        assertThat(stateColorBulb.bri, is(200));
+        assertThat(stateColorBulb.xy[0], is(0.5119));
+        assertThat(stateColorBulb.xy[1], is(0.4147));
+        assertThat(stateColorBulb.colormode, is(HueStateColorBulb.ColorMode.xy));
+        assertThat(stateColorBulb.toHSBType().getHue().intValue(), is((int) 27.47722590981918));
+        assertThat(stateColorBulb.toHSBType().getSaturation().intValue(), is(88));
+        assertThat(stateColorBulb.toHSBType().getBrightness().intValue(), is(78));
     }
 
     @Test
     public void allLightsAndSingleLight() throws Exception {
         ContentResponse response = commonSetup.sendGet("/testuser/lights");
-        assertEquals(200, response.getStatus());
+        assertThat(response.getStatus(), is(200));
 
         String body = response.getContentAsString();
 
@@ -372,7 +419,7 @@ public class LightsAndGroupsTests {
 
         // Single light access test
         response = commonSetup.sendGet("/testuser/lights/2");
-        assertEquals(200, response.getStatus());
+        assertThat(response.getStatus(), is(200));
         body = response.getContentAsString();
         assertThat(body, containsString("color"));
     }

--- a/bundles/org.openhab.io.hueemulation/src/test/java/org/openhab/io/hueemulation/internal/rest/RulesTests.java
+++ b/bundles/org.openhab.io.hueemulation/src/test/java/org/openhab/io/hueemulation/internal/rest/RulesTests.java
@@ -128,6 +128,7 @@ public class RulesTests {
 
         // Check hue entry
         HueRuleEntry entry = cs.ds.rules.get("demo1");
+        assertNotNull(entry);
         assertThat(entry.conditions.get(0).address, is("/lights/switch1/state/on"));
         assertThat(entry.conditions.get(0).operator, is(Operator.dx));
         assertThat(entry.actions.get(0).address, is("/lights/switch1/state"));
@@ -142,6 +143,7 @@ public class RulesTests {
         ruleRegistry.update(rule);
 
         entry = cs.ds.rules.get("demo1");
+        assertNotNull(entry);
         assertThat(entry.actions.get(0).address, is("/lights/switch2/state"));
         assertThat(entry.actions.get(0).method, is("PUT"));
         assertThat(entry.actions.get(0).body, is("{'on':false}"));
@@ -154,13 +156,12 @@ public class RulesTests {
         assertThat(entry, nullValue());
     }
 
-    @SuppressWarnings("null")
     @Test
     public void addGetRemoveRuleViaRest() throws Exception {
         // 1. Create
         String body = "{\"name\":\"test name\",\"description\":\"\",\"owner\":\"\",\"conditions\":[{\"address\":\"/lights/switch1/state/on\",\"operator\":\"dx\"}],\"actions\":[{\"address\":\"/lights/switch1/state\",\"method\":\"PUT\",\"body\":\"{\\u0027on\\u0027:true}\"}]}";
         ContentResponse response = commonSetup.sendPost("/testuser/rules", body);
-        assertEquals(200, response.getStatus());
+        assertThat(response.getStatus(), is(200));
         assertThat(response.getContentAsString(), containsString("success"));
 
         // 1.1 Check for entry
@@ -172,19 +173,21 @@ public class RulesTests {
 
         // 1.2 Check for rule
         Rule rule = ruleRegistry.get(idAndEntry.getKey());
+        assertNotNull(rule);
         assertThat(rule.getName(), is("test name"));
         assertThat(rule.getActions().get(0).getId(), is("-api-testuser-lights-switch1-state"));
         assertThat(rule.getActions().get(0).getTypeUID(), is("rules.HttpAction"));
 
         // 2. Get
         response = commonSetup.sendGet("/testuser/rules/" + idAndEntry.getKey());
-        assertEquals(200, response.getStatus());
+        assertThat(response.getStatus(), is(200));
         HueSceneEntry fromJson = new Gson().fromJson(response.getContentAsString(), HueSceneEntry.class);
+        assertNotNull(fromJson);
         assertThat(fromJson.name, is(idAndEntry.getValue().name));
 
         // 3. Remove
         response = commonSetup.sendDelete("/testuser/rules/" + idAndEntry.getKey());
-        assertEquals(200, response.getStatus());
+        assertThat(response.getStatus(), is(200));
         assertTrue(cs.ds.rules.isEmpty());
     }
 
@@ -205,7 +208,7 @@ public class RulesTests {
         // Modify (just the name)
         String body = "{ 'name':'A new name'}";
         ContentResponse response = commonSetup.sendPut("/testuser/rules/demo1", body);
-        assertEquals(200, response.getStatus());
+        assertThat(response.getStatus(), is(200));
         assertThat(response.getContentAsString(), containsString("name"));
 
         Entry<String, HueRuleEntry> idAndEntry = cs.ds.rules.entrySet().stream().findAny().get();
@@ -226,7 +229,7 @@ public class RulesTests {
         // Modify (Change condition)
         body = "{\"conditions\":[{\"address\":\"/lights/switch1/state/on\",\"operator\":\"ddx\"}]}";
         response = commonSetup.sendPut("/testuser/rules/demo1", body);
-        assertEquals(200, response.getStatus());
+        assertThat(response.getStatus(), is(200));
         assertThat(response.getContentAsString(), containsString("conditions"));
 
         idAndEntry = cs.ds.rules.entrySet().stream().findAny().get();
@@ -237,7 +240,7 @@ public class RulesTests {
         // Modify (Change action)
         body = "{\"actions\":[{\"address\":\"/lights/switch2/state\",\"method\":\"PUT\",\"body\":\"{\\u0027on\\u0027:false}\"}]}";
         response = commonSetup.sendPut("/testuser/rules/demo1", body);
-        assertEquals(200, response.getStatus());
+        assertThat(response.getStatus(), is(200));
         assertThat(response.getContentAsString(), containsString("actions"));
 
         idAndEntry = cs.ds.rules.entrySet().stream().findAny().get();
@@ -265,7 +268,9 @@ public class RulesTests {
         }.getType();
         String body = response.getContentAsString();
         Map<String, HueRuleEntry> fromJson = new Gson().fromJson(body, type);
+        assertNotNull(fromJson);
         HueRuleEntry entry = fromJson.get("demo1");
+        assertNotNull(entry);
         assertThat(entry.name, is("test name"));
         assertThat(entry.actions.get(0).address, is("/lights/switch1/state"));
         assertThat(entry.conditions.get(0).address, is("/lights/switch1/state/on"));

--- a/bundles/org.openhab.io.hueemulation/src/test/java/org/openhab/io/hueemulation/internal/rest/SceneTests.java
+++ b/bundles/org.openhab.io.hueemulation/src/test/java/org/openhab/io/hueemulation/internal/rest/SceneTests.java
@@ -18,6 +18,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.IOException;
 import java.lang.reflect.Type;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
@@ -101,7 +102,6 @@ public class SceneTests {
         commonSetup.dispose();
     }
 
-    @SuppressWarnings("null")
     @Test
     public void addUpdateRemoveSceneToRegistry() {
         Rule rule = RuleBuilder.create("demo1").withTags("scene") //
@@ -110,7 +110,11 @@ public class SceneTests {
         ruleRegistry.add(rule);
 
         HueSceneEntry sceneEntry = cs.ds.scenes.get("demo1");
-        assertThat(sceneEntry.lights.get(0), CoreMatchers.is("switch1"));
+        assertNotNull(sceneEntry);
+        List<String> lights = sceneEntry.lights;
+        assertNotNull(lights);
+        String light = lights.get(0);
+        assertThat(light, CoreMatchers.is("switch1"));
 
         // Update
         rule = RuleBuilder.create("demo1").withTags("scene") //
@@ -118,7 +122,11 @@ public class SceneTests {
         ruleRegistry.update(rule);
 
         sceneEntry = cs.ds.scenes.get("demo1");
-        assertThat(sceneEntry.lights.get(0), CoreMatchers.is("white1"));
+        assertNotNull(sceneEntry);
+        lights = sceneEntry.lights;
+        assertNotNull(lights);
+        light = lights.get(0);
+        assertThat(light, CoreMatchers.is("white1"));
 
         // Remove
 
@@ -127,40 +135,45 @@ public class SceneTests {
         assertThat(sceneEntry, CoreMatchers.nullValue());
     }
 
-    @SuppressWarnings("null")
     @Test
     public void addGetRemoveSceneViaRest() throws Exception {
         // 1. Create
         String body = "{ 'name':'Cozy dinner', 'recycle':false, 'lights':['switch1','white1'], 'type':'LightScene'}";
         ContentResponse response = commonSetup.sendPost("/testuser/scenes", body);
-        assertEquals(200, response.getStatus());
+        assertThat(response.getStatus(), is(200));
         assertThat(response.getContentAsString(), containsString("success"));
 
         // 1.1 Check for scene entry
         Entry<String, HueSceneEntry> entry = cs.ds.scenes.entrySet().stream().findAny().get();
+        assertNotNull(entry);
         assertThat(entry.getValue().name, is("Cozy dinner"));
-        assertThat(entry.getValue().lights.get(0), is("switch1"));
-        assertThat(entry.getValue().lights.get(1), is("white1"));
+        List<String> lights = entry.getValue().lights;
+        assertNotNull(lights);
+        String light = lights.get(0);
+        assertThat(light, is("switch1"));
+        light = lights.get(1);
+        assertThat(light, is("white1"));
 
         // 1.2 Check for rule
         Rule rule = ruleRegistry.get(entry.getKey());
+        assertNotNull(rule);
         assertThat(rule.getName(), is("Cozy dinner"));
         assertThat(rule.getActions().get(0).getId(), is("switch1"));
         assertThat(rule.getActions().get(1).getId(), is("white1"));
 
         // 2. Get
         response = commonSetup.sendGet("/testuser/scenes/" + entry.getKey());
-        assertEquals(200, response.getStatus());
+        assertThat(response.getStatus(), is(200));
         HueSceneEntry fromJson = new Gson().fromJson(response.getContentAsString(), HueSceneEntry.class);
+        assertNotNull(fromJson);
         assertThat(fromJson.name, is(entry.getValue().name));
 
         // 3. Remove
         response = commonSetup.sendDelete("/testuser/scenes/" + entry.getKey());
-        assertEquals(200, response.getStatus());
+        assertThat(response.getStatus(), is(200));
         assertTrue(cs.ds.scenes.isEmpty());
     }
 
-    @SuppressWarnings("null")
     @Test
     public void updateSceneViaRest() throws Exception {
         Rule rule = RuleBuilder.create("demo1").withTags("scene").withName("Some name") //
@@ -171,12 +184,16 @@ public class SceneTests {
         // 3. Modify (just the name)
         String body = "{ 'name':'A new name'}";
         ContentResponse response = commonSetup.sendPut("/testuser/scenes/demo1", body);
-        assertEquals(200, response.getStatus());
+        assertThat(response.getStatus(), is(200));
         assertThat(response.getContentAsString(), containsString("name"));
 
         Entry<String, HueSceneEntry> sceneEntry = cs.ds.scenes.entrySet().stream().findAny().get();
+        assertNotNull(sceneEntry);
         assertThat(sceneEntry.getValue().name, is("A new name"));
-        assertThat(sceneEntry.getValue().lights.get(0), is("switch1")); // nothing else should have changed
+        List<String> lights = sceneEntry.getValue().lights;
+        assertNotNull(lights);
+        String light = lights.get(0);
+        assertThat(light, is("switch1")); // nothing else should have changed
 
         // 3. Modify (just the lights)
         rule = RuleBuilder.create("demo1").withTags("scene").withName("Some name") //
@@ -190,22 +207,30 @@ public class SceneTests {
         // Without store lights
         body = "{ 'lights':['white1']}";
         response = commonSetup.sendPut("/testuser/scenes/demo1", body);
-        assertEquals(200, response.getStatus());
+        assertThat(response.getStatus(), is(200));
         assertThat(response.getContentAsString(), containsString("lights"));
 
         sceneEntry = cs.ds.scenes.entrySet().stream().findAny().get();
+        assertNotNull(sceneEntry);
         assertThat(sceneEntry.getValue().name, is("Some name")); // should not have changed
         assertThat(sceneEntry.getKey(), is(uid));
-        assertThat(sceneEntry.getValue().lights.get(0), is("switch1")); // storelightstate not set, lights not changed
+        lights = sceneEntry.getValue().lights;
+        assertNotNull(lights);
+        light = lights.get(0);
+        assertThat(light, is("switch1")); // storelightstate not set, lights not changed
 
         // With store lights
         body = "{ 'lights':['white1'], 'storelightstate':true }";
         response = commonSetup.sendPut("/testuser/scenes/demo1", body);
-        assertEquals(200, response.getStatus());
+        assertThat(response.getStatus(), is(200));
         assertThat(response.getContentAsString(), containsString("lights"));
 
         sceneEntry = cs.ds.scenes.entrySet().stream().findAny().get();
-        assertThat(sceneEntry.getValue().lights.get(0), is("white1"));
+        assertNotNull(sceneEntry);
+        lights = sceneEntry.getValue().lights;
+        assertNotNull(lights);
+        light = lights.get(0);
+        assertThat(light, is("white1"));
     }
 
     @Test
@@ -219,6 +244,7 @@ public class SceneTests {
         Type type = new TypeToken<Map<String, HueSceneEntry>>() {
         }.getType();
         Map<String, HueSceneEntry> fromJson = new Gson().fromJson(response.getContentAsString(), type);
+        assertNotNull(fromJson);
         assertTrue(fromJson.containsKey("demo1"));
     }
 }

--- a/bundles/org.openhab.io.hueemulation/src/test/java/org/openhab/io/hueemulation/internal/rest/ScheduleTests.java
+++ b/bundles/org.openhab.io.hueemulation/src/test/java/org/openhab/io/hueemulation/internal/rest/ScheduleTests.java
@@ -102,7 +102,6 @@ public class ScheduleTests {
         commonSetup.dispose();
     }
 
-    @SuppressWarnings("null")
     @Test
     public void addUpdateRemoveScheduleToRegistry() {
         HueCommand command = new HueCommand("/api/testuser/lights/1/state", "PUT", "{'on':true}");
@@ -116,9 +115,12 @@ public class ScheduleTests {
 
         // Check hue entry
         HueScheduleEntry sceneEntry = cs.ds.schedules.get("demo1");
-        assertThat(sceneEntry.command.address, is("/api/testuser/lights/1/state"));
-        assertThat(sceneEntry.command.method, is("PUT"));
-        assertThat(sceneEntry.command.body, is("{'on':true}"));
+        assertNotNull(sceneEntry);
+        command = sceneEntry.command;
+        assertNotNull(command);
+        assertThat(command.address, is("/api/testuser/lights/1/state"));
+        assertThat(command.method, is("PUT"));
+        assertThat(command.body, is("{'on':true}"));
         assertThat(sceneEntry.localtime, is(localtime));
 
         // Update
@@ -129,7 +131,10 @@ public class ScheduleTests {
         ruleRegistry.update(rule);
 
         sceneEntry = cs.ds.schedules.get("demo1");
-        assertThat(sceneEntry.command.address, is("/api/testuser/lights/1/state"));
+        assertNotNull(sceneEntry);
+        command = sceneEntry.command;
+        assertNotNull(command);
+        assertThat(command.address, is("/api/testuser/lights/1/state"));
         assertThat(sceneEntry.localtime, is(localtime));
 
         // Remove
@@ -139,43 +144,46 @@ public class ScheduleTests {
         assertThat(sceneEntry, nullValue());
     }
 
-    @SuppressWarnings("null")
     @Test
     public void addGetRemoveScheduleViaRest() throws Exception {
         // 1. Create
         String body = "{ 'name':'Wake up', 'description':'My wake up alarm', 'localtime':'2015-06-30T14:24:40'," + //
                 "'command':{'address':'/api/testuser/lights/1/state','method':'PUT','body':'{\"on\":true}'} }";
         ContentResponse response = commonSetup.sendPost("/testuser/schedules", body);
-        assertEquals(200, response.getStatus());
+        assertThat(response.getStatus(), is(200));
         assertThat(response.getContentAsString(), containsString("success"));
 
         // 1.1 Check for entry
         Entry<String, HueScheduleEntry> entry = cs.ds.schedules.entrySet().stream().findAny().get();
+        assertNotNull(entry);
         assertThat(entry.getValue().name, is("Wake up"));
-        assertThat(entry.getValue().command.address, is("/api/testuser/lights/1/state"));
-        assertThat(entry.getValue().command.method, is("PUT"));
-        assertThat(entry.getValue().command.body, is("{\"on\":true}"));
+        HueCommand command = entry.getValue().command;
+        assertNotNull(command);
+        assertThat(command.address, is("/api/testuser/lights/1/state"));
+        assertThat(command.method, is("PUT"));
+        assertThat(command.body, is("{\"on\":true}"));
         assertThat(entry.getValue().localtime, is("2015-06-30T14:24:40"));
 
         // 1.2 Check for rule
         Rule rule = ruleRegistry.get(entry.getKey());
+        assertNotNull(rule);
         assertThat(rule.getName(), is("Wake up"));
         assertThat(rule.getActions().get(0).getId(), is("command"));
         assertThat(rule.getActions().get(0).getTypeUID(), is("rules.HttpAction"));
 
         // 2. Get
         response = commonSetup.sendGet("/testuser/schedules/" + entry.getKey());
-        assertEquals(200, response.getStatus());
+        assertThat(response.getStatus(), is(200));
         HueSceneEntry fromJson = new Gson().fromJson(response.getContentAsString(), HueSceneEntry.class);
+        assertNotNull(fromJson);
         assertThat(fromJson.name, is(entry.getValue().name));
 
         // 3. Remove
         response = commonSetup.sendDelete("/testuser/schedules/" + entry.getKey());
-        assertEquals(200, response.getStatus());
+        assertThat(response.getStatus(), is(200));
         assertTrue(cs.ds.schedules.isEmpty());
     }
 
-    @SuppressWarnings("null")
     @Test
     public void updateScheduleViaRest() throws Exception {
         HueCommand command = new HueCommand("/api/testuser/lights/1/state", "PUT", "{'on':true}");
@@ -190,13 +198,16 @@ public class ScheduleTests {
         // Modify (just the name)
         String body = "{ 'name':'A new name'}";
         ContentResponse response = commonSetup.sendPut("/testuser/schedules/demo1", body);
-        assertEquals(200, response.getStatus());
+        assertThat(response.getStatus(), is(200));
         assertThat(response.getContentAsString(), containsString("name"));
 
         Entry<String, HueScheduleEntry> entry = cs.ds.schedules.entrySet().stream().findAny().get();
+        assertNotNull(entry);
         assertThat(entry.getValue().name, is("A new name"));
-        assertThat(entry.getValue().command.address, is("/api/testuser/lights/1/state")); // nothing else should have
-                                                                                          // changed
+        command = entry.getValue().command;
+        assertNotNull(command);
+        // nothing else should have changed
+        assertThat(command.address, is("/api/testuser/lights/1/state"));
         assertThat(entry.getValue().localtime, is(localtime));
 
         // Reset
@@ -212,10 +223,11 @@ public class ScheduleTests {
         // Modify (Change time)
         body = "{ 'localtime':'2015-06-30T14:24:40'}";
         response = commonSetup.sendPut("/testuser/schedules/demo1", body);
-        assertEquals(200, response.getStatus());
+        assertThat(response.getStatus(), is(200));
         assertThat(response.getContentAsString(), containsString("localtime"));
 
         entry = cs.ds.schedules.entrySet().stream().findAny().get();
+        assertNotNull(entry);
         assertThat(entry.getValue().name, is("test name")); // should not have changed
         assertThat(entry.getKey(), is(uid));
         assertThat(entry.getValue().localtime, is("2015-06-30T14:24:40"));
@@ -223,13 +235,16 @@ public class ScheduleTests {
         // Modify (Change command)
         body = "{ 'command':{'address':'/api/testuser/lights/2/state','method':'PUT','body':'{\"on\":true}'} }";
         response = commonSetup.sendPut("/testuser/schedules/demo1", body);
-        assertEquals(200, response.getStatus());
+        assertThat(response.getStatus(), is(200));
         assertThat(response.getContentAsString(), containsString("command"));
 
         entry = cs.ds.schedules.entrySet().stream().findAny().get();
+        assertNotNull(entry);
         assertThat(entry.getValue().name, is("test name")); // should not have changed
         assertThat(entry.getKey(), is(uid));
-        assertThat(entry.getValue().command.address, is("/api/testuser/lights/2/state"));
+        command = entry.getValue().command;
+        assertNotNull(command);
+        assertThat(command.address, is("/api/testuser/lights/2/state"));
     }
 
     @Test
@@ -247,6 +262,7 @@ public class ScheduleTests {
         Type type = new TypeToken<Map<String, HueSceneEntry>>() {
         }.getType();
         Map<String, HueSceneEntry> fromJson = new Gson().fromJson(response.getContentAsString(), type);
+        assertNotNull(fromJson);
         assertTrue(fromJson.containsKey("demo1"));
     }
 

--- a/bundles/org.openhab.io.hueemulation/src/test/java/org/openhab/io/hueemulation/internal/rest/SensorTests.java
+++ b/bundles/org.openhab.io.hueemulation/src/test/java/org/openhab/io/hueemulation/internal/rest/SensorTests.java
@@ -14,7 +14,7 @@ package org.openhab.io.hueemulation.internal.rest;
 
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jetty.client.HttpClient;
@@ -38,6 +38,7 @@ import org.openhab.core.library.types.OpenClosedType;
 import org.openhab.core.library.types.PercentType;
 import org.openhab.core.types.State;
 import org.openhab.io.hueemulation.internal.ConfigStore;
+import org.openhab.io.hueemulation.internal.dto.HueSensorEntry;
 import org.openhab.io.hueemulation.internal.rest.mocks.DummyItemRegistry;
 
 /**
@@ -94,23 +95,27 @@ public class SensorTests {
 
     @Test
     public void renameSensor() throws Exception {
-        assertThat(cs.ds.sensors.get("switch1").name, is("name1"));
+        HueSensorEntry sensorEntry = cs.ds.sensors.get("switch1");
+        assertNotNull(sensorEntry);
+        assertThat(sensorEntry.name, is("name1"));
 
         String body = "{'name':'name2'}";
         ContentResponse response = commonSetup.sendPut("/testuser/sensors/switch1", body);
-        assertEquals(200, response.getStatus());
+        assertThat(response.getStatus(), is(200));
 
         body = response.getContentAsString();
 
         assertThat(body, containsString("success"));
         assertThat(body, containsString("name"));
-        assertThat(cs.ds.sensors.get("switch1").name, is("name2"));
+        sensorEntry = cs.ds.sensors.get("switch1");
+        assertNotNull(sensorEntry);
+        assertThat(sensorEntry.name, is("name2"));
     }
 
     @Test
     public void allAndSingleSensor() throws Exception {
         ContentResponse response = commonSetup.sendGet("/testuser/sensors");
-        assertEquals(200, response.getStatus());
+        assertThat(response.getStatus(), is(200));
 
         String body = response.getContentAsString();
 
@@ -120,7 +125,7 @@ public class SensorTests {
 
         // Single light access test
         response = commonSetup.sendGet("/testuser/sensors/switch1");
-        assertEquals(200, response.getStatus());
+        assertThat(response.getStatus(), is(200));
         body = response.getContentAsString();
         assertThat(body, containsString("CLIPGenericFlag"));
     }

--- a/bundles/org.openhab.io.hueemulation/src/test/java/org/openhab/io/hueemulation/internal/upnp/UpnpTests.java
+++ b/bundles/org.openhab.io.hueemulation/src/test/java/org/openhab/io/hueemulation/internal/upnp/UpnpTests.java
@@ -14,7 +14,6 @@ package org.openhab.io.hueemulation.internal.upnp;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 
 import java.io.IOException;
@@ -104,7 +103,7 @@ public class UpnpTests {
     @Test
     public void descriptionWithoutAddress() throws Exception {
         ContentResponse response = commonSetup.client.newRequest(descriptionPath).send();
-        assertEquals(404, response.getStatus());
+        assertThat(response.getStatus(), is(404));
     }
 
     @Test
@@ -114,7 +113,7 @@ public class UpnpTests {
         r = subject.performAddressTest(r);
         subject.applyConfiguration(r);
         ContentResponse response = commonSetup.client.newRequest(descriptionPath).send();
-        assertEquals(200, response.getStatus());
+        assertThat(response.getStatus(), is(200));
         String body = response.getContentAsString();
         assertThat(body, is(subject.xmlDocWithAddress));
 


### PR DESCRIPTION
E.g. on `PUT` request for `http://openhab:8080/api/userid/config` with empty body:
```text
2025-10-29 20:55:12.568 [ERROR] [.AbstractFaultChainInitiatorObserver] - An unexpected error occurred during error handling. No further error processing will occur.
org.apache.cxf.interceptor.Fault: Cannot read field "devicename" because "changes" is null
 at org.apache.cxf.service.invoker.AbstractInvoker.createFault(AbstractInvoker.java:162) ~[bundleFile:3.6.8]
 at org.apache.cxf.service.invoker.AbstractInvoker.invoke(AbstractInvoker.java:128) ~[bundleFile:3.6.8]
 at org.apache.cxf.jaxrs.JAXRSInvoker.invoke(JAXRSInvoker.java:201) ~[bundleFile:3.6.8]
 at org.apache.cxf.jaxrs.JAXRSInvoker.invoke(JAXRSInvoker.java:104) ~[bundleFile:3.6.8]
 at org.apache.cxf.interceptor.ServiceInvokerInterceptor$1.run(ServiceInvokerInterceptor.java:59) ~[bundleFile:3.6.8]
 at org.apache.cxf.interceptor.ServiceInvokerInterceptor.handleMessage(ServiceInvokerInterceptor.java:96) ~[bundleFile:3.6.8]
 at org.apache.cxf.phase.PhaseInterceptorChain.doIntercept(PhaseInterceptorChain.java:307) ~[bundleFile:3.6.8]
 at org.apache.cxf.transport.ChainInitiationObserver.onMessage(ChainInitiationObserver.java:121) ~[bundleFile:3.6.8]
 at org.apache.cxf.transport.http.AbstractHTTPDestination.invoke(AbstractHTTPDestination.java:267) ~[bundleFile:3.6.8]
 at org.apache.cxf.transport.servlet.ServletController.invokeDestination(ServletController.java:234) ~[bundleFile:3.6.8]
 at org.apache.cxf.transport.servlet.ServletController.invoke(ServletController.java:208) ~[bundleFile:3.6.8]
 at org.apache.cxf.transport.servlet.ServletController.invoke(ServletController.java:160) ~[bundleFile:3.6.8]
 at org.apache.cxf.transport.servlet.CXFNonSpringServlet.invoke(CXFNonSpringServlet.java:225) ~[bundleFile:3.6.8]
 at org.apache.cxf.transport.servlet.AbstractHTTPServlet.handleRequest(AbstractHTTPServlet.java:304) ~[bundleFile:3.6.8]
 at org.apache.cxf.transport.servlet.AbstractHTTPServlet.doPut(AbstractHTTPServlet.java:234) ~[bundleFile:3.6.8]
 at javax.servlet.http.HttpServlet.service(HttpServlet.java:520) ~[bundleFile:4.0.4]
 at org.apache.cxf.transport.servlet.AbstractHTTPServlet.service(AbstractHTTPServlet.java:279) ~[bundleFile:3.6.8]
 at org.ops4j.pax.web.service.spi.servlet.OsgiInitializedServlet.service(OsgiInitializedServlet.java:102) ~[bundleFile:?]
 at org.eclipse.jetty.servlet.ServletHolder.handle(ServletHolder.java:799) ~[bundleFile:9.4.57.v20241219]
 at org.eclipse.jetty.servlet.ServletHandler$ChainEnd.doFilter(ServletHandler.java:1656) ~[bundleFile:9.4.57.v20241219]
 at org.ops4j.pax.web.service.spi.servlet.OsgiFilterChain.doFilter(OsgiFilterChain.java:113) ~[bundleFile:?]
 at org.ops4j.pax.web.service.jetty.internal.PaxWebServletHandler.doHandle(PaxWebServletHandler.java:334) ~[bundleFile:?]
 at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:143) ~[bundleFile:9.4.57.v20241219]
 at org.eclipse.jetty.security.SecurityHandler.handle(SecurityHandler.java:600) ~[bundleFile:9.4.57.v20241219]
 at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:127) ~[bundleFile:9.4.57.v20241219]
 at org.eclipse.jetty.server.handler.ScopedHandler.nextHandle(ScopedHandler.java:235) ~[bundleFile:9.4.57.v20241219]
 at org.eclipse.jetty.server.session.SessionHandler.doHandle(SessionHandler.java:1624) ~[bundleFile:9.4.57.v20241219]
 at org.eclipse.jetty.server.handler.ScopedHandler.nextHandle(ScopedHandler.java:233) ~[bundleFile:9.4.57.v20241219]
 at org.eclipse.jetty.server.handler.ContextHandler.doHandle(ContextHandler.java:1440) ~[bundleFile:9.4.57.v20241219]
 at org.eclipse.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:188) ~[bundleFile:9.4.57.v20241219]
 at org.eclipse.jetty.servlet.ServletHandler.doScope(ServletHandler.java:505) ~[bundleFile:9.4.57.v20241219]
 at org.eclipse.jetty.server.session.SessionHandler.doScope(SessionHandler.java:1594) ~[bundleFile:9.4.57.v20241219]
 at org.eclipse.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:186) ~[bundleFile:9.4.57.v20241219]
 at org.eclipse.jetty.server.handler.ContextHandler.doScope(ContextHandler.java:1355) ~[bundleFile:9.4.57.v20241219]
 at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:141) ~[bundleFile:9.4.57.v20241219]
 at org.eclipse.jetty.server.handler.ContextHandlerCollection.handle(ContextHandlerCollection.java:234) ~[bundleFile:9.4.57.v20241219]
 at org.ops4j.pax.web.service.jetty.internal.PrioritizedHandlerCollection.handle(PrioritizedHandlerCollection.java:96) ~[bundleFile:?]
 at org.eclipse.jetty.server.handler.gzip.GzipHandler.handle(GzipHandler.java:722) ~[bundleFile:9.4.57.v20241219]
 at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:127) ~[bundleFile:9.4.57.v20241219]
 at org.eclipse.jetty.server.Server.handle(Server.java:516) ~[bundleFile:9.4.57.v20241219]
 at org.eclipse.jetty.server.HttpChannel.lambda$handle$1(HttpChannel.java:487) ~[bundleFile:9.4.57.v20241219]
 at org.eclipse.jetty.server.HttpChannel.dispatch(HttpChannel.java:732) ~[bundleFile:9.4.57.v20241219]
 at org.eclipse.jetty.server.HttpChannel.handle(HttpChannel.java:479) ~[bundleFile:9.4.57.v20241219]
 at org.eclipse.jetty.server.HttpConnection.onFillable(HttpConnection.java:277) ~[bundleFile:9.4.57.v20241219]
 at org.eclipse.jetty.io.AbstractConnection$ReadCallback.succeeded(AbstractConnection.java:311) ~[bundleFile:9.4.57.v20241219]
 at org.eclipse.jetty.io.FillInterest.fillable(FillInterest.java:105) ~[bundleFile:9.4.57.v20241219]
 at org.eclipse.jetty.io.ChannelEndPoint$1.run(ChannelEndPoint.java:104) ~[bundleFile:9.4.57.v20241219]
 at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.runTask(EatWhatYouKill.java:338) ~[bundleFile:9.4.57.v20241219]
 at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.doProduce(EatWhatYouKill.java:315) ~[bundleFile:9.4.57.v20241219]
 at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.tryProduce(EatWhatYouKill.java:173) ~[bundleFile:9.4.57.v20241219]
 at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.run(EatWhatYouKill.java:131) ~[bundleFile:9.4.57.v20241219]
 at org.eclipse.jetty.util.thread.ReservedThreadExecutor$ReservedThread.run(ReservedThreadExecutor.java:409) ~[bundleFile:9.4.57.v20241219]
 at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:883) ~[bundleFile:9.4.57.v20241219]
 at org.eclipse.jetty.util.thread.QueuedThreadPool$Runner.run(QueuedThreadPool.java:1034) ~[bundleFile:9.4.57.v20241219]
 at java.lang.Thread.run(Thread.java:1583) [?:?]
Caused by: java.lang.NullPointerException: Cannot read field "devicename" because "changes" is null
 at org.openhab.io.hueemulation.internal.rest.ConfigurationAccess.putFullConfigApi(ConfigurationAccess.java:114) ~[?:?]
 at jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103) ~[?:?]
 at java.lang.reflect.Method.invoke(Method.java:580) ~[?:?]
 at org.apache.cxf.service.invoker.AbstractInvoker.performInvocation(AbstractInvoker.java:179) ~[bundleFile:3.6.8]
 at org.apache.cxf.service.invoker.AbstractInvoker.invoke(AbstractInvoker.java:96) ~[bundleFile:3.6.8]
 ... 53 more
```

Also fix warnings.