### PR TITLE
[jrubyscripting] Set .bundle directory to $USERDATA/cache/automation/ruby/.bundle

### DIFF
--- a/bundles/org.openhab.automation.jrubyscripting/src/main/java/org/openhab/automation/jrubyscripting/internal/JRubyScriptEngineConfiguration.java
+++ b/bundles/org.openhab.automation.jrubyscripting/src/main/java/org/openhab/automation/jrubyscripting/internal/JRubyScriptEngineConfiguration.java
@@ -241,6 +241,16 @@ public class JRubyScriptEngineConfiguration {
                     "The Gemfile setting is set to '{}' which is a directory. It should be set to a file. Setting it to '{}'",
                     gemfilePath, gemfile);
         }
+
+        File bundleUserConfigDir = gemfilePath.resolveSibling(".bundle").toFile();
+        if (!bundleUserConfigDir.exists()) {
+            boolean created = bundleUserConfigDir.mkdirs();
+            if (created) {
+                LOGGER.debug("Created directory for Ruby Bundler user config path: {}", bundleUserConfigDir);
+            } else {
+                LOGGER.warn("Could not create directory for Ruby Bundler user config path: {}", bundleUserConfigDir);
+            }
+        }
         return gemfile;
     }
 
@@ -432,6 +442,8 @@ public class JRubyScriptEngineConfiguration {
         setEnvironmentVariable(scriptEngine, "BUNDLE_USER_HOME", BUNDLE_USER_HOME.toString());
         if (bundleGemfile.exists()) {
             setEnvironmentVariable(scriptEngine, "BUNDLE_GEMFILE", bundleGemfile.toString());
+            setEnvironmentVariable(scriptEngine, "BUNDLE_USER_CONFIG",
+                    bundleGemfile.toPath().resolveSibling(".bundle").resolve("config").toString());
         }
 
         configureRubyLib(scriptEngine);

--- a/bundles/org.openhab.automation.jrubyscripting/src/main/java/org/openhab/automation/jrubyscripting/internal/JRubyScriptEngineConfiguration.java
+++ b/bundles/org.openhab.automation.jrubyscripting/src/main/java/org/openhab/automation/jrubyscripting/internal/JRubyScriptEngineConfiguration.java
@@ -49,6 +49,8 @@ public class JRubyScriptEngineConfiguration {
     public static final Path HOME_PATH = Path.of("automation", "ruby");
     public static final Path HOME_PATH_ABS = Path.of(OpenHAB.getConfigFolder()).resolve(HOME_PATH);
     private static final Path DEFAULT_GEMFILE_PATH = HOME_PATH_ABS.resolve("Gemfile");
+    private static final Path BUNDLE_USER_HOME = Path.of(OpenHAB.getUserDataFolder(), "cache", "automation", "ruby",
+            ".bundle");
 
     private static final Logger LOGGER = LoggerFactory.getLogger(JRubyScriptEngineConfiguration.class);
 
@@ -83,6 +85,18 @@ public class JRubyScriptEngineConfiguration {
 
     private String specificGemHome = "";
     private File bundleGemfile = DEFAULT_GEMFILE_PATH.toFile();
+
+    JRubyScriptEngineConfiguration() {
+        File dir = BUNDLE_USER_HOME.toFile();
+        if (!dir.exists()) {
+            boolean created = dir.mkdirs();
+            if (created) {
+                LOGGER.debug("Created directory for Ruby Bundler user path: {}", dir);
+            } else {
+                LOGGER.warn("Could not create directory for Ruby Bundler user path: {}", dir);
+            }
+        }
+    }
 
     /**
      * Update configuration
@@ -241,7 +255,7 @@ public class JRubyScriptEngineConfiguration {
 
     /**
      * Run bundle install or update.
-     * 
+     *
      * This is to be called at start up or configuration change,
      * so that gems are available when user scripts are run.
      *
@@ -302,7 +316,7 @@ public class JRubyScriptEngineConfiguration {
 
     /**
      * Install a gems in ScriptEngine
-     * 
+     *
      * @param engine Engine to install gems
      */
     synchronized void configureGems(ScriptEngine engine, boolean update) {
@@ -415,6 +429,7 @@ public class JRubyScriptEngineConfiguration {
     public void configureRubyEnvironment(ScriptEngine scriptEngine) {
         setEnvironmentVariable(scriptEngine, "GEM_HOME", getSpecificGemHome());
         setEnvironmentVariable(scriptEngine, "RUBYLIB", configuration.rubylib);
+        setEnvironmentVariable(scriptEngine, "BUNDLE_USER_HOME", BUNDLE_USER_HOME.toString());
         if (bundleGemfile.exists()) {
             setEnvironmentVariable(scriptEngine, "BUNDLE_GEMFILE", bundleGemfile.toString());
         }

--- a/bundles/org.openhab.automation.jrubyscripting/src/main/java/org/openhab/automation/jrubyscripting/internal/JRubyScriptEngineConfiguration.java
+++ b/bundles/org.openhab.automation.jrubyscripting/src/main/java/org/openhab/automation/jrubyscripting/internal/JRubyScriptEngineConfiguration.java
@@ -49,8 +49,7 @@ public class JRubyScriptEngineConfiguration {
     public static final Path HOME_PATH = Path.of("automation", "ruby");
     public static final Path HOME_PATH_ABS = Path.of(OpenHAB.getConfigFolder()).resolve(HOME_PATH);
     private static final Path DEFAULT_GEMFILE_PATH = HOME_PATH_ABS.resolve("Gemfile");
-    private static final Path BUNDLE_USER_HOME = Path.of(OpenHAB.getUserDataFolder(), "cache", "automation", "ruby",
-            ".bundle");
+    private static final Path BUNDLE_USER_HOME = Path.of(OpenHAB.getUserDataFolder(), "cache", "automation", "ruby");
 
     private static final Logger LOGGER = LoggerFactory.getLogger(JRubyScriptEngineConfiguration.class);
 
@@ -266,6 +265,8 @@ public class JRubyScriptEngineConfiguration {
                 require "bundler"
                 require "bundler/cli"
 
+                Gem.instance_variable_set(:@user_home, ENV['BUNDLE_USER_HOME'])
+
                 Bundler::CLI.start(["%s"])
                 """.formatted(operation);
 
@@ -293,6 +294,8 @@ public class JRubyScriptEngineConfiguration {
                 require "jruby"
                 JRuby.runtime.instance_config.update_native_env_enabled = false
                 require  "bundler"
+
+                Gem.instance_variable_set(:@user_home, ENV['BUNDLE_USER_HOME'])
 
                 Bundler.settings.temporary(auto_install: true) do
                   require "bundler/setup"
@@ -360,6 +363,8 @@ public class JRubyScriptEngineConfiguration {
                 require 'bundler/inline'
                 require 'openssl'
 
+                Gem.instance_variable_set(:@user_home, ENV['BUNDLE_USER_HOME'])
+
                 gemfile(%b) do
                   source 'https://rubygems.org/'
                 %s
@@ -424,10 +429,10 @@ public class JRubyScriptEngineConfiguration {
     public void configureRubyEnvironment(ScriptEngine scriptEngine) {
         setEnvironmentVariable(scriptEngine, "GEM_HOME", getSpecificGemHome());
         setEnvironmentVariable(scriptEngine, "RUBYLIB", configuration.rubylib);
+        setEnvironmentVariable(scriptEngine, "BUNDLE_USER_HOME", BUNDLE_USER_HOME.toString());
         if (bundleGemfile.exists()) {
             Path bundleUserConfigDir = bundleGemfile.toPath().resolveSibling(".bundle");
             ensureDirectoryExists(bundleUserConfigDir.toString(), "Ruby Bundler user config path");
-            setEnvironmentVariable(scriptEngine, "BUNDLE_USER_HOME", BUNDLE_USER_HOME.toString());
             setEnvironmentVariable(scriptEngine, "BUNDLE_USER_CONFIG",
                     bundleUserConfigDir.resolve("config").toString());
             setEnvironmentVariable(scriptEngine, "BUNDLE_GEMFILE", bundleGemfile.toString());

--- a/bundles/org.openhab.automation.jrubyscripting/src/main/java/org/openhab/automation/jrubyscripting/internal/JRubyScriptEngineConfiguration.java
+++ b/bundles/org.openhab.automation.jrubyscripting/src/main/java/org/openhab/automation/jrubyscripting/internal/JRubyScriptEngineConfiguration.java
@@ -49,6 +49,8 @@ public class JRubyScriptEngineConfiguration {
     public static final Path HOME_PATH = Path.of("automation", "ruby");
     public static final Path HOME_PATH_ABS = Path.of(OpenHAB.getConfigFolder()).resolve(HOME_PATH);
     private static final Path DEFAULT_GEMFILE_PATH = HOME_PATH_ABS.resolve("Gemfile");
+    private static final Path BUNDLE_USER_HOME = Path.of(OpenHAB.getUserDataFolder(), "cache", "automation", "ruby",
+            ".bundle");
 
     private static final Logger LOGGER = LoggerFactory.getLogger(JRubyScriptEngineConfiguration.class);
 
@@ -100,6 +102,7 @@ public class JRubyScriptEngineConfiguration {
         bundleGemfile = resolveGemfile();
         specificGemHome = resolveSpecificGemHome();
         ensureGemHomeExists(specificGemHome);
+        ensureDirectoryExists(BUNDLE_USER_HOME.toString(), "Ruby Bundler user path");
 
         configureSystemProperties();
 
@@ -200,15 +203,18 @@ public class JRubyScriptEngineConfiguration {
             return false;
         }
 
-        File gemHomeDirectory = new File(gemHome);
-        if (!gemHomeDirectory.exists()) {
-            LOGGER.debug("gem_home directory '{}' does not exist, creating", gemHome);
-            if (!gemHomeDirectory.mkdirs()) {
-                LOGGER.warn("Error creating gem_home directory: {}", gemHome);
-                return false;
+        return ensureDirectoryExists(gemHome, "gem_home directory");
+    }
+
+    private boolean ensureDirectoryExists(String dir, String description) {
+        File directory = new File(dir);
+        if (!directory.exists()) {
+            LOGGER.debug("{} '{}' does not exist, creating", description, dir);
+            if (!directory.mkdirs()) {
+                LOGGER.warn("Error creating {}: {}", description, dir);
             }
         }
-        return true;
+        return directory.exists();
     }
 
     private File resolveGemfile() {
@@ -416,12 +422,18 @@ public class JRubyScriptEngineConfiguration {
     public void configureRubyEnvironment(ScriptEngine scriptEngine) {
         setEnvironmentVariable(scriptEngine, "GEM_HOME", getSpecificGemHome());
         setEnvironmentVariable(scriptEngine, "RUBYLIB", configuration.rubylib);
+        setEnvironmentVariable(scriptEngine, "BUNDLE_USER_HOME", BUNDLE_USER_HOME.toString());
         if (bundleGemfile.exists()) {
+            Path bundleUserConfigDir = bundleGemfile.toPath().resolveSibling(".bundle");
+            ensureDirectoryExists(bundleUserConfigDir.toString(), "Ruby Bundler user config path");
+            setEnvironmentVariable(scriptEngine, "BUNDLE_USER_CONFIG",
+                    bundleUserConfigDir.resolve("config").toString());
             setEnvironmentVariable(scriptEngine, "BUNDLE_GEMFILE", bundleGemfile.toString());
         }
 
         configureRubyLib(scriptEngine);
         disallowExec(scriptEngine);
+        patchBundlerEnvironment(scriptEngine);
         configureOpenHABGem(scriptEngine);
     }
 
@@ -460,6 +472,31 @@ public class JRubyScriptEngineConfiguration {
                     """);
         } catch (ScriptException exception) {
             LOGGER.warn("Error preventing exec", unwrap(exception));
+        }
+    }
+
+    /**
+     * Override unbundle_env to reinsert BUNDLE_USER_HOME into the environment,
+     * so that the inline bundler creates the bundle cache in BUNDLE_USER_HOME instead of in ~openhab/.bundle
+     * See https://github.com/openhab/openhab-addons/issues/19489
+     *
+     * @param engine Engine in which to configure environment
+     */
+    private void patchBundlerEnvironment(ScriptEngine engine) {
+        try {
+            engine.eval("""
+                    require 'bundler'
+
+                    module BundlerEnvironmentOverride
+                      def unbundle_env(...)
+                        bundle_user_home = ENV['BUNDLE_USER_HOME']
+                        super.tap { |env| env['BUNDLE_USER_HOME'] = bundle_user_home }
+                      end
+                    end
+                    Bundler.singleton_class.prepend(BundlerEnvironmentOverride)
+                    """);
+        } catch (ScriptException exception) {
+            LOGGER.warn("Error patching Bundler environment", unwrap(exception));
         }
     }
 


### PR DESCRIPTION
set `BUNDLE_USER_HOME=$USERDATA/cache/automation/ruby/.bundle`
set `BUNDLE_USER_CONFIG=<Gemfile's directory>/.bundle/config` (by default `$CONF/automation/ruby/.bundle/config`)

Resolve #19489

```
openhab> jrubyscripting bundle config                                                                                               
Settings are listed in order of priority. The top value will be used.
gemfile
Set via BUNDLE_GEMFILE: "/openhab/conf/automation/ruby/Gemfile"

user_config
Set via BUNDLE_USER_CONFIG: "/openhab/conf/automation/ruby/.bundle/config"

user_home
Set via BUNDLE_USER_HOME: "/openhab/userdata/cache/automation/ruby/.bundle"


openhab> jrubyscripting bundle config get clean 
Settings for `clean` in order of priority. The top value will be used
You have not configured a value for `clean`
openhab> jrubyscripting bundle config set clean true
openhab> jrubyscripting bundle config get clean
Settings for `clean` in order of priority. The top value will be used
Set for your local app (/openhab/conf/automation/ruby/.bundle/config): true
Set for the current user (/openhab/conf/automation/ruby/.bundle/config): true
```

```
root@da1c4ae2491c:/openhab# cd conf/automation/ruby/.bundle/
root@da1c4ae2491c:/openhab/conf/automation/ruby/.bundle# ls
config
root@da1c4ae2491c:/openhab/conf/automation/ruby/.bundle# cat config 
---
BUNDLE_CLEAN: "true"
```

