### PR TITLE
[enocean] Add proper constraint for serial port `path` parameter

### DIFF
--- a/bundles/org.openhab.binding.enocean/src/main/resources/OH-INF/thing/bridge.xml
+++ b/bundles/org.openhab.binding.enocean/src/main/resources/OH-INF/thing/bridge.xml
@@ -16,6 +16,7 @@
 
 		<config-description>
 			<parameter name="path" type="text" required="true">
+				<context>serial-port</context>
 				<label>Path</label>
 				<description>Path to the EnOcean gateway</description>
 			</parameter>


### PR DESCRIPTION
When configuring an EnOcean bridge now the MainUI can support the user, forcing him to enter as path a valid address.  

If the address is invalid, (here has an additional `2` at the end) now the following message appears, mentioning all possible values.

<img width="747" height="654" alt="image" src="https://github.com/user-attachments/assets/62ecdf02-7f75-41ed-a17c-33312c686c6c" />
