### PR TITLE
[ecoflow] Fix missing updates for PowerStream channels

### DIFF
--- a/bundles/org.openhab.binding.ecoflow/src/main/java/org/openhab/binding/ecoflow/internal/handler/Delta2Handler.java
+++ b/bundles/org.openhab.binding.ecoflow/src/main/java/org/openhab/binding/ecoflow/internal/handler/Delta2Handler.java
@@ -129,8 +129,7 @@ public class Delta2Handler extends AbstractEcoflowHandler {
             new ChannelMapping("pd", "XT150Watts2", CHANNEL_ID_MAX_EXTRA_BATTERY2_POWER, 1, Units.WATT));
 
     public Delta2Handler(Thing thing, boolean isDelta2Max) {
-        super(thing, isDelta2Max ? Stream.concat(MAPPINGS.stream(), MAX_ONLY_MAPPINGS.stream()).toList() : MAPPINGS,
-                "params");
+        super(thing, isDelta2Max ? Stream.concat(MAPPINGS.stream(), MAX_ONLY_MAPPINGS.stream()).toList() : MAPPINGS);
     }
 
     @Override

--- a/bundles/org.openhab.binding.ecoflow/src/main/java/org/openhab/binding/ecoflow/internal/handler/PowerStreamHandler.java
+++ b/bundles/org.openhab.binding.ecoflow/src/main/java/org/openhab/binding/ecoflow/internal/handler/PowerStreamHandler.java
@@ -81,7 +81,7 @@ public class PowerStreamHandler extends AbstractEcoflowHandler {
             new ChannelMapping("20_1", "pv2CtrlMpptOffFlag", CHANNEL_ID_PV2_MPPT_ACTIVE, INV_SWITCH_CONVERTER));
 
     public PowerStreamHandler(Thing thing) {
-        super(thing, MAPPINGS, "param");
+        super(thing, MAPPINGS);
     }
 
     @Override


### PR DESCRIPTION
A 'quota' (update) MQTT message looks like this:
{ "cmdId":1,
  "cmdFunc":20,
  "addr":"iot",
  "params":{ "plugTotalWatts":0,
             "invOutputWatts":1000,
             [...]
           }
}

Previously, for the PowerStream, the 'params' object was named 'param'. It is unclear why exactly the change happened (cloud server change? PS firmware change?), but it seems to have happened on 2025-10-03.

Adjust to the change and log a warning instead of crashing if such a case ever happens again.
