### PR TITLE
[metofficedatahub] 2025 API Key adjustments - backport fix

### DIFF
--- a/bundles/org.openhab.binding.metofficedatahub/pom.xml
+++ b/bundles/org.openhab.binding.metofficedatahub/pom.xml
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
[metofficedatahub] 2025 API Key adjustments - backport fix

During the backport of [metofficedatahub] 2025 API Key adjustments ([#19627](https://github.com/openhab/openhab-addons/issues/19627)) it seem's like this file went astray. This is the corrected version of the file after a spotless apply.

After cloning the repo - I had to do this to build the backported version, so I presume this branch also need's the corrections.

@lsiepel are you good to merge this? Assuming the above is correct? 

Output before the fix is

`[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  51.557 s
[INFO] Finished at: 2025-11-09T22:03:17Z
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal com.diffplug.spotless:spotless-maven-plugin:2.44.3:check (codestyle_check) on project org.openhab.binding.metofficedatahub: The following files had format violations:
[ERROR]     pom.xml
[ERROR]         @@ -1,4 +1,6 @@
[ERROR]         -<?xml·version="1.0"·encoding="UTF-8"·standalone="no"?><project·xmlns="http://maven.apache.org/POM/4.0.0"·xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"·xsi:schemaLocation="http://maven.apache.org/POM/4.0.0·https://maven.apache.org/xsd/maven-4.0.0.xsd">
[ERROR]         +<?xml·version="1.0"·encoding="UTF-8"?>
[ERROR]         +<project·xmlns="http://maven.apache.org/POM/4.0.0"·xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
[ERROR]         +····xsi:schemaLocation="http://maven.apache.org/POM/4.0.0·https://maven.apache.org/xsd/maven-4.0.0.xsd">
[ERROR]
[ERROR]          ··<modelVersion>4.0.0</modelVersion>
[ERROR]
[ERROR] Run 'mvn spotless:apply' to fix these violations.
[ERROR] -> [Help 1]
[ERROR]
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.`

Output after the fix is:

`[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  02:37 min
[INFO] Finished at: 2025-11-09T22:06:16Z
[INFO] ------------------------------------------------------------------------
[INFO] Static code analysis summary report is available in:
[INFO] file:/C:/oh50xFix/openhab-addons/target/summary_report.html`