### PR TITLE
[jsscripting] Fix setTimeout/setInterval fails if delay not provided

### DIFF
--- a/bundles/org.openhab.automation.jsscripting/src/main/resources/node_modules/@jsscripting-globals.js
+++ b/bundles/org.openhab.automation.jsscripting/src/main/resources/node_modules/@jsscripting-globals.js
@@ -181,11 +181,15 @@
   globalThis.console = console;
   globalThis.setTimeout = function (functionRef, delay, ...args) {
     ThreadsafeTimers.setIdentifier(console.loggerName);
+    if (delay === undefined) delay = 0;
+    if (delay === null) delay = 0;
     return ThreadsafeTimers.setTimeout(() => functionRef(...args), delay);
   };
   globalThis.clearTimeout = ThreadsafeTimers.clearTimeout;
   globalThis.setInterval = function (functionRef, delay, ...args) {
     ThreadsafeTimers.setIdentifier(console.loggerName);
+    if (delay === undefined) delay = 0;
+    if (delay === null) delay = 0;
     return ThreadsafeTimers.setInterval(() => functionRef(...args), delay);
   };
   globalThis.clearInterval = ThreadsafeTimers.clearInterval;


### PR DESCRIPTION
According to the [mdn docs](https://developer.mozilla.org/en-US/docs/Web/API/Window/setTimeout), the delay parameter for setTimeout and setInterval is optional and may be omitted. 

Previously, such method calls failed as the undefined or null value was passed to the Java layer, which does not understand those values. 
This is fixed by now handling such values in the JS polyfills, making sure a valid number is always passed to the Java layer.