### PR TITLE
[tesla] Fix `IllegalStateException` when optional fields driveState or chargeState are missing

### DIFF
--- a/bundles/org.openhab.binding.tesla/src/main/java/org/openhab/binding/tesla/internal/handler/TeslaVehicleHandler.java
+++ b/bundles/org.openhab.binding.tesla/src/main/java/org/openhab/binding/tesla/internal/handler/TeslaVehicleHandler.java
@@ -951,10 +951,15 @@ public class TeslaVehicleHandler extends BaseThingHandler {
 
                         Set<Map.Entry<String, JsonElement>> entrySet = new HashSet<>();
 
-                        entrySet.addAll(gson.toJsonTree(driveState, DriveState.class).getAsJsonObject().entrySet());
+                        if (driveState != null) {
+                            entrySet.addAll(gson.toJsonTree(driveState, DriveState.class).getAsJsonObject().entrySet());
+                        }
                         entrySet.addAll(gson.toJsonTree(guiState, GUIState.class).getAsJsonObject().entrySet());
                         entrySet.addAll(gson.toJsonTree(vehicleState, VehicleState.class).getAsJsonObject().entrySet());
-                        entrySet.addAll(gson.toJsonTree(chargeState, ChargeState.class).getAsJsonObject().entrySet());
+                        if (chargeState != null) {
+                            entrySet.addAll(
+                                    gson.toJsonTree(chargeState, ChargeState.class).getAsJsonObject().entrySet());
+                        }
                         entrySet.addAll(gson.toJsonTree(climateState, ClimateState.class).getAsJsonObject().entrySet());
                         entrySet.addAll(
                                 gson.toJsonTree(softwareUpdate, SoftwareUpdate.class).getAsJsonObject().entrySet());


### PR DESCRIPTION
Both driveState and chargeState can be null, as indicated by earlier usages of these fields.
gson.toJsonTree(null, x) returns a JsonNull object, and calling getAsJsonObject() on an JsonNull Object throws an IllegalStateException "Not a JSON Object: null".
Due to this exception none of the fields from the response get updated in their channels.

