### PR TITLE
[openhabcloud] Check for existence of JSON keys before accessing

### DIFF
--- a/bundles/org.openhab.io.openhabcloud/src/main/java/org/openhab/io/openhabcloud/internal/CloudClient.java
+++ b/bundles/org.openhab.io.openhabcloud/src/main/java/org/openhab/io/openhabcloud/internal/CloudClient.java
@@ -428,11 +428,17 @@ public class CloudClient {
             // Create URI builder with base request URI of openHAB and path from request
             String newPath = URIUtil.addPaths(localBaseUrl, requestPath);
 
-            String source = requestHeadersJson.getString("x-openhab-source");
-            if (source == null) {
-                requestQueryJson.getString("source");
+            String source = null;
+            if (requestHeadersJson.has("x-openhab-source")) {
+                source = requestHeadersJson.getString("x-openhab-source");
             }
-            String userId = data.getString("userId");
+            if (source == null && requestQueryJson.has("source")) {
+                source = requestQueryJson.getString("source");
+            }
+            String userId = null;
+            if (data.has("userId")) {
+                userId = data.getString("userId");
+            }
             requestHeadersJson.put("x-openhab-source",
                     AbstractEvent.buildDelegatedSource(source, CloudService.CLOUD_EVENT_SOURCE, userId));
 


### PR DESCRIPTION
I mistakenly assumed `JSONObject` behaved like `Map` returning `null` if the key was not present. It does not, and it's necessary to check if the key exists before accessing it.

Fixes https://github.com/openhab/openhab-addons/issues/19673