### PR TITLE
[homeassistant] Fix channel definitions within groups

### DIFF
--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/ComponentChannel.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/ComponentChannel.java
@@ -119,7 +119,7 @@ public class ComponentChannel {
     }
 
     public ChannelDefinition channelDefinition() {
-        return new ChannelDefinitionBuilder(channel.getUID().getId(),
+        return new ChannelDefinitionBuilder(channel.getUID().getIdWithoutGroup(),
                 Objects.requireNonNull(channel.getChannelTypeUID())).withLabel(channel.getLabel()).build();
     }
 


### PR DESCRIPTION
Apparently ChannelDefinitions within ChannelGroupDefinitions should _not_ include the group ID.

Fixes #19678