### PR TITLE
[Astro] Fix range offset when combined with forceEvent

### DIFF
--- a/bundles/org.openhab.binding.astro/src/main/java/org/openhab/binding/astro/internal/job/Job.java
+++ b/bundles/org.openhab.binding.astro/src/main/java/org/openhab/binding/astro/internal/job/Job.java
@@ -136,11 +136,17 @@ public interface Job extends SchedulerRunnable, Runnable {
         Calendar start = range.getStart();
         Calendar end = range.getEnd();
 
-        if (config.forceEvent && start == null) {
-            start = getAdjustedEarliest(Calendar.getInstance(zone, locale), config);
-        }
-        if (config.forceEvent && end == null) {
-            end = getAdjustedLatest(Calendar.getInstance(zone, locale), config);
+        if (config.forceEvent) {
+            Calendar reference = start != null ? start : end;
+            if (reference == null) {
+                reference = Calendar.getInstance(zone, locale);
+            }
+            if (start == null) {
+                start = getAdjustedEarliest(truncateToMidnight(reference), config);
+            }
+            if (end == null) {
+                end = getAdjustedLatest(endOfDayDate(reference), config);
+            }
         }
 
         // depending on the location and configuration you might not have a valid range for day/night, so skip the


### PR DESCRIPTION
Part of this is a regression from #19310, and is discussed [here](https://community.openhab.org/t/need-help-getting-astro-sun-offset-to-work/167183/20).

The desired behavior isn't well-defined, but this fixes a bug where any offset would effectively be ignored if "force" is in effect. `null` endpoints will now translate to the earliest or latest possible time within the same date, depending on what end of the range it applies to.

It has also been documented (in code) and made sure that `00:00` gets special treatment because MainUI use that as "undefined". `applyConfig()` has been updated to more precisely apply "earliest" and "latest" limits. Some tests have also been added to better define the desired behavior.
