### PR TITLE
[amazonechocontrol] Fix `IllegalStateException` by removing JSON object

### DIFF
--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/dto/push/PushAudioPlayerStateTO.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/dto/push/PushAudioPlayerStateTO.java
@@ -21,7 +21,6 @@ import org.eclipse.jdt.annotation.NonNull;
  */
 public class PushAudioPlayerStateTO extends PushDeviceTO {
     public String mediaReferenceId;
-    public String quality;
     public boolean error;
     public AudioPlayerState audioPlayerState;
     public String errorMessage;


### PR DESCRIPTION
Resolves #19720 
This property was a String but clearly it's an object:
<img width="358" height="227" alt="image" src="https://github.com/user-attachments/assets/4740a519-351a-486b-97e8-241c9fdb266c" />

As it's used nowhere in the binding, I opt to remove it.