### PR TITLE
Prepare for SAT plugin 0.18.0

### DIFF
--- a/itests/org.openhab.binding.ntp.tests/src/main/java/org/openhab/binding/ntp/test/NtpOSGiTest.java
+++ b/itests/org.openhab.binding.ntp.tests/src/main/java/org/openhab/binding/ntp/test/NtpOSGiTest.java
@@ -30,6 +30,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.mockito.ArgumentMatchers;
 import org.openhab.binding.ntp.internal.NtpBindingConstants;
 import org.openhab.binding.ntp.internal.handler.NtpHandler;
@@ -76,6 +78,7 @@ import org.openhab.core.types.State;
  * @author Markus Rathgeb - Migrated tests from Groovy to pure Java
  * @author Erdoan Hadzhiyusein - Migrated tests to Java 8 and integrated the new DateTimeType
  */
+@Execution(ExecutionMode.SAME_THREAD)
 public class NtpOSGiTest extends JavaOSGiTest {
     private static TimeZone systemTimeZone;
     private static Locale locale;
@@ -123,6 +126,7 @@ public class NtpOSGiTest extends JavaOSGiTest {
     }
 
     @BeforeAll
+    @SuppressWarnings({ "PMD.SetDefaultTimeZone", "PMD.SetDefaultLocale" })
     public static void setUpClass() {
         // Initializing a new local server on this port
         timeServer = new SimpleNTPServer(TEST_PORT);
@@ -178,6 +182,7 @@ public class NtpOSGiTest extends JavaOSGiTest {
     }
 
     @AfterAll
+    @SuppressWarnings({ "PMD.SetDefaultTimeZone", "PMD.SetDefaultLocale" })
     public static void tearDownClass() {
         // Stopping the local time server
         timeServer.stopServer();


### PR DESCRIPTION
As SAT plugin 0.18.0 will generate compilation errors if an attempt is made to set the default `Locale` or `TimeZone`, some tests must be exempted for now. This PR suppresses PMD rules `SetDefaultTimeZone` and `SetDefaultLocale` for the NTP tests.

Ideally they should be rewritten to avoid this, but it is done for good reason and the original settings are restored after the test.
