### PR TITLE
[jsscripting] Upgrade to openhab-js 5.16.1

### DIFF
--- a/bundles/org.openhab.automation.jsscripting/pom.xml
+++ b/bundles/org.openhab.automation.jsscripting/pom.xml
@@ -17,7 +17,7 @@
   <properties>
     <!-- Remember to check if the fix https://github.com/openhab/openhab-core/pull/4437 still works when upgrading GraalJS -->
     <node.version>v22.17.1</node.version>
-    <ohjs.version>openhab@5.16.0</ohjs.version>
+    <ohjs.version>openhab@5.16.1</ohjs.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
Includes a critical bugfix fixing SystemStartlevelTriggers not working anymore.

Changelog: https://github.com/openhab/openhab-js/blob/main/CHANGELOG.md#5161-5160