### PR TITLE
[sunsynk] Adapt to user logon requires a nonce and sign.

### DIFF
--- a/bundles/org.openhab.binding.sunsynk/src/main/java/org/openhab/binding/sunsynk/internal/api/dto/Client.java
+++ b/bundles/org.openhab.binding.sunsynk/src/main/java/org/openhab/binding/sunsynk/internal/api/dto/Client.java
@@ -39,7 +39,7 @@ public class Client {
     public Client() {
     }
 
-    public static String getAccessTokenString() {
+    public String getAccessTokenString() {
         return APIdata.staticAccessToken;
     }
 

--- a/bundles/org.openhab.binding.sunsynk/src/main/java/org/openhab/binding/sunsynk/internal/api/dto/SunSynkLogin.java
+++ b/bundles/org.openhab.binding.sunsynk/src/main/java/org/openhab/binding/sunsynk/internal/api/dto/SunSynkLogin.java
@@ -26,7 +26,7 @@ import com.google.gson.annotations.SerializedName;
 
 @NonNullByDefault
 public class SunSynkLogin {
-    // {"sign": "MD5 sign", "nonce": "unix time", "username":"xxx", "password":"xxx", "grant_type":"password",
+    // {"sign":"MD5 sign", "nonce":"unix time", "username":"xxx", "password":"xxx", "grant_type":"password",
     // "client_id":"csp-web"}
     @SerializedName("sign")
     private String signature = "";
@@ -43,9 +43,9 @@ public class SunSynkLogin {
     @SerializedName("source")
     private String source = "sunsynk";
 
-    public SunSynkLogin(String UserName, String PassWord, String signature, Long nonce) {
-        this.userName = UserName;
-        this.passWord = PassWord;
+    public SunSynkLogin(String userName, String password, String signature, Long nonce) {
+        this.userName = userName;
+        this.passWord = password;
         this.signature = signature;
         this.nonce = nonce.toString();
     }


### PR DESCRIPTION
Client Authorisation breaking changes: SunSynk have modified there API logon again (27 November) the user log on now also requires a nonce and sign to receive the bearer token.

# Description
Sun Synk have released a new API logon process, as a consequence (since Thursday 27th November) the user now needs to authorise with a nonce and sign.

In addition to the (plain text) password being salted and RSA encrypted with a public key, a nonce based on Unix time and a signature made with an MD5 hash of the nonce and part of the public key are required. These are POSTed with the user name etc to obtain an access and refresh token that are then used as before.

# Testing
A new .jar will be available for [testing](https://github.com/LeeC77/OpenHAB_5_0_0_test_bindings).

The jar is in soak testing on my PC.

There is a community announcement about the [changes](https://community.openhab.org/t/new-sun-synk-connect-account-and-inverter-binding/155680/20?u=leec77)


