### PR TITLE
[netatmo] Add missing MAC address mapping for 'l'

### DIFF
--- a/bundles/org.openhab.binding.netatmo/README.md
+++ b/bundles/org.openhab.binding.netatmo/README.md
@@ -145,6 +145,7 @@ You have to calculate the ID for the outside module as follows: (it cannot be re
 - if the first serial character is "i": start with "03"
 - if the first serial character is "j": start with "04"
 - if the first serial character is "k": start with "05"
+- if the first serial character is "l": start with "06"
 
 append ":00:00:",
 


### PR DESCRIPTION
The char 'l' is missing in the documentation for the MAC Address Mapping of the internal serial numbers. Add this fact in the documentation.

