### PR TITLE
[energidataservice] Remove binding configuration

### DIFF
--- a/bundles/org.openhab.binding.energidataservice/README.md
+++ b/bundles/org.openhab.binding.energidataservice/README.md
@@ -8,15 +8,6 @@ This can be used to plan energy consumption, for example to calculate the cheape
 
 All channels are available for thing type `service`.
 
-## Binding Configuration
-
-This advanced configuration option can be used if the transition to the Day-Ahead Prices dataset is postponed.
-For the latest updates, please refer to the [Energi Data Service news](https://energidataservice.dk/news).
-
-| Name                   | Type    | Description                                                            | Default    | Required |
-| ---------------------- | ------- | ---------------------------------------------------------------------- | ---------- | -------- |
-| dayAheadTransitionDate | text    | The date when the addon switches to using the Day-Ahead Prices dataset | 2025-09-30 | no       |
-
 ## Thing Configuration
 
 ### `service` Thing Configuration

--- a/bundles/org.openhab.binding.energidataservice/src/main/java/org/openhab/binding/energidataservice/internal/factory/EnergiDataServiceHandlerFactory.java
+++ b/bundles/org.openhab.binding.energidataservice/src/main/java/org/openhab/binding/energidataservice/internal/factory/EnergiDataServiceHandlerFactory.java
@@ -14,7 +14,6 @@ package org.openhab.binding.energidataservice.internal.factory;
 
 import static org.openhab.binding.energidataservice.internal.EnergiDataServiceBindingConstants.*;
 
-import java.time.LocalDate;
 import java.util.Map;
 import java.util.Set;
 
@@ -25,7 +24,6 @@ import org.openhab.binding.energidataservice.internal.api.filter.DatahubTariffFi
 import org.openhab.binding.energidataservice.internal.handler.EnergiDataServiceHandler;
 import org.openhab.binding.energidataservice.internal.provider.Co2EmissionProvider;
 import org.openhab.binding.energidataservice.internal.provider.ElectricityPriceProvider;
-import org.openhab.core.config.core.ConfigParser;
 import org.openhab.core.i18n.TimeZoneProvider;
 import org.openhab.core.io.net.http.HttpClientFactory;
 import org.openhab.core.thing.Thing;
@@ -35,7 +33,6 @@ import org.openhab.core.thing.binding.ThingHandler;
 import org.openhab.core.thing.binding.ThingHandlerFactory;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.Modified;
 import org.osgi.service.component.annotations.Reference;
 
 /**
@@ -49,7 +46,6 @@ import org.osgi.service.component.annotations.Reference;
 public class EnergiDataServiceHandlerFactory extends BaseThingHandlerFactory {
 
     private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Set.of(THING_TYPE_SERVICE);
-    private static final String DAY_AHEAD_TRANSITION_DATE_CONFIG = "dayAheadTransitionDate";
 
     private final HttpClient httpClient;
     private final TimeZoneProvider timeZoneProvider;
@@ -66,16 +62,6 @@ public class EnergiDataServiceHandlerFactory extends BaseThingHandlerFactory {
         this.timeZoneProvider = timeZoneProvider;
         this.electricityPriceProvider = electricityPriceProvider;
         this.co2EmissionProvider = co2EmissionProvider;
-
-        configChanged(config);
-    }
-
-    @Modified
-    public void configChanged(Map<String, Object> config) {
-        String dayAheadDateValue = ConfigParser.valueAs(config.get(DAY_AHEAD_TRANSITION_DATE_CONFIG), String.class);
-        LocalDate dayAheadDate = dayAheadDateValue != null ? LocalDate.parse(dayAheadDateValue)
-                : DAY_AHEAD_TRANSITION_DATE;
-        electricityPriceProvider.setDayAheadTransitionDate(dayAheadDate);
     }
 
     @Override

--- a/bundles/org.openhab.binding.energidataservice/src/main/java/org/openhab/binding/energidataservice/internal/handler/EnergiDataServiceHandler.java
+++ b/bundles/org.openhab.binding.energidataservice/src/main/java/org/openhab/binding/energidataservice/internal/handler/EnergiDataServiceHandler.java
@@ -445,7 +445,7 @@ public class EnergiDataServiceHandler extends BaseThingHandler
             Currency currency = config.getCurrency();
             boolean isDKK = CURRENCY_DKK.equals(currency);
             TimeSeries spotPriceTimeSeries = new TimeSeries(REPLACE);
-            LocalDate dayAheadFirstDate = electricityPriceProvider.getDayAheadTransitionDate().plusDays(1);
+            LocalDate dayAheadFirstDate = DAY_AHEAD_TRANSITION_DATE.plusDays(1);
 
             if (startDate.isBefore(dayAheadFirstDate)) {
                 ElspotpriceRecord[] spotPriceRecords = apiController.getSpotPrices(config.priceArea, currency,

--- a/bundles/org.openhab.binding.energidataservice/src/main/java/org/openhab/binding/energidataservice/internal/provider/ElectricityPriceProvider.java
+++ b/bundles/org.openhab.binding.energidataservice/src/main/java/org/openhab/binding/energidataservice/internal/provider/ElectricityPriceProvider.java
@@ -17,7 +17,6 @@ import static org.openhab.binding.energidataservice.internal.EnergiDataServiceBi
 import java.math.BigDecimal;
 import java.time.Duration;
 import java.time.Instant;
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
@@ -84,7 +83,6 @@ public class ElectricityPriceProvider extends AbstractProvider<ElectricityPriceL
     private @Nullable ScheduledFuture<?> refreshFuture;
     private @Nullable ScheduledFuture<?> priceUpdateFuture;
     private RetryStrategy retryPolicy = RetryPolicyFactory.initial();
-    private LocalDate dayAheadTransitionDate = DAY_AHEAD_TRANSITION_DATE;
 
     @Activate
     public ElectricityPriceProvider(final @Reference Scheduler scheduler,
@@ -104,14 +102,6 @@ public class ElectricityPriceProvider extends AbstractProvider<ElectricityPriceL
     @Deactivate
     public void deactivate() {
         stopJobs();
-    }
-
-    public void setDayAheadTransitionDate(LocalDate transitionDate) {
-        dayAheadTransitionDate = transitionDate;
-    }
-
-    public LocalDate getDayAheadTransitionDate() {
-        return dayAheadTransitionDate;
     }
 
     public void subscribe(ElectricityPriceListener listener, Subscription subscription) {
@@ -412,8 +402,8 @@ public class ElectricityPriceProvider extends AbstractProvider<ElectricityPriceL
     }
 
     private Dataset getDayAheadDataset() {
-        return Instant.now()
-                .isBefore(dayAheadTransitionDate.atTime(DAILY_REFRESH_TIME_CET).atZone(NORD_POOL_TIMEZONE).toInstant())
+        return Instant.now().isBefore(
+                DAY_AHEAD_TRANSITION_DATE.atTime(DAILY_REFRESH_TIME_CET).atZone(NORD_POOL_TIMEZONE).toInstant())
                         ? Dataset.SpotPrices
                         : Dataset.DayAheadPrices;
     }

--- a/bundles/org.openhab.binding.energidataservice/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.binding.energidataservice/src/main/resources/OH-INF/addon/addon.xml
@@ -9,14 +9,4 @@
 	<connection>cloud</connection>
 	<countries>dk,no,se</countries>
 
-	<config-description>
-		<parameter name="dayAheadTransitionDate" type="text">
-			<context>date</context>
-			<label>Day-ahead Transition Date</label>
-			<description>The date when the addon switches to using the Day-Ahead Prices dataset</description>
-			<advanced>true</advanced>
-			<default>2025-09-30</default>
-		</parameter>
-	</config-description>
-
 </addon:addon>

--- a/bundles/org.openhab.binding.energidataservice/src/main/resources/OH-INF/i18n/energidataservice.properties
+++ b/bundles/org.openhab.binding.energidataservice/src/main/resources/OH-INF/i18n/energidataservice.properties
@@ -3,11 +3,6 @@
 addon.energidataservice.name = Energi Data Service Binding
 addon.energidataservice.description = This is the binding for Energi Data Service providing open energy data from Energinet.
 
-# add-on config
-
-addon.config.energidataservice.dayAheadTransitionDate.label = Day-ahead Transition Date
-addon.config.energidataservice.dayAheadTransitionDate.description = The date when the addon switches to using the Day-Ahead Prices dataset
-
 # thing types
 
 thing-type.energidataservice.service.label = Energi Data Service


### PR DESCRIPTION
The transition to quarter-hourly prices happened according to plan. Since we are now past that date, there is no longer a need for being able to override the transition date in the binding configuration.

Related to #18695