### PR TITLE
[homeassistant] Move binding to configuration to the proper place

### DIFF
--- a/bundles/org.openhab.binding.homeassistant/src/main/java/org/openhab/binding/homeassistant/internal/discovery/HomeAssistantDiscovery.java
+++ b/bundles/org.openhab.binding.homeassistant/src/main/java/org/openhab/binding/homeassistant/internal/discovery/HomeAssistantDiscovery.java
@@ -60,9 +60,9 @@ import org.slf4j.LoggerFactory;
  *
  * @author David Graeff - Initial contribution
  */
-@Component(service = DiscoveryService.class, configurationPid = "discovery.mqttha", property = Constants.SERVICE_PID
-        + "=discovery.mqttha")
-@ConfigurableService(category = "system", label = "Home Assistant Discovery", description_uri = "binding:mqtt.homeassistant")
+@Component(service = DiscoveryService.class, configurationPid = "org.openhab.binding.homeassistant", property = Constants.SERVICE_PID
+        + "=org.openhab.binding.homeassistant")
+@ConfigurableService(category = "binding", label = "Home Assistant Binding", description_uri = "binding:homeassistant")
 @NonNullByDefault
 public class HomeAssistantDiscovery extends AbstractMQTTDiscovery {
     private final Logger logger = LoggerFactory.getLogger(HomeAssistantDiscovery.class);

--- a/bundles/org.openhab.binding.homeassistant/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.binding.homeassistant/src/main/resources/OH-INF/addon/addon.xml
@@ -8,6 +8,8 @@
 	<description>Provides discovery and auto-configuration services for MQTT connected devices that provide Home Assistant
 		discovery metadata.</description>
 	<connection>local</connection>
+	<service-id>org.openhab.binding.homeassistant</service-id>
+	<config-description-ref uri="binding:homeassistant"/>
 
 	<discovery-methods>
 		<discovery-method>

--- a/bundles/org.openhab.binding.homeassistant/src/main/resources/OH-INF/i18n/homeassistant.properties
+++ b/bundles/org.openhab.binding.homeassistant/src/main/resources/OH-INF/i18n/homeassistant.properties
@@ -3,6 +3,11 @@
 addon.homeassistant.name = Home Assistant Binding
 addon.homeassistant.description = Provides discovery and auto-configuration services for MQTT connected devices that provide Home Assistant discovery metadata.
 
+# add-on config
+
+binding.config.homeassistant.status.label = Publish Online Status
+binding.config.homeassistant.status.description = Publish <tt>online</tt> to <tt>homeassistant/status</tt> when discovering Home Assistant things in order to trigger devices to publish up-to-date discovery information. If you also run Home Assistant <i>and</i> other services that depend on knowing if Home Assistant is not running, then it's possible for those services to be out-of-sync with the actual status of Home Assistant, and you may want to disable this.
+
 # channel types
 
 channel-type.homeassistant.color-advanced.label = Color
@@ -40,8 +45,6 @@ channel-type.config.homeassistant.channel.nodeid.description = Optional node nam
 channel-type.config.homeassistant.channel.objectid.label = Object ID
 channel-type.config.homeassistant.channel.objectid.description = Object ID of the component
 
-binding.config.homeassistant.status.label = Publish Online Status
-binding.config.homeassistant.status.description = Publish <tt>online</tt> to <tt>homeassistant/status</tt> when discovering Home Assistant things in order to trigger devices to publish up-to-date discovery information. If you also run Home Assistant <i>and</i> other services that depend on knowing if Home Assistant is not running, then it's possible for those services to be out-of-sync with the actual status of Home Assistant, and you may want to disable this.
 thing-type.config.homeassistant.device.basetopic.label = MQTT Base Prefix
 thing-type.config.homeassistant.device.basetopic.description = MQTT base prefix
 thing-type.config.homeassistant.device.topics.label = MQTT Config Topic


### PR DESCRIPTION
When it was part of the MQTT binding, it couldn't expose its config as binding-level, so we worked around that by putting it as a "system" service. We don't need to do that anymore, so put it where one would normally expect.

Closes #19525