### PR TITLE
[lifx] Eliminate log warnings for fixed color temperature lights

### DIFF
--- a/bundles/org.openhab.binding.lifx/src/main/java/org/openhab/binding/lifx/internal/handler/LifxLightHandler.java
+++ b/bundles/org.openhab.binding.lifx/src/main/java/org/openhab/binding/lifx/internal/handler/LifxLightHandler.java
@@ -187,12 +187,13 @@ public class LifxLightHandler extends BaseThingHandler {
             State colorTemperatureState = UnDefType.UNDEF;
             State colorTemperatureAbsoluteState = UnDefType.UNDEF;
             TemperatureRange temperatureRange = features.getTemperatureRange();
-            if (temperatureRange.getRange() > 0) {
+            int range = temperatureRange.getRange();
+            if (range > 0) {
                 stateDescriptionProvider.setMinMaxKelvin(new ChannelUID(thing.getUID(), CHANNEL_ABS_TEMPERATURE),
                         temperatureRange.getMinimum(), temperatureRange.getMaximum());
                 colorTemperatureState = kelvinToPercentType(updateColor.getKelvin(), temperatureRange);
                 colorTemperatureAbsoluteState = QuantityType.valueOf(updateColor.getKelvin(), Units.KELVIN);
-            } else {
+            } else if (range < 0) {
                 logger.warn("Thing {} invalid color temperature range {} .. {}", thing.getUID(),
                         temperatureRange.getMinimum(), temperatureRange.getMaximum());
             }


### PR DESCRIPTION
There are three light models which have fixed color temperatures i.e. having identical minimum and maximum color temperatures.

```
TR_2000_2000(2000, 2000),
TR_2100_2100(2100, 2100),
TR_2700_2700(2700, 2700),
```

The current binding issues logger warnings whenever the state of such a light is changed. 
This PR trivially supresses the logger warnings for such lights.

Resolves https://github.com/openhab/openhab-addons/issues/19782

Signed-off-by: Andrew Fiddian-Green <software@whitebear.ch>
