### PR TITLE
[pythonscripting] fix initial pip modules setup

### DIFF
--- a/bundles/org.openhab.automation.pythonscripting/src/main/java/org/openhab/automation/pythonscripting/internal/PythonScriptEngineHelper.java
+++ b/bundles/org.openhab.automation.pythonscripting/src/main/java/org/openhab/automation/pythonscripting/internal/PythonScriptEngineHelper.java
@@ -27,6 +27,7 @@ import java.util.Arrays;
 import java.util.Comparator;
 import java.util.Enumeration;
 import java.util.List;
+import java.util.UUID;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -39,7 +40,6 @@ import javax.script.ScriptException;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
-import org.openhab.core.automation.module.script.ScriptEngineFactory;
 import org.osgi.framework.FrameworkUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -57,7 +57,8 @@ public class PythonScriptEngineHelper {
     private static final Pattern VERSION_PATTERN = Pattern.compile("__version__\\s*=\\s*\"([^\"]*)\"",
             Pattern.CASE_INSENSITIVE);
 
-    public static void initPipModules(PythonScriptEngineConfiguration configuration, ScriptEngineFactory factory) {
+    public static void initPipModules(PythonScriptEngineConfiguration configuration,
+            PythonScriptEngineFactory factory) {
         String pipModulesConfig = configuration.getPIPModules().strip();
         if (pipModulesConfig.isEmpty()) {
             return;
@@ -86,7 +87,8 @@ public class PythonScriptEngineHelper {
                     exit(1)
                 """;
 
-        ScriptEngine engine = factory.createScriptEngine(PythonScriptEngineFactory.SCRIPT_TYPE);
+        ScriptEngine engine = factory.createScriptEngine(PythonScriptEngineFactory.SCRIPT_TYPE,
+                "python-setup-" + UUID.randomUUID().toString());
         if (engine != null) {
             engine.getContext().setAttribute("pipModules", pipModules, ScriptContext.ENGINE_SCOPE);
             try {

--- a/bundles/org.openhab.automation.pythonscripting/src/main/java/org/openhab/automation/pythonscripting/internal/console/PythonConsoleCommandExtension.java
+++ b/bundles/org.openhab.automation.pythonscripting/src/main/java/org/openhab/automation/pythonscripting/internal/console/PythonConsoleCommandExtension.java
@@ -34,7 +34,6 @@ import org.openhab.automation.pythonscripting.internal.console.handler.InfoCmd;
 import org.openhab.automation.pythonscripting.internal.console.handler.TypingCmd;
 import org.openhab.automation.pythonscripting.internal.console.handler.UpdateCmd;
 import org.openhab.core.automation.module.script.ScriptEngineContainer;
-import org.openhab.core.automation.module.script.ScriptEngineFactory;
 import org.openhab.core.automation.module.script.ScriptEngineManager;
 import org.openhab.core.config.core.ConfigDescriptionRegistry;
 import org.openhab.core.io.console.Console;
@@ -298,11 +297,7 @@ public class PythonConsoleCommandExtension extends AbstractConsoleCommandExtensi
                     engine = container.getScriptEngine();
                 }
             } else {
-                engine = pythonScriptEngineFactory.createScriptEngine(scriptType);
-                if (engine != null) {
-                    engine.getContext().setAttribute(ScriptEngineFactory.CONTEXT_KEY_ENGINE_IDENTIFIER,
-                            scriptIdentifier, ScriptContext.ENGINE_SCOPE);
-                }
+                engine = pythonScriptEngineFactory.createScriptEngine(scriptType, scriptIdentifier);
             }
 
             if (engine == null) {


### PR DESCRIPTION
A late hotfix.

This fixes the initial pip modules installation, if they are configured as a addon property.

```
org.openhab.automation.pythonscripting:pipModules = unificontrol,pyunifi
```

This does not affect the manual setup. You can still install pip modules via the openhab console.

I'm not sure if this is a good reason for a late pull request.

https://community.openhab.org/t/python-scripting-module-in-venv-cannot-be-loaded/