### PR TITLE
[homewizard] Fixed setting mode 'standby' for batteries not supporting the latest api version

### DIFF
--- a/bundles/org.openhab.binding.homewizard/src/main/java/org/openhab/binding/homewizard/internal/devices/HomeWizardBatteriesSubHandler.java
+++ b/bundles/org.openhab.binding.homewizard/src/main/java/org/openhab/binding/homewizard/internal/devices/HomeWizardBatteriesSubHandler.java
@@ -62,7 +62,7 @@ public class HomeWizardBatteriesSubHandler {
 
         switch (command.toFullString()) {
             case HomeWizardBindingConstants.BATTERIES_MODE_STANDBY: {
-                mode = HomeWizardBindingConstants.BATTERIES_MODE_ZERO;
+                mode = HomeWizardBindingConstants.BATTERIES_MODE_STANDBY;
                 permissions = "\"permissions\": [],";
                 break;
             }


### PR DESCRIPTION
In the latest api version, the preferred way to set standby mode is to set the mode to 'zero' without additional permissions. However, batteries which do not support this lastest api version do not support permissions and should still use mode 'standby'. 

When adding support for the lastest api version, only the new way was supported which caused a problem for batteries on older api versions.

This has now been corrected in the PR.