### PR TITLE
[modbus.lambda] Add handling DWord-Swapping for VdaE and VdAQ

### DIFF
--- a/bundles/org.openhab.binding.modbus.lambda/README.md
+++ b/bundles/org.openhab.binding.modbus.lambda/README.md
@@ -125,6 +125,8 @@ This group contains general operational information about the heat pump itself.
 | heat-pump-relais-state         | Number:Temperature        | true      | Heatpump Relais State for 2nd heating stage                             |
 | heat-pump-vdae                 | Number:Energy             | true      | Accumulated electrical energy consumption of compressor unit            |
 | heat-pump-vdaq                 | Number:Energy             | true      | Accumulated thermal energy output of compressor unit                    |
+| heat-pump-vdae-swap            | Number:Energy             | true      | Accumulated electrical energy consumption of compressor unit (DWord swapped) |
+| heat-pump-vdaq-swap            | Number:Energy             | true      | Accumulated thermal energy output of compressor unit (DWord swapped)         |
 
 ### Boiler Group
 

--- a/bundles/org.openhab.binding.modbus.lambda/src/main/java/org/openhab/binding/modbus/lambda/internal/LambdaBindingConstants.java
+++ b/bundles/org.openhab.binding.modbus.lambda/src/main/java/org/openhab/binding/modbus/lambda/internal/LambdaBindingConstants.java
@@ -88,6 +88,8 @@ public class LambdaBindingConstants {
     public static final String CHANNEL_HEAT_PUMP_RELAIS_STATE = "heat-pump-relais-state";
     public static final String CHANNEL_HEAT_PUMP_VDAE = "heat-pump-vdae";
     public static final String CHANNEL_HEAT_PUMP_VDAQ = "heat-pump-vdaq";
+    public static final String CHANNEL_HEAT_PUMP_VDAE_SWAP = "heat-pump-vdae-swap";
+    public static final String CHANNEL_HEAT_PUMP_VDAQ_SWAP = "heat-pump-vdaq-swap";
 
     // Boiler
     public static final String CHANNEL_BOILER_ERROR_NUMBER = "boiler-error-number";

--- a/bundles/org.openhab.binding.modbus.lambda/src/main/java/org/openhab/binding/modbus/lambda/internal/dto/HeatpumpBlock.java
+++ b/bundles/org.openhab.binding.modbus.lambda/src/main/java/org/openhab/binding/modbus/lambda/internal/dto/HeatpumpBlock.java
@@ -42,4 +42,6 @@ public class HeatpumpBlock {
     public int heatpumpRelaisState;
     public long heatpumpVdAE;
     public long heatpumpVdAQ;
+    public long heatpumpVdAEswap;
+    public long heatpumpVdAQswap;
 }

--- a/bundles/org.openhab.binding.modbus.lambda/src/main/java/org/openhab/binding/modbus/lambda/internal/handler/HeatpumpHandler.java
+++ b/bundles/org.openhab.binding.modbus.lambda/src/main/java/org/openhab/binding/modbus/lambda/internal/handler/HeatpumpHandler.java
@@ -451,6 +451,10 @@ public class HeatpumpHandler extends BaseThingHandler {
                 getScaled(block.heatpumpVdAE, KILOWATT_HOUR, -3.0));
         updateState(channelUID(GROUP_HEAT_PUMP, CHANNEL_HEAT_PUMP_VDAQ),
                 getScaled(block.heatpumpVdAQ, KILOWATT_HOUR, -3.0));
+        updateState(channelUID(GROUP_HEAT_PUMP, CHANNEL_HEAT_PUMP_VDAE_SWAP),
+                getScaled(block.heatpumpVdAEswap, KILOWATT_HOUR, -3.0));
+        updateState(channelUID(GROUP_HEAT_PUMP, CHANNEL_HEAT_PUMP_VDAQ_SWAP),
+                getScaled(block.heatpumpVdAQswap, KILOWATT_HOUR, -3.0));
 
         resetCommunicationError();
     }

--- a/bundles/org.openhab.binding.modbus.lambda/src/main/java/org/openhab/binding/modbus/lambda/internal/parser/AbstractBaseParser.java
+++ b/bundles/org.openhab.binding.modbus.lambda/src/main/java/org/openhab/binding/modbus/lambda/internal/parser/AbstractBaseParser.java
@@ -154,4 +154,13 @@ public class AbstractBaseParser {
     protected Long extractInt32(ModbusRegisterArray raw, int index, long def) {
         return Objects.requireNonNull(extractOptionalInt32(raw, index).orElse(def));
     }
+
+    protected Optional<Long> extractOptionalInt32Swap(ModbusRegisterArray raw, int index) {
+        return ModbusBitUtilities.extractStateFromRegisters(raw, index, ValueType.INT32_SWAP)
+                .map(DecimalType::longValue).filter(value -> value != 0);
+    }
+
+    protected Long extractInt32Swap(ModbusRegisterArray raw, int index, long def) {
+        return Objects.requireNonNull(extractOptionalInt32Swap(raw, index).orElse(def));
+    }
 }

--- a/bundles/org.openhab.binding.modbus.lambda/src/main/java/org/openhab/binding/modbus/lambda/internal/parser/HeatpumpBlockParser.java
+++ b/bundles/org.openhab.binding.modbus.lambda/src/main/java/org/openhab/binding/modbus/lambda/internal/parser/HeatpumpBlockParser.java
@@ -50,6 +50,8 @@ public class HeatpumpBlockParser extends AbstractBaseParser {
         block.heatpumpRelaisState = extractInt16(raw, 19, (short) 0);
         block.heatpumpVdAE = extractInt32(raw, 20, (long) 0);
         block.heatpumpVdAQ = extractInt32(raw, 22, (long) 0);
+        block.heatpumpVdAEswap = extractInt32Swap(raw, 20, (long) 0);
+        block.heatpumpVdAQswap = extractInt32Swap(raw, 22, (long) 0);
         return block;
     }
 }

--- a/bundles/org.openhab.binding.modbus.lambda/src/main/resources/OH-INF/i18n/lambda.properties
+++ b/bundles/org.openhab.binding.modbus.lambda/src/main/resources/OH-INF/i18n/lambda.properties
@@ -111,6 +111,8 @@ channel-type.modbus.heat-pump-request-heat-sink-channel.label = Heatpump request
 channel-type.modbus.heat-pump-relais-state-channel.label = Heatpump Relais State 
 channel-type.modbus.heat-pump-vdae-channel.label = Heatpump VdA E
 channel-type.modbus.heat-pump-vdaq-channel.label = Heatpump VdA Q
+channel-type.modbus.heat-pump-vdae-swap-channel.label = Heatpump VdA E (DWord swapped)
+channel-type.modbus.heat-pump-vdaq-swap-channel.label = Heatpump VdA Q (DWord swapped)
 
 # Boiler
 channel-type.modbus.boiler-error-number-channel.label = Boiler Error Number

--- a/bundles/org.openhab.binding.modbus.lambda/src/main/resources/OH-INF/thing/heat-pump-thing-types.xml
+++ b/bundles/org.openhab.binding.modbus.lambda/src/main/resources/OH-INF/thing/heat-pump-thing-types.xml
@@ -66,6 +66,8 @@
 			<channel id="heatpump-relais-state" typeId="heatpump-relais-state-channel"/>
 			<channel id="heat-pump-vdae" typeId="heat-pump-vdae"/>
 			<channel id="heat-pump-vdaq" typeId="heat-pump-vdaq"/>
+			<channel id="heat-pump-vdae-swap" typeId="heat-pump-vdae-swap"/>
+			<channel id="heat-pump-vdaq-swap" typeId="heat-pump-vdaq-swap"/>
 		</channels>
 	</channel-group-type>
 
@@ -262,6 +264,18 @@
 	<channel-type id="heat-pump-vdaq">
 		<item-type>Number:Energy</item-type>
 		<label>Heatpump VdA Q since last reset</label>
+		<state readOnly="true"/>
+	</channel-type>
+
+	<channel-type id="heat-pump-vdae-swap">
+		<item-type>Number:Energy</item-type>
+		<label>Heatpump VdA E since last reset (DWord swapped)</label>
+		<state readOnly="true"/>
+	</channel-type>
+
+	<channel-type id="heat-pump-vdaq-swap">
+		<item-type>Number:Energy</item-type>
+		<label>Heatpump VdA Q since last reset (DWord swapped)</label>
 		<state readOnly="true"/>
 	</channel-type>
 


### PR DESCRIPTION
Based on the Stiebel Eltron bundle by Paul Frank I contribute a bundle to manage Lambda Heat Pumps as a OSG addon to the Modbus Binding.

See the README.md for restrictions on usage.

The binding is based on the Modbus description of the manufacturer:
(https://lambda-wp.at/wp-content/uploads/2025/04/Modbus-Beschreibung-und-Protokoll.pdf)
A few parts of the description are not implemented. If you feel you need them, just open a request.

This addition corrects problems with the DWord-swapping of some heat pumps as mentioned in 
(https://github.com/openhab/openhab-addons/pull/19749)

