### PR TITLE
[astro] Don't attempt to publish state to trigger channels on linked

### DIFF
--- a/bundles/org.openhab.binding.astro/src/main/java/org/openhab/binding/astro/internal/handler/AstroThingHandler.java
+++ b/bundles/org.openhab.binding.astro/src/main/java/org/openhab/binding/astro/internal/handler/AstroThingHandler.java
@@ -183,6 +183,10 @@ public abstract class AstroThingHandler extends BaseThingHandler {
                 logger.error("Cannot find channel for {}", channelUID);
                 return;
             }
+            if (channel.getKind() == TRIGGER) {
+                // if the channel is a trigger channel, there is no state to publish
+                return;
+            }
             try {
                 AstroChannelConfig config = channel.getConfiguration().as(AstroChannelConfig.class);
                 updateState(channelUID, PropertyUtils.getState(channelUID, config, planet,


### PR DESCRIPTION
Reported on the community https://community.openhab.org/t/astro-binding-triggers-stop-working/128962/11.

When a channel is linked to an item, the AstroThingHandler tries to send the current value of that channel to the item.
For trigger channels, however there is no state to send, and the attempted method call through reflection causes a NoSuchMethodException to be thrown.