### PR TITLE
[matter] Prevent adding an OnOff switch to a Fan when not intended

### DIFF
--- a/bundles/org.openhab.binding.matter/matter-server/src/bridge/devices/FanDeviceType.ts
+++ b/bundles/org.openhab.binding.matter/matter-server/src/bridge/devices/FanDeviceType.ts
@@ -26,8 +26,7 @@ export class FanDeviceType extends BaseDeviceType {
 
     override defaultClusterValues() {
         return {
-            fanControl: { ...CustomFanControlServer.DEFAULTS },
-            onOff: { ...CustomOnOffServer.DEFAULTS },
+            fanControl: { ...CustomFanControlServer.DEFAULTS }
         };
     }
 }


### PR DESCRIPTION
This errant line added a OnOff switch regardless if a user actually configured one.