### PR TITLE
[modbus.e3dc] Fix example persistence configuration

### DIFF
--- a/bundles/org.openhab.binding.modbus.e3dc/README.md
+++ b/bundles/org.openhab.binding.modbus.e3dc/README.md
@@ -312,7 +312,6 @@ Strategies {
     everyMinute : "0 * * * * ?"
     everyHour : "0 0 * * * ?"
     everyDay  : "0 0 0 * * ?"
-    default = everyChange
 }
 
 Items {


### PR DESCRIPTION
Required after openhab/openhab-core#4682