### PR TITLE
[astro] Use configured time zone if none is specified

### DIFF
--- a/bundles/org.openhab.binding.astro/src/main/java/org/openhab/binding/astro/internal/action/AstroActions.java
+++ b/bundles/org.openhab.binding.astro/src/main/java/org/openhab/binding/astro/internal/action/AstroActions.java
@@ -26,12 +26,15 @@ import org.openhab.binding.astro.internal.model.SunPhaseName;
 import org.openhab.core.automation.annotation.ActionInput;
 import org.openhab.core.automation.annotation.ActionOutput;
 import org.openhab.core.automation.annotation.RuleAction;
+import org.openhab.core.i18n.TimeZoneProvider;
 import org.openhab.core.library.dimension.Intensity;
 import org.openhab.core.library.types.QuantityType;
 import org.openhab.core.thing.binding.ThingActions;
 import org.openhab.core.thing.binding.ThingActionsScope;
 import org.openhab.core.thing.binding.ThingHandler;
+import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ServiceScope;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -47,9 +50,12 @@ import org.slf4j.LoggerFactory;
 public class AstroActions implements ThingActions {
 
     private final Logger logger = LoggerFactory.getLogger(AstroActions.class);
+    private final TimeZoneProvider timeZoneProvider;
     private @Nullable AstroThingHandler handler;
 
-    public AstroActions() {
+    @Activate
+    public AstroActions(@Reference TimeZoneProvider timeZoneProvider) {
+        this.timeZoneProvider = timeZoneProvider;
         logger.debug("Astro actions service instanciated");
     }
 
@@ -71,7 +77,7 @@ public class AstroActions implements ThingActions {
         logger.debug("Astro action 'getAzimuth' called");
         AstroThingHandler theHandler = this.handler;
         if (theHandler != null) {
-            return theHandler.getAzimuth(date != null ? date : ZonedDateTime.now());
+            return theHandler.getAzimuth(date != null ? date : ZonedDateTime.now(timeZoneProvider.getTimeZone()));
         } else {
             logger.info("Astro Action service ThingHandler is null!");
         }
@@ -84,7 +90,7 @@ public class AstroActions implements ThingActions {
         logger.debug("Astro action 'getElevation' called");
         AstroThingHandler theHandler = this.handler;
         if (theHandler != null) {
-            return theHandler.getElevation(date != null ? date : ZonedDateTime.now());
+            return theHandler.getElevation(date != null ? date : ZonedDateTime.now(timeZoneProvider.getTimeZone()));
         } else {
             logger.info("Astro Action service ThingHandler is null!");
         }
@@ -98,7 +104,8 @@ public class AstroActions implements ThingActions {
         AstroThingHandler theHandler = this.handler;
         if (theHandler != null) {
             if (theHandler instanceof SunHandler sunHandler) {
-                Radiation radiation = sunHandler.getRadiationAt(date != null ? date : ZonedDateTime.now());
+                Radiation radiation = sunHandler
+                        .getRadiationAt(date != null ? date : ZonedDateTime.now(timeZoneProvider.getTimeZone()));
                 return radiation == null ? null : radiation.getTotal();
             } else {
                 logger.info("Astro Action service ThingHandler is not a SunHandler!");
@@ -120,7 +127,8 @@ public class AstroActions implements ThingActions {
             if (theHandler != null) {
                 if (theHandler instanceof SunHandler sunHandler) {
                     SunPhaseName phase = SunPhaseName.valueOf(phaseName.toUpperCase());
-                    return sunHandler.getEventTime(phase, date != null ? date : ZonedDateTime.now(),
+                    return sunHandler.getEventTime(phase,
+                            date != null ? date : ZonedDateTime.now(timeZoneProvider.getTimeZone()),
                             moment == null || AstroBindingConstants.EVENT_START.equalsIgnoreCase(moment));
                 } else {
                     logger.info("Astro Action service ThingHandler is not a SunHandler!");

--- a/bundles/org.openhab.binding.astro/src/main/java/org/openhab/binding/astro/internal/handler/AstroThingHandler.java
+++ b/bundles/org.openhab.binding.astro/src/main/java/org/openhab/binding/astro/internal/handler/AstroThingHandler.java
@@ -73,7 +73,7 @@ public abstract class AstroThingHandler extends BaseThingHandler {
 
     /** Logger Instance */
     private final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
-    private final SimpleDateFormat isoFormatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
+    private final SimpleDateFormat isoFormatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss", Locale.ROOT);
 
     /** Scheduler to schedule jobs */
     private final CronScheduler cronScheduler;


### PR DESCRIPTION
I created this to address the warnings (from the next version of the SAT plugin) that aren't taken care of by #19830 (https://github.com/openhab/openhab-addons/pull/19830#issuecomment-3681228996).

However, I discovered that there's a larger problem here, which is why this is a draft only.

`ZonedDateTime` is used as the type for the `date` parameter, but it seems to apply the default time zone automatically if none are specified. I don't know exactly where this happens, but it's probably somewhere either in Core or in the "REST API framework" in use. It's less than ideal if you actually want a "zoned" date, but the zone is applied implicitly outside your control.

Also, the date picker doesn't allow selecting a time zone, neither does the "field syntax validation" allow specifying one manually. Maybe you have some insight on what is or isn't possible here @florian-h05 ?

I'm not sure if using a "zoned" date is the correct thing to do here at all, because it becomes quite complicated to handle correctly. Does anybody know if it was intentionally chosen, or if it was just "out of convenience"?

As I see it, we either fix it so that the time zone can be specified, or we change the parameter to be without timezone and always applies the OH configured timezone. In the latter case, the parameter type shouldn't be `ZonedDateTime`, but probably `LocalDateTime`.