### PR TITLE
[jsscripting] Upgrade to openhab-js 5.16.2

### DIFF
--- a/bundles/org.openhab.automation.jsscripting/pom.xml
+++ b/bundles/org.openhab.automation.jsscripting/pom.xml
@@ -17,7 +17,7 @@
   <properties>
     <!-- Remember to check if the fix https://github.com/openhab/openhab-core/pull/4437 still works when upgrading GraalJS -->
     <node.version>v22.17.1</node.version>
-    <ohjs.version>openhab@5.16.1</ohjs.version>
+    <ohjs.version>openhab@5.16.2</ohjs.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
Includes an important bugfix, see https://github.com/openhab/openhab-js/blob/main/CHANGELOG.md#5162.
Fixes https://github.com/openhab/openhab-addons/issues/19870.

Should be backported to 5.1.x.