### PR TITLE
[yamahamusiccast] Fix NPE/instability on UDP state update

### DIFF
--- a/bundles/org.openhab.binding.yamahamusiccast/src/main/java/org/openhab/binding/yamahamusiccast/internal/YamahaMusiccastHandler.java
+++ b/bundles/org.openhab.binding.yamahamusiccast/src/main/java/org/openhab/binding/yamahamusiccast/internal/YamahaMusiccastHandler.java
@@ -936,18 +936,28 @@ public class YamahaMusiccastHandler extends BaseThingHandler {
             String responseCode = targetObject.getResponseCode();
 
             if ("0".equals(responseCode)) {
-                int dabPreset = targetObject.getDAB().getPreset();
-                int fmPreset = targetObject.getFM().getPreset();
+                var dab = targetObject.getDAB();
+                var fm = targetObject.getFM();
+                Integer dabPreset = null;
+                Integer fmPreset = null;
+                if (dab != null) {
+                    dabPreset = dab.getPreset();
+                }
+                if (fm != null) {
+                    fmPreset = fm.getPreset();
+                }
                 for (Channel channel : getThing().getChannels()) {
                     ChannelUID channelUID = channel.getUID();
                     channelWithoutGroup = channelUID.getIdWithoutGroup();
                     if (isLinked(channelUID)) {
                         switch (channelWithoutGroup) {
                             case CHANNEL_SELECTPRESET_DAB:
-                                updateState(channelUID, StringType.valueOf(String.valueOf(dabPreset)));
+                                updateState(channelUID, dabPreset == null ? UnDefType.NULL
+                                        : StringType.valueOf(String.valueOf(dabPreset)));
                                 break;
                             case CHANNEL_SELECTPRESET_FM:
-                                updateState(channelUID, StringType.valueOf(String.valueOf(fmPreset)));
+                                updateState(channelUID, fmPreset == null ? UnDefType.NULL
+                                        : StringType.valueOf(String.valueOf(fmPreset)));
                                 break;
                         }
                     }
@@ -1070,7 +1080,10 @@ public class YamahaMusiccastHandler extends BaseThingHandler {
         tmpString = getDistributionInfo(this.host);
         DistributionInfo targetObject = gson.fromJson(tmpString, DistributionInfo.class);
         if (targetObject != null) {
-            clients = targetObject.getClientList().size();
+            var clientList = targetObject.getClientList();
+            if (clientList != null) {
+                clients = clientList.size();
+            }
         }
 
         List<StateOption> options = new ArrayList<>();

--- a/bundles/org.openhab.binding.yamahamusiccast/src/main/java/org/openhab/binding/yamahamusiccast/internal/dto/PlayInfoTuner.java
+++ b/bundles/org.openhab.binding.yamahamusiccast/src/main/java/org/openhab/binding/yamahamusiccast/internal/dto/PlayInfoTuner.java
@@ -19,7 +19,6 @@ import com.google.gson.annotations.SerializedName;
  *
  * @author Markus Kastner - Initial contribution
  */
-
 public class PlayInfoTuner {
 
     @SerializedName("response_code")
@@ -29,10 +28,10 @@ public class PlayInfoTuner {
     private String band;
 
     @SerializedName("fm")
-    private fmObject fm;
+    private FmObject fm;
 
     @SerializedName("dab")
-    private dabObject dab;
+    private DabObject dab;
 
     public String getResponseCode() {
         if (responseCode == null) {
@@ -48,15 +47,15 @@ public class PlayInfoTuner {
         return band;
     }
 
-    public fmObject getFM() {
+    public FmObject getFM() {
         return fm;
     }
 
-    public dabObject getDAB() {
+    public DabObject getDAB() {
         return dab;
     }
 
-    public class fmObject {
+    public static class FmObject {
         @SerializedName("preset")
         private int preset = 0;
         @SerializedName("freq")
@@ -71,7 +70,7 @@ public class PlayInfoTuner {
         }
     }
 
-    public class dabObject {
+    public static class DabObject {
         @SerializedName("preset")
         private int preset = 0;
         @SerializedName("service_label")


### PR DESCRIPTION
Regression from #19798.

The changes from #19798 cause serious issues with UDP state updates, where a single UDP update from a device with FM and without DAB (should) cause a NPE, but no NPE is logged and the UDP update processing stops completely.