### PR TITLE
[jdbc] Upgrade MySQL Connector/J to 9.5.0

### DIFF
--- a/bundles/org.openhab.persistence.jdbc/README.md
+++ b/bundles/org.openhab.persistence.jdbc/README.md
@@ -15,7 +15,7 @@ The following databases are currently supported and tested:
 | [H2](https://www.h2database.com/)            | [h2-2.3.232.jar](https://mvnrepository.com/artifact/com.h2database/h2)                                                                      |
 | [HSQLDB](http://hsqldb.org/)                 | [hsqldb-2.7.4.jar](https://mvnrepository.com/artifact/org.hsqldb/hsqldb)                                                                    |
 | [MariaDB](https://mariadb.org/)              | [mariadb-java-client-3.5.5.jar](https://mvnrepository.com/artifact/org.mariadb.jdbc/mariadb-java-client)                                    |
-| [MySQL](https://www.mysql.com/)              | [mysql-connector-j-9.4.0.jar](https://mvnrepository.com/artifact/com.mysql/mysql-connector-j)                                               |
+| [MySQL](https://www.mysql.com/)              | [mysql-connector-j-9.5.0.jar](https://mvnrepository.com/artifact/com.mysql/mysql-connector-j)                                               |
 | [PostgreSQL](https://www.postgresql.org/)    | [postgresql-42.7.7.jar](https://mvnrepository.com/artifact/org.postgresql/postgresql)                                                       |
 | [SQLite](https://www.sqlite.org/)            | [sqlite-jdbc-3.50.3.0.jar](https://mvnrepository.com/artifact/org.xerial/sqlite-jdbc)                                                       |
 | [TimescaleDB](https://www.timescale.com/)    | [postgresql-42.7.7.jar](https://mvnrepository.com/artifact/org.postgresql/postgresql)                                                       |

--- a/bundles/org.openhab.persistence.jdbc/pom.xml
+++ b/bundles/org.openhab.persistence.jdbc/pom.xml
@@ -29,7 +29,7 @@
     <h2.version>2.3.232</h2.version>
     <hsqldb.version>2.7.4</hsqldb.version>
     <mariadb.version>3.5.5</mariadb.version>
-    <mysql.version>9.4.0</mysql.version>
+    <mysql.version>9.5.0</mysql.version>
     <postgresql.version>42.7.7</postgresql.version>
     <sqlite.version>3.50.3.0</sqlite.version>
     <oracle.version>23.5.0.2407</oracle.version>

--- a/bundles/org.openhab.persistence.jdbc/src/main/feature/feature.xml
+++ b/bundles/org.openhab.persistence.jdbc/src/main/feature/feature.xml
@@ -36,7 +36,7 @@
 	<feature name="openhab-persistence-jdbc-mysql" description="JDBC Persistence MySQL" version="${project.version}">
 		<configfile finalname="${openhab.conf}/services/jdbc.cfg" override="false">mvn:org.openhab.addons.features.karaf/org.openhab.addons.features.karaf.openhab-addons-external/${project.version}/cfg/jdbc</configfile>
 		<feature prerequisite="false" dependency="false">openhab-runtime-base</feature>
-		<bundle start-level="80">mvn:com.mysql/mysql-connector-j/9.4.0</bundle>
+		<bundle start-level="80">mvn:com.mysql/mysql-connector-j/9.5.0</bundle>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.persistence.jdbc/${project.version}</bundle>
 	</feature>
 

--- a/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/internal/JdbcConfiguration.java
+++ b/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/internal/JdbcConfiguration.java
@@ -333,7 +333,7 @@ public class JdbcConfiguration {
                         warn += "\tMariaDB:   version >= 3.5.5 from              https://mvnrepository.com/artifact/org.mariadb.jdbc/mariadb-java-client\n";
                         break;
                     case "mysql":
-                        warn += "\tMySQL:     version >= 9.4.0 from              https://mvnrepository.com/artifact/com.mysql/mysql-connector-j\n";
+                        warn += "\tMySQL:     version >= 9.5.0 from              https://mvnrepository.com/artifact/com.mysql/mysql-connector-j\n";
                         break;
                     case "postgresql":
                         warn += "\tPostgreSQL:version >= 42.7.7 from             https://mvnrepository.com/artifact/org.postgresql/postgresql\n";


### PR DESCRIPTION
Release notes:
- https://dev.mysql.com/doc/relnotes/connector-j/en/

Library:
- https://mvnrepository.com/artifact/com.mysql/mysql-connector-j/9.5.0

Previous upgrade: #19172