### PR TITLE
[tuya] Avoid refresh if there are no measurables

### DIFF
--- a/bundles/org.openhab.binding.tuya/src/main/java/org/openhab/binding/tuya/internal/handler/TuyaDeviceHandler.java
+++ b/bundles/org.openhab.binding.tuya/src/main/java/org/openhab/binding/tuya/internal/handler/TuyaDeviceHandler.java
@@ -562,15 +562,15 @@ public class TuyaDeviceHandler extends BaseThingHandler implements DeviceInfoSub
     public void initialize() {
         configuration = getConfigAs(DeviceConfiguration.class);
 
-        boolean hasMeasurables = false;
+        boolean hasStatusDps = false;
         for (var e : schemaDps.values()) {
             if (e.readOnly) {
-                hasMeasurables = true;
+                hasStatusDps = true;
                 break;
             }
         }
-        if (!hasMeasurables) {
-            logger.debug("{}: no measurables - polling disabled", thing.getUID().getId());
+        if (!hasStatusDps) {
+            logger.debug("{}: no status DPs - polling disabled", thing.getUID().getId());
             configuration.pollingInterval = 0;
         }
 


### PR DESCRIPTION
If all the DPs are functions asking the device to refresh measured values is pointless. Some devices return a null result for DP_REFRESH, some just ignore it entirely. Ignoring it causes a timeout which leads to the binding reconnecting - over and over and over...

Fixes #19880 