### PR TITLE
[homematic] Properly consider special values in DP value validation

### DIFF
--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/handler/HomematicThingHandler.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/handler/HomematicThingHandler.java
@@ -450,7 +450,7 @@ public class HomematicThingHandler extends BaseThingHandler {
 
             Map<String, Number> specialValues = dp.getSpecialValues();
             if (specialValues != null) {
-                Number value = dp.isFloatType() ? dp.getDoubleValue() : dp.getIntegerValue();
+                Number value = dp.getNumericValue();
                 for (Number special : specialValues.values()) {
                     if (value.equals(special)) {
                         return dp.getValue();

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/model/HmDatapoint.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/model/HmDatapoint.java
@@ -160,9 +160,19 @@ public class HmDatapoint implements Cloneable {
         return null;
     }
 
+    public @Nullable Number getNumericValue() {
+        if (isFloatType()) {
+            return getDoubleValue();
+        } else if (isIntegerType()) {
+            return getIntegerValue();
+        } else {
+            return null;
+        }
+    }
+
     public @Nullable Integer getIntegerValue() {
-        if (value instanceof Integer) {
-            return (int) value;
+        if (value instanceof Integer intValue) {
+            return intValue;
         } else if (value != null) {
             return Integer.parseInt(value.toString());
         } else {
@@ -171,8 +181,8 @@ public class HmDatapoint implements Cloneable {
     }
 
     public @Nullable Double getDoubleValue() {
-        if (value instanceof Double) {
-            return (double) value;
+        if (value instanceof Double doubleValue) {
+            return doubleValue;
         } else if (value != null) {
             return Double.parseDouble(value.toString());
         } else {
@@ -435,15 +445,16 @@ public class HmDatapoint implements Cloneable {
         dp.setReadable(readable);
         dp.setTrigger(trigger);
         dp.setDefaultValue(defaultValue);
+        dp.setSpecialValues(specialValues);
         return dp;
     }
 
     @Override
     public String toString() {
         return String.format("""
-                %s[name=%s,value=%s,defaultValue=%s,type=%s,minValue=%s,maxValue=%s,options=%s,\
+                %s[name=%s,value=%s,defaultValue=%s,type=%s,minValue=%s,maxValue=%s,specialValues=%s,options=%s,\
                 readOnly=%b,readable=%b,unit=%s,description=%s,info=%s,paramsetType=%s,virtual=%b,trigger=%b]\
-                """, getClass().getSimpleName(), name, value, defaultValue, type, minValue, maxValue,
+                """, getClass().getSimpleName(), name, value, defaultValue, type, minValue, maxValue, specialValues,
                 (options == null ? null : String.join(";", options)), readOnly, readable, unit, description, info,
                 paramsetType, virtual, trigger);
     }


### PR DESCRIPTION
This was added in #19284, but the fix was incomplete for two reasons:
- The special values were initially populated in the DP, but not properly copied when later cloning the DP into the channel
- The DP value was implicitly converted to a Double in the ternary that differentiated between integer and float types

Fixes #13477
