### PR TITLE
[tapocontrol] Fix HS200 Physical Button Not Updating Item State & Add Device State

### DIFF
--- a/bundles/org.openhab.binding.tapocontrol/README.md
+++ b/bundles/org.openhab.binding.tapocontrol/README.md
@@ -105,8 +105,8 @@ All devices support some of the following channels:
 |           | currentTemp      | Number:Temperature     | Current Temperature                 | T310, T315                                                              |
 |           | currentHumidity  | Number:Dimensionless   | Current relative humidity in %      | T310, T315                                                              |
 | effects   | fxName           | String                 | Active lightning effect             | L530, L900, L920, L930                                                  |
-| device    | wifiSignal       | Number                 | WiFi-quality-level                  | P100, P105, P110, P115, L510, L530, L610, L630, L900, L920, L930        |
-|           | onTime           | Number:Time            | seconds output is on                | P100, P105, P110, P115, L510, L530, L900, L920, L930                    |
+| device    | wifiSignal       | Number                 | WiFi-quality-level                  | P100, P105, P110, P115, L510, L530, L610, L630, L900, L920, L930, HS200 |
+|           | onTime           | Number:Time            | seconds output is on                | P100, P105, P110, P115, L510, L530, L900, L920, L930, HS200             |
 |           | signalStrength   | Number                 | RF-quality-level                    | T110                                                                    |
 |           | isOnline         | Switch                 | Device is Online                    | T110                                                                    |
 |           | batteryLow       | Switch                 | Battery of device is low            | T110                                                                    |

--- a/bundles/org.openhab.binding.tapocontrol/src/main/java/org/openhab/binding/tapocontrol/internal/constants/TapoThingConstants.java
+++ b/bundles/org.openhab.binding.tapocontrol/src/main/java/org/openhab/binding/tapocontrol/internal/constants/TapoThingConstants.java
@@ -124,11 +124,12 @@ public class TapoThingConstants {
     public static final Set<ThingTypeUID> SUPPORTED_ENERGY_DATA_UIDS = Set.of(P110_THING_TYPE, P115_THING_TYPE);
 
     /*** THINGS WITH CHANNEL GROUPS ***/
-    public static final Set<ThingTypeUID> CHANNEL_GROUP_THING_SET = Collections.unmodifiableSet(
-            Stream.of(SUPPORTED_BRIDGE_UIDS, SUPPORTED_HUB_UIDS, SUPPORTED_SOCKET_UIDS, SUPPORTED_SOCKET_STRIP_UIDS,
+    public static final Set<ThingTypeUID> CHANNEL_GROUP_THING_SET = Collections.unmodifiableSet(Stream
+            .of(SUPPORTED_BRIDGE_UIDS, SUPPORTED_HUB_UIDS, SUPPORTED_SOCKET_UIDS, SUPPORTED_SOCKET_STRIP_UIDS,
                     SUPPORTED_WHITE_BULB_UIDS, SUPPORTED_COLOR_BULB_UIDS, SUPPORTED_LIGHT_STRIP_UIDS,
                     SUPPORTED_SMART_CONTACTS, SUPPORTED_MOTION_SENSORS, SUPPORTED_WEATHER_SENSORS,
-                    SUPPORTED_SMART_SWITCHES).flatMap(Set::stream).collect(Collectors.toSet()));
+                    SUPPORTED_SMART_SWITCHES, SUPPORTED_LIGHT_SWITCH_UIDS)
+            .flatMap(Set::stream).collect(Collectors.toSet()));
 
     public static final String CHILD_REPRESENTATION_PROPERTY = "serialNumber";
 

--- a/bundles/org.openhab.binding.tapocontrol/src/main/java/org/openhab/binding/tapocontrol/internal/devices/wifi/lightswitch/TapoLightSwitchData.java
+++ b/bundles/org.openhab.binding.tapocontrol/src/main/java/org/openhab/binding/tapocontrol/internal/devices/wifi/lightswitch/TapoLightSwitchData.java
@@ -12,6 +12,8 @@
  */
 package org.openhab.binding.tapocontrol.internal.devices.wifi.lightswitch;
 
+import static org.openhab.binding.tapocontrol.internal.TapoControlHandlerFactory.GSON;
+
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.binding.tapocontrol.internal.devices.dto.TapoBaseDeviceData;
 
@@ -24,6 +26,10 @@ public class TapoLightSwitchData extends TapoBaseDeviceData {
     @Expose(serialize = true, deserialize = true)
     private boolean deviceOn = false;
 
+    @SerializedName("on_time")
+    @Expose(serialize = true, deserialize = true)
+    private int onTime = 0;
+
     public void switchOnOff(boolean on) {
         deviceOn = on;
     }
@@ -34,5 +40,18 @@ public class TapoLightSwitchData extends TapoBaseDeviceData {
 
     public boolean isOff() {
         return !deviceOn;
+    }
+
+    public Number getOnTime() {
+        return onTime;
+    }
+
+    @Override
+    public String toString() {
+        return toJson();
+    }
+
+    public String toJson() {
+        return GSON.toJson(this);
     }
 }

--- a/bundles/org.openhab.binding.tapocontrol/src/main/java/org/openhab/binding/tapocontrol/internal/devices/wifi/lightswitch/TapoLightSwitchHandler.java
+++ b/bundles/org.openhab.binding.tapocontrol/src/main/java/org/openhab/binding/tapocontrol/internal/devices/wifi/lightswitch/TapoLightSwitchHandler.java
@@ -19,6 +19,7 @@ import static org.openhab.binding.tapocontrol.internal.helpers.utils.TypeUtils.*
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.binding.tapocontrol.internal.devices.wifi.TapoBaseDeviceHandler;
 import org.openhab.core.library.types.OnOffType;
+import org.openhab.core.library.unit.Units;
 import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.Thing;
 import org.openhab.core.types.Command;
@@ -82,5 +83,10 @@ public class TapoLightSwitchHandler extends TapoBaseDeviceHandler {
 
     protected void updateChannels(TapoLightSwitchData deviceData) {
         updateState(getChannelID(CHANNEL_GROUP_ACTUATOR, CHANNEL_OUTPUT), getOnOffType(deviceData.isOn()));
+        updateState(getChannelID(CHANNEL_GROUP_DEVICE, CHANNEL_WIFI_STRENGTH),
+                getDecimalType(deviceData.getSignalLevel()));
+        updateState(getChannelID(CHANNEL_GROUP_DEVICE, CHANNEL_ONTIME),
+                getTimeType(deviceData.getOnTime(), Units.SECOND));
+        updateState(getChannelID(CHANNEL_GROUP_DEVICE, CHANNEL_OVERHEAT), getOnOffType(deviceData.isOverheated()));
     }
 }

--- a/bundles/org.openhab.binding.tapocontrol/src/main/resources/OH-INF/thing/HS200.xml
+++ b/bundles/org.openhab.binding.tapocontrol/src/main/resources/OH-INF/thing/HS200.xml
@@ -15,6 +15,7 @@
 		<semantic-equipment-tag>WallSwitch</semantic-equipment-tag>
 		<channel-groups>
 			<channel-group id="actuator" typeId="lightSwitch"/>
+			<channel-group id="device" typeId="deviceState"/>
 		</channel-groups>
 		<representation-property>macAddress</representation-property>
 


### PR DESCRIPTION
This commit fixes an issue where the physical button press for the [HS200](https://github.com/openhab/openhab-addons/pull/19924) was not updating the item state as the SUPPORTED_LIGHT_SWITCH_UIDS was missing in CHANNEL_GROUP_THING_SET. It also adds support for device state which includes WiFi signal strength, onTime (in seconds), and overheated status which are both part of the response JSON from the HS200.

Shout out to @jaywiseman1971 for helping me find this.

JAR File: https://nextcloud.simmonyau.com/s/ze74PPkDAAs9e4B