### PR TITLE
[smsmodem] Remove license header from 3rd party file

### DIFF
--- a/bundles/org.openhab.binding.smsmodem/src/3rdparty/java/org/smslib/UnrecoverableSmslibException.java
+++ b/bundles/org.openhab.binding.smsmodem/src/3rdparty/java/org/smslib/UnrecoverableSmslibException.java
@@ -1,15 +1,3 @@
-/**
- * Copyright (c) 2010-2026 Contributors to the openHAB project
- *
- * See the NOTICE file(s) distributed with this work for additional
- * information.
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0
- *
- * SPDX-License-Identifier: EPL-2.0
- */
 package org.smslib;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;


### PR DESCRIPTION
This prevents recurring issues when running `mvn license:format` because it doesn't update license headers in 3rd party directories. Last this had to be handled manually in #19939.

Since the source file is just a standard exception class, there is no reason for having an openHAB license header.

It exists because of a small modification made here:

https://github.com/openhab/openhab-addons/blob/13e6000fbc253ea86d9c35efdc0fcaf12a9fcc29/bundles/org.openhab.binding.smsmodem/src/3rdparty/java/org/smslib/MessageReader.java#L319-L323

compared to:

https://github.com/tdelenikas/smslib/blob/dd3651a4105498032bb14add528ab4362d991823/smslib/src/main/java/org/smslib/gateway/modem/MessageReader.java#L331-L333

and in some other places as well.

An alternative solution would be to move it to the `org.openhab.binding.smsmodel` namespace, but I don't think this is worth the effort or any better.