### PR TITLE
[hueemulation] Upgrade JUPnP to 3.0.4

### DIFF
--- a/bundles/org.openhab.io.hueemulation/pom.xml
+++ b/bundles/org.openhab.io.hueemulation/pom.xml
@@ -49,7 +49,7 @@
     <dependency>
       <groupId>org.jupnp</groupId>
       <artifactId>org.jupnp</artifactId>
-      <version>3.0.1</version>
+      <version>3.0.4</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
This fixes some bugs (see https://github.com/jupnp/jupnp/releases) and brings the dependency back in sync with core - see openhab/openhab-core#5201.

We might consider backporting this to 5.1.