### PR TITLE
[shelly] Refactor ShellyManagerCache cleanup

### DIFF
--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/discovery/ShellyBasicDiscoveryService.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/discovery/ShellyBasicDiscoveryService.java
@@ -151,6 +151,8 @@ public class ShellyBasicDiscoveryService extends AbstractDiscoveryService {
             if (result.isHttpAccessUnauthorized()) {
                 // create shellyunknown thing - will be changed during thing initialization with valid credentials
                 thingUID = ShellyThingCreator.getThingUIDForUnknown(name, model, mode);
+            } else {
+                logger.debug("{}: Unable to discover device: {}", name, e.getMessage());
             }
         } catch (IllegalArgumentException | IOException e) { // maybe some format description was buggy
             logger.debug("Discovery: Unable to discover thing", e);

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/manager/ShellyManagerActionPage.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/manager/ShellyManagerActionPage.java
@@ -51,8 +51,10 @@ public class ShellyManagerActionPage extends ShellyManagerPage {
     private final Logger logger = LoggerFactory.getLogger(ShellyManagerActionPage.class);
 
     public ShellyManagerActionPage(ConfigurationAdmin configurationAdmin, ShellyTranslationProvider translationProvider,
-            HttpClient httpClient, String localIp, int localPort, ShellyHandlerFactory handlerFactory) {
-        super(configurationAdmin, translationProvider, httpClient, localIp, localPort, handlerFactory);
+            HttpClient httpClient, String localIp, int localPort, ShellyHandlerFactory handlerFactory,
+            ShellyManagerCache<String, FwRepoEntry> firmwareRepo, ShellyManagerCache<String, FwArchList> firmwareArch) {
+        super(configurationAdmin, translationProvider, httpClient, localIp, localPort, handlerFactory, firmwareRepo,
+                firmwareArch);
     }
 
     @Override

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/manager/ShellyManagerCache.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/manager/ShellyManagerCache.java
@@ -83,7 +83,7 @@ public class ShellyManagerCache<K, V> {
                 }
             }
 
-            if (storage.size() == 0) {
+            if (storage.isEmpty()) {
                 cancelJob(); // stop background cleanup
             }
         }

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/manager/ShellyManagerCache.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/manager/ShellyManagerCache.java
@@ -34,7 +34,7 @@ public class ShellyManagerCache<K, V> {
     protected final ScheduledExecutorService scheduler = ThreadPoolManager.getScheduledPool("ShellyManagerThreadpool");
     private static final long EXPIRY_IN_MILLIS = 15 * 60 * 1000; // 15min
 
-    private record CacheEntry<V>(Long created, V value) {
+    private record CacheEntry<V> (Long created, V value) {
     }
 
     // Non-thread-safe HashMap: all access to 'storage' is synchronized on this instance

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/manager/ShellyManagerCache.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/manager/ShellyManagerCache.java
@@ -34,7 +34,7 @@ public class ShellyManagerCache<K, V> {
     protected final ScheduledExecutorService scheduler = ThreadPoolManager.getScheduledPool("ShellyManagerThreadpool");
     private static final long EXPIRY_IN_MILLIS = 15 * 60 * 1000; // 15min
 
-    private record CacheEntry<V>(Long created, V value) {
+    private record CacheEntry<V> (Long created, V value) {
     }
 
     // All access must be guarded by "this"
@@ -100,5 +100,4 @@ public class ShellyManagerCache<K, V> {
         cancelJob();
         storage.clear();
     }
-
 }

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/manager/ShellyManagerConstants.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/manager/ShellyManagerConstants.java
@@ -150,7 +150,4 @@ public class ShellyManagerConstants {
     public static final String FWREPO_TEST_URL = "https://repo.shelly.cloud/files/firmware/";
     public static final String FWREPO_ARCH_URL = "http://archive.shelly-tools.de/archive.php";
     public static final String FWREPO_ARCFILE_URL = "http://archive.shelly-tools.de/version/";
-
-    public static final int CACHE_TIMEOUT_DEF_MIN = 60; // Default timeout for cache entries
-    public static final int CACHE_TIMEOUT_FW_MIN = 15; // Cache entries for the firmware list 15min
 }

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/manager/ShellyManagerImageLoader.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/manager/ShellyManagerImageLoader.java
@@ -41,8 +41,10 @@ public class ShellyManagerImageLoader extends ShellyManagerPage {
 
     public ShellyManagerImageLoader(ConfigurationAdmin configurationAdmin,
             ShellyTranslationProvider translationProvider, HttpClient httpClient, String localIp, int localPort,
-            ShellyHandlerFactory handlerFactory) {
-        super(configurationAdmin, translationProvider, httpClient, localIp, localPort, handlerFactory);
+            ShellyHandlerFactory handlerFactory, ShellyManagerCache<String, FwRepoEntry> firmwareRepo,
+            ShellyManagerCache<String, FwArchList> firmwareArch) {
+        super(configurationAdmin, translationProvider, httpClient, localIp, localPort, handlerFactory, firmwareRepo,
+                firmwareArch);
     }
 
     @Override

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/manager/ShellyManagerOtaPage.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/manager/ShellyManagerOtaPage.java
@@ -55,8 +55,10 @@ public class ShellyManagerOtaPage extends ShellyManagerPage {
     protected final Logger logger = LoggerFactory.getLogger(ShellyManagerOtaPage.class);
 
     public ShellyManagerOtaPage(ConfigurationAdmin configurationAdmin, ShellyTranslationProvider translationProvider,
-            HttpClient httpClient, String localIp, int localPort, ShellyHandlerFactory handlerFactory) {
-        super(configurationAdmin, translationProvider, httpClient, localIp, localPort, handlerFactory);
+            HttpClient httpClient, String localIp, int localPort, ShellyHandlerFactory handlerFactory,
+            ShellyManagerCache<String, FwRepoEntry> firmwareRepo, ShellyManagerCache<String, FwArchList> firmwareArch) {
+        super(configurationAdmin, translationProvider, httpClient, localIp, localPort, handlerFactory, firmwareRepo,
+                firmwareArch);
     }
 
     @Override

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/manager/ShellyManagerOverviewPage.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/manager/ShellyManagerOverviewPage.java
@@ -54,8 +54,10 @@ public class ShellyManagerOverviewPage extends ShellyManagerPage {
 
     public ShellyManagerOverviewPage(ConfigurationAdmin configurationAdmin,
             ShellyTranslationProvider translationProvider, HttpClient httpClient, String localIp, int localPort,
-            ShellyHandlerFactory handlerFactory) {
-        super(configurationAdmin, translationProvider, httpClient, localIp, localPort, handlerFactory);
+            ShellyHandlerFactory handlerFactory, ShellyManagerCache<String, FwRepoEntry> firmwareRepo,
+            ShellyManagerCache<String, FwArchList> firmwareArch) {
+        super(configurationAdmin, translationProvider, httpClient, localIp, localPort, handlerFactory, firmwareRepo,
+                firmwareArch);
     }
 
     @Override

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/manager/ShellyManagerServlet.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/manager/ShellyManagerServlet.java
@@ -13,7 +13,7 @@
 package org.openhab.binding.shelly.internal.manager;
 
 import static org.openhab.binding.shelly.internal.manager.ShellyManagerConstants.*;
-import static org.openhab.binding.shelly.internal.util.ShellyUtils.*;
+import static org.openhab.binding.shelly.internal.util.ShellyUtils.getString;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -28,15 +28,8 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
-import org.openhab.binding.shelly.internal.ShellyHandlerFactory;
 import org.openhab.binding.shelly.internal.api.ShellyApiException;
 import org.openhab.binding.shelly.internal.manager.ShellyManagerPage.ShellyMgrResponse;
-import org.openhab.binding.shelly.internal.provider.ShellyTranslationProvider;
-import org.openhab.core.io.net.http.HttpClientFactory;
-import org.openhab.core.net.HttpServiceUtil;
-import org.openhab.core.net.NetworkAddressService;
-import org.osgi.service.cm.ConfigurationAdmin;
-import org.osgi.service.component.ComponentContext;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.ConfigurationPolicy;
@@ -65,18 +58,10 @@ public class ShellyManagerServlet extends HttpServlet {
     private final String className;
 
     @Activate
-    public ShellyManagerServlet(@Reference ConfigurationAdmin configurationAdmin,
-            @Reference NetworkAddressService networkAddressService, @Reference HttpClientFactory httpClientFactory,
-            @Reference ShellyHandlerFactory handlerFactory, @Reference ShellyTranslationProvider translationProvider,
-            ComponentContext componentContext, Map<String, Object> config) {
-        className = substringAfterLast(getClass().toString(), ".");
-        String localIp = getString(networkAddressService.getPrimaryIpv4HostAddress());
-        Integer localPort = HttpServiceUtil.getHttpServicePort(componentContext.getBundleContext());
-        this.manager = new ShellyManager(configurationAdmin, translationProvider,
-                httpClientFactory.getCommonHttpClient(), localIp, localPort, handlerFactory);
-
-        // Promote Shelly Manager usage
-        logger.info("{}", translationProvider.get("status.managerstarted", localIp, localPort.toString()));
+    public ShellyManagerServlet(@Reference ShellyManager shellyManager) {
+        className = getClass().getSimpleName();
+        this.manager = shellyManager;
+        logger.debug("{} started", className);
     }
 
     @Deactivate


### PR DESCRIPTION
The implementation was refactored to use scheduleWithFixedDelay() instead of an endless loop with sleep() calls. In addition the cashes are allocated on demand (when used) rather than at initialization time, esp. if Shelly Manager is not used.
