### PR TITLE
[homematic] Omit virtual 'configuration' channel from config description

### DIFF
--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/type/HomematicTypeGeneratorImpl.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/type/HomematicTypeGeneratorImpl.java
@@ -275,6 +275,12 @@ public class HomematicTypeGeneratorImpl implements HomematicTypeGenerator {
         List<ConfigDescriptionParameterGroup> groups = new ArrayList<>();
 
         for (HmChannel channel : device.getChannels()) {
+            if (device.getHomegearId() != null && channel.getNumber() == CONFIGURATION_CHANNEL_NUMBER) {
+                // Homegear duplicates the device's configuration into channel 0,
+                // so there's no need for the global ones in that case
+                continue;
+            }
+
             String groupName = "HMG_" + channel.getNumber();
             String groupLabel = MetadataUtils.getDescription("CHANNEL_NAME") + " " + channel.getNumber();
             groups.add(ConfigDescriptionParameterGroupBuilder.create(groupName).withLabel(groupLabel).build());

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/type/HomematicTypeGeneratorImpl.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/type/HomematicTypeGeneratorImpl.java
@@ -30,6 +30,7 @@ import org.openhab.binding.homematic.internal.misc.MiscUtils;
 import org.openhab.binding.homematic.internal.model.HmChannel;
 import org.openhab.binding.homematic.internal.model.HmDatapoint;
 import org.openhab.binding.homematic.internal.model.HmDevice;
+import org.openhab.binding.homematic.internal.model.HmGatewayInfo;
 import org.openhab.binding.homematic.internal.model.HmParamsetType;
 import org.openhab.core.config.core.ConfigDescriptionBuilder;
 import org.openhab.core.config.core.ConfigDescriptionParameter;
@@ -275,7 +276,8 @@ public class HomematicTypeGeneratorImpl implements HomematicTypeGenerator {
         List<ConfigDescriptionParameterGroup> groups = new ArrayList<>();
 
         for (HmChannel channel : device.getChannels()) {
-            if (device.getHomegearId() != null && channel.getNumber() == CONFIGURATION_CHANNEL_NUMBER) {
+            if (HmGatewayInfo.ID_HOMEGEAR.equals(device.getGatewayId())
+                    && channel.getNumber() == CONFIGURATION_CHANNEL_NUMBER) {
                 // Homegear duplicates the device's configuration into channel 0,
                 // so there's no need for the global ones in that case
                 continue;


### PR DESCRIPTION
The central has a concept of 'per-device' and 'per-channel' parameters, which are fetched from it using the 'getParamsetDescription' RPC call, providing an address in the form 'MEQ1234567' (for per-device parameters) or 'MEQ1234567:1' (for per-channel parameters). The binding reflects that difference by giving each device a HmChannel instance with channel number -1 that points to address format for per-device parameters.
However, it seems like at least Homegear duplicates the per-device parameters into channel 0, as can be seen in this log excerpt:

[...]
2026-01-06 10:26:43.054 [TRACE] [nal.communicator.client.BinRpcClient] - Client BinRpcRequest: getParamsetDescription()
LEQ0401456
MASTER

2026-01-06 10:26:43.054 [TRACE] [al.communicator.client.SocketHandler] - Returning socket for port 2001 2026-01-06 10:26:43.315 [TRACE] [nal.communicator.client.BinRpcClient] - Client BinRpcResponse: {
        ADAPTIVE_REGULATION=
        {
                DEFAULT=2
                FLAGS=1
                ID=ADAPTIVE_REGULATION
                MAX=2
                MIN=0
                OPERATIONS=7
                TAB_ORDER=145
                TYPE=ENUM
                UNIT=
                VALUE_LIST=
                [
                        OFF with default values
                        OFF with determined values
                        ON
                ]
        }
[...]

2026-01-06 10:26:43.316 [TRACE] [nal.communicator.client.BinRpcClient] - Client BinRpcRequest: getParamsetDescription()
LEQ0401456:0
MASTER

2026-01-06 10:26:43.316 [TRACE] [al.communicator.client.SocketHandler] - Returning socket for port 2001 2026-01-06 10:26:43.575 [TRACE] [nal.communicator.client.BinRpcClient] - Client BinRpcResponse: {
        ADAPTIVE_REGULATION=
        {
                DEFAULT=2
                FLAGS=1
                ID=ADAPTIVE_REGULATION
                MAX=2
                MIN=0
                OPERATIONS=7
                TAB_ORDER=145
                TYPE=ENUM
                UNIT=
                VALUE_LIST=
                [
                        OFF with default values
                        OFF with determined values
                        ON
                ]
        }
[...]

To avoid the redundancy, we skip the global parameters (with its somewhat misleading title 'Channel -1' for devices connected to Homegear.

<!--
Thanks for contributing to the openHAB project!
Please describe the goal and effect of your PR here.
Pay attention to the below notes and to *the guidelines* for this repository.
Feel free to delete any comment sections in the template (starting with "<!--").

ATTENTION: Don't use "git merge" when working with your pull request branch!
This can clutter your Git history and make your PR unusable.
Use "git rebase" instead. See this forum post for further details:
https://community.openhab.org/t/rebase-your-code-or-how-to-fix-your-git-history-before-requesting-a-pull/129358

All PRs should be created using the "main" branch as base.
Important bugfixes are cherry-picked by maintainers to the patch release branch after a PR has been merged.

Add one or more appropriate labels to make your PR show up in the release notes.
E.g. enhancement, bug, documentation, new binding
This can only be done by yourself if you already contributed to this repo.

If your PR's code is not backward compatible with previous releases (which
should be avoided), add a message to the release notes by filing another PR:
https://github.com/openhab/openhab-distro/blob/main/distributions/openhab/src/main/resources/bin/update.lst

# Title

Provide a short summary in the *Title* above. It will show up in the release notes.
For example:
- [homematic] Improve communication with weak signal devices
- [timemachine][WIP] Initial contribution

# Description

Please give a few sentences describing the overall goals of the pull request.
Give enough details to make the improvement and changes of the PR understandable
to both developers and tech-savy users.

Please keep the following in mind:
- What is the classification of the PR, e.g. Bugfix, Improvement, Novel Addition, ... ?
- Did you describe the PRs motivation and goal?
- Did you provide a link to any prior discussion, e.g. an issue or community forum thread?
- Did you describe new features for the end user?
- Did you describe any noteworthy changes in usage for the end user?
- Was the documentation updated accordingly, e.g. the add-on README?
- Does your contribution follow the coding guidelines:
  https://www.openhab.org/docs/developer/guidelines.html
- Did you check for any (relevant) issues from the static code analysis:
  https://www.openhab.org/docs/developer/bindings/#include-the-binding-in-the-build
- Did you sign-off your work:
  https://www.openhab.org/docs/developer/contributing.html#sign-your-work

# Testing

Your pull request will automatically be built and available under the following folder:
https://openhab.jfrog.io/ui/native/libs-pullrequest-local/org/openhab/addons/bundles/

It is a good practice to add a URL to your built JAR in this pull request description,
so it is easier for the community to test your Add-on.
If your pull request contains a new binding, it will likely take some time
before it is reviewed and processed by maintainers.
That said, consider submitting your Add-on in the Marketplace:
https://community.openhab.org/c/marketplace/69

Don't forget to submit a thread about your Add-on in the openHAB community:
https://community.openhab.org/c/add-ons 
-->
