### PR TITLE
[jpa] Fix querying of DimmerItems

### DIFF
--- a/bundles/org.openhab.persistence.jpa/src/main/java/org/openhab/persistence/jpa/internal/JpaHistoricItem.java
+++ b/bundles/org.openhab.persistence.jpa/src/main/java/org/openhab/persistence/jpa/internal/JpaHistoricItem.java
@@ -134,7 +134,7 @@ public class JpaHistoricItem implements HistoricItem {
                 }
             }
         } else if (item instanceof DimmerItem) {
-            state = new PercentType(Integer.parseInt(pItem.getValue()));
+            state = PercentType.valueOf(pItem.getValue());
         } else if (item instanceof SwitchItem) {
             state = OnOffType.valueOf(pItem.getValue());
         } else if (item instanceof ContactItem) {


### PR DESCRIPTION
Integer.parseInt was choking if a dimmer item had sub-integer precision

