### PR TITLE
features/header.xml: update Karaf XML schema version

### DIFF
--- a/features/openhab-addons/src/main/resources/header.xml
+++ b/features/openhab-addons/src/main/resources/header.xml
@@ -13,6 +13,6 @@
 	SPDX-License-Identifier: EPL-2.0
 
 -->
-<features name="${project.artifactId}-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
+<features name="${project.artifactId}-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.6.0">
 
 	<repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>


### PR DESCRIPTION
All possible XML Karaf Feature Schema versions, including history, are available at https://github.com/apache/karaf/tree/main/features/core/src/main/resources/org/apache/karaf/features .

This does not change the line
```xml
<features name="org.openhab.binding.mynewbinding-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
```
in org.openhab.binding.mynewbinding/src/main/feature/feature.xml, created by `cd bundles && ./create_openhab_binding_skeleton.sh`.