### PR TITLE
[homekit.binding] Improve thread synchronization

### DIFF
--- a/bundles/org.openhab.binding.homekit/src/main/java/org/openhab/binding/homekit/internal/transport/IpTransport.java
+++ b/bundles/org.openhab.binding.homekit/src/main/java/org/openhab/binding/homekit/internal/transport/IpTransport.java
@@ -71,7 +71,7 @@ public class IpTransport implements AutoCloseable {
     /**
      * SpotBugs incorrectly assumes that {@link SynchronousQueue#poll(long, TimeUnit)} never returns {@code null}.
      * According to the Javadoc, the method returns {@code null} if the specified waiting time elapses before an
-     * element becomes available.
+     * element becomes available. So this wrapper method correctly annotates the return value as nullable.
      */
     private static byte @Nullable [][] synchronousQueuePollNullable(SynchronousQueue<byte[][]> queue, long timeout,
             TimeUnit unit) throws InterruptedException {
@@ -222,7 +222,7 @@ public class IpTransport implements AutoCloseable {
                 });
                 // wait for both write and read to complete
                 writeFuture.get(TIMEOUT_MILLI_SECONDS, TimeUnit.MILLISECONDS);
-                response = sillySynchronousQueuePoll(responseQueue, TIMEOUT_MILLI_SECONDS, TimeUnit.MILLISECONDS);
+                response = synchronousQueuePollNullable(responseQueue, TIMEOUT_MILLI_SECONDS, TimeUnit.MILLISECONDS);
                 if (response == null) {
                     throw new TimeoutException("Timed out waiting for HTTP response");
                 }


### PR DESCRIPTION
This PR fixes the following issues in the `IpTransport` class:

1. Prefixes the accessory remote IP address to i/o log messages, for easier identification.
2. Logs warnings if EVENT messages arrive between sending a GET and receiving its response.
3. Improves thread synchronization.

Resolves #20003

Signed-off-by: Andrew Fiddian-Green <software@whitebear.ch>
