### PR TITLE
[shelly] Fix warnings

### DIFF
--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/manager/ShellyManagerCache.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/manager/ShellyManagerCache.java
@@ -52,7 +52,7 @@ public class ShellyManagerCache<K, V> {
         return entry == null ? null : entry.value;
     }
 
-    public V put(K key, V value) {
+    public @Nullable V put(K key, V value) {
         CacheEntry<V> entry = new CacheEntry<>(System.currentTimeMillis(), value);
         synchronized (this) {
             entry = storage.put(key, entry);
@@ -86,9 +86,10 @@ public class ShellyManagerCache<K, V> {
     }
 
     private synchronized void cancelJob() {
+        ScheduledFuture<?> cleanupJob = this.cleanupJob;
         if (cleanupJob != null) {
             cleanupJob.cancel(true);
-            cleanupJob = null;
+            this.cleanupJob = null;
         }
     }
 


### PR DESCRIPTION
Fix two warnings introduced in #19969:
```text
[WARNING] src\main\java\org\openhab\binding\shelly\internal\manager\ShellyManagerCache.java:[61,32] Null type mismatch (type annotations): 'null' is not compatible to the free type variable 'V'
[WARNING] src\main\java\org\openhab\binding\shelly\internal\manager\ShellyManagerCache.java:[90,13] Potential null pointer access: this expression has a '@Nullable' type
```