### PR TITLE
[Astro] 5.1.x Fix premature event scheduling

### DIFF
--- a/bundles/org.openhab.binding.astro/src/main/java/org/openhab/binding/astro/internal/handler/AstroThingHandler.java
+++ b/bundles/org.openhab.binding.astro/src/main/java/org/openhab/binding/astro/internal/handler/AstroThingHandler.java
@@ -22,7 +22,6 @@ import java.time.ZonedDateTime;
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Collection;
-import java.util.Date;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -73,7 +72,7 @@ public abstract class AstroThingHandler extends BaseThingHandler {
 
     /** Logger Instance */
     private final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
-    private final SimpleDateFormat isoFormatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
+    private final SimpleDateFormat loggerFormatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS", Locale.ROOT);
 
     /** Scheduler to schedule jobs */
     private final CronScheduler cronScheduler;
@@ -317,14 +316,14 @@ public abstract class AstroThingHandler extends BaseThingHandler {
         monitor.lock();
         try {
             tidyScheduledFutures();
-            sleepTime = eventAt.getTimeInMillis() - new Date().getTime();
+            sleepTime = eventAt.getTimeInMillis() - System.currentTimeMillis();
             ScheduledFuture<?> future = scheduler.schedule(job, sleepTime, TimeUnit.MILLISECONDS);
             scheduledFutures.add(future);
         } finally {
             monitor.unlock();
         }
         if (logger.isDebugEnabled()) {
-            final String formattedDate = this.isoFormatter.format(eventAt.getTime());
+            final String formattedDate = this.loggerFormatter.format(eventAt.getTime());
             logger.debug("Scheduled {} in {}ms (at {})", job, sleepTime, formattedDate);
         }
     }

--- a/bundles/org.openhab.binding.astro/src/main/java/org/openhab/binding/astro/internal/job/Job.java
+++ b/bundles/org.openhab.binding.astro/src/main/java/org/openhab/binding/astro/internal/job/Job.java
@@ -53,8 +53,15 @@ public interface Job extends SchedulerRunnable, Runnable {
     static void schedule(AstroThingHandler astroHandler, Job job, Calendar eventAt, TimeZone zone, Locale locale) {
         try {
             Calendar today = Calendar.getInstance(zone, locale);
-            if (isSameDay(eventAt, today) && isTimeGreaterEquals(eventAt, today)) {
+            boolean sameDay;
+            if ((sameDay = isSameDay(eventAt, today)) && isTimeGreaterEquals(eventAt, today)) {
                 astroHandler.schedule(job, eventAt);
+            } else if (logger.isDebugEnabled()) {
+                if (sameDay) {
+                    logger.debug("Not scheduling {} since it's in the past ({})", job, eventAt.getTime());
+                } else {
+                    logger.debug("Not scheduling {} since it's at another date ({})", job, eventAt.getTime());
+                }
             }
         } catch (Exception ex) {
             logger.error("{}", ex.getMessage(), ex);
@@ -155,7 +162,7 @@ public interface Job extends SchedulerRunnable, Runnable {
             return range;
         }
 
-        return new Range(truncateToSecond(applyConfig(start, config)), truncateToSecond(applyConfig(end, config)));
+        return new Range(applyConfig(start, config), applyConfig(end, config));
     }
 
     /**

--- a/bundles/org.openhab.binding.astro/src/main/java/org/openhab/binding/astro/internal/model/Range.java
+++ b/bundles/org.openhab.binding.astro/src/main/java/org/openhab/binding/astro/internal/model/Range.java
@@ -91,6 +91,14 @@ public class Range {
         return cal.getTimeInMillis() >= matchStart && cal.getTimeInMillis() < matchEnd;
     }
 
+    @Override
+    public String toString() {
+        Calendar start = this.start;
+        Calendar end = this.end;
+        return new StringBuilder(70).append("Range [").append(start == null ? "undefined" : start.getTime())
+                .append(" -> ").append(end == null ? "undefined" : end.getTime()).append(']').toString();
+    }
+
     private static Comparator<@Nullable Calendar> nullSafeCalendarComparator = (c1, c2) -> {
         if (c1 == null) {
             return (c2 == null) ? 0 : -1;


### PR DESCRIPTION
This is a backport of #19982. It's slightly reduced in logging changes because things have changed in the binding in the meanwhile, but it does what's important - gets rid of the truncation to seconds for schedule times.