### PR TITLE
[ecovacs] Catch more exceptions when parsing vacuum data

### DIFF
--- a/bundles/org.openhab.binding.ecovacs/src/main/java/org/openhab/binding/ecovacs/internal/api/impl/EcovacsApiImpl.java
+++ b/bundles/org.openhab.binding.ecovacs/src/main/java/org/openhab/binding/ecovacs/internal/api/impl/EcovacsApiImpl.java
@@ -67,7 +67,6 @@ import org.openhab.binding.ecovacs.internal.api.impl.dto.response.portal.PortalI
 import org.openhab.binding.ecovacs.internal.api.impl.dto.response.portal.PortalIotCommandXmlResponse;
 import org.openhab.binding.ecovacs.internal.api.impl.dto.response.portal.PortalIotProductResponse;
 import org.openhab.binding.ecovacs.internal.api.impl.dto.response.portal.PortalLoginResponse;
-import org.openhab.binding.ecovacs.internal.api.util.DataParsingException;
 import org.openhab.binding.ecovacs.internal.api.util.HashUtil;
 import org.openhab.core.OpenHAB;
 import org.slf4j.Logger;
@@ -306,7 +305,7 @@ public final class EcovacsApiImpl implements EcovacsApi {
         }
         try {
             return command.convertResponse(commandResponse, desc.protoVersion, gson);
-        } catch (DataParsingException e) {
+        } catch (Exception e) {
             logger.debug("Converting response for command {} failed", command, e);
             throw new EcovacsApiException(e);
         }

--- a/bundles/org.openhab.binding.ecovacs/src/main/java/org/openhab/binding/ecovacs/internal/api/impl/EcovacsIotMqDevice.java
+++ b/bundles/org.openhab.binding.ecovacs/src/main/java/org/openhab/binding/ecovacs/internal/api/impl/EcovacsIotMqDevice.java
@@ -38,7 +38,6 @@ import org.openhab.binding.ecovacs.internal.api.impl.dto.response.portal.PortalC
 import org.openhab.binding.ecovacs.internal.api.impl.dto.response.portal.PortalLoginResponse;
 import org.openhab.binding.ecovacs.internal.api.model.CleanLogRecord;
 import org.openhab.binding.ecovacs.internal.api.model.DeviceCapability;
-import org.openhab.binding.ecovacs.internal.api.util.DataParsingException;
 import org.openhab.core.io.net.http.TrustAllTrustManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -179,7 +178,7 @@ public class EcovacsIotMqDevice implements EcovacsDevice {
                     String eventName = receivedTopic.split("/")[2].toLowerCase();
                     logger.trace("{}: Got MQTT message on topic {}: {}", getSerialNumber(), receivedTopic, payload);
                     parser.handleMessage(eventName, payload);
-                } catch (DataParsingException e) {
+                } catch (Exception e) {
                     listener.onEventStreamFailure(this, e);
                 }
             };

--- a/bundles/org.openhab.binding.ecovacs/src/main/java/org/openhab/binding/ecovacs/internal/api/impl/EcovacsXmppDevice.java
+++ b/bundles/org.openhab.binding.ecovacs/src/main/java/org/openhab/binding/ecovacs/internal/api/impl/EcovacsXmppDevice.java
@@ -147,7 +147,7 @@ public class EcovacsXmppDevice implements EcovacsDevice {
                     return command.convertResponse(responseObj, ProtocolVersion.XML, gson);
                 }
             }
-        } catch (DataParsingException | ParserConfigurationException | TransformerException e) {
+        } catch (Exception e) {
             throw new EcovacsApiException(e);
         }
 


### PR DESCRIPTION
Missing fields in the responses so far went uncaught:

```
2026-01-08 14:19:31.852 [WARN ] [mmon.WrappedScheduledExecutorService] - Scheduled runnable ended with an exception: java.lang.NullPointerException: Cannot invoke "java.lang.Integer.intValue()" because "resp.waterAmount" is null
	at org.openhab.binding.ecovacs.internal.api.commands.GetMoppingWaterAmountCommand.convertResponse(GetMoppingWaterAmountCommand.java:45) ~[?:?]
	at org.openhab.binding.ecovacs.internal.api.commands.GetMoppingWaterAmountCommand.convertResponse(GetMoppingWaterAmountCommand.java:1) ~[?:?]
	at org.openhab.binding.ecovacs.internal.api.impl.EcovacsApiImpl.sendIotCommand(EcovacsApiImpl.java:308) ~[?:?]
	at org.openhab.binding.ecovacs.internal.api.impl.EcovacsIotMqDevice.sendCommand(EcovacsIotMqDevice.java:98) ~[?:?]
	at org.openhab.binding.ecovacs.internal.handler.EcovacsVacuumHandler.lambda$15(EcovacsVacuumHandler.java:632) ~[?:?]
	at org.openhab.binding.ecovacs.internal.handler.EcovacsVacuumHandler.doWithDevice(EcovacsVacuumHandler.java:822) ~[?:?]
	at org.openhab.binding.ecovacs.internal.handler.EcovacsVacuumHandler.pollData(EcovacsVacuumHandler.java:591) ~[?:?]
	at org.openhab.binding.ecovacs.internal.api.util.SchedulerTask.run(SchedulerTask.java:95) ~[?:?]
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:572) ~[?:?]
	at java.util.concurrent.FutureTask.run(FutureTask.java:317) ~[?:?]
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:304) ~[?:?]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144) ~[?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642) ~[?:?]
	at java.lang.Thread.run(Thread.java:1583) [?:?]
```

Make sure to catch those and make the user aware of it by setting the thing to offline / communication error instead of just emitting a warning in the log, so they get a chance to report that problem. With the previous behavior everything apparently was OK, but channels were not populated correctly.

(The root cause for the particular stack trace above was a wrong feature flag, which will be fixed in a separate MR)