### PR TITLE
[androiddebugbridge] Add security warning in documentation

### DIFF
--- a/bundles/org.openhab.binding.androiddebugbridge/README.md
+++ b/bundles/org.openhab.binding.androiddebugbridge/README.md
@@ -1,6 +1,8 @@
 # Android Debug Bridge Binding
 
-## _WARNING: there is much evidence that installing Debug Bridge on your Android device poses a strong security threat e.g. to enable Trojan horse software that could compromise it, or other LAN devices!!_
+:::warning
+There is much evidence that installing Debug Bridge on your Android device poses a strong security threat e.g. to enable Trojan horse software that could compromise it, or other LAN devices!_
+:::
 
 This binding allows to connect to android devices through the adb protocol.
 


### PR DESCRIPTION
It has recently been reported that having Android Debug Bridge running on home devices (e.g. Fire TV Sticks) can pose a major Trojan Horse security risk. 

There is actually no evidence whether (or not) the OH ADB binding can itself be a potential exploit vector for this risk. However for reasons of prudence I think we should not auto suggest this addon for new installations by potentially naive users.

Signed-off-by: Andrew Fiddian-Green <software@whitebear.ch>
