### PR TITLE
[roborock] Fix warning about invalid channel `fw-features`

### DIFF
--- a/bundles/org.openhab.binding.roborock/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.roborock/src/main/resources/OH-INF/thing/thing-types.xml
@@ -140,7 +140,6 @@
 			<channel id="multi-maps-list" typeId="multi-maps-list"/>
 			<channel id="room-mapping" typeId="room-mapping"/>
 			<channel id="routine-mapping" typeId="routine-mapping"/>
-			<channel id="fw-features" typeId="fw-features"/>
 			<channel id="customize-clean-mode" typeId="customize-clean-mode"/>
 			<channel id="carpet-mode" typeId="carpet-mode"/>
 		</channels>


### PR DESCRIPTION
Fixes https://github.com/openhab/openhab-addons/issues/20014