### PR TITLE
[enocean] Fix SenderIdOffset issue during teach-in

### DIFF
--- a/bundles/org.openhab.binding.enocean/src/main/java/org/openhab/binding/enocean/internal/handler/EnOceanBridgeHandler.java
+++ b/bundles/org.openhab.binding.enocean/src/main/java/org/openhab/binding/enocean/internal/handler/EnOceanBridgeHandler.java
@@ -348,10 +348,7 @@ public class EnOceanBridgeHandler extends ConfigStatusBridgeHandler implements T
     public @Nullable Integer getNextSenderId(String enoceanId) {
         EnOceanBridgeConfig config = getConfigAs(EnOceanBridgeConfig.class);
         Integer senderId = config.nextSenderId;
-        if (senderId == null) {
-            return null;
-        }
-        if (sendingThings[senderId] == null) {
+        if (senderId != null && sendingThings[senderId] == null) {
             Configuration c = this.editConfiguration();
             c.put(PARAMETER_NEXT_SENDERID, null);
             updateConfiguration(c);


### PR DESCRIPTION
# Description
Teach-in of new devices is not possible and aborts with error message `Could not get new SenderIdOffset`. During teach-in process the entry from the bridge configuration for SenderId is taken. This is by default empty ("null"). Due to the initial "null"-check in `public @Nullable Integer getNextSenderId(String enoceanId)`, the function is left, no SenderId is defined and the error message is posted. 

`2026-01-10 07:09:28.720 [DEBUG] [nternal.handler.EnOceanBridgeHandler] - Smack teach in activated
2026-01-10 07:09:28.720 [TRACE] [ernal.transceiver.EnOceanTransceiver] - Response handled
2026-01-10 07:09:32.923 [TRACE] [ernal.transceiver.EnOceanTransceiver] - Received Sync Byte
2026-01-10 07:09:32.924 [TRACE] [ernal.transceiver.EnOceanTransceiver] - >> Received header, data length 13 optional length 7 packet type 1
2026-01-10 07:09:32.986 [DEBUG] [ernal.transceiver.EnOceanTransceiver] - RADIO_ERP1 with RORG UTE for 051BF240 payload D4A00246001201D2051BF2400000FFFFFFFF2A00 received
2026-01-10 07:09:32.987 [INFO ] [ernal.transceiver.EnOceanTransceiver] - Received teach in message from 051BF240
2026-01-10 07:09:32.988 [INFO ] [covery.EnOceanDeviceDiscoveryService] - EnOcean Package discovered, RORG UTE, payload D4A00246001201D2051BF24000, additional 00FFFFFFFF2A00
2026-01-10 07:09:33.038 [DEBUG] [covery.EnOceanDeviceDiscoveryService] - Sending UTE response to 051BF240
2026-01-10 07:09:33.038 [WARN ] [covery.EnOceanDeviceDiscoveryService] - **Could not get new SenderIdOffset** <== `

# Changes
With the fix, the initial "null"-check is removed (it still takes place at the  end of the routine in case bridge and device have no SenderId and no empty SenderId is found). 

After change the teach-in is possible again:
`2026-01-10 07:15:17.746 [DEBUG] [nternal.handler.EnOceanBridgeHandler] - Smack teach in activated
2026-01-10 07:15:17.746 [TRACE] [ernal.transceiver.EnOceanTransceiver] - Response handled
2026-01-10 07:15:20.834 [TRACE] [ernal.transceiver.EnOceanTransceiver] - Received Sync Byte
2026-01-10 07:15:20.835 [TRACE] [ernal.transceiver.EnOceanTransceiver] - >> Received header, data length 13 optional length 7 packet type 1
2026-01-10 07:15:20.881 [DEBUG] [ernal.transceiver.EnOceanTransceiver] - RADIO_ERP1 with RORG UTE for 051BF240 payload D4A00246001201D2051BF2400000FFFFFFFF2A00 received
2026-01-10 07:15:20.882 [INFO ] [ernal.transceiver.EnOceanTransceiver] - Received teach in message from 051BF240
2026-01-10 07:15:20.883 [INFO ] [covery.EnOceanDeviceDiscoveryService] - EnOcean Package discovered, RORG UTE, payload D4A00246001201D2051BF24000, additional 00FFFFFFFF2A00
2026-01-10 07:15:20.947 [DEBUG] [covery.EnOceanDeviceDiscoveryService] - Sending UTE response to 051BF240
2026-01-10 07:15:20.948 [DEBUG] [ernal.transceiver.EnOceanTransceiver] - Enqueue new send request with ESP3 type RADIO_ERP1 without callback
2026-01-10 07:15:20.948 [DEBUG] [ernal.transceiver.EnOceanTransceiver] - Sending data, type RADIO_ERP1, payload D4910246001201D2XXXXXX018F01051BF240FF00
2026-01-10 07:15:20.948 [TRACE] [ernal.transceiver.EnOceanTransceiver] - Sending raw data: 55000D0701FDD4910246001201D2XXXXXX018F01051BF240FF0099
2026-01-10 07:15:20.948 [DEBUG] [covery.EnOceanDeviceDiscoveryService] - **Teach in response for 051BF240 with new senderId XXXXXX01 (= offset 1) sent**
2026-01-10 07:15:20.971 [INFO ] [g.discovery.internal.PersistentInbox] - Added new thing 'enocean:measurementSwitch:85af2f3224:051BF240' to inbox.`

# Testing
Tested with a USB300 bridge connected remotly (rfc2217) and a Nodon Sin-2-2-01 and Nodon MSP-2-1-x1

Link to JAR files: https://github.com/pudermueller/openhab-addons/releases/tag/enocean-binding-5.2.0-SNAPSHOT-fix