### PR TITLE
[tuya] Avoid refresh if no measurables on status update

### DIFF
--- a/bundles/org.openhab.binding.tuya/src/main/java/org/openhab/binding/tuya/internal/handler/TuyaDeviceHandler.java
+++ b/bundles/org.openhab.binding.tuya/src/main/java/org/openhab/binding/tuya/internal/handler/TuyaDeviceHandler.java
@@ -177,7 +177,7 @@ public class TuyaDeviceHandler extends BaseThingHandler implements DeviceInfoSub
             }
         }
 
-        if (needRefresh) {
+        if (needRefresh && configuration.pollingInterval > 0) {
             TuyaDevice tuyaDevice = this.tuyaDevice;
             if (tuyaDevice != null) {
                 ScheduledFuture<?> pollingJob = this.pollingJob;


### PR DESCRIPTION
# [tuya]

# Description

Addition to https://github.com/openhab/openhab-addons/pull/19930

Looks like there was a logic error here - we should not try to send refresh to device if it has no read-only DPs because some devices will ignore it completely and it will lead to disconnect as no response is sent 

Fixes https://github.com/openhab/openhab-addons/issues/19880

# Testing

Tested with devices having deviceId `m51ym56ydzrx9js7` - none of DPs are read only there, which caused next behavior: after connection and status update polling is initiated and DP_REFRESH sent out; device ignores DP_REFRESH and after 1 second (write response timeout) we mark connection as dead and reconnect

```
17:04:22.730 [INFO ] [hab.event.ThingStatusInfoChangedEvent] - Thing 'tuya:tuyaDevice:kitchen_sink_led' changed from ONLINE to ONLINE: Waiting for device wake up17:04:23.733 [DEBUG] [inding.tuya.internal.local.TuyaDevice] - 3153277670039f187c3d/192.168.0.158:6668: reconnect
17:04:23.737 [DEBUG] [inding.tuya.internal.local.TuyaDevice] - 3153277670039f187c3d/192.168.0.158:6668: channel connected
17:04:23.737 [DEBUG] [ya.internal.handler.TuyaDeviceHandler] - kitchen_sink_led: connected
17:04:23.737 [DEBUG] [a.internal.local.handlers.TuyaEncoder] - 3153277670039f187c3d/192.168.0.158:6668: Sending DP_QUERY, payload {devId=3153277670039f187c3d, uid=3153277670039f187c3d, t=1768057463, dps=[], gwId=3153277670039f187c3d}
17:04:23.737 [INFO ] [hab.event.ThingStatusInfoChangedEvent] - Thing 'tuya:tuyaDevice:kitchen_sink_led' changed from ONLINE: Waiting for device wake up to ONLINE
17:04:23.770 [DEBUG] [a.internal.local.handlers.TuyaDecoder] - 3153277670039f187c3d/192.168.0.158:6668: Received MessageWrapper{commandType=DP_QUERY, content='TcpStatusPayload{protocol=-1, devId='3153277670039f187c3d', gwId='', uid='', t=0, dps={1=true, 9=0.0, 38=2, 41=, 42=, 43=}, data=Data{dps={}}}'}
17:04:24.774 [DEBUG] [a.internal.local.handlers.TuyaEncoder] - 3153277670039f187c3d/192.168.0.158:6668: Sending DP_REFRESH, payload {dpId=[]}
17:04:25.778 [DEBUG] [inding.tuya.internal.local.TuyaDevice] - 3153277670039f187c3d192.168.0.158: Connection seems to be dead.
17:04:25.778 [DEBUG] [inding.tuya.internal.local.TuyaDevice] - 3153277670039f187c3d/192.168.0.158:6668: channel closed
17:04:25.778 [DEBUG] [ya.internal.handler.TuyaDeviceHandler] - kitchen_sink_led: disconnected
```

After fix we do not send DP_REFRESH on status update anymore and just use heartbeat