### PR TITLE
[homekit.binding] Fix UoM for state updates

### DIFF
--- a/bundles/org.openhab.binding.homekit/src/main/java/org/openhab/binding/homekit/internal/handler/HomekitAccessoryHandler.java
+++ b/bundles/org.openhab.binding.homekit/src/main/java/org/openhab/binding/homekit/internal/handler/HomekitAccessoryHandler.java
@@ -73,7 +73,6 @@ import org.openhab.core.types.Command;
 import org.openhab.core.types.RefreshType;
 import org.openhab.core.types.State;
 import org.openhab.core.types.StateDescription;
-import org.openhab.core.types.StateDescriptionFragment;
 import org.openhab.core.types.StateOption;
 import org.openhab.core.types.UnDefType;
 import org.openhab.core.types.util.UnitUtils;
@@ -293,7 +292,7 @@ public class HomekitAccessoryHandler extends HomekitBaseAccessoryHandler {
                     if (acceptedItemType.startsWith(CoreItemFactory.NUMBER)) {
                         String[] itemTypeParts = acceptedItemType.split(":");
                         if (itemTypeParts.length > 1
-                                && getStateDescription(channel) instanceof StateDescriptionFragment stateDescription
+                                && getStateDescription(channel) instanceof StateDescription stateDescription
                                 && UnitUtils.parseUnit(stateDescription.getPattern()) instanceof Unit<?> channelUnit
                                 && itemTypeParts[1].equalsIgnoreCase(UnitUtils.getDimensionName(channelUnit))) {
                             yield QuantityType.valueOf(value.getAsNumber().doubleValue(), channelUnit);


### PR DESCRIPTION
This fixes numbers with dimension, such as `Number:Temperature` or `Number:Dimensionless` being updated as `DecimalType` rather than `QuantityType`.

Related to #20005