### PR TITLE
[tuya] Remove extraneous toLowerCase

### DIFF
--- a/bundles/org.openhab.binding.tuya/src/main/java/org/openhab/binding/tuya/internal/TuyaChannelTypeProvider.java
+++ b/bundles/org.openhab.binding.tuya/src/main/java/org/openhab/binding/tuya/internal/TuyaChannelTypeProvider.java
@@ -167,7 +167,7 @@ public class TuyaChannelTypeProvider implements ChannelTypeProvider {
         channelTypeId = channelTypeId.substring(i + 1);
 
         // Build with a channelTypeId of just the lower-cased DP identifier and set defaults for all text.
-        channelType = channelTypeFromSchema(channelTypeUID, productId, channelTypeId.toLowerCase());
+        channelType = channelTypeFromSchema(channelTypeUID, productId, channelTypeId);
         if (channelType != null) {
             // Localize that (e.g. using channel-type.tuya.cur_voltage.label = ...)
             channelType = localizationService.createLocalizedChannelType(bundle, channelType, locale);


### PR DESCRIPTION
Should not lower case the channel ID when looking it up in the schema.

Fixes #20019 