### PR TITLE
[shelly][WIP] Refactor mDNS Discovery handler

### DIFF
--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/ShellyDevices.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/ShellyDevices.java
@@ -47,7 +47,7 @@ public class ShellyDevices {
     public static final String SHELLYDT_3EM = "SHEM-3";
     public static final String SHELLYDT_HT = "SHHT-1";
     public static final String SHELLYDT_SMOKE = "SHSM-01";
-    public static final String SHELLYDT_FLOOD = "SH-FLOOD ";
+    public static final String SHELLYDT_FLOOD = "SH-FLOOD";
     public static final String SHELLYDT_DOORWINDOW = "SHDW-1";
     public static final String SHELLYDT_DOORWINDOW2 = "SHDW-2";
     public static final String SHELLYDT_UNI = "SHUNI-1";
@@ -309,7 +309,7 @@ public class ShellyDevices {
             .of(GROUP_DUO_THING_TYPES, GROUP_RGBW2_THING_TYPES, Set.of(THING_TYPE_SHELLYBULB)).flatMap(Set::stream)
             .collect(Collectors.toUnmodifiableSet());
 
-    // iX Decvices
+    // iX Devices
     public static final Set<ThingTypeUID> GROUP_IX_THING_TYPES = Set.of( //
             THING_TYPE_SHELLYIX3, THING_TYPE_SHELLYPLUSI4, THING_TYPE_SHELLYPLUSI4DC);
 

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/Shelly2ApiClient.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/Shelly2ApiClient.java
@@ -23,7 +23,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Random;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -106,7 +105,6 @@ import org.slf4j.LoggerFactory;
 @NonNullByDefault
 public class Shelly2ApiClient extends ShellyHttpClient implements ShellyDiscoveryInterface {
     private final Logger logger = LoggerFactory.getLogger(Shelly2ApiClient.class);
-    protected final Random random = new Random();
     protected final ShellyStatusRelay relayStatus = new ShellyStatusRelay();
     protected final ShellyStatusSensor sensorData = new ShellyStatusSensor();
     protected final ArrayList<ShellyRollerStatus> rollerStatus = new ArrayList<>();

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/Shelly2ApiClient.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/Shelly2ApiClient.java
@@ -108,7 +108,7 @@ public class Shelly2ApiClient extends ShellyHttpClient implements ShellyDiscover
     protected final ShellyStatusRelay relayStatus = new ShellyStatusRelay();
     protected final ShellyStatusSensor sensorData = new ShellyStatusSensor();
     protected final ArrayList<ShellyRollerStatus> rollerStatus = new ArrayList<>();
-    protected @Nullable ShellyThingInterface thing;
+    protected volatile @Nullable ShellyThingInterface thing;
 
     private static final String RPC_SRC_PREFIX = "ohshelly-";
     private static final AtomicInteger REQUEST_ID = new AtomicInteger(1);

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/Shelly2ApiRpc.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/Shelly2ApiRpc.java
@@ -25,10 +25,12 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.UncheckedIOException;
+import java.nio.channels.AsynchronousCloseException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -109,7 +111,8 @@ public class Shelly2ApiRpc extends Shelly2ApiClient implements ShellyApiInterfac
     private final Logger logger = LoggerFactory.getLogger(Shelly2ApiRpc.class);
     private final ShellyThingTable thingTable;
 
-    protected boolean initialized = false;
+    private final AtomicBoolean initialized = new AtomicBoolean(false);
+
     private @Nullable Shelly2RpcSocket rpcSocket;
     private @Nullable Shelly2AuthChallenge authInfo;
     private final WebSocketClient client;
@@ -135,7 +138,7 @@ public class Shelly2ApiRpc extends Shelly2ApiClient implements ShellyApiInterfac
     @Override
     public void initialize(String thingName, ShellyThingConfiguration config) throws ShellyApiException {
         setConfig(thingName, config);
-        if (initialized) {
+        if (isInitialized()) {
             logger.debug("{}: Disconnect Rpc Socket on initialize", thingName);
             disconnect();
         }
@@ -146,12 +149,12 @@ public class Shelly2ApiRpc extends Shelly2ApiClient implements ShellyApiInterfac
         rpcSocket = new Shelly2RpcSocket(thingName, thingTable, config.deviceIp, client);
         rpcSocket.addMessageHandler(this);
         this.rpcSocket = rpcSocket;
-        initialized = true;
+        initialized.set(true);
     }
 
     @Override
     public boolean isInitialized() {
-        return initialized;
+        return initialized.get();
     }
 
     @Override
@@ -772,16 +775,18 @@ public class Shelly2ApiRpc extends Shelly2ApiClient implements ShellyApiInterfac
 
     @Override
     public void onError(Throwable cause) {
+        String message = "WebSocket error: " + getString(cause.getMessage());
         if (logger.isDebugEnabled()) {
-            if (cause instanceof EofException || cause instanceof EOFException) {
+            if (cause instanceof EofException || cause instanceof EOFException
+                    || cause instanceof AsynchronousCloseException || "Shutdown".equals(cause.getMessage())) {
                 logger.debug("{}: WebSocket was closed ungracefully", thingName);
             } else {
-                logger.debug("{}: WebSocket error", thingName, cause);
+                logger.debug("{}: {}", thingName, message, cause);
             }
         }
         ShellyThingInterface thing = this.thing;
         if (thing != null && thing.getProfile().alwaysOn) {
-            thingOffline("WebSocket error");
+            thingOffline(message);
         }
     }
 
@@ -1352,7 +1357,16 @@ public class Shelly2ApiRpc extends Shelly2ApiClient implements ShellyApiInterfac
         if (rpcSocket.isConnected()) {
             logger.trace("{}: Disconnect Rpc Socket", thingName);
         }
-        rpcSocket.disconnect();
+
+        try {
+            rpcSocket.disconnect();
+        } catch (Exception e) {
+            if (e.getCause() instanceof AsynchronousCloseException) {
+                // Channel was closed intentionally, ignore
+            } else {
+                throw e;
+            }
+        }
     }
 
     public Shelly2RpctInterface getRpcHandler() {
@@ -1364,15 +1378,15 @@ public class Shelly2ApiRpc extends Shelly2ApiClient implements ShellyApiInterfac
         Shelly2RpcSocket rpcSocket = this.rpcSocket;
         if (rpcSocket == null) {
             logger.debug("{}: Cannot close RPC socket since it's null", thingName);
-            initialized = false;
+            initialized.set(false);
             return;
         }
-        if (initialized || rpcSocket.isConnected()) {
+        if (initialized.get() || rpcSocket.isConnected()) {
             logger.debug("{}: Closing Rpc API (socket is {})", thingName,
                     rpcSocket.isConnected() ? "connected" : "disconnected");
         }
         disconnect();
-        initialized = false;
+        initialized.set(false);
     }
 
     private void incProtErrors() {

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/Shelly2ApiRpc.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/Shelly2ApiRpc.java
@@ -108,13 +108,15 @@ import org.slf4j.LoggerFactory;
  */
 @NonNullByDefault
 public class Shelly2ApiRpc extends Shelly2ApiClient implements ShellyApiInterface, Shelly2RpctInterface {
+    private final AtomicBoolean initialized = new AtomicBoolean(false);
     private final Logger logger = LoggerFactory.getLogger(Shelly2ApiRpc.class);
     private final ShellyThingTable thingTable;
 
-    private final AtomicBoolean initialized = new AtomicBoolean(false);
+    private final Object stateLock = new Object();
+    private AtomicBoolean discovery = new AtomicBoolean(false);
+    private @Nullable Shelly2RpcSocket rpcSocket; // TODO: Must be made thread-safe
+    private @Nullable Shelly2AuthChallenge authInfo; // TODO: Must be made thread-safe
 
-    private @Nullable Shelly2RpcSocket rpcSocket;
-    private @Nullable Shelly2AuthChallenge authInfo;
     private final WebSocketClient client;
 
     // Plus devices support up to 3 scripts, Pro devices up to 10
@@ -131,27 +133,25 @@ public class Shelly2ApiRpc extends Shelly2ApiClient implements ShellyApiInterfac
     public Shelly2ApiRpc(String thingName, ShellyThingTable thingTable, ShellyThingInterface thing,
             WebSocketClient webSocketClient) {
         super(thingName, thing);
-        this.thingTable = thingTable;
+        synchronized (stateLock) {
+            this.thingTable = thingTable;
+        }
         this.client = webSocketClient;
     }
 
     @Override
     public void initialize(String thingName, ShellyThingConfiguration config) throws ShellyApiException {
-        setConfig(thingName, config);
-        if (isInitialized()) {
-            logger.debug("{}: Disconnect Rpc Socket on initialize", thingName);
-            disconnect();
-        }
-
-        logger.debug("{}: Initialize APIv2 (tname={}", thingName, Thread.currentThread().getName());
-
         Shelly2RpcSocket rpcSocket = this.rpcSocket;
         if (rpcSocket != null) {
+            logger.debug("{}: Disconnect RPC Socket on initialize", thingName);
             rpcSocket.disconnect();
         }
         rpcSocket = new Shelly2RpcSocket(thingName, thingTable, config.deviceIp, client);
         rpcSocket.addMessageHandler(this);
-        this.rpcSocket = rpcSocket;
+        synchronized (stateLock) {
+            this.rpcSocket = rpcSocket;
+        }
+
         initialized.set(true);
     }
 
@@ -598,36 +598,34 @@ public class Shelly2ApiRpc extends Shelly2ApiClient implements ShellyApiInterfac
 
     @Override
     public void onConnect(String deviceIp, boolean connected) {
-        thing = thingTable.getThing(deviceIp);
-        logger.debug("{}: Get thing from thingTable", thingName);
+        logger.debug("{}: Connected, get thing from thingTable", thingName);
+        ShellyThingTable thingTable;
+        synchronized (stateLock) {
+            thingTable = this.thingTable;
+            thing = thingTable.getThing(deviceIp);
+        }
     }
 
     @Override
     public void onNotifyStatus(Shelly2RpcNotifyStatus message) throws ShellyApiException {
         logger.debug("{}: NotifyStatus update received: {}", thingName, gson.toJson(message));
-        ShellyThingInterface t = thing;
-        if (t == null) {
-            logger.debug("{}: No matching thing on NotifyStatus for {}, ignore (src={}, dst={})", thingName, thingName,
-                    message.src, message.dst);
-            return;
-        }
-        if (t.isStopping()) {
-            logger.debug("{}: Thing is shutting down, ignore WebSocket message", thingName);
-            return;
-        }
-        if (!t.isThingOnline() && t.getThingStatusDetail() != ThingStatusDetail.CONFIGURATION_PENDING) {
-            logger.debug("{}: Thing is not in online state/connectable, ignore NotifyStatus", thingName);
+
+        ShellyThingInterface thing = this.thing;
+        // checkThingStatusAndRestartWatchdog() display a message on null
+        if (!checkThingStatusAndRestartWatchdog(message.src, "n/a") || thing == null) {
             return;
         }
 
-        getThing().incProtMessages();
         if (message.error != null) {
             if (message.error.code == HttpStatus.UNAUTHORIZED_401 && !getString(message.error.message).isEmpty()) {
                 // Save nonce for notification
+                // TODO: synchronize
                 Shelly2AuthChallenge auth = gson.fromJson(message.error.message, Shelly2AuthChallenge.class);
                 if (auth != null && auth.realm == null) {
                     logger.debug("{}: Authentication data received: {}", thingName, message.error.message);
-                    authInfo = auth;
+                    synchronized (stateLock) {
+                        authInfo = auth;
+                    }
                 }
             } else {
                 logger.debug("{}: Error status received - {} {}", thingName, message.error.code, message.error.message);
@@ -637,8 +635,8 @@ public class Shelly2ApiRpc extends Shelly2ApiClient implements ShellyApiInterfac
 
         Shelly2NotifyStatus params = message.params;
         if (params != null) {
-            if (getThing().getThingStatusDetail() != ThingStatusDetail.FIRMWARE_UPDATING) {
-                getThing().setThingOnline();
+            if (thing.getThingStatusDetail() != ThingStatusDetail.FIRMWARE_UPDATING) {
+                thing.setThingOnline();
             }
 
             boolean updated = false;
@@ -662,9 +660,10 @@ public class Shelly2ApiRpc extends Shelly2ApiClient implements ShellyApiInterfac
                 }
             }
 
+            // TODO synchronize
             profile.status = status;
             if (updated) {
-                getThing().restartWatchdog();
+                thing.restartWatchdog();
             }
         }
     }
@@ -675,8 +674,11 @@ public class Shelly2ApiRpc extends Shelly2ApiClient implements ShellyApiInterfac
         ShellyDeviceProfile profile = getProfile();
         Shelly2RpcNotifyEvent message = fromJson(gson, eventJSON, Shelly2RpcNotifyEvent.class);
 
-        getThing().incProtMessages();
-        getThing().restartWatchdog();
+        ShellyThingInterface thing = this.thing;
+        // checkThingStatusAndRestartWatchdog() display a message on null
+        if (!checkThingStatusAndRestartWatchdog(message.src, "n/a") || thing == null) {
+            return;
+        }
 
         for (Shelly2NotifyEvent e : message.params.events) {
             switch (e.event) {
@@ -685,7 +687,7 @@ public class Shelly2ApiRpc extends Shelly2ApiClient implements ShellyApiInterfac
                     String bgroup = getProfile().getInputGroup(e.id);
                     updateChannel(bgroup, CHANNEL_INPUT + profile.getInputSuffix(e.id),
                             getOnOff(SHELLY2_EVENT_BTNDOWN.equals(getString(e.event))));
-                    getThing().triggerButton(profile.getInputGroup(e.id), e.id, mapValue(MAP_INPUT_EVENT_ID, e.event));
+                    thing.triggerButton(profile.getInputGroup(e.id), e.id, mapValue(MAP_INPUT_EVENT_ID, e.event));
                     break;
 
                 case SHELLY2_EVENT_1PUSH:
@@ -698,6 +700,8 @@ public class Shelly2ApiRpc extends Shelly2ApiClient implements ShellyApiInterfac
                         ShellyInputState input = relayStatus.inputs.get(e.id);
                         input.event = getString(MAP_INPUT_EVENT_TYPE.get(e.event));
                         input.eventCount = getInteger(input.eventCount) + 1;
+
+                        // TODO: synchronize
                         relayStatus.inputs.set(e.id, input);
                         profile.status.inputs.set(e.id, input);
 
@@ -706,18 +710,17 @@ public class Shelly2ApiRpc extends Shelly2ApiClient implements ShellyApiInterfac
                                 getStringType(input.event));
                         updateChannel(group, CHANNEL_STATUS_EVENTCOUNT + profile.getInputSuffix(e.id),
                                 getDecimal(input.eventCount));
-                        getThing().triggerButton(profile.getInputGroup(e.id), e.id,
-                                mapValue(MAP_INPUT_EVENT_ID, e.event));
+                        thing.triggerButton(profile.getInputGroup(e.id), e.id, mapValue(MAP_INPUT_EVENT_ID, e.event));
                     }
                     break;
                 case SHELLY2_EVENT_CFGCHANGED:
                     logger.debug("{}: Configuration update detected, re-initialize", thingName);
-                    getThing().requestUpdates(1, true); // refresh config
+                    thing.requestUpdates(1, true); // refresh config
                     break;
 
                 case SHELLY2_EVENT_OTASTART:
                     logger.debug("{}: Firmware update started: {}", thingName, getString(e.msg));
-                    getThing().setThingStatus(ThingStatus.OFFLINE, ThingStatusDetail.FIRMWARE_UPDATING,
+                    thing.setThingStatus(ThingStatus.OFFLINE, ThingStatusDetail.FIRMWARE_UPDATING,
                             "offline.status-error-fwupgrade");
                     break;
                 case SHELLY2_EVENT_OTAPROGRESS:
@@ -725,30 +728,50 @@ public class Shelly2ApiRpc extends Shelly2ApiClient implements ShellyApiInterfac
                     break;
                 case SHELLY2_EVENT_OTADONE:
                     logger.debug("{}: Firmware update completed with status {}", thingName, getString(e.msg));
-                    getThing().setThingStatus(ThingStatus.OFFLINE, ThingStatusDetail.DUTY_CYCLE,
+                    thing.setThingStatus(ThingStatus.OFFLINE, ThingStatusDetail.DUTY_CYCLE,
                             "message.offline.status-error-fwcompleted");
                     break;
                 case SHELLY2_EVENT_RESTART:
                     logger.debug("{}: Device was restarted: {}", thingName, getString(e.msg));
-                    getThing().setThingStatus(ThingStatus.OFFLINE, ThingStatusDetail.DUTY_CYCLE,
+                    thing.setThingStatus(ThingStatus.OFFLINE, ThingStatusDetail.DUTY_CYCLE,
                             "offline.status-error-restarted");
-                    getThing().postEvent(ALARM_TYPE_RESTARTED, true);
+                    thing.postEvent(ALARM_TYPE_RESTARTED, true);
                     break;
                 case SHELLY2_EVENT_SLEEP:
                     logger.debug("{}: Connection terminated, e.g. device in sleep mode", thingName);
                     break;
                 case SHELLY2_EVENT_WIFICONNFAILED:
                     logger.debug("{}: WiFi connect failed, check setup, reason {}", thingName, getInteger(e.reason));
-                    getThing().postEvent(e.event, false);
+                    thing.postEvent(e.event, false);
                     break;
                 case SHELLY2_EVENT_WIFIDISCONNECTED:
                     logger.debug("{}: WiFi disconnected, reason {}", thingName, getInteger(e.reason));
-                    getThing().postEvent(e.event, false);
+                    thing.postEvent(e.event, false);
                     break;
                 default:
                     logger.debug("{}: Event {} was not handled", thingName, e.event);
             }
         }
+    }
+
+    private boolean checkThingStatusAndRestartWatchdog(String src, String dst) {
+        ShellyThingInterface thing = this.thing;
+        if (thing == null) {
+            logger.debug("{}: No matching thing, ignore message (dst={}, discovery={}", src, dst, discovery.get());
+            return false;
+        }
+        if (thing.isStopping()) {
+            logger.debug("{}: Thing is shutting down, ignore WebSocket message", thingName);
+            return false;
+        }
+        if (!thing.isThingOnline() && thing.getThingStatusDetail() != ThingStatusDetail.CONFIGURATION_PENDING) {
+            logger.debug("{}: Thing is not in online state/connectable, ignore NotifyStatus", thingName);
+            return false;
+        }
+
+        thing.incProtMessages();
+        thing.restartWatchdog();
+        return true;
     }
 
     @Override
@@ -764,7 +787,7 @@ public class Shelly2ApiRpc extends Shelly2ApiClient implements ShellyApiInterfac
             logger.debug("{}: WebSocket connection closed, status = {}/{}", thingName, statusCode, reason);
             if ("Bye".equalsIgnoreCase(reason)) {
                 logger.debug("{}: Device went to sleep mode or was restarted", thingName);
-            } else if (statusCode == StatusCode.ABNORMAL && getProfile().alwaysOn) {
+            } else if (statusCode == StatusCode.ABNORMAL && !discovery.get() && getProfile().alwaysOn) {
                 // e.g. device rebooted
                 if (getThing().getThingStatusDetail() != ThingStatusDetail.DUTY_CYCLE) {
                     thingOffline("WebSocket connection closed abnormally");
@@ -787,6 +810,7 @@ public class Shelly2ApiRpc extends Shelly2ApiClient implements ShellyApiInterfac
                 logger.debug("{}: {}", thingName, message, cause);
             }
         }
+
         ShellyThingInterface thing = this.thing;
         if (thing != null && thing.getProfile().alwaysOn) {
             thingOffline(message);
@@ -878,6 +902,7 @@ public class Shelly2ApiRpc extends Shelly2ApiClient implements ShellyApiInterfac
             // Update status when not yet initialized
             getStatus();
         }
+        // TODO: Return copy?
         return relayStatus;
     }
 
@@ -1149,16 +1174,6 @@ public class Shelly2ApiRpc extends Shelly2ApiClient implements ShellyApiInterfac
         return ""; // Gen2 uses WS to publish debug log
     }
 
-    /*
-     * The following API calls are not yet relevant, because currently there a no Plus/Pro (Gen2) devices of those
-     * categories (e.g. bulbs)
-     */
-
-    @Override
-    public void setLightParm(int lightIndex, String parm, String value) throws ShellyApiException {
-        throw new ShellyApiException("API call not implemented");
-    }
-
     @Override
     public void setLightParms(int lightIndex, Map<String, String> parameters) throws ShellyApiException {
         Shelly2RpcRequestParams params = new Shelly2RpcRequestParams();
@@ -1184,6 +1199,16 @@ public class Shelly2ApiRpc extends Shelly2ApiClient implements ShellyApiInterfac
 
             apiRequest(SHELLYRPC_METHOD_RGBW_SET, params, String.class);
         }
+        throw new ShellyApiException("API call not implemented");
+    }
+
+    /*
+     * The following API calls are not yet relevant, because currently there a no Plus/Pro (Gen2) devices of those
+     * categories (e.g. bulbs)
+     */
+
+    @Override
+    public void setLightParm(int lightIndex, String parm, String value) throws ShellyApiException {
         throw new ShellyApiException("API call not implemented");
     }
 
@@ -1259,9 +1284,13 @@ public class Shelly2ApiRpc extends Shelly2ApiClient implements ShellyApiInterfac
     }
 
     private void asyncApiRequest(String method) throws ShellyApiException {
-        Shelly2RpcBaseMessage request = buildRequest(method, null);
         reconnect();
-        Shelly2RpcSocket rpcSocket = this.rpcSocket;
+
+        Shelly2RpcBaseMessage request = buildRequest(method, null);
+        Shelly2RpcSocket rpcSocket;
+        synchronized (stateLock) {
+            rpcSocket = this.rpcSocket;
+        }
         if (rpcSocket != null && rpcSocket.isConnected()) {
             rpcSocket.sendMessage(gson.toJson(request)); // submit, result will be async
         } else {
@@ -1281,25 +1310,28 @@ public class Shelly2ApiRpc extends Shelly2ApiClient implements ShellyApiInterfac
             String auth = getString(res.authChallenge);
             if (res.isHttpAccessUnauthorized() && !auth.isEmpty()) {
                 String[] options = auth.split(",");
-                Shelly2AuthChallenge authInfo = this.authInfo = new Shelly2AuthChallenge();
-                for (String o : options) {
-                    String key = substringBefore(o, "=").stripLeading().trim();
-                    String value = substringAfter(o, "=").replace("\"", "").trim();
-                    switch (key) {
-                        case "Digest qop":
-                            authInfo.authType = SHELLY2_AUTHTTYPE_DIGEST;
-                            break;
-                        case "realm":
-                            authInfo.realm = value;
-                            break;
-                        case "nonce":
-                            // authInfo.nonce = Long.parseLong(value, 16);
-                            authInfo.nonce = value;
-                            break;
-                        case "algorithm":
-                            authInfo.algorithm = value;
-                            break;
+                synchronized (stateLock) {
+                    Shelly2AuthChallenge authInfo = new Shelly2AuthChallenge();
+                    for (String o : options) {
+                        String key = substringBefore(o, "=").stripLeading().trim();
+                        String value = substringAfter(o, "=").replace("\"", "").trim();
+                        switch (key) {
+                            case "Digest qop":
+                                authInfo.authType = SHELLY2_AUTHTTYPE_DIGEST;
+                                break;
+                            case "realm":
+                                authInfo.realm = value;
+                                break;
+                            case "nonce":
+                                // authInfo.nonce = Long.parseLong(value, 16);
+                                authInfo.nonce = value;
+                                break;
+                            case "algorithm":
+                                authInfo.algorithm = value;
+                                break;
+                        }
                     }
+                    this.authInfo = authInfo;
                 }
                 req = buildRequest(method, params); // update RPC message id
                 json = rpcPost(gson.toJson(req));
@@ -1337,22 +1369,29 @@ public class Shelly2ApiRpc extends Shelly2ApiClient implements ShellyApiInterfac
     }
 
     private String rpcPost(String postData) throws ShellyApiException {
+        Shelly2AuthChallenge authInfo;
+        synchronized (stateLock) {
+            authInfo = this.authInfo;
+        }
         return httpPost(authInfo, postData);
     }
 
     private void reconnect() throws ShellyApiException {
-        Shelly2RpcSocket rpcSocket = this.rpcSocket;
+        Shelly2RpcSocket rpcSocket;
+        synchronized (stateLock) {
+            rpcSocket = this.rpcSocket;
+        }
         if (rpcSocket != null) {
             if (!rpcSocket.isConnected()) {
-                logger.debug("{}: Connect RPC Socket", thingName);
+                logger.debug("{}: Connect RPC Socket (discovery = {})", thingName, discovery);
                 rpcSocket.connect();
             }
         } else {
-            throw new ShellyApiException("RPC socket is not connected");
+            throw new ShellyApiException("rpcSocket is not connected");
         }
     }
 
-    private void disconnect() {
+    private void disconnect() throws ShellyApiException {
         Shelly2RpcSocket rpcSocket = this.rpcSocket;
         if (rpcSocket == null) {
             return;
@@ -1378,18 +1417,23 @@ public class Shelly2ApiRpc extends Shelly2ApiClient implements ShellyApiInterfac
 
     @Override
     public void close() {
-        Shelly2RpcSocket rpcSocket = this.rpcSocket;
-        if (rpcSocket == null) {
-            logger.debug("{}: Cannot close RPC socket since it's null", thingName);
+        try {
+            Shelly2RpcSocket rpcSocket = this.rpcSocket;
+            if (rpcSocket == null) {
+                // socket already closed
+                return;
+            }
+
+            if (logger.isDebugEnabled()) {
+                logger.debug("{}: Closing Rpc API (socket is {}, discovery={})", thingName,
+                        rpcSocket.isConnected() ? "connected" : "disconnected", discovery);
+            }
+            disconnect();
+        } catch (Exception e) {
+            logger.warn("{}: Closing socket failed, poteltial resource leak", thingName, e);
+        } finally {
             initialized.set(false);
-            return;
         }
-        if (initialized.get() || rpcSocket.isConnected()) {
-            logger.debug("{}: Closing Rpc API (socket is {})", thingName,
-                    rpcSocket.isConnected() ? "connected" : "disconnected");
-        }
-        disconnect();
-        initialized.set(false);
     }
 
     private void incProtErrors() {

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/Shelly2ApiRpc.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/Shelly2ApiRpc.java
@@ -142,6 +142,9 @@ public class Shelly2ApiRpc extends Shelly2ApiClient implements ShellyApiInterfac
             logger.debug("{}: Disconnect Rpc Socket on initialize", thingName);
             disconnect();
         }
+
+        logger.debug("{}: Initialize APIv2 (tname={}", thingName, Thread.currentThread().getName());
+
         Shelly2RpcSocket rpcSocket = this.rpcSocket;
         if (rpcSocket != null) {
             rpcSocket.disconnect();
@@ -1259,7 +1262,7 @@ public class Shelly2ApiRpc extends Shelly2ApiClient implements ShellyApiInterfac
         Shelly2RpcBaseMessage request = buildRequest(method, null);
         reconnect();
         Shelly2RpcSocket rpcSocket = this.rpcSocket;
-        if (rpcSocket != null) {
+        if (rpcSocket != null && rpcSocket.isConnected()) {
             rpcSocket.sendMessage(gson.toJson(request)); // submit, result will be async
         } else {
             throw new ShellyApiException("RPC socket isn't connected, cannot send async request");

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/Shelly2RpcSocket.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/Shelly2RpcSocket.java
@@ -337,25 +337,7 @@ public class Shelly2RpcSocket implements WriteCallback {
                         } else {
                             for (Shelly2NotifyEvent e : events.params.events) {
                                 if (getString(e.event).startsWith(SHELLY2_EVENT_BLUPREFIX)) {
-                                    String address = getString(e.blu != null ? e.blu.addr : "").replace(":", "");
-                                    if (thingTable.findThing(address) != null) {
-                                        // known device
-                                        ShellyThingInterface thing = thingTable.getThing(address);
-                                        Shelly2ApiRpc api = (Shelly2ApiRpc) thing.getApi();
-                                        handler = api.getRpcHandler();
-                                        handler.onNotifyEvent(receivedMessage);
-                                    } else {
-                                        // new device
-                                        if (SHELLY2_EVENT_BLUSCAN.equals(e.event)) {
-                                            addBluThing(getString(message.src), e.blu, thingTable);
-                                        } else {
-                                            if (logger.isDebugEnabled()) {
-                                                logger.debug(
-                                                        "{}: NotifyEvent {} for unknown BLU device {} or Thing in Inbox",
-                                                        message.src, e.event, e.blu.addr);
-                                            }
-                                        }
-                                    }
+                                    handleBluEvent(e, message, receivedMessage);
                                 } else {
                                     handler.onNotifyEvent(receivedMessage);
                                 }
@@ -374,6 +356,29 @@ public class Shelly2RpcSocket implements WriteCallback {
         } catch (ShellyApiException | IllegalArgumentException e) {
             if (logger.isDebugEnabled()) {
                 logger.debug("{}: Unable to process Rpc message ({}): {}", thingName, e.getMessage(), receivedMessage);
+            }
+        }
+    }
+
+    private void handleBluEvent(Shelly2NotifyEvent e, Shelly2RpcBaseMessage message, String receivedMessage)
+            throws ShellyApiException {
+        ShellyThingTable thingTable = this.thingTable;
+        String address = getString(e.blu != null ? e.blu.addr : "").replace(":", "");
+        if (thingTable.findThing(address) != null) {
+            // known device
+            ShellyThingInterface thing = thingTable.getThing(address);
+            Shelly2ApiRpc api = (Shelly2ApiRpc) thing.getApi();
+            Shelly2RpctInterface bluHandler = api.getRpcHandler();
+            bluHandler.onNotifyEvent(receivedMessage);
+        } else {
+            // new device
+            if (SHELLY2_EVENT_BLUSCAN.equals(e.event)) {
+                addBluThing(message.src, e.blu, thingTable);
+            } else {
+                if (logger.isDebugEnabled()) {
+                    logger.debug("{}: NotifyEvent {} for unknown BLU device {} or Thing in Inbox", message.src, e.event,
+                            e.blu != null ? e.blu.addr : "");
+                }
             }
         }
     }

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/Shelly2RpcSocket.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/Shelly2RpcSocket.java
@@ -331,7 +331,9 @@ public class Shelly2RpcSocket implements WriteCallback {
                         Shelly2RpcNotifyEvent events = fromJson(gson, receivedMessage, Shelly2RpcNotifyEvent.class);
                         events.src = message.src;
                         if (events.params == null || events.params.events == null) {
-                            logger.debug("{}: Malformed event data: {}", thingName, receivedMessage);
+                            if (logger.isDebugEnabled()) {
+                                logger.debug("{}: Malformed event data: {}", thingName, receivedMessage);
+                            }
                         } else {
                             for (Shelly2NotifyEvent e : events.params.events) {
                                 if (getString(e.event).startsWith(SHELLY2_EVENT_BLUPREFIX)) {
@@ -347,9 +349,11 @@ public class Shelly2RpcSocket implements WriteCallback {
                                         if (SHELLY2_EVENT_BLUSCAN.equals(e.event)) {
                                             addBluThing(getString(message.src), e.blu, thingTable);
                                         } else {
-                                            logger.debug(
-                                                    "{}: NotifyEvent {} for unknown BLU device {} or Thing in Inbox",
-                                                    message.src, e.event, e.blu.addr);
+                                            if (logger.isDebugEnabled()) {
+                                                logger.debug(
+                                                        "{}: NotifyEvent {} for unknown BLU device {} or Thing in Inbox",
+                                                        message.src, e.event, e.blu.addr);
+                                            }
                                         }
                                     }
                                 } else {
@@ -368,7 +372,9 @@ public class Shelly2RpcSocket implements WriteCallback {
                 }
             }
         } catch (ShellyApiException | IllegalArgumentException e) {
-            logger.debug("{}: Unable to process Rpc message ({}): {}", thingName, e.getMessage(), receivedMessage);
+            if (logger.isDebugEnabled()) {
+                logger.debug("{}: Unable to process Rpc message ({}): {}", thingName, e.getMessage(), receivedMessage);
+            }
         }
     }
 

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/Shelly2RpcSocket.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/Shelly2RpcSocket.java
@@ -497,7 +497,7 @@ public class Shelly2RpcSocket implements WriteCallback {
     public static WebSocketClient createWebSocketClient(WebSocketFactory webSocketFactory, String consumerName) {
         WebSocketClient client = webSocketFactory.createWebSocketClient(consumerName);
         client.setConnectTimeout(SHELLY_API_TIMEOUT_MS);
-        client.setStopTimeout(1000);
+        client.setStopTimeout(3000);
         return client;
     }
 }

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/ShellyBluApi.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/ShellyBluApi.java
@@ -79,11 +79,11 @@ public class ShellyBluApi extends Shelly2ApiRpc {
 
     @Override
     public void initialize(String thingName, ShellyThingConfiguration config) throws ShellyApiException {
-        if (!initialized) {
+        if (!isInitialized()) {
             setConfig(thingName, config);
             connected = false;
-            initialized = true;
         }
+        super.initialize(thingName, config);
     }
 
     @Override

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/discovery/ShellyBasicDiscoveryService.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/discovery/ShellyBasicDiscoveryService.java
@@ -17,9 +17,10 @@ import static org.openhab.binding.shelly.internal.ShellyDevices.*;
 import static org.openhab.binding.shelly.internal.util.ShellyUtils.*;
 import static org.openhab.core.thing.Thing.*;
 
+import java.util.HashMap;
 import java.util.Hashtable;
 import java.util.Map;
-import java.util.TreeMap;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
@@ -48,7 +49,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Device discovery creates a thing in the inbox for each vehicle
+ * Device discovery creates a thing in the inbox for each discovered Shelly
  * found in the data received from {@link ShellyBasicDiscoveryService}.
  *
  * @author Markus Michels - Initial Contribution
@@ -61,7 +62,10 @@ public class ShellyBasicDiscoveryService extends AbstractDiscoveryService {
     private final BundleContext bundleContext;
     private final ShellyThingTable thingTable;
     private static final int TIMEOUT = 10;
-    private @Nullable ServiceRegistration<?> discoveryService;
+    private volatile @Nullable ServiceRegistration<?> discoveryService;
+
+    private final AtomicBoolean active = new AtomicBoolean(false);
+    private final Object lifecycleLock = new Object();
 
     public ShellyBasicDiscoveryService(BundleContext bundleContext, ShellyThingTable thingTable) {
         super(SUPPORTED_THING_TYPES, TIMEOUT);
@@ -69,9 +73,18 @@ public class ShellyBasicDiscoveryService extends AbstractDiscoveryService {
         this.thingTable = thingTable;
     }
 
-    public void registerDeviceDiscoveryService() {
-        if (discoveryService == null) {
-            discoveryService = bundleContext.registerService(DiscoveryService.class.getName(), this, new Hashtable<>());
+    public synchronized void registerDeviceDiscoveryService() {
+        synchronized (lifecycleLock) {
+            if (!active.get() && discoveryService == null) {
+                try {
+                    active.set(true);
+                    discoveryService = bundleContext.registerService(DiscoveryService.class.getName(), this,
+                            new Hashtable<>());
+                } catch (IllegalStateException e) {
+                    active.set(false);
+                    logger.warn("Failed to register Shelly Discovery Service: {}", e.getMessage());
+                }
+            }
         }
     }
 
@@ -81,36 +94,65 @@ public class ShellyBasicDiscoveryService extends AbstractDiscoveryService {
         thingTable.startScan();
     }
 
-    public void discoveredResult(ThingTypeUID tuid, String model, String serviceName, String address,
+    public void discoveredResult(ThingTypeUID tuid, String model, String serviceName, String macAddress,
             Map<String, Object> properties) {
+        if (!active.get()) {
+            logger.debug("{}: Discovery Service is stopping, ignore new result", serviceName);
+            return;
+        }
+
+        // TO-DO: tuid is passed, but never used
         ThingUID uid = ShellyThingCreator.getThingUID(serviceName, model, "");
-        logger.debug("Adding discovered thing with id {}", uid.toString());
-        properties.put(PROPERTY_MAC_ADDRESS, address);
+        logger.debug("Adding discovered thing with id {}/{}", uid, tuid);
+
+        Map<String, Object> props = new HashMap<>(properties);
+        props.put(PROPERTY_MAC_ADDRESS, macAddress);
+
         String thingLabel = "Shelly BLU " + model + " (" + serviceName + ")";
-        DiscoveryResult result = DiscoveryResultBuilder.create(uid).withProperties(properties)
+        DiscoveryResult result = DiscoveryResultBuilder.create(uid).withProperties(props)
                 .withRepresentationProperty(PROPERTY_DEV_NAME).withLabel(thingLabel).build();
-        thingDiscovered(result);
+        discoveredResult(result);
     }
 
     public void discoveredResult(DiscoveryResult result) {
-        thingDiscovered(result);
+        synchronized (lifecycleLock) {
+            if (!active.get()) {
+                logger.debug("Discovery Service is stopping, ignore new result");
+                return;
+            }
+            thingDiscovered(result);
+        }
     }
 
     public void unregisterDeviceDiscoveryService() {
-        ServiceRegistration<?> discoveryService = this.discoveryService;
-        if (discoveryService != null) {
-            discoveryService.unregister();
+        ServiceRegistration<?> serviceToUnregister;
+        synchronized (lifecycleLock) {
+            if (!active.get() && discoveryService == null) {
+                return;
+            }
+            active.set(false);
+            serviceToUnregister = discoveryService;
+            discoveryService = null;
+        }
+
+        // Unregister outside the synchronized block to avoid deadlocks
+        if (serviceToUnregister != null) {
+            try {
+                serviceToUnregister.unregister();
+            } catch (IllegalStateException e) {
+                logger.debug("Discovery service already unregistered");
+            }
         }
     }
 
     @Override
     public void deactivate() {
-        super.deactivate();
         unregisterDeviceDiscoveryService();
+        super.deactivate();
     }
 
     public static @Nullable DiscoveryResult createResult(boolean gen2, String hostname, String ipAddress,
-            ShellyBindingConfiguration bindingConfig, HttpClient httpClient, ShellyTranslationProvider messages,
+            ShellyThingConfiguration config, HttpClient httpClient, ShellyTranslationProvider messages,
             ShellyThingTable thingTable) {
         Logger logger = LoggerFactory.getLogger(ShellyBasicDiscoveryService.class);
         ThingUID thingUID = null;
@@ -124,10 +166,9 @@ public class ShellyBasicDiscoveryService extends AbstractDiscoveryService {
         String name = hostname; // will become the realm for auth response
         String deviceName = "";
         String thingType = "";
-        Map<String, Object> properties = new TreeMap<>();
+        Map<String, Object> properties;
 
         try {
-            ShellyThingConfiguration config = fillConfig(bindingConfig, ipAddress, name);
             if (gen2) {
                 api = new Shelly2ApiClient(name, config, httpClient);
             } else {
@@ -146,10 +187,27 @@ public class ShellyBasicDiscoveryService extends AbstractDiscoveryService {
             mode = getString(devInfo.mode);
             profile = api.getDeviceProfile(ShellyThingCreator.getThingTypeUID(name, model, mode), devInfo);
             deviceName = profile.name;
-            properties = ShellyBaseHandler.fillDeviceProperties(profile);
+            properties = new HashMap<>(ShellyBaseHandler.fillDeviceProperties(profile));
 
             // get thing type from device name
             thingUID = ShellyThingCreator.getThingUID(name, model, mode);
+
+            addProperty(properties, PROPERTY_MAC_ADDRESS, mac);
+            addProperty(properties, CONFIG_DEVICEIP, ipAddress);
+            addProperty(properties, PROPERTY_MODEL_ID, model);
+            addProperty(properties, PROPERTY_SERVICE_NAME, name);
+            addProperty(properties, PROPERTY_DEV_NAME, deviceName);
+            addProperty(properties, PROPERTY_DEV_TYPE, thingType);
+            addProperty(properties, PROPERTY_DEV_GEN, gen2 ? "2" : "1");
+            addProperty(properties, PROPERTY_DEV_MODE, mode);
+            addProperty(properties, PROPERTY_DEV_AUTH, auth ? "yes" : "no");
+
+            String thingLabel = deviceName.isEmpty() ? name + " - " + ipAddress
+                    : deviceName + " (" + name + "@" + ipAddress + ")";
+            logger.debug("{}: Adding Thing to Inbox (type {}, model {}, mode={}), ip={}, mac={}", name, thingType,
+                    model, mode, ipAddress, mac);
+            return DiscoveryResultBuilder.create(thingUID).withProperties(properties).withLabel(thingLabel)
+                    .withRepresentationProperty(PROPERTY_SERVICE_NAME).build();
         } catch (ShellyApiException e) {
             ShellyApiResult result = e.getApiResult();
             if (result.isHttpAccessUnauthorized()) {
@@ -170,27 +228,10 @@ public class ShellyBasicDiscoveryService extends AbstractDiscoveryService {
             }
         }
 
-        if (thingUID != null) {
-            addProperty(properties, PROPERTY_MAC_ADDRESS, mac);
-            addProperty(properties, CONFIG_DEVICEIP, ipAddress);
-            addProperty(properties, PROPERTY_MODEL_ID, model);
-            addProperty(properties, PROPERTY_SERVICE_NAME, name);
-            addProperty(properties, PROPERTY_DEV_NAME, deviceName);
-            addProperty(properties, PROPERTY_DEV_TYPE, thingType);
-            addProperty(properties, PROPERTY_DEV_GEN, gen2 ? "2" : "1");
-            addProperty(properties, PROPERTY_DEV_MODE, mode);
-            addProperty(properties, PROPERTY_DEV_AUTH, auth ? "yes" : "no");
-
-            String thingLabel = deviceName.isEmpty() ? name + " - " + ipAddress
-                    : deviceName + " (" + name + "@" + ipAddress + ")";
-            logger.debug("{}: Adding Thing to Inbox (type {}, model {}, mode={})", name, thingType, model, mode);
-            return DiscoveryResultBuilder.create(thingUID).withProperties(properties).withLabel(thingLabel)
-                    .withRepresentationProperty(PROPERTY_SERVICE_NAME).build();
-        }
-
         return null;
     }
 
+    // TODO: Is this used?
     public static ShellyThingConfiguration fillConfig(ShellyBindingConfiguration bindingConfig, String address,
             String realm) {
         ShellyThingConfiguration config = new ShellyThingConfiguration();
@@ -199,6 +240,7 @@ public class ShellyBasicDiscoveryService extends AbstractDiscoveryService {
         config.userId = getString(bindingConfig.defaultUserId);
         config.password = getString(bindingConfig.defaultPassword);
         config.localIp = getString(bindingConfig.localIP);
+        config.localIp = bindingConfig.localIP;
         return config;
     }
 

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/discovery/ShellyMDNSDiscoveryParticipant.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/discovery/ShellyMDNSDiscoveryParticipant.java
@@ -32,6 +32,7 @@ import org.openhab.binding.shelly.internal.config.ShellyBindingConfiguration;
 import org.openhab.binding.shelly.internal.config.ShellyThingConfiguration;
 import org.openhab.binding.shelly.internal.handler.ShellyThingTable;
 import org.openhab.binding.shelly.internal.provider.ShellyTranslationProvider;
+import org.openhab.binding.shelly.internal.util.ShellyCacheList;
 import org.openhab.core.config.discovery.DiscoveryResult;
 import org.openhab.core.config.discovery.mdns.MDNSDiscoveryParticipant;
 import org.openhab.core.i18n.LocaleProvider;
@@ -64,6 +65,7 @@ public class ShellyMDNSDiscoveryParticipant implements MDNSDiscoveryParticipant 
      * <code>_shelly._tcp.local.</code> as well.
      */
     private static final String SERVICE_TYPE = "_http._tcp.local.";
+    private static final long MDNS_CACHE_TIMEOUT_SEC = 15;
 
     private final Logger logger = LoggerFactory.getLogger(ShellyMDNSDiscoveryParticipant.class);
     private final ShellyBindingConfiguration bindingConfig = new ShellyBindingConfiguration();
@@ -78,6 +80,16 @@ public class ShellyMDNSDiscoveryParticipant implements MDNSDiscoveryParticipant 
     public static boolean isValidShellyServiceName(String serviceName) {
         return SHELLY_SERVICE_NAME_PATTERN.matcher(serviceName).matches();
     }
+
+    private class MDNSCacheEntry {
+        String ipAddress = "";
+
+        public MDNSCacheEntry(String ipAddress) {
+            this.ipAddress = ipAddress;
+        }
+    }
+
+    private final ShellyCacheList<String, MDNSCacheEntry> MDNSCache = new ShellyCacheList<>(MDNS_CACHE_TIMEOUT_SEC);
 
     @Activate
     public ShellyMDNSDiscoveryParticipant(@Reference ConfigurationAdmin configurationAdmin,
@@ -130,6 +142,17 @@ public class ShellyMDNSDiscoveryParticipant implements MDNSDiscoveryParticipant 
             logger.trace("{}: Shelly device discovered with empty IP address (service-name={})", serviceName, service);
             return null;
         }
+
+        // Shelly might send multiple mDNS annoucements in a row, those trigger multiple (parallel) discoveries on the
+        // OH side, which is inefficent and causes side effects -> ignore duplicates within MDNS_CACHE_TIMEOUT_SEC secs
+        MDNSCacheEntry result = MDNSCache.get(serviceName);
+        if (result != null && address.equals(result.ipAddress)) {
+            logger.trace("{}: Discovered Shelly Device with IP address {} is already known", serviceName, address);
+            return null;
+        }
+        MDNSCacheEntry entry = new MDNSCacheEntry(address);
+        MDNSCache.put(serviceName, entry);
+
         logger.debug("{}: Shelly device discovered: IP address={}", serviceName, address);
 
         try {

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/discovery/ShellyMDNSDiscoveryParticipant.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/discovery/ShellyMDNSDiscoveryParticipant.java
@@ -14,10 +14,11 @@ package org.openhab.binding.shelly.internal.discovery;
 
 import static org.openhab.binding.shelly.internal.ShellyBindingConstants.BINDING_ID;
 import static org.openhab.binding.shelly.internal.ShellyDevices.SUPPORTED_THING_TYPES;
-import static org.openhab.binding.shelly.internal.util.ShellyUtils.*;
+import static org.openhab.binding.shelly.internal.util.ShellyUtils.getString;
 
 import java.io.IOException;
 import java.net.Inet4Address;
+import java.util.Dictionary;
 import java.util.Locale;
 import java.util.Set;
 import java.util.regex.Pattern;
@@ -35,8 +36,8 @@ import org.openhab.binding.shelly.internal.provider.ShellyTranslationProvider;
 import org.openhab.binding.shelly.internal.util.ShellyCacheList;
 import org.openhab.core.config.discovery.DiscoveryResult;
 import org.openhab.core.config.discovery.mdns.MDNSDiscoveryParticipant;
-import org.openhab.core.i18n.LocaleProvider;
 import org.openhab.core.io.net.http.HttpClientFactory;
+import org.openhab.core.net.NetworkAddressService;
 import org.openhab.core.thing.ThingTypeUID;
 import org.openhab.core.thing.ThingUID;
 import org.osgi.service.cm.Configuration;
@@ -44,6 +45,7 @@ import org.osgi.service.cm.ConfigurationAdmin;
 import org.osgi.service.component.ComponentContext;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Modified;
 import org.osgi.service.component.annotations.Reference;
 import org.slf4j.Logger;
@@ -65,7 +67,7 @@ public class ShellyMDNSDiscoveryParticipant implements MDNSDiscoveryParticipant 
      * <code>_shelly._tcp.local.</code> as well.
      */
     private static final String SERVICE_TYPE = "_http._tcp.local.";
-    private static final long MDNS_CACHE_TIMEOUT_SEC = 15;
+    private static final long MDNS_CACHE_TIMEOUT_SEC = 10;
 
     private final Logger logger = LoggerFactory.getLogger(ShellyMDNSDiscoveryParticipant.class);
     private final ShellyBindingConfiguration bindingConfig = new ShellyBindingConfiguration();
@@ -73,6 +75,7 @@ public class ShellyMDNSDiscoveryParticipant implements MDNSDiscoveryParticipant 
     private final ShellyThingTable thingTable;
     private final HttpClient httpClient;
     private final ConfigurationAdmin configurationAdmin;
+    private final NetworkAddressService networkAddressService;
 
     public static final Pattern SHELLY_SERVICE_NAME_PATTERN = Pattern
             .compile("^([a-z0-9]*shelly[a-z0-9]*)-([a-z0-9]+)$", Pattern.CASE_INSENSITIVE);
@@ -81,10 +84,10 @@ public class ShellyMDNSDiscoveryParticipant implements MDNSDiscoveryParticipant 
         return SHELLY_SERVICE_NAME_PATTERN.matcher(serviceName).matches();
     }
 
-    private class MDNSCacheEntry {
-        String ipAddress = "";
+    private static final class MDNSCacheEntry {
+        private final String ipAddress;
 
-        public MDNSCacheEntry(String ipAddress) {
+        MDNSCacheEntry(String ipAddress) {
             this.ipAddress = ipAddress;
         }
     }
@@ -93,15 +96,16 @@ public class ShellyMDNSDiscoveryParticipant implements MDNSDiscoveryParticipant 
 
     @Activate
     public ShellyMDNSDiscoveryParticipant(@Reference ConfigurationAdmin configurationAdmin,
-            @Reference HttpClientFactory httpClientFactory, @Reference LocaleProvider localeProvider,
+            @Reference NetworkAddressService networkAddressService, @Reference HttpClientFactory httpClientFactory,
             @Reference ShellyTranslationProvider translationProvider, @Reference ShellyThingTable thingTable,
             ComponentContext componentContext) {
         logger.debug("Activating Shelly mDNS discovery service");
         this.configurationAdmin = configurationAdmin;
+        this.networkAddressService = networkAddressService;
         this.messages = translationProvider;
         this.httpClient = httpClientFactory.getCommonHttpClient();
         this.thingTable = thingTable;
-        bindingConfig.updateFromProperties(componentContext.getProperties());
+        updateBindingConfig(componentContext);
     }
 
     @Override
@@ -122,21 +126,50 @@ public class ShellyMDNSDiscoveryParticipant implements MDNSDiscoveryParticipant 
     @Modified
     protected void modified(final ComponentContext componentContext) {
         logger.debug("Shelly Binding Configuration refreshed");
-        bindingConfig.updateFromProperties(componentContext.getProperties());
+        updateBindingConfig(componentContext);
+    }
+
+    private void updateBindingConfig(final ComponentContext componentContext) {
+        synchronized (bindingConfig) {
+            try {
+                Dictionary<String, Object> properties = componentContext.getProperties();
+                if (properties != null) {
+                    bindingConfig.updateFromProperties(properties);
+                }
+
+                Configuration serviceConfig = configurationAdmin.getConfiguration("binding." + BINDING_ID);
+                if (serviceConfig != null && serviceConfig.getProperties() != null) {
+                    bindingConfig.updateFromProperties(serviceConfig.getProperties());
+                }
+                if (bindingConfig.localIP.isBlank()) {
+                    String primary = networkAddressService.getPrimaryIpv4HostAddress();
+                    if (primary != null && !primary.isBlank()) {
+                        bindingConfig.localIP = primary;
+                    }
+                }
+            } catch (IOException | IllegalStateException e) {
+                logger.debug("Failed to update binding configuration", e);
+            }
+        }
     }
 
     @Override
     public @Nullable DiscoveryResult createResult(final ServiceInfo service) {
         // Shelly Duo: Name starts with "Shelly" rather than "shelly"
-        String serviceName = service.getName().toLowerCase(Locale.ROOT);
+        String serviceName = getString(service.getName()).toLowerCase(Locale.ROOT);
+
+        if (logger.isTraceEnabled()) {
+            logger.trace("{}: mDNS Service Info: {}", serviceName, service.getNiceTextString());
+        }
         if (!isValidShellyServiceName(serviceName)) {
+            logger.trace("{}: serviceName doesn't match name pattern (e.g. Shelly device name), ignore", serviceName);
             return null;
         }
 
         String address = "";
         Inet4Address[] hostAddresses = service.getInet4Addresses();
-        if ((hostAddresses != null) && (hostAddresses.length > 0)) {
-            address = substringAfter(hostAddresses[0].toString(), "/");
+        if (hostAddresses != null && hostAddresses.length > 0) {
+            address = hostAddresses[0].getHostAddress();
         }
         if (address.isEmpty()) {
             logger.trace("{}: Shelly device discovered with empty IP address (service-name={})", serviceName, service);
@@ -145,34 +178,29 @@ public class ShellyMDNSDiscoveryParticipant implements MDNSDiscoveryParticipant 
 
         // Shelly might send multiple mDNS annoucements in a row, those trigger multiple (parallel) discoveries on the
         // OH side, which is inefficent and causes side effects -> ignore duplicates within MDNS_CACHE_TIMEOUT_SEC secs
-        MDNSCacheEntry result = MDNSCache.get(serviceName);
-        if (result != null && address.equals(result.ipAddress)) {
-            logger.trace("{}: Discovered Shelly Device with IP address {} is already known", serviceName, address);
+        boolean newEntry = MDNSCache.putIfAbsent(serviceName, new MDNSCacheEntry(address),
+                (oldV, newV) -> oldV.ipAddress.equals(newV.ipAddress));
+        if (!newEntry) {
+            logger.trace("{}: Discovered  device with IP address {} is already known", serviceName, address);
             return null;
         }
-        MDNSCacheEntry entry = new MDNSCacheEntry(address);
-        MDNSCache.put(serviceName, entry);
 
-        logger.debug("{}: Shelly device discovered: IP address={}", serviceName, address);
+        logger.debug("{}: Shelly device with IP address {} discovered)", serviceName, address);
 
         try {
             // Get device settings
-            Configuration serviceConfig = configurationAdmin.getConfiguration("binding." + BINDING_ID);
-            if (serviceConfig.getProperties() != null) {
-                bindingConfig.updateFromProperties(serviceConfig.getProperties());
-            }
-
-            ShellyThingConfiguration config = new ShellyThingConfiguration();
-            config.deviceIp = address;
-            config.userId = bindingConfig.defaultUserId;
-            config.password = bindingConfig.defaultPassword;
-
             String gen = getString(service.getPropertyString("gen"));
             boolean gen2 = "2".equals(gen) || "3".equals(gen) || "4".equals(gen)
                     || ShellyDeviceProfile.isGeneration2(serviceName);
-            return ShellyBasicDiscoveryService.createResult(gen2, serviceName, address, bindingConfig, httpClient,
+
+            final ShellyThingConfiguration thingConfig;
+            synchronized (bindingConfig) {
+                thingConfig = ShellyBasicDiscoveryService.fillConfig(bindingConfig, address, serviceName);
+            }
+
+            return ShellyBasicDiscoveryService.createResult(gen2, serviceName, address, thingConfig, httpClient,
                     messages, thingTable);
-        } catch (IOException e) {
+        } catch (Exception e) {
             logger.debug("{}: Exception on processing serviceInfo '{}'", serviceName, service.getNiceTextString(), e);
             return null;
         }
@@ -185,10 +213,20 @@ public class ShellyMDNSDiscoveryParticipant implements MDNSDiscoveryParticipant 
         if (serviceName == null) {
             return null;
         }
+        serviceName = serviceName.toLowerCase(Locale.ROOT);
         if (!isValidShellyServiceName(serviceName)) {
             logger.debug("{} is not a valid Shelly service name", serviceName);
             return null;
         }
         return ShellyThingCreator.getThingUID(serviceName);
+    }
+
+    @Deactivate
+    protected void deactivate() {
+        try {
+            MDNSCache.dispose();
+        } catch (Exception e) {
+            logger.debug("Error during deactivation", e);
+        }
     }
 }

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/discovery/ShellyThingCreator.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/discovery/ShellyThingCreator.java
@@ -18,9 +18,9 @@ import static org.openhab.binding.shelly.internal.api1.Shelly1ApiJsonDTO.*;
 import static org.openhab.binding.shelly.internal.util.ShellyUtils.*;
 import static org.openhab.core.thing.Thing.PROPERTY_MODEL_ID;
 
+import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
-import java.util.TreeMap;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
@@ -112,7 +112,7 @@ public class ShellyThingCreator {
     public static void addBluThing(String gateway, Shelly2NotifyBluEventData data, ShellyThingTable thingTable) {
         String model = getString(data.name);
         String bluClass = substringBefore(model, "-").toUpperCase(Locale.ROOT);
-        String mac = getString(data.addr).replaceAll(":", "");
+        String mac = getString(data.addr).replace(":", "").toLowerCase(Locale.ROOT);
 
         ThingTypeUID thingTypeUID = THING_TYPE_BY_DEVICE_TYPE.get(model);
         if (thingTypeUID == null) {
@@ -123,18 +123,22 @@ public class ShellyThingCreator {
             return;
         }
 
-        String serviceName = getBluServiceName(getString(data.name), mac);
-        Map<String, Object> properties = new TreeMap<>();
-        addProperty(properties, PROPERTY_MODEL_ID, model);
-        addProperty(properties, PROPERTY_SERVICE_NAME, serviceName);
-        addProperty(properties, PROPERTY_DEV_NAME, data.name);
-        addProperty(properties, PROPERTY_DEV_TYPE, thingTypeUID.getId());
-        addProperty(properties, PROPERTY_DEV_GEN, "BLU");
-        addProperty(properties, PROPERTY_GW_DEVICE, gateway);
-        addProperty(properties, CONFIG_DEVICEADDRESS, mac);
+        try {
+            String serviceName = getBluServiceName(getString(data.name), mac);
+            Map<String, Object> properties = new HashMap<>();
+            addProperty(properties, PROPERTY_MODEL_ID, model);
+            addProperty(properties, PROPERTY_SERVICE_NAME, serviceName);
+            addProperty(properties, PROPERTY_DEV_NAME, data.name);
+            addProperty(properties, PROPERTY_DEV_TYPE, thingTypeUID.getId());
+            addProperty(properties, PROPERTY_DEV_GEN, "BLU");
+            addProperty(properties, PROPERTY_GW_DEVICE, gateway);
+            addProperty(properties, CONFIG_DEVICEADDRESS, mac);
 
-        LOGGER.debug("{}: Create thing {} for BLU device {} / {}", gateway, thingTypeUID, model, mac);
-        thingTable.discoveredResult(thingTypeUID, model, serviceName, mac, properties);
+            LOGGER.debug("{}: Create thing {} for BLU device {} / {}", gateway, thingTypeUID, model, mac);
+            thingTable.discoveredResult(thingTypeUID, model, serviceName, mac, properties);
+        } catch (IllegalArgumentException e) {
+            LOGGER.debug("{}: {} (BLU class={}, model={}, MAC: {})", gateway, e.getMessage(), bluClass, model, mac);
+        }
     }
 
     private static void addProperty(Map<String, Object> properties, String key, @Nullable String value) {

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/handler/ShellyBaseHandler.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/handler/ShellyBaseHandler.java
@@ -294,6 +294,11 @@ public abstract class ShellyBaseHandler extends BaseThingHandler
         cache.clear();
         resetStats();
 
+        if (getThingStatusDetail().equals(ThingStatusDetail.CONFIGURATION_ERROR)) {
+            logger.debug("{}: Thing configuration error, cancel initialization", thingName);
+            return false;
+        }
+
         profile.initFromThingType(thing.getThingTypeUID());
         logger.debug(
                 "{}: Start initializing for thing {}, type {}, Device address {}, Gen2: {}, isBlu: {}, alwaysOn: {}, hasBattery: {}, CoIoT: {}",

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/handler/ShellyBaseHandler.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/handler/ShellyBaseHandler.java
@@ -331,6 +331,7 @@ public abstract class ShellyBaseHandler extends BaseThingHandler
         if (config.realm.isEmpty()) {
             config.realm = getString(device.hostname).toLowerCase(Locale.ROOT);
             api.setConfig(thingName, config); // update config
+            api.setConfig(thingName, config);
         }
 
         ShellyDeviceProfile tmpPrf = api.getDeviceProfile(thing.getThingTypeUID(), profile.device);
@@ -611,8 +612,8 @@ public abstract class ShellyBaseHandler extends BaseThingHandler
             for (Shelly2APClient client : profile.status.rangeExtender.apClients) {
                 String secondaryIp = config.deviceIp + ":" + client.mport.toString();
                 String name = SERVICE_NAME_SHELLYPLUSRANGE_PREFIX + "-" + client.mac.replaceAll(":", "");
-                DiscoveryResult result = ShellyBasicDiscoveryService.createResult(true, name, secondaryIp,
-                        bindingConfig, httpClient, messages, thingTable);
+                DiscoveryResult result = ShellyBasicDiscoveryService.createResult(true, name, secondaryIp, config,
+                        httpClient, messages, thingTable);
                 if (result != null) {
                     thingTable.discoveredResult(result);
                 }
@@ -1501,7 +1502,7 @@ public abstract class ShellyBaseHandler extends BaseThingHandler
                 }
             }
         } catch (ShellyApiException | RuntimeException e) {
-            logger.debug("{}: Unable to initialize Device Profile", thingName, e);
+            logger.debug("{}: Unable to initialize Device Profile: {}", thingName, e.toString());
         } finally {
             refreshSettings = false;
         }

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/handler/ShellyThingTable.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/handler/ShellyThingTable.java
@@ -123,14 +123,14 @@ public class ShellyThingTable {
         }
     }
 
-    public void discoveredResult(ThingTypeUID uid, String model, String serviceName, String address,
+    public void discoveredResult(ThingTypeUID tuid, String model, String serviceName, String address,
             Map<String, Object> properties) {
         ShellyBasicDiscoveryService discoveryService;
         synchronized (this) {
             discoveryService = this.discoveryService;
         }
         if (discoveryService != null) {
-            discoveryService.discoveredResult(uid, model, serviceName, address, properties);
+            discoveryService.discoveredResult(tuid, model, serviceName, address, properties);
         }
     }
 

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/manager/ShellyManager.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/manager/ShellyManager.java
@@ -29,6 +29,7 @@ import org.openhab.binding.shelly.internal.manager.ShellyManagerPage.FwArchList;
 import org.openhab.binding.shelly.internal.manager.ShellyManagerPage.FwRepoEntry;
 import org.openhab.binding.shelly.internal.manager.ShellyManagerPage.ShellyMgrResponse;
 import org.openhab.binding.shelly.internal.provider.ShellyTranslationProvider;
+import org.openhab.binding.shelly.internal.util.ShellyCacheList;
 import org.openhab.core.io.net.http.HttpClientFactory;
 import org.openhab.core.net.HttpServiceUtil;
 import org.openhab.core.net.NetworkAddressService;
@@ -51,8 +52,8 @@ import org.slf4j.LoggerFactory;
 public class ShellyManager {
     private final Map<String, ShellyManagerPage> pages;
     private final Logger logger = LoggerFactory.getLogger(ShellyManager.class);
-    private final ShellyManagerCache<String, FwRepoEntry> firmwareRepo;
-    private final ShellyManagerCache<String, FwArchList> firmwareArch;
+    private final ShellyCacheList<String, FwRepoEntry> firmwareRepo;
+    private final ShellyCacheList<String, FwArchList> firmwareArch;
 
     @Activate
     public ShellyManager(@Reference ConfigurationAdmin configurationAdmin,
@@ -63,8 +64,8 @@ public class ShellyManager {
         Integer localPort = HttpServiceUtil.getHttpServicePort(componentContext.getBundleContext());
         HttpClient httpClient = httpClientFactory.getCommonHttpClient();
         Map<String, ShellyManagerPage> pages = new LinkedHashMap<>();
-        firmwareRepo = new ShellyManagerCache<>();
-        firmwareArch = new ShellyManagerCache<>();
+        firmwareRepo = new ShellyCacheList<>();
+        firmwareArch = new ShellyCacheList<>();
 
         pages.put(SHELLY_MGR_OVERVIEW_URI, new ShellyManagerOverviewPage(configurationAdmin, translationProvider,
                 httpClient, localIp, localPort, handlerFactory, firmwareRepo, firmwareArch));

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/manager/ShellyManagerActionPage.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/manager/ShellyManagerActionPage.java
@@ -36,6 +36,7 @@ import org.openhab.binding.shelly.internal.api1.Shelly1HttpApi;
 import org.openhab.binding.shelly.internal.config.ShellyThingConfiguration;
 import org.openhab.binding.shelly.internal.handler.ShellyManagerInterface;
 import org.openhab.binding.shelly.internal.provider.ShellyTranslationProvider;
+import org.openhab.binding.shelly.internal.util.ShellyCacheList;
 import org.openhab.core.thing.ThingStatusDetail;
 import org.osgi.service.cm.ConfigurationAdmin;
 import org.slf4j.Logger;
@@ -52,7 +53,7 @@ public class ShellyManagerActionPage extends ShellyManagerPage {
 
     public ShellyManagerActionPage(ConfigurationAdmin configurationAdmin, ShellyTranslationProvider translationProvider,
             HttpClient httpClient, String localIp, int localPort, ShellyHandlerFactory handlerFactory,
-            ShellyManagerCache<String, FwRepoEntry> firmwareRepo, ShellyManagerCache<String, FwArchList> firmwareArch) {
+            ShellyCacheList<String, FwRepoEntry> firmwareRepo, ShellyCacheList<String, FwArchList> firmwareArch) {
         super(configurationAdmin, translationProvider, httpClient, localIp, localPort, handlerFactory, firmwareRepo,
                 firmwareArch);
     }

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/manager/ShellyManagerImageLoader.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/manager/ShellyManagerImageLoader.java
@@ -26,6 +26,7 @@ import org.openhab.binding.shelly.internal.ShellyHandlerFactory;
 import org.openhab.binding.shelly.internal.api.ShellyApiException;
 import org.openhab.binding.shelly.internal.handler.ShellyManagerInterface;
 import org.openhab.binding.shelly.internal.provider.ShellyTranslationProvider;
+import org.openhab.binding.shelly.internal.util.ShellyCacheList;
 import org.osgi.service.cm.ConfigurationAdmin;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -41,8 +42,8 @@ public class ShellyManagerImageLoader extends ShellyManagerPage {
 
     public ShellyManagerImageLoader(ConfigurationAdmin configurationAdmin,
             ShellyTranslationProvider translationProvider, HttpClient httpClient, String localIp, int localPort,
-            ShellyHandlerFactory handlerFactory, ShellyManagerCache<String, FwRepoEntry> firmwareRepo,
-            ShellyManagerCache<String, FwArchList> firmwareArch) {
+            ShellyHandlerFactory handlerFactory, ShellyCacheList<String, FwRepoEntry> firmwareRepo,
+            ShellyCacheList<String, FwArchList> firmwareArch) {
         super(configurationAdmin, translationProvider, httpClient, localIp, localPort, handlerFactory, firmwareRepo,
                 firmwareArch);
     }

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/manager/ShellyManagerOtaPage.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/manager/ShellyManagerOtaPage.java
@@ -40,6 +40,7 @@ import org.openhab.binding.shelly.internal.api1.Shelly1ApiJsonDTO.ShellySettings
 import org.openhab.binding.shelly.internal.config.ShellyThingConfiguration;
 import org.openhab.binding.shelly.internal.handler.ShellyManagerInterface;
 import org.openhab.binding.shelly.internal.provider.ShellyTranslationProvider;
+import org.openhab.binding.shelly.internal.util.ShellyCacheList;
 import org.openhab.core.thing.ThingStatusDetail;
 import org.osgi.service.cm.ConfigurationAdmin;
 import org.slf4j.Logger;
@@ -56,7 +57,7 @@ public class ShellyManagerOtaPage extends ShellyManagerPage {
 
     public ShellyManagerOtaPage(ConfigurationAdmin configurationAdmin, ShellyTranslationProvider translationProvider,
             HttpClient httpClient, String localIp, int localPort, ShellyHandlerFactory handlerFactory,
-            ShellyManagerCache<String, FwRepoEntry> firmwareRepo, ShellyManagerCache<String, FwArchList> firmwareArch) {
+            ShellyCacheList<String, FwRepoEntry> firmwareRepo, ShellyCacheList<String, FwArchList> firmwareArch) {
         super(configurationAdmin, translationProvider, httpClient, localIp, localPort, handlerFactory, firmwareRepo,
                 firmwareArch);
     }

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/manager/ShellyManagerOverviewPage.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/manager/ShellyManagerOverviewPage.java
@@ -33,6 +33,7 @@ import org.openhab.binding.shelly.internal.config.ShellyThingConfiguration;
 import org.openhab.binding.shelly.internal.handler.ShellyDeviceStats;
 import org.openhab.binding.shelly.internal.handler.ShellyManagerInterface;
 import org.openhab.binding.shelly.internal.provider.ShellyTranslationProvider;
+import org.openhab.binding.shelly.internal.util.ShellyCacheList;
 import org.openhab.binding.shelly.internal.util.ShellyVersionDTO;
 import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.library.types.OnOffType;
@@ -55,8 +56,8 @@ public class ShellyManagerOverviewPage extends ShellyManagerPage {
 
     public ShellyManagerOverviewPage(ConfigurationAdmin configurationAdmin,
             ShellyTranslationProvider translationProvider, HttpClient httpClient, String localIp, int localPort,
-            ShellyHandlerFactory handlerFactory, ShellyManagerCache<String, FwRepoEntry> firmwareRepo,
-            ShellyManagerCache<String, FwArchList> firmwareArch) {
+            ShellyHandlerFactory handlerFactory, ShellyCacheList<String, FwRepoEntry> firmwareRepo,
+            ShellyCacheList<String, FwArchList> firmwareArch) {
         super(configurationAdmin, translationProvider, httpClient, localIp, localPort, handlerFactory, firmwareRepo,
                 firmwareArch);
     }

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/manager/ShellyManagerPage.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/manager/ShellyManagerPage.java
@@ -53,6 +53,7 @@ import org.openhab.binding.shelly.internal.config.ShellyThingConfiguration;
 import org.openhab.binding.shelly.internal.handler.ShellyDeviceStats;
 import org.openhab.binding.shelly.internal.handler.ShellyManagerInterface;
 import org.openhab.binding.shelly.internal.provider.ShellyTranslationProvider;
+import org.openhab.binding.shelly.internal.util.ShellyCacheList;
 import org.openhab.core.library.types.DateTimeType;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.thing.Thing;
@@ -88,8 +89,8 @@ public class ShellyManagerPage {
     protected final Map<String, String> htmlTemplates = new HashMap<>();
     protected final Gson gson = new Gson();
 
-    protected final ShellyManagerCache<String, FwRepoEntry> firmwareRepo;
-    protected final ShellyManagerCache<String, FwArchList> firmwareArch;
+    protected final ShellyCacheList<String, FwRepoEntry> firmwareRepo;
+    protected final ShellyCacheList<String, FwArchList> firmwareArch;
 
     public static class ShellyMgrResponse {
         public @Nullable Object data = "";
@@ -148,7 +149,7 @@ public class ShellyManagerPage {
 
     public ShellyManagerPage(ConfigurationAdmin configurationAdmin, ShellyTranslationProvider translationProvider,
             HttpClient httpClient, String localIp, int localPort, ShellyHandlerFactory handlerFactory,
-            ShellyManagerCache<String, FwRepoEntry> firmwareRepo, ShellyManagerCache<String, FwArchList> firmwareArch) {
+            ShellyCacheList<String, FwRepoEntry> firmwareRepo, ShellyCacheList<String, FwArchList> firmwareArch) {
         this.configurationAdmin = configurationAdmin;
         this.resources = translationProvider;
         this.handlerFactory = handlerFactory;

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/provider/ShellyChannelDefinitions.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/provider/ShellyChannelDefinitions.java
@@ -526,10 +526,7 @@ public class ShellyChannelDefinitions {
         addChannel(thing, newChannels, emeter.frequency != null, group, CHANNEL_EMETER_FREQUENCY);
         addChannel(thing, newChannels, emeter.pf != null, group, CHANNEL_EMETER_PFACTOR); // EM has no PF. but power
         addChannel(thing, newChannels, true, group, CHANNEL_LAST_UPDATE);
-        ShellyThingInterface handler = (ShellyThingInterface) thing.getHandler();
-        if (handler != null) {
-            addChannel(thing, newChannels, handler.getProfile().isEM50, group, CHANNEL_DEVST_RESETTOTAL); // 3EM
-        }
+        addChannel(thing, newChannels, profile.isEM50, group, CHANNEL_DEVST_RESETTOTAL); // 3EM
         return newChannels;
     }
 

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/util/ShellyCacheList.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/util/ShellyCacheList.java
@@ -16,9 +16,11 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.function.BiPredicate;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
@@ -32,10 +34,9 @@ import org.openhab.core.common.ThreadPoolManager;
  */
 @NonNullByDefault
 public class ShellyCacheList<K, V> {
-    protected final ScheduledExecutorService scheduler = ThreadPoolManager
-            .getScheduledPool("ShellyCacheListThreadpool");
+    private final ScheduledExecutorService scheduler = ThreadPoolManager.getScheduledPool("ShellyCacheListThreadpool");
     private static final long EXPIRY_IN_SEC = 15 * 60; // 15min
-    private long experyInSec;
+    private final long expiryInSec;
 
     private record CacheEntry<V> (Long created, V value) {
     }
@@ -44,44 +45,62 @@ public class ShellyCacheList<K, V> {
     private final @NonNullByDefault({}) Map<K, CacheEntry<V>> storage = new HashMap<>();
 
     // All access must be guarded by "this"
-    private @Nullable ScheduledFuture<?> cleanupJob;
+    private volatile @Nullable ScheduledFuture<?> cleanupJob;
 
     public ShellyCacheList() {
-        experyInSec = EXPIRY_IN_SEC;
+        expiryInSec = EXPIRY_IN_SEC;
     }
 
-    public ShellyCacheList(long experyInSec) {
-        this.experyInSec = experyInSec;
+    public ShellyCacheList(long expiryInSec) {
+        this.expiryInSec = expiryInSec;
     }
 
     @Nullable
     public synchronized V get(K key) {
+        Objects.requireNonNull(key, "key must not be null");
         CacheEntry<V> entry = storage.get(key);
         return entry == null ? null : entry.value;
     }
 
     public @Nullable V put(K key, V value) {
-        CacheEntry<V> entry = new CacheEntry<>(System.currentTimeMillis(), value);
+        Objects.requireNonNull(key, "key must not be null");
+        Objects.requireNonNull(value, "value must not be null");
+
+        CacheEntry<V> previous;
         synchronized (this) {
-            entry = storage.put(key, entry);
+            previous = storage.put(key, new CacheEntry<>(System.currentTimeMillis(), value));
             startJob(); // start background cleanup
         }
-        return entry == null ? null : value;
+        return previous == null ? null : previous.value();
+    }
+
+    public synchronized boolean putIfAbsent(K key, V value, BiPredicate<V, V> isDuplicate) {
+        Objects.requireNonNull(key, "key must not be null");
+        Objects.requireNonNull(value, "value must not be null");
+
+        CacheEntry<V> existing = storage.get(key);
+        if (existing != null) {
+            if (!isExpired(existing) && isDuplicate.test(existing.value(), value)) {
+                return false;
+            }
+        }
+        storage.put(key, new CacheEntry<>(System.currentTimeMillis(), value));
+        startJob();
+        return true;
     }
 
     private synchronized void startJob() {
         if (cleanupJob == null) {
-            cleanupJob = scheduler.scheduleWithFixedDelay(this::cleanupMap, experyInSec, experyInSec, TimeUnit.SECONDS);
+            cleanupJob = scheduler.scheduleWithFixedDelay(this::cleanupMap, expiryInSec, expiryInSec, TimeUnit.SECONDS);
         }
     }
 
     private void cleanupMap() {
-        long currentTime = System.currentTimeMillis();
         Entry<K, CacheEntry<V>> entry;
         synchronized (this) {
             for (Iterator<Entry<K, CacheEntry<V>>> iterator = storage.entrySet().iterator(); iterator.hasNext();) {
                 entry = iterator.next();
-                if (currentTime > (entry.getValue().created.longValue() + experyInSec * 1000)) {
+                if (isExpired(entry.getValue())) {
                     iterator.remove();
                 }
             }
@@ -90,6 +109,10 @@ public class ShellyCacheList<K, V> {
                 cancelJob(); // stop background cleanup
             }
         }
+    }
+
+    public boolean isExpired(CacheEntry<V> ce) {
+        return System.currentTimeMillis() > (ce.created() + expiryInSec * 1000);
     }
 
     private synchronized void cancelJob() {

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/util/ShellyUtils.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/util/ShellyUtils.java
@@ -91,7 +91,7 @@ public class ShellyUtils {
                     throw new ShellyApiException(PRE + className + " from JSON: " + json);
                 }
                 return obj;
-            } catch (JsonSyntaxException e) {
+            } catch (JsonSyntaxException | IllegalStateException e) {
                 throw new ShellyApiException(
                         PRE + className + " from JSON (syntax/format error: " + e.getMessage() + "): " + json, e);
             } catch (RuntimeException e) {

--- a/bundles/org.openhab.binding.shelly/src/test/java/org/openhab/binding/shelly/internal/util/ShellyCacheListTest.java
+++ b/bundles/org.openhab.binding.shelly/src/test/java/org/openhab/binding/shelly/internal/util/ShellyCacheListTest.java
@@ -1,0 +1,211 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.shelly.internal.util;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+/**
+ * Test class for {@link ShellyCacheList}
+ *
+ * @author Markus Michels - Initial contribution
+ */
+@Timeout(10)
+public class ShellyCacheListTest {
+    private static final int TEST_TTL_SECONDS = 1; // Short TTL for testing
+    private ShellyCacheList<String, String> cache;
+
+    @BeforeEach
+    public void setUp() {
+        cache = new ShellyCacheList<>(TEST_TTL_SECONDS);
+    }
+
+    @Test
+    public void testPutAndGet() {
+        // Test basic put and get operations
+        assertNull(cache.put("key1", "value1"));
+        assertEquals("value1", cache.get("key1"));
+        assertEquals("value1", cache.put("key1", "value2"));
+        assertEquals("value2", cache.get("key1"));
+    }
+
+    @Test
+    public void testGetNonExistent() {
+        assertNull(cache.get("nonexistent"));
+    }
+
+    @Test
+    public void testExpiration() throws InterruptedException {
+        // Test that entries expire after TTL
+        cache.put("key1", "value1");
+        assertNotNull(cache.get("key1"), "Entry should exist before TTL");
+
+        // Wait for TTL to expire plus a small buffer
+        // We need to await 2*TEST_TTL_SECONDS: initial delay + interval
+        Thread.sleep((2 * TEST_TTL_SECONDS * 1000) + 100);
+
+        assertNull(cache.get("key1"), "Entry should be null after TTL expires");
+    }
+
+    @Test
+    public void testPutIfAbsentOrSame() {
+        // Test with new key - should add the entry
+        assertTrue(cache.putIfAbsent("key1", "value1", (v1, v2) -> false));
+        assertEquals("value1", cache.get("key1"), "Should add new entry");
+
+        // Test with same key and value, but different duplicate check
+        assertTrue(cache.putIfAbsent("key1", "value1", (v1, v2) -> false),
+                "Should return true when values are the same but not marked as duplicates");
+
+        // Test with same key but different value and always-true duplicate check
+        assertFalse(cache.putIfAbsent("key1", "value2", (v1, v2) -> true),
+                "Should return false when marked as duplicate");
+        assertEquals("value1", cache.get("key1"), "Value should not change when marked as duplicate");
+
+        // Test with expired entry
+        cache.put("expiredKey", "oldValue");
+        // Simulate expiration by manipulating the cache directly (reflection would be needed for a real test)
+        // For now, we'll just test the non-expired case
+        assertTrue(cache.putIfAbsent("expiredKey", "newValue", (v1, v2) -> false),
+                "Should return true for expired entry");
+    }
+
+    @Test
+    public void testPutIfAbsentOrSameWithDifferentComparators() {
+        // Test with case-insensitive comparison
+        cache.put("key1", "VALUE1");
+        assertFalse(cache.putIfAbsent("key1", "value1", (v1, v2) -> v1 != null && v1.equalsIgnoreCase(v2)),
+                "Should detect as same value with case-insensitive comparison");
+
+        // Test with substring matching
+        cache.put("key2", "prefix_value_suffix");
+        assertFalse(cache.putIfAbsent("key2", "value", (v1, v2) -> v1 != null && v1.contains(v2)),
+                "Should detect as same value with substring matching");
+
+        // Test with custom object comparison
+        cache.put("key3", "{\"id\":1,\"name\":\"test\"}");
+        assertFalse(cache.putIfAbsent("key3", "{\"id\":1,\"name\":\"test\"}", (v1, v2) -> {
+            return v1 != null && v1.replaceAll("\\s", "").equals(v2.replaceAll("\\s", ""));
+        }), "Same JSON content should be suppressed");
+        assertTrue(cache.putIfAbsent("key3", "{\"name\":\"test\",\"id\":1}", (v1, v2) -> {
+            // Simple JSON comparison (in a real test, use a proper JSON parser)
+            return v1 != null && v1.replaceAll("\\s", "").equals(v2.replaceAll("\\s", ""));
+        }), "Should detect as same JSON content ");
+    }
+
+    @Test
+    public void testConcurrentPutIfAbsentOrSame() throws InterruptedException {
+        final int THREAD_COUNT = 5;
+        final int OPERATIONS_PER_THREAD = 100;
+        Thread[] threads = new Thread[THREAD_COUNT];
+
+        for (int i = 0; i < THREAD_COUNT; i++) {
+            final int threadId = i;
+            threads[i] = new Thread(() -> {
+                try {
+                    for (int j = 0; j < OPERATIONS_PER_THREAD; j++) {
+                        String key = "key-" + threadId;
+                        String value = "value-" + threadId + "-" + j;
+
+                        // Only one thread should succeed in adding each key
+                        boolean added = cache.putIfAbsent(key, value, (v1, v2) -> false);
+                        if (added) {
+                            // Verify we can read back the value we just added
+                            String result = cache.get(key);
+                            assertNotNull(result, "Added value should be retrievable");
+                            assertTrue(result.startsWith("value-" + threadId + "-"));
+                        }
+                    }
+                } catch (Exception e) {
+                    fail("Thread " + threadId + " failed: " + e.getMessage());
+                }
+            });
+            threads[i].start();
+        }
+
+        // Wait for all threads to complete
+        for (Thread t : threads) {
+            t.join();
+        }
+
+        // Verify final state
+        for (int i = 0; i < THREAD_COUNT; i++) {
+            String key = "key-" + i;
+            String value = cache.get(key);
+            assertNotNull(value, "Each thread should have set at least one value for its key");
+            assertTrue(value.startsWith("value-" + i + "-"), "Value should match the thread that set it");
+        }
+    }
+
+    @Test
+    public void testCleanup() throws InterruptedException {
+        // Add an entry and verify it's there
+        cache.put("key1", "value1");
+        assertNotNull(cache.get("key1"));
+
+        // Wait for TTL to expire plus a small buffer
+        Thread.sleep((2 * TEST_TTL_SECONDS * 1000) + 100);
+
+        // Trigger cleanup by adding a new entry
+        cache.put("key2", "value2");
+
+        // First entry should be cleaned up, second should exist
+        assertNull(cache.get("key1"), "Expired entry should be cleaned up");
+        assertNotNull(cache.get("key2"), "New entry should exist");
+    }
+
+    @Test
+    public void testDispose() {
+        // Add some entries
+        cache.put("key1", "value1");
+        cache.put("key2", "value2");
+
+        // Dispose and verify cleanup
+        cache.dispose();
+
+        // Verify all entries are gone
+        assertNull(cache.get("key1"));
+        assertNull(cache.get("key2"));
+    }
+
+    @Test
+    public void testNullHandling() {
+        // Test null key
+        assertThrows(NullPointerException.class, () -> cache.putIfAbsent(null, "value", (v1, v2) -> false));
+
+        // Test null value
+        assertThrows(NullPointerException.class, () -> cache.put("key", null));
+    }
+
+    @Test
+    public void testLargeNumberOfEntries() {
+        // Test with a larger number of entries
+        final int ENTRY_COUNT = 1000;
+        for (int i = 0; i < ENTRY_COUNT; i++) {
+            String key = "key-" + i;
+            String value = "value-" + i;
+            boolean added = cache.putIfAbsent(key, value, (v1, v2) -> false);
+            assertTrue(added, "Should add new entry: " + key);
+        }
+
+        // Verify all entries are retrievable
+        for (int i = 0; i < ENTRY_COUNT; i++) {
+            String key = "key-" + i;
+            String expected = "value-" + i;
+            assertEquals(expected, cache.get(key), "Should retrieve value for key: " + key);
+        }
+    }
+}


### PR DESCRIPTION
Users are reporting Plug S Gen3 crashing / running out of memory. Analyzing the device debug log shows
- duplicate id messages
- RPC JSON.src is not what it has to be (openhab-a.b.c.d, instead openhab-) for some of the calls
- Device heap going down

It turned out that a lack of thread safeties of the binding's mDNS handler is causing issues. This is getting serious in a Docker environment, because binding is receiving parallel mDNS discovery results (@Nadahar have a good explanation here: https://github.com/openhab/openhab-addons/issues/19777#issuecomment-3736194806)

This PR
- fixes a bug resulting in src="ohshelly-" rather than "src=ohshelly-a.b.c.d", but I think this is cosmetic only.
- "jsonrpc":"2.0" added to all outbound RPC requests (not mandatory, but conforming to the API spec)
-  holds the mDNS info for 15sec and ignores new ones by the same device (send in parallel) within that timeframe. This also means that the binding does not send /shelly, GetConfig and GetStatus to pull device information as part of the discovery process (check the "already known" messages at TRACE level) within that time. @jlaur I renamed ShellyManagerCache to ShellyCacheList (now generic utility class) and did some improvements.
- adds the thread name of the "discovered" and "already known" messages and see different thread pools
- Optimized speed for discovery handler, e.g. binding config is only loaded on startup and change rather than each time processing a discovery result
- Significantly improves thread-safetiness for MDNSDiscoveryParticipant and ShellyBasicDiscoveryService classes
- For Gen1 devices the process issued a /shelly twice - fixed
- Finally each thread now starts with a base for the request id and then increments on each request. This avoids "duplicate ids" when multiple (discovery) threads start with id=1. -> maybe a separate PR
- test coverage increased

Awaiting #20069, #20094 

Closing
- #19777

