### PR TITLE
[teslascope] Fix rediscovery of existing `vehicle` Things

### DIFF
--- a/bundles/org.openhab.binding.teslascope/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.teslascope/src/main/resources/OH-INF/thing/thing-types.xml
@@ -118,6 +118,8 @@
 			<property name="thingTypeVersion">2</property>
 		</properties>
 
+		<representation-property>publicID</representation-property>
+
 		<config-description>
 			<parameter name="publicID" type="text" required="true">
 				<label>Vehicle Public ID</label>


### PR DESCRIPTION
Fixes cars being detected when thing uid is not set to the publicId from teslascope.