### PR TITLE
[astro] Fix test warnings

### DIFF
--- a/bundles/org.openhab.binding.astro/src/test/java/org/openhab/binding/astro/internal/CommonTestConstants.java
+++ b/bundles/org.openhab.binding.astro/src/test/java/org/openhab/binding/astro/internal/CommonTestConstants.java
@@ -14,12 +14,15 @@ package org.openhab.binding.astro.internal;
 
 import java.math.BigDecimal;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
 /**
  * Contains some test data used across different tests
  *
  * @author Svilen Valkanov - Initial contribution
  * @author Christoph Weitkamp - Migrated tests to pure Java
  */
+@NonNullByDefault
 public final class CommonTestConstants {
 
     public static final String TEST_SUN_THING_ID = "testSunThingId";

--- a/bundles/org.openhab.binding.astro/src/test/java/org/openhab/binding/astro/internal/handler/CommandTest.java
+++ b/bundles/org.openhab.binding.astro/src/test/java/org/openhab/binding/astro/internal/handler/CommandTest.java
@@ -21,6 +21,7 @@ import java.time.Instant;
 import java.time.InstantSource;
 import java.time.ZoneId;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.junit.jupiter.api.Test;
 import org.openhab.binding.astro.internal.model.Sun;
 import org.openhab.core.config.core.Configuration;
@@ -45,6 +46,7 @@ import org.openhab.core.types.State;
  * @author Svilen Valkanov - Reworked to plain unit tests
  * @author Christoph Weitkamp - Migrated tests to pure Java
  */
+@NonNullByDefault
 public class CommandTest {
 
     @Test

--- a/bundles/org.openhab.binding.astro/src/test/java/org/openhab/binding/astro/internal/handler/ParametrizedStateTestCases.java
+++ b/bundles/org.openhab.binding.astro/src/test/java/org/openhab/binding/astro/internal/handler/ParametrizedStateTestCases.java
@@ -17,6 +17,7 @@ import static org.openhab.binding.astro.internal.CommonTestConstants.*;
 import java.util.Arrays;
 import java.util.List;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.core.library.types.DateTimeType;
 import org.openhab.core.library.types.QuantityType;
 import org.openhab.core.library.unit.Units;
@@ -31,6 +32,7 @@ import org.openhab.core.library.unit.Units;
  * @author Erdoan Hadzhiyusein - Adapted the class to work with the new DateTimeType
  * @author Christoph Weitkamp - Introduced UoM and migrated tests to pure Java
  */
+@NonNullByDefault
 public final class ParametrizedStateTestCases {
 
     public static final double TEST_LATITUDE = 22.4343;

--- a/bundles/org.openhab.binding.astro/src/test/java/org/openhab/binding/astro/internal/handler/StateTest.java
+++ b/bundles/org.openhab.binding.astro/src/test/java/org/openhab/binding/astro/internal/handler/StateTest.java
@@ -32,6 +32,8 @@ import java.util.TimeZone;
 
 import javax.measure.Unit;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -63,6 +65,7 @@ import org.openhab.core.types.State;
  */
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
+@NonNullByDefault
 public class StateTest {
 
     // These test result timestamps are adapted for the +03:00 time zone
@@ -70,11 +73,11 @@ public class StateTest {
     private static final ZoneId ZONE_ID = TIME_ZONE.toZoneId();
     private static final Locale LOCALE = Locale.of("ar", "iq");
 
-    private @Mock TimeZoneProvider timeZoneProvider;
-    private @Mock Thing thing;
-    private @Mock CronScheduler scheduler;
-    private @Mock LocaleProvider localeProvider;
-    private @Mock Channel channel;
+    private @Mock @NonNullByDefault({}) TimeZoneProvider timeZoneProvider;
+    private @Mock @NonNullByDefault({}) Thing thing;
+    private @Mock @NonNullByDefault({}) CronScheduler scheduler;
+    private @Mock @NonNullByDefault({}) LocaleProvider localeProvider;
+    private @Mock @NonNullByDefault({}) Channel channel;
 
     @BeforeEach
     public void init() {
@@ -100,6 +103,9 @@ public class StateTest {
 
     private void assertStateUpdate(String thingID, String channelId, State expectedState) throws Exception {
         AstroThingHandler handler = getHandler(thingID);
+        if (handler == null) {
+            throw new IllegalStateException("hander should not be null");
+        }
 
         when(channel.getUID()).thenReturn(new ChannelUID(getThingUID(thingID), channelId));
         when(channel.getConfiguration()).thenReturn(new Configuration());
@@ -124,11 +130,11 @@ public class StateTest {
             case (TEST_MOON_THING_ID):
                 return new ThingUID(THING_TYPE_MOON, thingID);
             default:
-                return null;
+                return new ThingUID("error");
         }
     }
 
-    private AstroThingHandler getHandler(String thingID) {
+    private @Nullable AstroThingHandler getHandler(String thingID) {
         LocalDateTime time = LocalDateTime.of(TEST_YEAR, TEST_MONTH, TEST_DAY, 0, 0);
         ZonedDateTime zonedTime = ZonedDateTime.ofLocal(time, ZONE_ID, null);
         InstantSource instantSource = InstantSource.fixed(zonedTime.toInstant());

--- a/bundles/org.openhab.binding.astro/src/test/java/org/openhab/binding/astro/internal/handler/ValidConfigurationTest.java
+++ b/bundles/org.openhab.binding.astro/src/test/java/org/openhab/binding/astro/internal/handler/ValidConfigurationTest.java
@@ -20,6 +20,7 @@ import java.time.Instant;
 import java.time.InstantSource;
 import java.time.ZoneId;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.junit.jupiter.api.Test;
 import org.openhab.core.config.core.Configuration;
 import org.openhab.core.i18n.LocaleProvider;
@@ -42,13 +43,14 @@ import org.openhab.core.thing.binding.ThingHandlerCallback;
  * @author Svilen Valkanov - Reworked to plain unit tests, removed irrelevant tests
  * @author Christoph Weitkamp - Migrated tests to pure Java
  */
+@NonNullByDefault
 public class ValidConfigurationTest {
 
     private static final String NULL_LONGITUDE = "51.2,null";
     private static final String NULL_LATITUDE = "null,25.4";
 
     @Test
-    public void testIfGeolocationIsProvidedForASunThing_theThingStatusBecomesONLINE() {
+    public void testIfGeolocationIsProvidedForASunThingTheThingStatusBecomesONLINE() {
         Configuration thingConfiguration = new Configuration();
         thingConfiguration.put(GEOLOCATION_PROPERTY, GEOLOCATION_VALUE);
         thingConfiguration.put(INTERVAL_PROPERTY, INTERVAL_DEFAULT_VALUE);
@@ -56,7 +58,7 @@ public class ValidConfigurationTest {
     }
 
     @Test
-    public void testIfGeolocationIsProvidedForAMoonThing_theThingStatusBecomesONLINE() {
+    public void testIfGeolocationIsProvidedForAMoonThingTheThingStatusBecomesONLINE() {
         Configuration thingConfiguration = new Configuration();
         thingConfiguration.put(GEOLOCATION_PROPERTY, GEOLOCATION_VALUE);
         thingConfiguration.put(INTERVAL_PROPERTY, INTERVAL_DEFAULT_VALUE);
@@ -64,49 +66,49 @@ public class ValidConfigurationTest {
     }
 
     @Test
-    public void testIfGeolocationForASunThingIsNull_theThingStatusBecomesOFFLINE() {
+    public void testIfGeolocationForASunThingIsNullTheThingStatusBecomesOFFLINE() {
         Configuration thingConfiguration = new Configuration();
         thingConfiguration.put(GEOLOCATION_PROPERTY, null);
         assertThingStatus(thingConfiguration, ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR);
     }
 
     @Test
-    public void testIfGeolocationForAMoonThingIsNull_theThingStatusBecomesOFFLINE() {
+    public void testIfGeolocationForAMoonThingIsNullTheThingStatusBecomesOFFLINE() {
         Configuration thingConfiguration = new Configuration();
         thingConfiguration.put(GEOLOCATION_PROPERTY, null);
         assertThingStatus(thingConfiguration, ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR);
     }
 
     @Test
-    public void testIfTheLatitudeForASunThingIsNull_theThingStatusBecomesOFFLINE() {
+    public void testIfTheLatitudeForASunThingIsNullTheThingStatusBecomesOFFLINE() {
         Configuration thingConfiguration = new Configuration();
         thingConfiguration.put(GEOLOCATION_PROPERTY, NULL_LATITUDE);
         assertThingStatus(thingConfiguration, ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR);
     }
 
     @Test
-    public void testIfTheLatitudeForAMoonThingIsNull_theThingStatusBecomesOFFLINE() {
+    public void testIfTheLatitudeForAMoonThingIsNullTheThingStatusBecomesOFFLINE() {
         Configuration thingConfiguration = new Configuration();
         thingConfiguration.put(GEOLOCATION_PROPERTY, NULL_LATITUDE);
         assertThingStatus(thingConfiguration, ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR);
     }
 
     @Test
-    public void testIfTheLongitudeForASunThingIsNull_theThingStatusBecomesOFFLINE() {
+    public void testIfTheLongitudeForASunThingIsNullTheThingStatusBecomesOFFLINE() {
         Configuration thingConfiguration = new Configuration();
         thingConfiguration.put(GEOLOCATION_PROPERTY, NULL_LONGITUDE);
         assertThingStatus(thingConfiguration, ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR);
     }
 
     @Test
-    public void testIfTheLongitudeForAMoonThingIsNull_theThingStatusBecomesOFFLINE() {
+    public void testIfTheLongitudeForAMoonThingIsNullTheThingStatusBecomesOFFLINE() {
         Configuration thingConfiguration = new Configuration();
         thingConfiguration.put(GEOLOCATION_PROPERTY, NULL_LONGITUDE);
         assertThingStatus(thingConfiguration, ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR);
     }
 
     @Test
-    public void testIfTheIntervalForASunThingIsLessThan1_theThingStatusBecomesOFFLINE() {
+    public void testIfTheIntervalForASunThingIsLessThan1TheThingStatusBecomesOFFLINE() {
         Configuration thingConfiguration = new Configuration();
         thingConfiguration.put(GEOLOCATION_PROPERTY, GEOLOCATION_VALUE);
         thingConfiguration.put(INTERVAL_PROPERTY, Integer.valueOf(0));
@@ -114,7 +116,7 @@ public class ValidConfigurationTest {
     }
 
     @Test
-    public void testIfTheIntervalForAMoonThingIsLessThan1_theThingStatusBecomesOFFLINE() {
+    public void testIfTheIntervalForAMoonThingIsLessThan1TheThingStatusBecomesOFFLINE() {
         Configuration thingConfiguration = new Configuration();
         thingConfiguration.put(GEOLOCATION_PROPERTY, GEOLOCATION_VALUE);
         thingConfiguration.put(INTERVAL_PROPERTY, Integer.valueOf(0));
@@ -122,7 +124,7 @@ public class ValidConfigurationTest {
     }
 
     @Test
-    public void testIfTheIntervalForASunThingIsGreaterThan86400_theThingStatusBecomesOFFLINE() {
+    public void testIfTheIntervalForASunThingIsGreaterThan86400TheThingStatusBecomesOFFLINE() {
         Configuration thingConfiguration = new Configuration();
         thingConfiguration.put(GEOLOCATION_PROPERTY, GEOLOCATION_VALUE);
         thingConfiguration.put(INTERVAL_PROPERTY, Integer.valueOf(86401));
@@ -130,7 +132,7 @@ public class ValidConfigurationTest {
     }
 
     @Test
-    public void testIfTheIntervalForAMoonThingIsGreaterThan86400_theThingStatusBecomesOFFLINE() {
+    public void testIfTheIntervalForAMoonThingIsGreaterThan86400TheThingStatusBecomesOFFLINE() {
         Configuration thingConfiguration = new Configuration();
         thingConfiguration.put(GEOLOCATION_PROPERTY, GEOLOCATION_VALUE);
         thingConfiguration.put(INTERVAL_PROPERTY, Integer.valueOf(86401));


### PR DESCRIPTION
#20000, despite its "clean" number, brought in some warnings from the "itests" bundle, again "polluting" the binding. This takes care of those warnings.