### PR TITLE
[shelly] Remove duplicated and misspelled DTO fields

### DIFF
--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api1/Shelly1ApiJsonDTO.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api1/Shelly1ApiJsonDTO.java
@@ -685,10 +685,6 @@ public class Shelly1ApiJsonDTO {
         public Boolean rainSensor; // Flood: true=in rain mode
 
         // FW 1.5.7: Door Window
-        @SerializedName("dark_treshold")
-        public Integer darkTreshold; // Illumination definition for "dark" in lux
-        @SerializedName("twilight_treshold")
-        public Integer twiLightTreshold; // Illumination definition for "twilight" in lux
         @SerializedName("dark_url")
         public String darkUrl; // URL to report to when luminance <= dark_threshold
         @SerializedName("twilight_url")
@@ -717,8 +713,14 @@ public class Shelly1ApiJsonDTO {
         public ShellyMotionSettings motion;
         @SerializedName("tamper_sensitivity")
         public Integer tamperSensitivity;
+        /**
+         * Illumination level threshold for dark condition.
+         */
         @SerializedName("dark_threshold")
         public Integer darkThreshold;
+        /**
+         * Illumination level threshold for twilight condition.
+         */
         @SerializedName("twilight_threshold")
         public Integer twilightThreshold;
 

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/Shelly2ApiJsonDTO.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/Shelly2ApiJsonDTO.java
@@ -303,7 +303,7 @@ public class Shelly2ApiJsonDTO {
             @SerializedName("factory_reset")
             public Boolean factoryReset;
             @SerializedName("report_thr")
-            public Double reportTreshold; // only for type analog
+            public Double reportThreshold; // only for type analog
         }
 
         public class Shelly2DevConfigSwitch {


### PR DESCRIPTION
Follow-up to https://github.com/openhab/openhab-addons/pull/20084#issuecomment-3763909652

According to the [documentation](https://shelly-api-docs.shelly.cloud/gen1/#shelly-motion-settings):

Attribute | Type | Description
-- | -- | --
dark_threshold | number | Illumination level threshold for dark condition.
twilight_threshold | number | Illumination level threshold for twilight condition.

The fields are currently unused, but fixing them now can avoid future issues.