### PR TITLE
[froniuswattpilot] Upgrade wattpilot4j to 2.3.0 & OSGi-ify it

### DIFF
--- a/bundles/org.openhab.binding.froniuswattpilot/pom.xml
+++ b/bundles/org.openhab.binding.froniuswattpilot/pom.xml
@@ -18,8 +18,9 @@
     <dependency>
       <groupId>dev.digiried</groupId>
       <artifactId>wattpilot4j</artifactId>
-      <version>2.2.1</version>
-      <scope>compile</scope>
+      <version>2.3.0</version>
+      <!-- provided as OSGi bundle at runtime, available only at compile time -->
+      <scope>provided</scope>
     </dependency>
   </dependencies>
 

--- a/bundles/org.openhab.binding.froniuswattpilot/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.froniuswattpilot/src/main/feature/feature.xml
@@ -4,7 +4,7 @@
 
 	<feature name="openhab-binding-froniuswattpilot" description="Fronius Wattpilot Binding" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
-		<bundle dependency="true">mvn:dev.digiried/wattpilot4j/2.2.1</bundle>
+		<bundle dependency="true">mvn:dev.digiried/wattpilot4j/2.3.0</bundle>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.froniuswattpilot/${project.version}</bundle>
 	</feature>
 </features>


### PR DESCRIPTION
See https://github.com/florian-h05/wattpilot4j/releases/tag/v2.3.0. This mainly adds support for newer models, which use BCrypt for password hashing.