### PR TITLE
[tasmotaplug] Fix command mapping for power channel 3

### DIFF
--- a/bundles/org.openhab.binding.tasmotaplug/src/main/java/org/openhab/binding/tasmotaplug/internal/TasmotaPlugBindingConstants.java
+++ b/bundles/org.openhab.binding.tasmotaplug/src/main/java/org/openhab/binding/tasmotaplug/internal/TasmotaPlugBindingConstants.java
@@ -70,7 +70,7 @@ public class TasmotaPlugBindingConstants {
             VOLT_AMPERE_REACTIVE, POWER_FACTOR, ENERGY_TODAY, ENERGY_YESTERDAY, ENERGY_TOTAL, ENERGY_TOTAL_START);
 
     // Map of the channel ids to tasmota command strings
-    public static final Map<String, String> COMMAND_MAP = Map.of(POWER, "Power", POWER2, "Power2", "POWER3", "Power3",
+    public static final Map<String, String> COMMAND_MAP = Map.of(POWER, "Power", POWER2, "Power2", POWER3, "Power3",
             POWER4, "Power4", PULSE_TIME, "PulseTime", PULSE_TIME2, "PulseTime2", PULSE_TIME3, "PulseTime3",
             PULSE_TIME4, "PulseTime4");
 }


### PR DESCRIPTION
# [tasmotaplug] Fix command mapping for power channel 3

Relais of channel 3 can not be switched on/off. Channel-ID is `power3` but command-map contains `POWER3`.
Log:
`Unsupported channelId: power3`