### PR TITLE
[roborock] Fix status#clean-area channel

### DIFF
--- a/bundles/org.openhab.binding.roborock/src/main/java/org/openhab/binding/roborock/internal/RoborockVacuumHandler.java
+++ b/bundles/org.openhab.binding.roborock/src/main/java/org/openhab/binding/roborock/internal/RoborockVacuumHandler.java
@@ -559,7 +559,8 @@ public class RoborockVacuumHandler extends BaseThingHandler {
             updateState(CHANNEL_FAN_POWER, new DecimalType(getStatus.result[0].fanPower));
             updateState(CHANNEL_FAN_CONTROL,
                     new DecimalType(FanModeType.getType(getStatus.result[0].fanPower).getId()));
-            updateState(CHANNEL_CLEAN_AREA, new QuantityType<>(getStatus.result[0].cleanArea, SIUnits.SQUARE_METRE));
+            updateState(CHANNEL_CLEAN_AREA,
+                    new QuantityType<>(getStatus.result[0].cleanArea / 1000000D, SIUnits.SQUARE_METRE));
             updateState(CHANNEL_CLEAN_TIME,
                     new QuantityType<>(TimeUnit.SECONDS.toMinutes(getStatus.result[0].cleanTime), Units.MINUTE));
             updateState(CHANNEL_DND_ENABLED, new DecimalType(getStatus.result[0].dndEnabled));


### PR DESCRIPTION
The status#clean-area channel had no code to update it. This PR addresses this and updates the channel with the appropriate date from the roborock API.