### PR TITLE
[solarman] Fix definition for Deye SG01HP3

### DIFF
--- a/bundles/org.openhab.binding.solarman/src/main/resources/definitions/deye_sg01hp3.yaml
+++ b/bundles/org.openhab.binding.solarman/src/main/resources/definitions/deye_sg01hp3.yaml
@@ -35,7 +35,7 @@ requests:
     end: 0x029F
     mb_functioncode: 0x03
   - start: 0x02A0
-    end: 0x02A8
+    end: 0x02A9
     mb_functioncode: 0x03
 
 parameters:


### PR DESCRIPTION
# [solarman] Fix definition for Deye SG01HP3

# Description

Definition for Deye SG01HP3 contains channel `PV3 Current`, which is not updated currently, because it's register is not read from invertor.