### PR TITLE
[openweathermap] Add unit hints for pollution channels

### DIFF
--- a/bundles/org.openhab.binding.openweathermap/src/main/resources/OH-INF/thing/channel-types.xml
+++ b/bundles/org.openhab.binding.openweathermap/src/main/resources/OH-INF/thing/channel-types.xml
@@ -890,7 +890,7 @@
 	</channel-type>
 
 	<channel-type id="particulate-matter-2dot5">
-		<item-type>Number:Density</item-type>
+		<item-type unitHint="µg/m³">Number:Density</item-type>
 		<label>Particulate Matter - PM2.5</label>
 		<description>Current density of particles less than 2.5 µm in diameter.</description>
 		<tags>
@@ -901,7 +901,7 @@
 	</channel-type>
 
 	<channel-type id="forecasted-particulate-matter-2dot5">
-		<item-type>Number:Density</item-type>
+		<item-type unitHint="µg/m³">Number:Density</item-type>
 		<label>Forecasted Particulate Matter - PM2.5</label>
 		<description>Forecasted density of particles less than 2.5 µm in diameter.</description>
 		<tags>
@@ -912,7 +912,7 @@
 	</channel-type>
 
 	<channel-type id="forecasted-particulate-matter-10">
-		<item-type>Number:Density</item-type>
+		<item-type unitHint="µg/m³">Number:Density</item-type>
 		<label>Forecasted Particulate Matter - PM10</label>
 		<description>Forecasted density of particles less than 10 µm in diameter.</description>
 		<tags>
@@ -923,7 +923,7 @@
 	</channel-type>
 
 	<channel-type id="particulate-matter-10">
-		<item-type>Number:Density</item-type>
+		<item-type unitHint="µg/m³">Number:Density</item-type>
 		<label>Particulate Matter - PM10</label>
 		<description>Current density of particles less than 10 µm in diameter.</description>
 		<tags>
@@ -934,7 +934,7 @@
 	</channel-type>
 
 	<channel-type id="carbon-monoxide">
-		<item-type>Number:Density</item-type>
+		<item-type unitHint="µg/m³">Number:Density</item-type>
 		<label>Carbon Monoxide</label>
 		<description>Current concentration of carbon monoxide.</description>
 		<tags>
@@ -945,7 +945,7 @@
 	</channel-type>
 
 	<channel-type id="forecasted-carbon-monoxide">
-		<item-type>Number:Density</item-type>
+		<item-type unitHint="µg/m³">Number:Density</item-type>
 		<label>Forecasted Carbon Monoxide</label>
 		<description>Forecasted concentration of carbon monoxide.</description>
 		<tags>
@@ -956,7 +956,7 @@
 	</channel-type>
 
 	<channel-type id="nitrogen-monoxide">
-		<item-type>Number:Density</item-type>
+		<item-type unitHint="µg/m³">Number:Density</item-type>
 		<label>Nitrogen Monoxide</label>
 		<description>Current concentration of nitrogen monoxide.</description>
 		<tags>
@@ -966,7 +966,7 @@
 	</channel-type>
 
 	<channel-type id="forecasted-nitrogen-monoxide">
-		<item-type>Number:Density</item-type>
+		<item-type unitHint="µg/m³">Number:Density</item-type>
 		<label>Forecasted Nitrogen Monoxide</label>
 		<description>Forecasted concentration of nitrogen monoxide.</description>
 		<tags>
@@ -976,7 +976,7 @@
 	</channel-type>
 
 	<channel-type id="nitrogen-dioxide">
-		<item-type>Number:Density</item-type>
+		<item-type unitHint="µg/m³">Number:Density</item-type>
 		<label>Nitrogen Dioxide</label>
 		<description>Current concentration of nitrogen dioxide.</description>
 		<tags>
@@ -986,7 +986,7 @@
 	</channel-type>
 
 	<channel-type id="forecasted-nitrogen-dioxide">
-		<item-type>Number:Density</item-type>
+		<item-type unitHint="µg/m³">Number:Density</item-type>
 		<label>Forecasted Nitrogen Dioxide</label>
 		<description>Forecasted concentration of nitrogen dioxide.</description>
 		<tags>
@@ -996,7 +996,7 @@
 	</channel-type>
 
 	<channel-type id="ozone">
-		<item-type>Number:Density</item-type>
+		<item-type unitHint="µg/m³">Number:Density</item-type>
 		<label>Ozone</label>
 		<description>Current concentration of ozone.</description>
 		<tags>
@@ -1007,7 +1007,7 @@
 	</channel-type>
 
 	<channel-type id="forecasted-ozone">
-		<item-type>Number:Density</item-type>
+		<item-type unitHint="µg/m³">Number:Density</item-type>
 		<label>Forecasted Ozone</label>
 		<description>Forecasted concentration of ozone.</description>
 		<tags>
@@ -1018,7 +1018,7 @@
 	</channel-type>
 
 	<channel-type id="sulphur-dioxide">
-		<item-type>Number:Density</item-type>
+		<item-type unitHint="µg/m³">Number:Density</item-type>
 		<label>Sulphur Dioxide</label>
 		<description>Current concentration of sulphur dioxide.</description>
 		<tags>
@@ -1028,7 +1028,7 @@
 	</channel-type>
 
 	<channel-type id="forecasted-sulphur-dioxide">
-		<item-type>Number:Density</item-type>
+		<item-type unitHint="µg/m³">Number:Density</item-type>
 		<label>Forecasted Sulphur Dioxide</label>
 		<description>Forecasted concentration of sulphur dioxide.</description>
 		<tags>
@@ -1038,7 +1038,7 @@
 	</channel-type>
 
 	<channel-type id="ammonia">
-		<item-type>Number:Density</item-type>
+		<item-type unitHint="µg/m³">Number:Density</item-type>
 		<label>Ammonia</label>
 		<description>Current concentration of ammonia.</description>
 		<tags>
@@ -1048,7 +1048,7 @@
 	</channel-type>
 
 	<channel-type id="forecasted-ammonia">
-		<item-type>Number:Density</item-type>
+		<item-type unitHint="µg/m³">Number:Density</item-type>
 		<label>Forecasted Ammonia</label>
 		<description>Forecasted concentration of ammonia.</description>
 		<tags>


### PR DESCRIPTION
Added unit hints for pollution channels according to [owm documentation](http://openweathermap.org/api/air-pollution?collection=environmental&collection=environmental&collection=environmental#fields).

Currently `Add Equipment to Model` chooses kg/m3 which stays 0 all the time.