### PR TITLE
[roku] Unable to connect via host name

### DIFF
--- a/bundles/org.openhab.binding.roku/src/main/java/org/openhab/binding/roku/internal/handler/RokuHandler.java
+++ b/bundles/org.openhab.binding.roku/src/main/java/org/openhab/binding/roku/internal/handler/RokuHandler.java
@@ -102,9 +102,7 @@ public class RokuHandler extends BaseThingHandler {
 
         final @Nullable String host = config.hostName;
 
-        if (host != null && !EMPTY.equals(host)) {
-            this.communicator = new RokuCommunicator(httpClient, host, config.port);
-        } else {
+        if (host == null || EMPTY.equals(host)) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, "Host Name must be specified");
             return;
         }


### PR DESCRIPTION
[roku] Add Host header to prevent 403 Forbidden when using a hostname instead of IP address

Roku ECP will give a 403 Forbidden if you attempt to access it via hostname without setting a Host header equal to the resolved IP address. This is not an issue when an IP address is specified instead of a hostname when configuring the Roku binding. This change will attempt to resolve the user supplied host to an IP. If it fails it will just assume it was an IP address to start with. To keep the code minimal the Host header is always set (even when it was originally an IP though is harmless).
