### PR TITLE
[solaredge] Fix EOFException during temporary internet connection loss (Live Data polling)

### DIFF
--- a/bundles/org.openhab.binding.solaredge/src/main/java/org/openhab/binding/solaredge/internal/command/AggregateDataUpdatePrivateApi.java
+++ b/bundles/org.openhab.binding.solaredge/src/main/java/org/openhab/binding/solaredge/internal/command/AggregateDataUpdatePrivateApi.java
@@ -104,6 +104,7 @@ public class AggregateDataUpdatePrivateApi extends AbstractCommand implements So
         if (!HttpStatus.Code.OK.equals(getCommunicationStatus().getHttpCode())) {
             if (retries++ < MAX_RETRIES) {
                 handler.getWebInterface().enqueueCommand(this);
+                return;
             }
         } else {
             String json = getContentAsString(StandardCharsets.UTF_8);

--- a/bundles/org.openhab.binding.solaredge/src/main/java/org/openhab/binding/solaredge/internal/command/AggregateDataUpdatePublicApi.java
+++ b/bundles/org.openhab.binding.solaredge/src/main/java/org/openhab/binding/solaredge/internal/command/AggregateDataUpdatePublicApi.java
@@ -96,6 +96,7 @@ public class AggregateDataUpdatePublicApi extends AbstractCommand implements Sol
         if (!HttpStatus.Code.OK.equals(getCommunicationStatus().getHttpCode())) {
             if (retries++ < MAX_RETRIES) {
                 handler.getWebInterface().enqueueCommand(this);
+                return;
             }
         } else {
             String json = getContentAsString(StandardCharsets.UTF_8);

--- a/bundles/org.openhab.binding.solaredge/src/main/java/org/openhab/binding/solaredge/internal/command/LiveDataUpdateMeterless.java
+++ b/bundles/org.openhab.binding.solaredge/src/main/java/org/openhab/binding/solaredge/internal/command/LiveDataUpdateMeterless.java
@@ -65,6 +65,7 @@ public class LiveDataUpdateMeterless extends AbstractCommand implements SolarEdg
         if (!HttpStatus.Code.OK.equals(getCommunicationStatus().getHttpCode())) {
             if (retries++ < MAX_RETRIES) {
                 handler.getWebInterface().enqueueCommand(this);
+                return;
             }
         } else {
             String json = getContentAsString(StandardCharsets.UTF_8);

--- a/bundles/org.openhab.binding.solaredge/src/main/java/org/openhab/binding/solaredge/internal/command/LiveDataUpdatePrivateApi.java
+++ b/bundles/org.openhab.binding.solaredge/src/main/java/org/openhab/binding/solaredge/internal/command/LiveDataUpdatePrivateApi.java
@@ -65,6 +65,7 @@ public class LiveDataUpdatePrivateApi extends AbstractCommand implements SolarEd
         if (!HttpStatus.Code.OK.equals(getCommunicationStatus().getHttpCode())) {
             if (retries++ < MAX_RETRIES) {
                 handler.getWebInterface().enqueueCommand(this);
+                return;
             }
         } else {
             String json = getContentAsString(StandardCharsets.UTF_8);

--- a/bundles/org.openhab.binding.solaredge/src/main/java/org/openhab/binding/solaredge/internal/command/LiveDataUpdatePublicApi.java
+++ b/bundles/org.openhab.binding.solaredge/src/main/java/org/openhab/binding/solaredge/internal/command/LiveDataUpdatePublicApi.java
@@ -64,6 +64,7 @@ public class LiveDataUpdatePublicApi extends AbstractCommand implements SolarEdg
         if (!HttpStatus.Code.OK.equals(getCommunicationStatus().getHttpCode())) {
             if (retries++ < MAX_RETRIES) {
                 handler.getWebInterface().enqueueCommand(this);
+                return;
             }
         } else {
             String json = getContentAsString(StandardCharsets.UTF_8);

--- a/bundles/org.openhab.binding.solaredge/src/main/java/org/openhab/binding/solaredge/internal/connector/CommunicationStatus.java
+++ b/bundles/org.openhab.binding.solaredge/src/main/java/org/openhab/binding/solaredge/internal/connector/CommunicationStatus.java
@@ -12,6 +12,13 @@
  */
 package org.openhab.binding.solaredge.internal.connector;
 
+import java.io.EOFException;
+import java.net.SocketTimeoutException;
+import java.net.UnknownHostException;
+import java.util.concurrent.TimeoutException;
+
+import javax.net.ssl.SSLException;
+
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.jetty.http.HttpStatus.Code;
@@ -57,5 +64,28 @@ public class CommunicationStatus {
             return httpCode.getMessage();
         }
         return "";
+    }
+
+    /**
+     * Returns a sanitized message suitable for Thing status details.
+     */
+    public final String getUserFacingMessage() {
+        Exception error = this.error;
+        if (error != null) {
+            if (error instanceof SocketTimeoutException || error instanceof TimeoutException) {
+                return "Request timed out";
+            } else if (error instanceof UnknownHostException) {
+                return "DNS resolution failed";
+            } else if (error instanceof EOFException || error instanceof SSLException) {
+                return "Connection to SolarEdge interrupted";
+            }
+            return "Communication error";
+        }
+
+        Code httpCode = this.httpCode;
+        if (httpCode != null && httpCode.getMessage() != null && !httpCode.getMessage().isEmpty()) {
+            return httpCode.getMessage();
+        }
+        return "Communication error";
     }
 }

--- a/bundles/org.openhab.binding.solaredge/src/main/java/org/openhab/binding/solaredge/internal/handler/SolarEdgeGenericHandler.java
+++ b/bundles/org.openhab.binding.solaredge/src/main/java/org/openhab/binding/solaredge/internal/handler/SolarEdgeGenericHandler.java
@@ -160,15 +160,16 @@ public class SolarEdgeGenericHandler extends BaseThingHandler implements SolarEd
     }
 
     private void updateOnlineStatus(CommunicationStatus status) {
+        String detailMessage = status.getUserFacingMessage();
         switch (status.getHttpCode()) {
             case SERVICE_UNAVAILABLE:
-                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE, status.getMessage());
+                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE, detailMessage);
                 break;
             case OK:
                 updateStatus(ThingStatus.ONLINE, ThingStatusDetail.NONE);
                 break;
             default:
-                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, status.getMessage());
+                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, detailMessage);
         }
     }
 


### PR DESCRIPTION
**Problem**
With the Live Data polling interval set to 1 minute, a short internet outage (e.g. router reconnect) can cause the underlying HTTPS request to fail (often with EOFException on Jetty level).

While the stack trace is only visible in debug mode, the Thing still goes OFFLINE and shows an unhelpful status detail such as:
```
decryptedEndPoint@7f511781{l=/xxx.xxx.xxx.xxx:57914,r=monitoring.solaredge.com/104.18.28.187:443,OPEN,fill=-,flush=-,to=59904/0}
```

Because the status was updated immediately on the first failed poll, the Thing could switch to OFFLINE even though the binding was already retrying the request.

**Solution**
This change adjusts the completion handling so the listener/Thing status is updated after the retry logic:
	•	If the HTTP status is not OK, the command is retried (up to MAX_RETRIES)
	•	The listener status update is executed at the end of onComplete(), so the final status reflects the last retry outcome
	•	Successful responses continue to parse JSON and update channels as before

**Result**
	•	Prevents unnecessary/early OFFLINE transitions during short connectivity glitches
	•	Avoids exposing Jetty internal endpoint strings as Thing status detail
	•	Keeps the retry mechanism effective without spamming status changes
	•	No behavioral change for successful polls

**Implementation**
	•	Moved updateListenerStatus() out of the immediate error branch and execute it once at the end of onComplete()
	•	Retry scheduling remains unchanged

**Testing**
	•	Live Data polling: 1 minute
	•	Simulated WAN disconnect/reconnect during polling
	•	Verified that transient failures no longer immediately force the Thing OFFLINE while retries are pending
	•	Verified normal recovery once connectivity is restored