### PR TITLE
[matter] Fix roller shutter percentage conversion

### DIFF
--- a/bundles/org.openhab.binding.matter/src/main/java/org/openhab/binding/matter/internal/controller/devices/converter/WindowCoveringConverter.java
+++ b/bundles/org.openhab.binding.matter/src/main/java/org/openhab/binding/matter/internal/controller/devices/converter/WindowCoveringConverter.java
@@ -78,7 +78,7 @@ public class WindowCoveringConverter extends GenericConverter<WindowCoveringClus
                     break;
             }
         } else if (command instanceof PercentType percentType) {
-            moveCommand(WindowCoveringCluster.goToLiftPercentage(percentType.intValue()));
+            moveCommand(WindowCoveringCluster.goToLiftPercentage(percentType.intValue() * 100));
         }
         super.handleCommand(channelUID, command);
     }

--- a/bundles/org.openhab.binding.matter/src/test/java/org/openhab/binding/matter/internal/controller/devices/converter/WindowCoveringConverterTest.java
+++ b/bundles/org.openhab.binding.matter/src/test/java/org/openhab/binding/matter/internal/controller/devices/converter/WindowCoveringConverterTest.java
@@ -95,7 +95,7 @@ class WindowCoveringConverterTest extends BaseMatterConverterTest {
         ChannelUID channelUID = new ChannelUID("matter:node:test:12345:1#windowcovering-lift");
         converter.handleCommand(channelUID, new PercentType(50));
         verify(mockHandler, times(1)).sendClusterCommand(eq(1), eq(WindowCoveringCluster.CLUSTER_NAME),
-                eq(WindowCoveringCluster.goToLiftPercentage(50)));
+                eq(WindowCoveringCluster.goToLiftPercentage(5000)));
     }
 
     @Test


### PR DESCRIPTION
Fixes #20290

The Matter window covering specification expects lift percentage values in the range 0-10000 (per-10000 units), while OpenHAB's PercentType uses 0-100. The current code was passing the percent value directly without scaling, causing roller shutters to only move 1% for every 100% command sent.

Multiply the PercentType value by 100 before passing to `goToLiftPercentage()` to correctly scale from OpenHAB's 0-100 range to Matter's 0-10000 range.