### PR TITLE
[evohome] Fix deprecated Honeywell URL

### DIFF
--- a/bundles/org.openhab.binding.evohome/src/main/java/org/openhab/binding/evohome/internal/api/EvohomeApiConstants.java
+++ b/bundles/org.openhab.binding.evohome/src/main/java/org/openhab/binding/evohome/internal/api/EvohomeApiConstants.java
@@ -22,9 +22,9 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
  */
 @NonNullByDefault
 public class EvohomeApiConstants {
-    public static final String URL_V2_AUTH = "https://tccna.honeywell.com/Auth/OAuth/Token";
+    public static final String URL_V2_AUTH = "https://tccna.resideo.com/Auth/OAuth/Token"; //tccna.honeywell.com appears to have been deprecated February 2026
 
-    public static final String URL_V2_BASE = "https://tccna.honeywell.com/WebAPI/emea/api/v1/";
+    public static final String URL_V2_BASE = "https://tccna.resideo.com/WebAPI/emea/api/v1/"; //tccna.honeywell.com appears to have been deprecated February 2026
 
     public static final String URL_V2_ACCOUNT = "userAccount";
     public static final String URL_V2_INSTALLATION_INFO = "location/installationInfo?userId=%s&includeTemperatureControlSystems=True";// {userId}


### PR DESCRIPTION
Bugfix: 
It looks like the original Honeywell API URL (https://tccna.honeywell.com) has been deprecated and replaced by https://tccna.resideo.com.

Manually built jar has been confirmed to address the issue (https://community.openhab.org/t/evohome-binding-broken/168649)