### PR TITLE
[shelly] Fix most warnings

### DIFF
--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api/ShellyApiException.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api/ShellyApiException.java
@@ -23,6 +23,7 @@ import java.net.SocketException;
 import java.net.SocketTimeoutException;
 import java.net.UnknownHostException;
 import java.text.MessageFormat;
+import java.util.Locale;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 
@@ -110,7 +111,7 @@ public class ShellyApiException extends Exception {
         Class<?> extype = !isEmpty() ? getCauseClass() : null;
         return (extype != null) && ((extype == TimeoutException.class) || extype == InterruptedException.class
                 || extype == SocketTimeoutException.class
-                || nonNullString(getMessage()).toLowerCase().contains("timeout"));
+                || nonNullString(getMessage()).toLowerCase(Locale.ROOT).contains("timeout"));
     }
 
     public boolean isConnectionError() {

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api/ShellyApiResult.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api/ShellyApiResult.java
@@ -15,6 +15,8 @@ package org.openhab.binding.shelly.internal.api;
 import static org.eclipse.jetty.http.HttpStatus.*;
 import static org.openhab.binding.shelly.internal.api1.Shelly1ApiJsonDTO.*;
 
+import java.util.Locale;
+
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.jetty.client.api.ContentResponse;
@@ -73,7 +75,8 @@ public class ShellyApiResult {
     }
 
     public boolean isHttpTimeout() {
-        return httpCode == -1 || response.toUpperCase().contains(SHELLY_APIERR_TIMEOUT.toLowerCase());
+        return httpCode == -1
+                || response.toUpperCase(Locale.ROOT).contains(SHELLY_APIERR_TIMEOUT.toLowerCase(Locale.ROOT));
     }
 
     public boolean isHttpServerError() {

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api/ShellyDeviceProfile.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api/ShellyDeviceProfile.java
@@ -20,6 +20,7 @@ import static org.openhab.binding.shelly.internal.util.ShellyUtils.*;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -149,10 +150,11 @@ public class ShellyDeviceProfile {
 
         // General settings
         if (getString(device.hostname).isEmpty() && !getString(device.mac).isEmpty()) {
-            device.hostname = device.mac.length() >= 12 ? "shelly-" + device.mac.toUpperCase().substring(6, 11)
+            device.hostname = device.mac.length() >= 12
+                    ? "shelly-" + device.mac.toUpperCase(Locale.ROOT).substring(6, 11)
                     : "unknown";
         }
-        device.mode = getString(settings.mode).toLowerCase();
+        device.mode = getString(settings.mode).toLowerCase(Locale.ROOT);
         name = getString(settings.name);
         hwRev = settings.hwinfo != null ? getString(settings.hwinfo.hwRevision) : "";
         hwBatchId = settings.hwinfo != null ? getString(settings.hwinfo.batchId.toString()) : "";
@@ -190,8 +192,8 @@ public class ShellyDeviceProfile {
     }
 
     public boolean containsEventUrl(String json, String eventType) {
-        String settings = json.toLowerCase();
-        return settings.contains((eventType + SHELLY_EVENTURL_SUFFIX).toLowerCase());
+        String settings = json.toLowerCase(Locale.ROOT);
+        return settings.contains((eventType + SHELLY_EVENTURL_SUFFIX).toLowerCase(Locale.ROOT));
     }
 
     public boolean isInitialized() {

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api/ShellyHttpClient.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api/ShellyHttpClient.java
@@ -176,7 +176,8 @@ public class ShellyHttpClient {
                 } else {
                     if (basicAuth) {
                         String bearer = config.userId + ":" + config.password;
-                        authHeader = HTTP_AUTH_TYPE_BASIC + " " + Base64.getEncoder().encodeToString(bearer.getBytes());
+                        authHeader = HTTP_AUTH_TYPE_BASIC + " "
+                                + Base64.getEncoder().encodeToString(bearer.getBytes(StandardCharsets.UTF_8));
                     }
                 }
                 if (!authHeader.isEmpty()) {

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api1/Shelly1CoIoTProtocol.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api1/Shelly1CoIoTProtocol.java
@@ -17,6 +17,7 @@ import static org.openhab.binding.shelly.internal.api1.Shelly1ApiJsonDTO.*;
 import static org.openhab.binding.shelly.internal.util.ShellyUtils.*;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -78,7 +79,7 @@ public class Shelly1CoIoTProtocol {
         String rGroup = getProfile().numRelays <= 1 ? CHANNEL_GROUP_RELAY_CONTROL
                 : CHANNEL_GROUP_RELAY_CONTROL + rIndex;
 
-        switch (sen.type.toLowerCase()) {
+        switch (sen.type.toLowerCase(Locale.ROOT)) {
             case "b": // BatteryLevel +
                 updateChannel(updates, CHANNEL_GROUP_BATTERY, CHANNEL_SENSOR_BAT_LEVEL,
                         toQuantityType(s.value, 0, Units.PERCENT));
@@ -95,7 +96,7 @@ public class Shelly1CoIoTProtocol {
                         toQuantityType(s.value, DIGITS_LUX, Units.LUX));
                 break;
             case "s": // CatchAll
-                switch (sen.desc.toLowerCase()) {
+                switch (sen.desc.toLowerCase(Locale.ROOT)) {
                     case "state": // Relay status +
                     case "output":
                         updatePower(profile, updates, rIndex, sen, s, sensorUpdates);
@@ -320,7 +321,7 @@ public class Shelly1CoIoTProtocol {
         int idx = -1;
         CoIotDescrBlk blk = blkMap.get(sen.links);
         if (blk != null) {
-            String desc = blk.desc.toLowerCase();
+            String desc = blk.desc.toLowerCase(Locale.ROOT);
             if (desc.startsWith(SHELLY_CLASS_RELAY) || desc.startsWith(SHELLY_CLASS_ROLLER)
                     || desc.startsWith(SHELLY_CLASS_LIGHT) || desc.startsWith(SHELLY_CLASS_EMETER)) {
                 if (desc.contains("_")) { // CoAP v2

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api1/Shelly1CoIoTVersion1.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api1/Shelly1CoIoTVersion1.java
@@ -17,6 +17,7 @@ import static org.openhab.binding.shelly.internal.api1.Shelly1ApiJsonDTO.*;
 import static org.openhab.binding.shelly.internal.util.ShellyUtils.*;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -79,10 +80,10 @@ public class Shelly1CoIoTVersion1 extends Shelly1CoIoTProtocol implements Shelly
         Integer rIndex = Integer.parseInt(sen.links) + 1;
         String rGroup = getProfile().numRelays <= 1 ? CHANNEL_GROUP_RELAY_CONTROL
                 : CHANNEL_GROUP_RELAY_CONTROL + rIndex;
-        switch (sen.type.toLowerCase()) {
+        switch (sen.type.toLowerCase(Locale.ROOT)) {
             case "t": // Temperature +
                 Double value = getDouble(s.value);
-                switch (sen.desc.toLowerCase()) {
+                switch (sen.desc.toLowerCase(Locale.ROOT)) {
                     case "temperature": // Sensor Temp
                         if (getString(getProfile().settings.temperatureUnits)
                                 .equalsIgnoreCase(SHELLY_TEMP_FAHRENHEIT)) {
@@ -126,7 +127,7 @@ public class Shelly1CoIoTVersion1 extends Shelly1CoIoTProtocol implements Shelly
                 updateChannel(updates, mGroup, CHANNEL_LAST_UPDATE, getTimestamp());
                 break;
             case "s" /* CatchAll */:
-                switch (sen.desc.toLowerCase()) {
+                switch (sen.desc.toLowerCase(Locale.ROOT)) {
                     case "overtemp":
                         if (s.value == 1) {
                             thingHandler.postEvent(ALARM_TYPE_OVERTEMP, true);
@@ -256,7 +257,7 @@ public class Shelly1CoIoTVersion1 extends Shelly1CoIoTProtocol implements Shelly
         if (sen.type == null) {
             sen.type = "";
         }
-        String desc = sen.desc.toLowerCase();
+        String desc = sen.desc.toLowerCase(Locale.ROOT);
 
         // RGBW2 reports Power_0, Power_1, Power_2, Power_3; same for VSwitch and Brightness, all of them linkted to L:0
         // we break it up to Power with L:0, Power with L:1...
@@ -277,7 +278,7 @@ public class Shelly1CoIoTVersion1 extends Shelly1CoIoTProtocol implements Shelly
             }
         }
 
-        switch (sen.type.toLowerCase()) {
+        switch (sen.type.toLowerCase(Locale.ROOT)) {
             case "w": // old devices/firmware releases use "W", new ones "P"
                 sen.type = "P";
                 sen.desc = "Power";
@@ -302,7 +303,7 @@ public class Shelly1CoIoTVersion1 extends Shelly1CoIoTProtocol implements Shelly
                 break;
         }
 
-        switch (sen.desc.toLowerCase()) {
+        switch (sen.desc.toLowerCase(Locale.ROOT)) {
             case "motion": // fix acc to spec it's T=M
                 sen.type = "M";
                 sen.desc = "Motion";
@@ -325,13 +326,13 @@ public class Shelly1CoIoTVersion1 extends Shelly1CoIoTProtocol implements Shelly
             case "e cnt 1 [w-min]":
             case "e cnt 2 [w-min]":
             case "e cnt total [w-min]": // 4 Pro
-                sen.desc = sen.desc.toLowerCase().replace("e cnt", "energy counter");
+                sen.desc = sen.desc.toLowerCase(Locale.ROOT).replace("e cnt", "energy counter");
                 break;
 
         }
 
         if (sen.desc.isEmpty()) {
-            switch (sen.type.toLowerCase()) {
+            switch (sen.type.toLowerCase(Locale.ROOT)) {
                 case "p":
                     sen.desc = "Power";
                     break;

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api1/Shelly1CoIoTVersion2.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api1/Shelly1CoIoTVersion2.java
@@ -22,6 +22,7 @@ import static org.openhab.binding.shelly.internal.api1.Shelly1ApiJsonDTO.*;
 import static org.openhab.binding.shelly.internal.util.ShellyUtils.*;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -352,7 +353,7 @@ public class Shelly1CoIoTVersion2 extends Shelly1CoIoTProtocol implements Shelly
                 reason = getString(s.valueStr);
                 updateChannel(updates, CHANNEL_GROUP_ROL_CONTROL, CHANNEL_ROL_CONTROL_STOPR, getStringType(reason));
                 if (!reason.isEmpty() && !reason.equalsIgnoreCase(SHELLY_API_STOPR_NORMAL)) {
-                    thingHandler.postEvent("ROLLER_" + reason.toUpperCase(), true);
+                    thingHandler.postEvent("ROLLER_" + reason.toUpperCase(Locale.ROOT), true);
                 }
             case "6106": // A, flood, 0/1, -1
                 updateChannel(updates, CHANNEL_GROUP_SENSOR, CHANNEL_SENSOR_FLOOD, OnOffType.from(value == 1));

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api1/Shelly1CoapHandler.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api1/Shelly1CoapHandler.java
@@ -20,6 +20,7 @@ import java.net.SocketException;
 import java.net.UnknownHostException;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.TreeMap;
 
@@ -185,7 +186,8 @@ public class Shelly1CoapHandler implements Shelly1CoapListener {
                     if (devid.contains("#") && profile.device.mac != null) {
                         // Format: <device type>#<mac address>#<coap version>
                         String macid = substringBetween(devid, "#", "#");
-                        if (getString(profile.device.mac).toUpperCase().contains(macid.toUpperCase())) {
+                        if (getString(profile.device.mac).toUpperCase(Locale.ROOT)
+                                .contains(macid.toUpperCase(Locale.ROOT))) {
                             match = true;
                             break;
                         }

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api1/Shelly1CoapJSonDTO.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api1/Shelly1CoapJSonDTO.java
@@ -15,6 +15,7 @@ package org.openhab.binding.shelly.internal.api1;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.SerializedName;
@@ -148,7 +149,7 @@ public class Shelly1CoapJSonDTO {
                     CoIotDescrBlk blk = new CoIotDescrBlk();
                     in.beginObject();
                     while (in.hasNext()) {
-                        switch (in.nextName().toUpperCase()) {
+                        switch (in.nextName().toUpperCase(Locale.ROOT)) {
                             case "I":
                                 blk.id = in.nextString();
                                 break;
@@ -181,7 +182,7 @@ public class Shelly1CoapJSonDTO {
                     in.beginObject();
                     while (in.hasNext()) {
                         String tag = in.nextName();
-                        switch (tag.toUpperCase()) {
+                        switch (tag.toUpperCase(Locale.ROOT)) {
                             case "I":
                                 sen.id = in.nextString();
                                 break;

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api1/Shelly1EventServlet.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api1/Shelly1EventServlet.java
@@ -87,19 +87,19 @@ public class Shelly1EventServlet extends HttpServlet {
             Map<String, String[]> parameters = request.getParameterMap();
             logger.debug("Shelly1EventServlet: {} Request from {}:{}{}?{}", request.getProtocol(), ipAddress,
                     request.getRemotePort(), path, parameters.toString());
-            if (!path.toLowerCase().startsWith(SHELLY1_CALLBACK_URI) || !path.contains("/event/shelly")) {
+            if (!path.toLowerCase(Locale.ROOT).startsWith(SHELLY1_CALLBACK_URI) || !path.contains("/event/shelly")) {
                 logger.warn("Shelly1EventServlet received unknown request: path = {}", path);
                 return;
             }
 
-            deviceName = substringBetween(path, "/event/", "/").toLowerCase();
+            deviceName = substringBetween(path, "/event/", "/").toLowerCase(Locale.ROOT);
             if (path.contains("/" + EVENT_TYPE_RELAY + "/") || path.contains("/" + EVENT_TYPE_ROLLER + "/")
                     || path.contains("/" + EVENT_TYPE_LIGHT + "/")) {
-                index = substringAfterLast(path, "/").toLowerCase();
+                index = substringAfterLast(path, "/").toLowerCase(Locale.ROOT);
                 type = substringBetween(path, deviceName + "/", "/" + index);
             } else {
                 index = "";
-                type = substringAfterLast(path, "/").toLowerCase();
+                type = substringAfterLast(path, "/").toLowerCase(Locale.ROOT);
             }
             logger.trace("{}: Process event of type type={}, index={}", deviceName, type, index);
 

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api1/Shelly1HttpApi.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api1/Shelly1HttpApi.java
@@ -20,6 +20,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -191,7 +192,8 @@ public class Shelly1HttpApi extends ShellyHttpClient implements ShellyApiInterfa
 
     @Override
     public void setRelayTurn(int id, String turnMode) throws ShellyApiException {
-        callApi(getControlUriPrefix(id) + "?" + SHELLY_LIGHT_TURN + "=" + turnMode.toLowerCase(), String.class);
+        callApi(getControlUriPrefix(id) + "?" + SHELLY_LIGHT_TURN + "=" + turnMode.toLowerCase(Locale.ROOT),
+                String.class);
     }
 
     @Override
@@ -201,7 +203,7 @@ public class Shelly1HttpApi extends ShellyHttpClient implements ShellyApiInterfa
 
     @Override
     public ShellyShortLightStatus setLightTurn(int id, String turnMode) throws ShellyApiException {
-        return callApi(getControlUriPrefix(id) + "?" + SHELLY_LIGHT_TURN + "=" + turnMode.toLowerCase(),
+        return callApi(getControlUriPrefix(id) + "?" + SHELLY_LIGHT_TURN + "=" + turnMode.toLowerCase(Locale.ROOT),
                 ShellyShortLightStatus.class);
     }
 
@@ -249,7 +251,7 @@ public class Shelly1HttpApi extends ShellyHttpClient implements ShellyApiInterfa
             status.charger = profile.settings.externalPower != 0;
         }
         if (status.tmp != null && status.tmp.tC == null && status.tmp.value != null) { // Motion is is missing tC and tF
-            status.tmp.tC = getString(status.tmp.units).toUpperCase().equals(SHELLY_TEMP_FAHRENHEIT)
+            status.tmp.tC = getString(status.tmp.units).toUpperCase(Locale.ROOT).equals(SHELLY_TEMP_FAHRENHEIT)
                     ? ImperialUnits.FAHRENHEIT.getConverterTo(SIUnits.CELSIUS).convert(status.tmp.value).doubleValue()
                     : status.tmp.value;
         }

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/Shelly2ApiClient.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/Shelly2ApiClient.java
@@ -20,6 +20,7 @@ import static org.openhab.binding.shelly.internal.util.ShellyUtils.*;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Random;
@@ -471,7 +472,7 @@ public class Shelly2ApiClient extends ShellyHttpClient implements ShellyDiscover
         rsettings.autoOn = getBool(cs.autoOn) ? cs.autoOnDelay : 0;
         rsettings.autoOff = getBool(cs.autoOff) ? cs.autoOffDelay : 0;
         rsettings.hasTimer = false;
-        rsettings.btnType = mapValue(MAP_INMODE_BTNTYPE, getString(cs.mode).toLowerCase());
+        rsettings.btnType = mapValue(MAP_INMODE_BTNTYPE, getString(cs.mode).toLowerCase(Locale.ROOT));
         relays.add(rsettings);
     }
 

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/Shelly2ApiJsonDTO.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/Shelly2ApiJsonDTO.java
@@ -350,7 +350,7 @@ public class Shelly2ApiJsonDTO {
             @SerializedName("blink_mode_selector")
             public String blinkModeSelector;
             @SerializedName("phase_selector")
-            public String phase_selector;
+            public String phaseSelector;
             @SerializedName("monitor_phase_sequence")
             public Boolean monitorPhaseSequence;
         }
@@ -363,7 +363,7 @@ public class Shelly2ApiJsonDTO {
         public class Shelly2DevConfigCover {
             public class Shelly2DeviceConfigCoverMotor {
                 @SerializedName("idle_power_thr")
-                public Double idle_powerThr;
+                public Double idlePowerThr;
             }
 
             public class Shelly2DeviceConfigCoverSafetySwitch {
@@ -893,7 +893,7 @@ public class Shelly2ApiJsonDTO {
             @SerializedName("fs_free")
             public Long fsFree;
             @SerializedName("cfg_rev")
-            public Integer cfg_rev;
+            public Integer cfgRev;
             @SerializedName("available_updates")
             public Shelly2DeviceStatusSysAvlUpdate availableUpdates;
             @SerializedName("webhook_rev")
@@ -1160,12 +1160,12 @@ public class Shelly2ApiJsonDTO {
         public Shelly2RpcMessageError error;
     }
 
-    public static String SHELLY2_AUTHDEF_USER = "admin";
-    public static String SHELLY2_AUTHTTYPE_DIGEST = "digest";
-    public static String SHELLY2_AUTHTTYPE_STRING = "string";
-    public static String SHELLY2_AUTHALG_SHA256 = "SHA-256";
+    public static final String SHELLY2_AUTHDEF_USER = "admin";
+    public static final String SHELLY2_AUTHTTYPE_DIGEST = "digest";
+    public static final String SHELLY2_AUTHTTYPE_STRING = "string";
+    public static final String SHELLY2_AUTHALG_SHA256 = "SHA-256";
     // = ':auth:'+HexHash("dummy_method:dummy_uri");
-    public static String SHELLY2_AUTH_NOISE = "6370ec69915103833b5222b368555393393f098bfbfbb59f47e0590af135f062";
+    public static final String SHELLY2_AUTH_NOISE = "6370ec69915103833b5222b368555393393f098bfbfbb59f47e0590af135f062";
 
     public static class Shelly2AuthChallenge { // on 401 message contains the auth info
         @SerializedName("auth_type")

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/Shelly2ApiRpc.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/Shelly2ApiRpc.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -433,7 +434,7 @@ public class Shelly2ApiRpc extends Shelly2ApiClient implements ShellyApiInterfac
             if (cl != null) {
                 try (InputStream inputStream = cl.getResourceAsStream(file)) {
                     if (inputStream != null) {
-                        code = new BufferedReader(new InputStreamReader(inputStream)).lines()
+                        code = new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8)).lines()
                                 .collect(Collectors.joining("\n"));
                     }
                 } catch (IOException | UncheckedIOException e) {
@@ -482,7 +483,10 @@ public class Shelly2ApiRpc extends Shelly2ApiClient implements ShellyApiInterfac
                 if (ourId == -1) {
                     // find free script id
                     ourId = 0;
-                    for (ourId = 1; ourId <= MAX_SCRIPT_ID && testScriptId(scriptList, ourId); ourId++) {
+                    for (ourId = 1; ourId <= MAX_SCRIPT_ID; ourId++) {
+                        if (!testScriptId(scriptList, ourId)) {
+                            break;
+                        }
                     }
                 }
                 if (ourId <= MAX_SCRIPT_ID) {

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/ShellyBluApi.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/ShellyBluApi.java
@@ -238,10 +238,9 @@ public class ShellyBluApi extends Shelly2ApiRpc {
                                 sensorData.tmp.units = SHELLY_TEMP_CELSIUS;
                                 sensorData.tmp.isValid = true;
                                 sensorData.tmp.tC = e.blu.temperatures[0];
-                            } else {
-                                // BLU TRV reports current temp and target temp
-                                // However, we don't support BLU TRV yet, so ignore
                             }
+                            // BLU TRV reports current temp and target temp
+                            // However, we don't support BLU TRV yet, so ignore
                         }
                         if (e.blu.humidity != null) {
                             sensorData.hum.value = e.blu.humidity;

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/ShellyBluJsonDTO.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/ShellyBluJsonDTO.java
@@ -83,6 +83,7 @@ public class ShellyBluJsonDTO {
         public Long firmware32;
 
         public Integer rssi;
-        public Integer tx_power;
+        @SerializedName("tx_power")
+        public Integer txPower;
     }
 }

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/discovery/ShellyMDNSDiscoveryParticipant.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/discovery/ShellyMDNSDiscoveryParticipant.java
@@ -18,6 +18,7 @@ import static org.openhab.binding.shelly.internal.util.ShellyUtils.*;
 
 import java.io.IOException;
 import java.net.Inet4Address;
+import java.util.Locale;
 import java.util.Set;
 import java.util.regex.Pattern;
 
@@ -114,8 +115,8 @@ public class ShellyMDNSDiscoveryParticipant implements MDNSDiscoveryParticipant 
 
     @Override
     public @Nullable DiscoveryResult createResult(final ServiceInfo service) {
-        String serviceName = service.getName().toLowerCase(); // Shelly Duo: Name starts with "Shelly" rather than
-                                                              // "shelly"
+        // Shelly Duo: Name starts with "Shelly" rather than "shelly"
+        String serviceName = service.getName().toLowerCase(Locale.ROOT);
         if (!isValidShellyServiceName(serviceName)) {
             return null;
         }

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/discovery/ShellyThingCreator.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/discovery/ShellyThingCreator.java
@@ -18,6 +18,7 @@ import static org.openhab.binding.shelly.internal.api1.Shelly1ApiJsonDTO.*;
 import static org.openhab.binding.shelly.internal.util.ShellyUtils.*;
 import static org.openhab.core.thing.Thing.PROPERTY_MODEL_ID;
 
+import java.util.Locale;
 import java.util.Map;
 import java.util.TreeMap;
 
@@ -69,7 +70,7 @@ public class ShellyThingCreator {
         if (THING_TYPE_SHELLYPROTECTED_STR.equals(serviceName)) {
             return THING_TYPE_SHELLYPROTECTED;
         }
-        String serviceNameLowerCase = serviceName.toLowerCase();
+        String serviceNameLowerCase = serviceName.toLowerCase(Locale.ROOT);
         String type = substringBefore(serviceNameLowerCase, "-");
         if (type.isEmpty()) {
             throw new IllegalArgumentException("Invalid serviceName format: " + serviceName);
@@ -110,7 +111,7 @@ public class ShellyThingCreator {
 
     public static void addBluThing(String gateway, Shelly2NotifyBluEventData data, ShellyThingTable thingTable) {
         String model = getString(data.name);
-        String bluClass = substringBefore(model, "-").toUpperCase();
+        String bluClass = substringBefore(model, "-").toUpperCase(Locale.ROOT);
         String mac = getString(data.addr).replaceAll(":", "");
 
         ThingTypeUID thingTypeUID = THING_TYPE_BY_DEVICE_TYPE.get(model);
@@ -155,7 +156,7 @@ public class ShellyThingCreator {
         if (uid != null) {
             String serviceName = uid.getId();
             if (!serviceName.isEmpty()) {
-                return serviceName + "-" + mac.replaceAll(":", "").toLowerCase();
+                return serviceName + "-" + mac.replaceAll(":", "").toLowerCase(Locale.ROOT);
             }
         }
 

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/handler/ShellyBaseHandler.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/handler/ShellyBaseHandler.java
@@ -22,6 +22,7 @@ import static org.openhab.core.thing.Thing.*;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.concurrent.ScheduledFuture;
@@ -296,8 +297,8 @@ public abstract class ShellyBaseHandler extends BaseThingHandler
         profile.initFromThingType(thing.getThingTypeUID());
         logger.debug(
                 "{}: Start initializing for thing {}, type {}, Device address {}, Gen2: {}, isBlu: {}, alwaysOn: {}, hasBattery: {}, CoIoT: {}",
-                thingName, getThing().getLabel(), thingType, config.deviceAddress.toUpperCase(), gen2, profile.isBlu,
-                profile.alwaysOn, profile.hasBattery, config.eventsCoIoT);
+                thingName, getThing().getLabel(), thingType, config.deviceAddress.toUpperCase(Locale.ROOT), gen2,
+                profile.isBlu, profile.alwaysOn, profile.hasBattery, config.eventsCoIoT);
         if (config.deviceAddress.isEmpty()) {
             setThingOfflineAndDisconnect(ThingStatusDetail.CONFIGURATION_ERROR,
                     "config-status.error.missing-device-address");
@@ -328,7 +329,7 @@ public abstract class ShellyBaseHandler extends BaseThingHandler
             return false;
         }
         if (config.realm.isEmpty()) {
-            config.realm = getString(device.hostname).toLowerCase();
+            config.realm = getString(device.hostname).toLowerCase(Locale.ROOT);
             api.setConfig(thingName, config); // update config
         }
 
@@ -835,7 +836,7 @@ public abstract class ShellyBaseHandler extends BaseThingHandler
 
         if (force || !lastAlarm.equals(event)
                 || (lastAlarm.equals(event) && now() > stats.lastAlarmTs + HEALTH_CHECK_INTERVAL_SEC)) {
-            switch (event.toUpperCase()) {
+            switch (event.toUpperCase(Locale.ROOT)) {
                 case "":
                 case "0": // DW2 1.8
                 case SHELLY_WAKEUPT_SENSOR:
@@ -854,7 +855,7 @@ public abstract class ShellyBaseHandler extends BaseThingHandler
                 default:
                     logger.debug("{}: {}", thingName, messages.get("event.triggered", event));
                     triggerChannel(channelId, event);
-                    cache.updateChannel(channelId, getStringType(event.toUpperCase()));
+                    cache.updateChannel(channelId, getStringType(event.toUpperCase(Locale.ROOT)));
                     stats.lastAlarm = event;
                     stats.lastAlarmTs = (long) now();
                     stats.alarms++;
@@ -973,7 +974,7 @@ public abstract class ShellyBaseHandler extends BaseThingHandler
                     case SHELLY_EVENT_ALARM_OFF:
                     case SHELLY_EVENT_VIBRATION: // DW2
                         channel = CHANNEL_SENSOR_ALARM_STATE;
-                        payload = event.toUpperCase();
+                        payload = event.toUpperCase(Locale.ROOT);
                         break;
 
                     default:
@@ -981,11 +982,11 @@ public abstract class ShellyBaseHandler extends BaseThingHandler
                 }
 
                 if (!onoff.isEmpty()) {
-                    updateChannel(group, onoff, OnOffType.from(event.toLowerCase().contains("_on")));
+                    updateChannel(group, onoff, OnOffType.from(event.toLowerCase(Locale.ROOT).contains("_on")));
                 }
                 if (!payload.isEmpty()) {
                     // Pass event to trigger channel
-                    payload = payload.toUpperCase();
+                    payload = payload.toUpperCase(Locale.ROOT);
                     logger.debug("{}: Post event {}", thingName, payload);
                     triggerChannel(mkChannelId(group, channel), payload);
                 }
@@ -1012,7 +1013,7 @@ public abstract class ShellyBaseHandler extends BaseThingHandler
         final Map<String, String> properties = getThing().getProperties();
         thingName = getString(properties.get(PROPERTY_SERVICE_NAME));
         if (thingName.isEmpty()) {
-            thingName = getString(thingType + "-" + getString(getThing().getUID().getId())).toLowerCase();
+            thingName = getString(thingType + "-" + getString(getThing().getUID().getId())).toLowerCase(Locale.ROOT);
         }
 
         config = getConfigAs(ShellyThingConfiguration.class);
@@ -1020,13 +1021,13 @@ public abstract class ShellyBaseHandler extends BaseThingHandler
             config.deviceAddress = config.deviceIp;
         }
         if (config.deviceAddress.isEmpty()) {
-            logger.debug("{}: IP/MAC address for the device must not be empty", thingName); // may not set in .things
-                                                                                            // file
+            // may not be set in .things file
+            logger.debug("{}: IP/MAC address for the device must not be empty", thingName);
             return false;
         }
 
-        config.deviceAddress = config.deviceAddress.toLowerCase().replace(":", ""); // remove : from MAC address and
-                                                                                    // convert to lower case
+        // remove : from MAC address and convert to lower case
+        config.deviceAddress = config.deviceAddress.toLowerCase(Locale.ROOT).replace(":", "");
         if (!config.deviceIp.isEmpty()) {
             try {
                 String ip = config.deviceIp.contains(":") ? substringBefore(config.deviceIp, ":") : config.deviceIp;
@@ -1272,7 +1273,7 @@ public abstract class ShellyBaseHandler extends BaseThingHandler
             changed = updateChannel(CHANNEL_GROUP_DEV_STATUS, CHANNEL_DEVST_WAKEUP, getStringType(reason));
             changed |= !lastWakeupReason.isEmpty() && !lastWakeupReason.equals(newVal);
             if (changed) {
-                postEvent(reason.toUpperCase(), true);
+                postEvent(reason.toUpperCase(Locale.ROOT), true);
             }
             lastWakeupReason = newVal;
         }

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/handler/ShellyBluHandler.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/handler/ShellyBluHandler.java
@@ -29,7 +29,7 @@ import org.slf4j.LoggerFactory;
  */
 @NonNullByDefault
 public class ShellyBluHandler extends ShellyBaseHandler {
-    private static final Logger LOGGER = LoggerFactory.getLogger(ShellyBluHandler.class);
+    private final Logger logger = LoggerFactory.getLogger(ShellyBluHandler.class);
 
     public ShellyBluHandler(final Thing thing, final ShellyTranslationProvider translationProvider,
             final ShellyBindingConfiguration bindingConfig, final ShellyThingTable thingTable,
@@ -39,7 +39,7 @@ public class ShellyBluHandler extends ShellyBaseHandler {
 
     @Override
     public void initialize() {
-        LOGGER.debug("Thing is using  {}", this.getClass());
+        logger.debug("Thing is using  {}", this.getClass());
         super.initialize();
     }
 }

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/handler/ShellyComponents.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/handler/ShellyComponents.java
@@ -17,6 +17,7 @@ import static org.openhab.binding.shelly.internal.api1.Shelly1ApiJsonDTO.*;
 import static org.openhab.binding.shelly.internal.util.ShellyUtils.*;
 
 import java.util.List;
+import java.util.Locale;
 
 import javax.measure.MetricPrefix;
 
@@ -416,7 +417,7 @@ public class ShellyComponents {
                 updated |= changed;
             }
             if (sdata.tmp != null && getBool(sdata.tmp.isValid)) {
-                Double temp = getString(sdata.tmp.units).toUpperCase().equals(SHELLY_TEMP_CELSIUS)
+                Double temp = getString(sdata.tmp.units).toUpperCase(Locale.ROOT).equals(SHELLY_TEMP_CELSIUS)
                         ? getDouble(sdata.tmp.tC)
                         : getDouble(sdata.tmp.tF);
                 updated |= updateTempChannel(thingHandler, CHANNEL_GROUP_SENSOR, CHANNEL_SENSOR_TEMP,

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/handler/ShellyLightHandler.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/handler/ShellyLightHandler.java
@@ -17,6 +17,7 @@ import static org.openhab.binding.shelly.internal.api1.Shelly1ApiJsonDTO.*;
 import static org.openhab.binding.shelly.internal.util.ShellyUtils.*;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.TreeMap;
 
@@ -277,7 +278,7 @@ public class ShellyLightHandler extends ShellyBaseHandler {
     }
 
     private boolean handleFullColor(ShellyColorUtils col, Command command) throws IllegalArgumentException {
-        String color = command.toString().toLowerCase();
+        String color = command.toString().toLowerCase(Locale.ROOT);
         if (color.contains(",")) {
             col.fromRGBW(color);
         } else if (color.equals(SHELLY_COLOR_RED)) {

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/manager/ShellyManager.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/manager/ShellyManager.java
@@ -17,6 +17,7 @@ import static org.openhab.binding.shelly.internal.util.ShellyUtils.getString;
 
 import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.Locale;
 import java.util.Map;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -91,7 +92,7 @@ public class ShellyManager {
 
     public ShellyMgrResponse generateContent(String path, Map<String, String[]> parameters) throws ShellyApiException {
         for (Map.Entry<String, ShellyManagerPage> page : pages.entrySet()) {
-            if (path.toLowerCase().startsWith(page.getKey())) {
+            if (path.toLowerCase(Locale.ROOT).startsWith(page.getKey())) {
                 ShellyManagerPage p = page.getValue();
                 return p.generateContent(path, parameters);
             }

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/manager/ShellyManagerActionPage.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/manager/ShellyManagerActionPage.java
@@ -427,10 +427,9 @@ public class ShellyManagerActionPage extends ShellyManagerPage {
 
         if (!gen2 && profile.extFeatures) {
             list.put(ACTION_OTACHECK, "Check for Update");
-            boolean debug_enable = getBool(profile.settings.debugEnable);
-            list.put(!debug_enable ? ACTION_ENDEBUG : ACTION_DISDEBUG,
-                    !debug_enable ? "Enable Debug" : "Disable Debug");
-            if (debug_enable) {
+            boolean debugEnable = getBool(profile.settings.debugEnable);
+            list.put(!debugEnable ? ACTION_ENDEBUG : ACTION_DISDEBUG, !debugEnable ? "Enable Debug" : "Disable Debug");
+            if (debugEnable) {
                 list.put(ACTION_GETDEB, "Get Debug log");
                 list.put(ACTION_GETDEB1, "Get Debug log1");
             }

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/manager/ShellyManagerOverviewPage.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/manager/ShellyManagerOverviewPage.java
@@ -19,6 +19,7 @@ import static org.openhab.binding.shelly.internal.util.ShellyUtils.*;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.TreeMap;
 
@@ -62,9 +63,9 @@ public class ShellyManagerOverviewPage extends ShellyManagerPage {
 
     @Override
     public ShellyMgrResponse generateContent(String path, Map<String, String[]> parameters) throws ShellyApiException {
-        String filter = getUrlParm(parameters, URLPARM_FILTER).toLowerCase();
-        String action = getUrlParm(parameters, URLPARM_ACTION).toLowerCase();
-        String uidParm = getUrlParm(parameters, URLPARM_UID).toLowerCase();
+        String filter = getUrlParm(parameters, URLPARM_FILTER).toLowerCase(Locale.ROOT);
+        String action = getUrlParm(parameters, URLPARM_ACTION).toLowerCase(Locale.ROOT);
+        String uidParm = getUrlParm(parameters, URLPARM_UID).toLowerCase(Locale.ROOT);
 
         logger.debug("Generating overview for {} devices", getThingHandlers().size());
 

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/manager/ShellyManagerPage.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/manager/ShellyManagerPage.java
@@ -22,8 +22,10 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Timer;
 import java.util.TimerTask;
@@ -173,7 +175,7 @@ public class ShellyManagerPage {
         if (cl != null) {
             try (InputStream inputStream = cl.getResourceAsStream(file)) {
                 if (inputStream != null) {
-                    html = new BufferedReader(new InputStreamReader(inputStream)).lines()
+                    html = new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8)).lines()
                             .collect(Collectors.joining("\n"));
                     htmlTemplates.put(template, html);
                 }
@@ -332,7 +334,7 @@ public class ShellyManagerPage {
             default:
                 statusIcon = ts.toString();
         }
-        properties.put(ATTRIBUTE_STATUS_ICON, statusIcon.toLowerCase());
+        properties.put(ATTRIBUTE_STATUS_ICON, statusIcon.toLowerCase(Locale.ROOT));
 
         return properties;
     }

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/manager/ShellyManagerServlet.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/manager/ShellyManagerServlet.java
@@ -18,6 +18,7 @@ import static org.openhab.binding.shelly.internal.util.ShellyUtils.getString;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintWriter;
+import java.util.Locale;
 import java.util.Map;
 
 import javax.servlet.Servlet;
@@ -77,7 +78,7 @@ public class ShellyManagerServlet extends HttpServlet {
             return;
         }
 
-        String path = getString(request.getRequestURI()).toLowerCase();
+        String path = getString(request.getRequestURI()).toLowerCase(Locale.ROOT);
         String ipAddress = request.getHeader("HTTP_X_FORWARDED_FOR");
         ShellyMgrResponse output = new ShellyMgrResponse();
         PrintWriter print = null;
@@ -89,7 +90,7 @@ public class ShellyManagerServlet extends HttpServlet {
             Map<String, String[]> parameters = request.getParameterMap();
             logger.debug("{}: {} Request from {}:{}{}?{}", className, request.getProtocol(), ipAddress,
                     request.getRemotePort(), path, parameters.toString());
-            if (!path.toLowerCase().startsWith(SERVLET_URI)) {
+            if (!path.toLowerCase(Locale.ROOT).startsWith(SERVLET_URI)) {
                 logger.warn("{} received unknown request: path = {}", className, path);
                 return;
             }

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/util/ShellyUtils.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/util/ShellyUtils.java
@@ -23,7 +23,6 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.time.DateTimeException;
 import java.time.Instant;
-import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
@@ -302,7 +301,7 @@ public class ShellyUtils {
     public static DateTimeType getTimestamp(String zone, long timestamp) {
         try {
             ZoneId zoneId = !zone.isEmpty() ? ZoneId.of(zone) : ZoneId.systemDefault();
-            ZonedDateTime zdt = LocalDateTime.now().atZone(zoneId);
+            ZonedDateTime zdt = ZonedDateTime.now(zoneId);
             int delta = zdt.getOffset().getTotalSeconds();
             return new DateTimeType(Instant.ofEpochSecond(timestamp - delta));
         } catch (DateTimeException e) {

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/util/ShellyVersionDTO.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/util/ShellyVersionDTO.java
@@ -12,6 +12,8 @@
  */
 package org.openhab.binding.shelly.internal.util;
 
+import java.util.Locale;
+
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 
@@ -162,7 +164,8 @@ public class ShellyVersionDTO {
         if (version == null) {
             return false;
         }
-        return version.isEmpty() || version.contains("???") || version.toLowerCase().contains("master")
-                || (version.toLowerCase().contains("-rc") || version.toLowerCase().contains("beta"));
+        return version.isEmpty() || version.contains("???") || version.toLowerCase(Locale.ROOT).contains("master")
+                || (version.toLowerCase(Locale.ROOT).contains("-rc")
+                        || version.toLowerCase(Locale.ROOT).contains("beta"));
     }
 }


### PR DESCRIPTION
I've been going through the binding and fixed the warnings that can be fixed easily, without any major modification of the code.

This is the "before" report:

<img width="1572" height="487" alt="image" src="https://github.com/user-attachments/assets/4b719d71-3cd2-4ec6-960c-45ff75ae764f" />

This is the "after" report:

<img width="1569" height="243" alt="image" src="https://github.com/user-attachments/assets/709d10c2-b9b6-4896-bd6c-4cac7bb7cda7" />

There are a few left that can't be handled, the two TODO warnings are temporary - planned PRs will get rid of them. The static logger warning must either be suppressed, lived with, or the name of the class must be changed to end with `Util` (because the rules allow static loggers in such classes). The class is in effect a utility class, the methods that log are static, so the logger must be static.

The timezone warning can't easily be avoided as things are now, but could be avoided with https://github.com/openhab/openhab-core/pull/5357 merged, by using `DateTimeType.now().truncatedTo(ChronoUnit.SECONDS)`.