### PR TITLE
Change deprecated `required` element to attribute

### DIFF
--- a/bundles/org.openhab.binding.broadlink/src/main/resources/OH-INF/config/config.xml
+++ b/bundles/org.openhab.binding.broadlink/src/main/resources/OH-INF/config/config.xml
@@ -6,36 +6,31 @@
 	https://openhab.org/schemas/config-description-1.0.0.xsd">
 
 	<config-description uri="thing-type:broadlink:config">
-		<parameter name="ipAddress" type="text">
+		<parameter name="ipAddress" type="text" required="true">
 			<context>network-address</context>
 			<label>Network Address</label>
 			<description>IP address or hostname of the device.</description>
-			<required>true</required>
 		</parameter>
-		<parameter name="staticIp" type="boolean">
+		<parameter name="staticIp" type="boolean" required="true">
 			<context>network-address</context>
 			<label>Static IP</label>
 			<description>Will the device always be given this network address?</description>
-			<required>true</required>
 			<advanced>true</advanced>
 			<default>true</default>
 		</parameter>
-		<parameter name="port" type="integer" min="1" max="65535">
+		<parameter name="port" type="integer" min="1" max="65535" required="true">
 			<default>80</default>
 			<label>Network Port</label>
 			<description>Network port of the device.</description>
-			<required>true</required>
 			<advanced>true</advanced>
 		</parameter>
-		<parameter name="macAddress" type="text">
+		<parameter name="macAddress" type="text" required="true">
 			<label>MAC Address</label>
 			<description>MAC address of the device.</description>
-			<required>true</required>
 		</parameter>
-		<parameter name="pollingInterval" type="integer" min="1" step="1">
+		<parameter name="pollingInterval" type="integer" min="1" step="1" required="true">
 			<label>Polling Interval</label>
 			<description>The interval in seconds for polling the status of the device.</description>
-			<required>true</required>
 			<default>30</default>
 			<advanced>true</advanced>
 		</parameter>

--- a/bundles/org.openhab.binding.broadlink/src/main/resources/OH-INF/config/rm-config.xml
+++ b/bundles/org.openhab.binding.broadlink/src/main/resources/OH-INF/config/rm-config.xml
@@ -6,44 +6,38 @@
 	https://openhab.org/schemas/config-description-1.0.0.xsd">
 
 	<config-description uri="thing-type:broadlink:rmconfig">
-		<parameter name="ipAddress" type="text">
+		<parameter name="ipAddress" type="text" required="true">
 			<context>network-address</context>
 			<label>Network Address</label>
 			<description>IP address or hostname of the device.</description>
-			<required>true</required>
 		</parameter>
-		<parameter name="staticIp" type="boolean">
+		<parameter name="staticIp" type="boolean" required="true">
 			<context>network-address</context>
 			<label>Static IP</label>
 			<description>Will the device always be given this network address?</description>
-			<required>true</required>
 			<advanced>true</advanced>
 			<default>true</default>
 		</parameter>
-		<parameter name="port" type="integer" min="1" max="65535">
+		<parameter name="port" type="integer" min="1" max="65535" required="true">
 			<default>80</default>
 			<label>Network Port</label>
 			<description>Network port of the device.</description>
-			<required>true</required>
 			<advanced>true</advanced>
 		</parameter>
-		<parameter name="macAddress" type="text">
+		<parameter name="macAddress" type="text" required="true">
 			<label>MAC Address</label>
 			<description>MAC address of the device.</description>
-			<required>true</required>
 		</parameter>
-		<parameter name="pollingInterval" type="integer" min="30" step="1">
+		<parameter name="pollingInterval" type="integer" min="30" step="1" required="true">
 			<label>Polling Interval</label>
 			<description>The interval in seconds for polling the status of the device.</description>
-			<required>true</required>
 			<default>30</default>
 			<advanced>true</advanced>
 		</parameter>
-		<parameter name="nameOfCommandToLearn" type="text">
+		<parameter name="nameOfCommandToLearn" type="text" required="true">
 			<label>Name of IR/RF command to learn</label>
 			<description>Enter name of the IR or RF command to learn when using the learn Command channel</description>
 			<default>DEVICE_ON</default>
-			<required>true</required>
 		</parameter>
 	</config-description>
 </config-description:config-descriptions>

--- a/bundles/org.openhab.binding.broadlink/src/main/resources/OH-INF/config/rmpro-config.xml
+++ b/bundles/org.openhab.binding.broadlink/src/main/resources/OH-INF/config/rmpro-config.xml
@@ -6,44 +6,38 @@
 	https://openhab.org/schemas/config-description-1.0.0.xsd">
 
 	<config-description uri="thing-type:broadlink:rmproconfig">
-		<parameter name="ipAddress" type="text">
+		<parameter name="ipAddress" type="text" required="true">
 			<context>network-address</context>
 			<label>Network Address</label>
 			<description>IP address or hostname of the device.</description>
-			<required>true</required>
 		</parameter>
-		<parameter name="staticIp" type="boolean">
+		<parameter name="staticIp" type="boolean" required="true">
 			<context>network-address</context>
 			<label>Static IP</label>
 			<description>Will the device always be given this network address?</description>
-			<required>true</required>
 			<advanced>true</advanced>
 			<default>true</default>
 		</parameter>
-		<parameter name="port" type="integer" min="1" max="65535">
+		<parameter name="port" type="integer" min="1" max="65535" required="true">
 			<default>80</default>
 			<label>Network Port</label>
 			<description>Network port of the device.</description>
-			<required>true</required>
 			<advanced>true</advanced>
 		</parameter>
-		<parameter name="macAddress" type="text">
+		<parameter name="macAddress" type="text" required="true">
 			<label>MAC Address</label>
 			<description>MAC address of the device.</description>
-			<required>true</required>
 		</parameter>
-		<parameter name="pollingInterval" type="integer" min="30" step="1">
+		<parameter name="pollingInterval" type="integer" min="30" step="1" required="true">
 			<label>Polling Interval</label>
 			<description>The interval in seconds for polling the status of the device.</description>
-			<required>true</required>
 			<default>30</default>
 			<advanced>true</advanced>
 		</parameter>
-		<parameter name="nameOfCommandToLearn" type="text">
+		<parameter name="nameOfCommandToLearn" type="text" required="true">
 			<label>Name of IR/RF command to learn</label>
 			<description>Enter name of the IR or RF command to learn when using the learn Command channel</description>
 			<default>DEVICE_ON</default>
-			<required>true</required>
 		</parameter>
 	</config-description>
 </config-description:config-descriptions>

--- a/bundles/org.openhab.binding.ecoflow/src/main/resources/OH-INF/config/config.xml
+++ b/bundles/org.openhab.binding.ecoflow/src/main/resources/OH-INF/config/config.xml
@@ -5,14 +5,12 @@
 	xsi:schemaLocation="https://openhab.org/schemas/config-description/v1.0.0 https://openhab.org/schemas/config-description-1.0.0.xsd">
 
 	<config-description uri="thing-type:ecoflow:ecoflow-api">
-		<parameter name="accessKey" type="text">
+		<parameter name="accessKey" type="text" required="true">
 			<label>Access Key</label>
-			<required>true</required>
 		</parameter>
-		<parameter name="secretKey" type="text">
+		<parameter name="secretKey" type="text" required="true">
 			<label>Secret Key</label>
 			<context>password</context>
-			<required>true</required>
 		</parameter>
 	</config-description>
 

--- a/bundles/org.openhab.binding.ecovacs/src/main/resources/OH-INF/thing/bridge.xml
+++ b/bundles/org.openhab.binding.ecovacs/src/main/resources/OH-INF/thing/bridge.xml
@@ -11,17 +11,15 @@
 		<semantic-equipment-tag>WebService</semantic-equipment-tag>
 
 		<config-description>
-			<parameter name="email" type="text">
+			<parameter name="email" type="text" required="true">
 				<label>Email</label>
 				<context>email</context>
 				<description>Email address for logging in to Ecovacs server</description>
-				<required>true</required>
 			</parameter>
-			<parameter name="password" type="text">
+			<parameter name="password" type="text" required="true">
 				<label>Password</label>
 				<context>password</context>
 				<description>Password for logging in to Ecovacs server</description>
-				<required>true</required>
 			</parameter>
 			<parameter name="continent" type="text">
 				<label>Continent</label>

--- a/bundles/org.openhab.binding.flume/src/main/resources/OH-INF/thing/flume-cloud-connector.xml
+++ b/bundles/org.openhab.binding.flume/src/main/resources/OH-INF/thing/flume-cloud-connector.xml
@@ -10,42 +10,36 @@
 		<semantic-equipment-tag>WebService</semantic-equipment-tag>
 
 		<config-description>
-			<parameter name="username" type="text">
+			<parameter name="username" type="text" required="true">
 				<label>Flume Username</label>
 				<description>Flume cloud portal username</description>
-				<required>true</required>
 			</parameter>
-			<parameter name="password" type="text">
+			<parameter name="password" type="text" required="true">
 				<label>Flume Password</label>
 				<context>password</context>
 				<description>Flume cloud portal password</description>
-				<required>true</required>
 			</parameter>
-			<parameter name="clientId" type="text">
+			<parameter name="clientId" type="text" required="true">
 				<label>Flume Client ID</label>
 				<description>Visit Flume cloud portal to get client ID</description>
-				<required>true</required>
 			</parameter>
-			<parameter name="clientSecret" type="text">
+			<parameter name="clientSecret" type="text" required="true">
 				<label>Flume Client Secret</label>
 				<context>password</context>
 				<description>Visit Flume cloud portal to get client secret</description>
-				<required>true</required>
 			</parameter>
-			<parameter name="refreshIntervalInstanteous" type="integer" min="1" step="1" unit="min">
+			<parameter name="refreshIntervalInstanteous" type="integer" min="1" step="1" unit="min" required="false">
 				<label>Instantaneous Refresh Interval</label>
 				<description>Minutes between fetching current flow rate from the cloud service (total cloud fetches is rate-limited
 					to 120/hour)</description>
-				<required>false</required>
 				<advanced>true</advanced>
 				<default>1</default>
 				<unitLabel>minutes</unitLabel>
 			</parameter>
-			<parameter name="refreshIntervalCumulative" type="integer" min="1" step="5" unit="min">
+			<parameter name="refreshIntervalCumulative" type="integer" min="1" step="5" unit="min" required="false">
 				<label>Cumulative Refresh Interval</label>
 				<description>Minutes between fetching cumulative usage from the cloud service (total cloud fetches is rate-limited
 					to 120/hour)</description>
-				<required>false</required>
 				<advanced>true</advanced>
 				<default>5</default>
 				<unitLabel>minutes</unitLabel>

--- a/bundles/org.openhab.binding.flume/src/main/resources/OH-INF/thing/flume-device.xml
+++ b/bundles/org.openhab.binding.flume/src/main/resources/OH-INF/thing/flume-device.xml
@@ -25,10 +25,9 @@
 		<representation-property>id</representation-property>
 
 		<config-description>
-			<parameter name="id" type="text">
+			<parameter name="id" type="text" required="true">
 				<label>ID</label>
 				<description>Device ID</description>
-				<required>true</required>
 			</parameter>
 		</config-description>
 	</thing-type>

--- a/bundles/org.openhab.binding.huesync/src/main/resources/OH-INF/config/config.xml
+++ b/bundles/org.openhab.binding.huesync/src/main/resources/OH-INF/config/config.xml
@@ -9,18 +9,16 @@
 			<label>Connection</label>
 		</parameter-group>
 
-		<parameter name="host" type="text" groupName="connection">
+		<parameter name="host" type="text" groupName="connection" required="true">
 			<context>network-address</context>
 			<label>Address</label>
 			<description>Network address of the HDMI Sync Box.</description>
-			<required>true</required>
 		</parameter>
-		<parameter name="port" type="integer" min="1" max="65535" groupName="connection">
+		<parameter name="port" type="integer" min="1" max="65535" groupName="connection" required="true">
 			<label>Port</label>
 			<description>Port of the HDMI Sync Box.</description>
 			<advanced>true</advanced>
 			<default>443</default>
-			<required>true</required>
 		</parameter>
 		<parameter name="registrationId" type="text" groupName="connection">
 			<label>Registration Id</label>
@@ -36,11 +34,11 @@
 				seconds to grant the binding the required permissions.</description>
 			<advanced>true</advanced>
 		</parameter>
-		<parameter name="statusUpdateInterval" type="integer" min="1" step="1" unit="s" groupName="connection">
+		<parameter name="statusUpdateInterval" type="integer" min="1" step="1" unit="s" groupName="connection"
+			required="true">
 			<label>Update Interval</label>
 			<description>Seconds between fetching values from the Hue Sync Box.</description>
 			<advanced>true</advanced>
-			<required>true</required>
 			<default>10</default>
 			<unitLabel>Seconds</unitLabel>
 		</parameter>

--- a/bundles/org.openhab.binding.irobot/src/main/resources/OH-INF/config/thing.xml
+++ b/bundles/org.openhab.binding.irobot/src/main/resources/OH-INF/config/thing.xml
@@ -5,11 +5,10 @@
 	xsi:schemaLocation="https://openhab.org/schemas/config-description/v1.0.0 https://openhab.org/schemas/config-description-1.0.0.xsd">
 
 	<config-description uri="thing-type:irobot:thing">
-		<parameter name="ipaddress" type="text">
+		<parameter name="ipaddress" type="text" required="true">
 			<context>network-address</context>
 			<label>Network Address</label>
 			<description>Network address of the robot</description>
-			<required>true</required>
 		</parameter>
 		<parameter name="blid" type="text">
 			<label>Robot ID</label>

--- a/bundles/org.openhab.binding.senseenergy/src/main/resources/OH-INF/thing/cloud-connector.xml
+++ b/bundles/org.openhab.binding.senseenergy/src/main/resources/OH-INF/thing/cloud-connector.xml
@@ -13,13 +13,11 @@
 				<label>Email</label>
 				<context>text</context>
 				<description>Sense account email address</description>
-				<required>true</required>
 			</parameter>
 			<parameter name="password" type="text" required="true">
 				<label>Password</label>
 				<context>password</context>
 				<description>Sense account password</description>
-				<required>true</required>
 			</parameter>
 		</config-description>
 	</bridge-type>

--- a/bundles/org.openhab.binding.senseenergy/src/main/resources/OH-INF/thing/monitor.xml
+++ b/bundles/org.openhab.binding.senseenergy/src/main/resources/OH-INF/thing/monitor.xml
@@ -32,10 +32,9 @@
 		<representation-property>id</representation-property>
 
 		<config-description>
-			<parameter name="id" type="integer">
+			<parameter name="id" type="integer" required="true">
 				<label>ID</label>
 				<description>Device ID (only known from the openHAB log or when devices is discovered).</description>
-				<required>true</required>
 			</parameter>
 		</config-description>
 

--- a/bundles/org.openhab.binding.senseenergy/src/main/resources/OH-INF/thing/proxy-device.xml
+++ b/bundles/org.openhab.binding.senseenergy/src/main/resources/OH-INF/thing/proxy-device.xml
@@ -31,12 +31,11 @@
 					rage".</description>
 			</parameter>
 
-			<parameter name="voltage" type="decimal" unit="V">
+			<parameter name="voltage" type="decimal" unit="V" required="true">
 				<label>Voltage</label>
 				<description>Supply voltage for device.</description>
 				<unitLabel>V</unitLabel>
 				<default>120</default>
-				<required>true</required>
 			</parameter>
 
 			<parameter name="macAddress" type="text">

--- a/bundles/org.openhab.binding.siemenshvac/src/main/resources/OH-INF/thing/ozw.xml
+++ b/bundles/org.openhab.binding.siemenshvac/src/main/resources/OH-INF/thing/ozw.xml
@@ -10,24 +10,21 @@
 		<description>This is an OZW IP interface</description>
 		<semantic-equipment-tag>NetworkAppliance</semantic-equipment-tag>
 		<config-description>
-			<parameter name="baseUrl" type="text" pattern="(http|https):\/\/(.+)\/">
+			<parameter name="baseUrl" type="text" pattern="(http|https):\/\/(.+)\/" required="true">
 				<label>Base URL</label>
 				<context>url</context>
 				<description>The URL of the Siemens HVAC IP gateway. Must be in the format http://hostname/ or
 					https://hostname/.
 					Don't forget the trailing '/'.</description>
-				<required>true</required>
 			</parameter>
-			<parameter name="userName" type="text">
+			<parameter name="userName" type="text" required="false">
 				<description>User name of the Siemens HVAC gateway</description>
-				<required>false</required>
 				<label>User Name</label>
 				<default>Administrator</default>
 			</parameter>
-			<parameter name="userPassword" type="text">
+			<parameter name="userPassword" type="text" required="false">
 				<context>password</context>
 				<description>User password of the Siemens HVAC gateway</description>
-				<required>false</required>
 				<label>User Password</label>
 				<default>password</default>
 			</parameter>

--- a/bundles/org.openhab.binding.souliss/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.souliss/src/main/resources/OH-INF/thing/thing-types.xml
@@ -16,9 +16,8 @@
 				<label>IPv4 Address</label>
 				<description>LAN IP address (mandatory)
 				</description>
-				<required>true</required>
 			</parameter>
-			<parameter name="gatewayWanAddress" type="text" required="false"
+			<parameter name="gatewayWanAddress" type="text" required="true"
 				pattern="^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$|^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)+([A-Za-z]|[A-Za-z][A-Za-z0-9\-]*[A-Za-z0-9])$">
 				<label>IPv4 WAN Address</label>
 				<description>WAN hostname or IP in case of external network access
@@ -30,7 +29,6 @@
 				<description>UDP port of the gateway.</description>
 				<advanced>true</advanced>
 				<default>230</default>
-				<required>true</required>
 			</parameter>
 			<parameter name="preferredLocalPortNumber" type="integer" required="true">
 				<label>Local Port Number</label>
@@ -38,70 +36,61 @@
 				</description>
 				<default>23000</default>
 				<advanced>true</advanced>
-				<required>true</required>
 			</parameter>
 
-			<parameter name="pingInterval" type="integer" min="1" max="300" unit="s">
+			<parameter name="pingInterval" type="integer" min="1" max="300" unit="s" required="true">
 				<label>Ping Interval</label>
 				<description>Interval in seconds to check for device presence.</description>
 				<default>30</default>
 				<advanced>true</advanced>
-				<required>true</required>
 			</parameter>
-			<parameter name="subscriptionInterval" type="integer" min="2" max="240" unit="s">
+			<parameter name="subscriptionInterval" type="integer" min="2" max="240" unit="s" required="true">
 				<label>Subscription Interval</label>
 				<description>Interval in seconds to subscribe to the Souliss gateway.
 				</description>
 				<default>30</default>
 				<advanced>true</advanced>
-				<required>true</required>
 			</parameter>
-			<parameter name="healthyInterval" type="integer" min="1" max="240" unit="s">
+			<parameter name="healthyInterval" type="integer" min="1" max="240" unit="s" required="true">
 				<label>Healthy Interval</label>
 				<description>Interval in seconds to send node health.
 				</description>
 				<default>60</default>
 				<advanced>true</advanced>
-				<required>true</required>
 			</parameter>
 
-			<parameter name="sendInterval" type="integer" min="5" max="5000" unit="ms">
+			<parameter name="sendInterval" type="integer" min="5" max="5000" unit="ms" required="true">
 				<label>Send Interval</label>
 				<description>Interval in milliseconds to get packet from binding queue and send it to Souliss. First packet is sent
 					immediately.
 				</description>
 				<default>30</default>
 				<advanced>true</advanced>
-				<required>true</required>
 			</parameter>
 
-			<parameter name="timeoutToRequeue" type="integer" min="0" max="10000" unit="ms">
+			<parameter name="timeoutToRequeue" type="integer" min="0" max="10000" unit="ms" required="true">
 				<label>Timeout to Requeue</label>
 				<description>Interval in milliseconds to requeue packet in queue if not yet executed</description>
-				<required>true</required>
 				<default>5000</default>
 				<advanced>true</advanced>
 			</parameter>
 
-			<parameter name="timeoutToRemovePacket" type="integer" min="0" max="60000" unit="ms">
+			<parameter name="timeoutToRemovePacket" type="integer" min="0" max="60000" unit="ms" required="true">
 				<label>Timeout to Remove Packet</label>
 				<description>Interval in milliseconds to remove packet from queue if not yet executed </description>
-				<required>true</required>
 				<default>20000</default>
 				<advanced>true</advanced>
 			</parameter>
 
-			<parameter name="userIndex" type="integer" required="true">
+			<parameter name="userIndex" type="integer" required="true" required="true">
 				<label>User Index</label>
 				<description>User Index</description>
 				<default>70</default>
-				<required>true</required>
 			</parameter>
-			<parameter name="nodeIndex" type="integer" required="true">
+			<parameter name="nodeIndex" type="integer" required="true" required="true">
 				<label>Node Index</label>
 				<description>Node Index</description>
 				<default>120</default>
-				<required>true</required>
 			</parameter>
 		</config-description>
 	</bridge-type>
@@ -121,26 +110,22 @@
 		</channels>
 
 		<config-description>
-			<parameter name="node" type="integer" min="0" max="256">
+			<parameter name="node" type="integer" min="0" max="256" required="true">
 				<label>Node</label>
 				<description>Node</description>
-				<required>true</required>
 			</parameter>
-			<parameter name="slot" type="integer" min="0" max="256">
+			<parameter name="slot" type="integer" min="0" max="256" required="true">
 				<label>Slot</label>
 				<description>Slot</description>
-				<required>true</required>
 			</parameter>
-			<parameter name="sleep" type="integer" min="1" max="1000">
+			<parameter name="sleep" type="integer" min="1" max="1000" required="false">
 				<label>Sleep</label>
 				<description>Set sleep timer in cycles (conf.parameter: "sleep")</description>
-				<required>false</required>
 				<default>5</default>
 			</parameter>
-			<parameter name="secureSend" type="boolean">
+			<parameter name="secureSend" type="boolean" required="false">
 				<label>Secure Send</label>
 				<description> (conf.parameter: "secureSend") </description>
-				<required>false</required>
 				<default>true</default>
 			</parameter>
 		</config-description>
@@ -159,26 +144,22 @@
 			<channel id="healthy" typeId="healthy"/>
 		</channels>
 		<config-description>
-			<parameter name="node" type="integer" min="0" max="256">
+			<parameter name="node" type="integer" min="0" max="256" required="true">
 				<label>Node</label>
 				<description>Node</description>
-				<required>true</required>
 			</parameter>
-			<parameter name="slot" type="integer" min="0" max="256">
+			<parameter name="slot" type="integer" min="0" max="256" required="true">
 				<label>Slot</label>
 				<description>Slot</description>
-				<required>true</required>
 			</parameter>
-			<parameter name="sleep" type="integer" min="1" max="1000">
+			<parameter name="sleep" type="integer" min="1" max="1000" required="false">
 				<label>Sleep</label>
 				<description>Set sleep timer in cycles</description>
-				<required>false</required>
 				<default>5</default>
 			</parameter>
-			<parameter name="secureSend" type="boolean">
+			<parameter name="secureSend" type="boolean" required="false">
 				<label>Secure Send</label>
 				<description/>
-				<required>false</required>
 				<default>true</default>
 			</parameter>
 		</config-description>
@@ -198,15 +179,13 @@
 			<channel id="healthy" typeId="healthy"/>
 		</channels>
 		<config-description>
-			<parameter name="node" type="integer" min="0" max="256">
+			<parameter name="node" type="integer" min="0" max="256" required="true">
 				<label>Node</label>
 				<description>Node</description>
-				<required>true</required>
 			</parameter>
-			<parameter name="slot" type="integer" min="0" max="256">
+			<parameter name="slot" type="integer" min="0" max="256" required="true">
 				<label>Slot</label>
 				<description>Slot</description>
-				<required>true</required>
 			</parameter>
 		</config-description>
 	</thing-type>
@@ -223,15 +202,13 @@
 			<channel id="healthy" typeId="healthy"/>
 		</channels>
 		<config-description>
-			<parameter name="node" type="integer" min="0" max="256">
+			<parameter name="node" type="integer" min="0" max="256" required="true">
 				<label>Node</label>
 				<description>Node</description>
-				<required>true</required>
 			</parameter>
-			<parameter name="slot" type="integer" min="0" max="256">
+			<parameter name="slot" type="integer" min="0" max="256" required="true">
 				<label>Slot</label>
 				<description>Slot</description>
-				<required>true</required>
 			</parameter>
 		</config-description>
 	</thing-type>
@@ -255,27 +232,23 @@
 		</channels>
 
 		<config-description>
-			<parameter name="node" type="integer" min="0" max="256">
+			<parameter name="node" type="integer" min="0" max="256" required="true">
 				<label>Node</label>
 				<description>Node</description>
-				<required>true</required>
 			</parameter>
-			<parameter name="slot" type="integer" min="0" max="256">
+			<parameter name="slot" type="integer" min="0" max="256" required="true">
 				<label>Slot</label>
 				<description>Slot</description>
-				<required>true</required>
 			</parameter>
-			<parameter name="sleep" type="integer" min="1" max="1000">
+			<parameter name="sleep" type="integer" min="1" max="1000" required="false">
 				<label>Sleep</label>
 				<description>Set sleep timer in cycles</description>
-				<required>false</required>
 				<default>5</default>
 			</parameter>
 
-			<parameter name="secureSend" type="boolean">
+			<parameter name="secureSend" type="boolean" required="false">
 				<label>Secure Send</label>
 				<description/>
-				<required>false</required>
 				<default>true</default>
 			</parameter>
 		</config-description>
@@ -294,27 +267,23 @@
 			<channel id="healthy" typeId="healthy"/>
 		</channels>
 		<config-description>
-			<parameter name="node" type="integer" min="0" max="256">
+			<parameter name="node" type="integer" min="0" max="256" required="true">
 				<label>Node</label>
 				<description>Node</description>
-				<required>true</required>
 			</parameter>
-			<parameter name="slot" type="integer" min="0" max="256">
+			<parameter name="slot" type="integer" min="0" max="256" required="true">
 				<label>Slot</label>
 				<description>Slot</description>
-				<required>true</required>
 			</parameter>
-			<parameter name="sleep" type="integer" min="1" max="1000">
+			<parameter name="sleep" type="integer" min="1" max="1000" required="false">
 				<label>Sleep</label>
 				<description>Set sleep timer in cycles</description>
-				<required>false</required>
 				<default>5</default>
 			</parameter>
 
-			<parameter name="secureSend" type="boolean">
+			<parameter name="secureSend" type="boolean" required="false">
 				<label>Secure Send</label>
 				<description/>
-				<required>false</required>
 				<default>true</default>
 			</parameter>
 		</config-description>
@@ -337,20 +306,17 @@
 		</channels>
 
 		<config-description>
-			<parameter name="node" type="integer" min="0" max="256">
+			<parameter name="node" type="integer" min="0" max="256" required="true">
 				<label>Node</label>
 				<description>Node</description>
-				<required>true</required>
 			</parameter>
-			<parameter name="slot" type="integer" min="0" max="256">
+			<parameter name="slot" type="integer" min="0" max="256" required="true">
 				<label>Slot</label>
 				<description>Slot</description>
-				<required>true</required>
 			</parameter>
-			<parameter name="sleep" type="integer" min="1" max="1000">
+			<parameter name="sleep" type="integer" min="1" max="1000" required="false">
 				<label>Sleep</label>
 				<description>Set sleep timer in cycles</description>
-				<required>false</required>
 				<default>5</default>
 			</parameter>
 		</config-description>
@@ -392,15 +358,13 @@
 			<channel id="healthy" typeId="healthy"/>
 		</channels>
 		<config-description>
-			<parameter name="node" type="integer" min="0" max="256">
+			<parameter name="node" type="integer" min="0" max="256" required="true">
 				<label>Node</label>
 				<description>Node</description>
-				<required>true</required>
 			</parameter>
-			<parameter name="slot" type="integer" min="0" max="256">
+			<parameter name="slot" type="integer" min="0" max="256" required="true">
 				<label>Slot</label>
 				<description>Slot</description>
-				<required>true</required>
 			</parameter>
 		</config-description>
 	</thing-type>
@@ -418,20 +382,17 @@
 			<channel id="healthy" typeId="healthy"/>
 		</channels>
 		<config-description>
-			<parameter name="node" type="integer" min="0" max="256">
+			<parameter name="node" type="integer" min="0" max="256" required="true">
 				<label>Node</label>
 				<description>Node</description>
-				<required>true</required>
 			</parameter>
-			<parameter name="slot" type="integer" min="0" max="256">
+			<parameter name="slot" type="integer" min="0" max="256" required="true">
 				<label>Slot</label>
 				<description>Slot</description>
-				<required>true</required>
 			</parameter>
-			<parameter name="secureSend" type="boolean">
+			<parameter name="secureSend" type="boolean" required="false">
 				<label>Secure Send</label>
 				<description/>
-				<required>false</required>
 				<default>true</default>
 			</parameter>
 		</config-description>
@@ -450,20 +411,17 @@
 			<channel id="healthy" typeId="healthy"/>
 		</channels>
 		<config-description>
-			<parameter name="node" type="integer" min="0" max="256">
+			<parameter name="node" type="integer" min="0" max="256" required="true">
 				<label>Node</label>
 				<description>Node</description>
-				<required>true</required>
 			</parameter>
-			<parameter name="slot" type="integer" min="0" max="256">
+			<parameter name="slot" type="integer" min="0" max="256" required="true">
 				<label>Slot</label>
 				<description>Slot</description>
-				<required>true</required>
 			</parameter>
-			<parameter name="secureSend" type="boolean">
+			<parameter name="secureSend" type="boolean" required="false">
 				<label>Secure Send</label>
 				<description/>
-				<required>false</required>
 				<default>true</default>
 			</parameter>
 		</config-description>
@@ -498,15 +456,13 @@
 			<property name="thingTypeVersion">1</property>
 		</properties>
 		<config-description>
-			<parameter name="node" type="integer" min="0" max="256">
+			<parameter name="node" type="integer" min="0" max="256" required="true">
 				<label>Node</label>
 				<description>Node</description>
-				<required>true</required>
 			</parameter>
-			<parameter name="slot" type="integer" min="0" max="256">
+			<parameter name="slot" type="integer" min="0" max="256" required="true">
 				<label>Slot</label>
 				<description>Slot</description>
-				<required>true</required>
 			</parameter>
 		</config-description>
 	</thing-type>
@@ -534,20 +490,17 @@
 			<property name="thingTypeVersion">1</property>
 		</properties>
 		<config-description>
-			<parameter name="node" type="integer" min="0" max="256">
+			<parameter name="node" type="integer" min="0" max="256" required="true">
 				<label>Node</label>
 				<description>Node</description>
-				<required>true</required>
 			</parameter>
-			<parameter name="slot" type="integer" min="0" max="256">
+			<parameter name="slot" type="integer" min="0" max="256" required="true">
 				<label>Slot</label>
 				<description>Slot</description>
-				<required>true</required>
 			</parameter>
-			<parameter name="secureSend" type="boolean">
+			<parameter name="secureSend" type="boolean" required="false">
 				<label>Secure Send</label>
 				<description/>
-				<required>false</required>
 				<default>true</default>
 			</parameter>
 		</config-description>
@@ -576,20 +529,17 @@
 			<property name="thingTypeVersion">1</property>
 		</properties>
 		<config-description>
-			<parameter name="node" type="integer" min="0" max="256">
+			<parameter name="node" type="integer" min="0" max="256" required="true">
 				<label>Node</label>
 				<description>Node</description>
-				<required>true</required>
 			</parameter>
-			<parameter name="slot" type="integer" min="0" max="256">
+			<parameter name="slot" type="integer" min="0" max="256" required="true">
 				<label>Slot</label>
 				<description>Slot</description>
-				<required>true</required>
 			</parameter>
-			<parameter name="secureSend" type="boolean">
+			<parameter name="secureSend" type="boolean" required="false">
 				<label>Secure Send</label>
 				<description/>
-				<required>false</required>
 				<default>true</default>
 			</parameter>
 		</config-description>
@@ -609,15 +559,13 @@
 			<channel id="healthy" typeId="healthy"/>
 		</channels>
 		<config-description>
-			<parameter name="node" type="integer" min="0" max="256">
+			<parameter name="node" type="integer" min="0" max="256" required="true">
 				<label>Node</label>
 				<description>Node</description>
-				<required>true</required>
 			</parameter>
-			<parameter name="slot" type="integer" min="0" max="256">
+			<parameter name="slot" type="integer" min="0" max="256" required="true">
 				<label>Slot</label>
 				<description>Slot</description>
-				<required>true</required>
 			</parameter>
 		</config-description>
 	</thing-type>
@@ -635,15 +583,13 @@
 			<channel id="healthy" typeId="healthy"/>
 		</channels>
 		<config-description>
-			<parameter name="node" type="integer" min="0" max="256">
+			<parameter name="node" type="integer" min="0" max="256" required="true">
 				<label>Node</label>
 				<description>Node</description>
-				<required>true</required>
 			</parameter>
-			<parameter name="slot" type="integer" min="0" max="256">
+			<parameter name="slot" type="integer" min="0" max="256" required="true">
 				<label>Slot</label>
 				<description>Slot</description>
-				<required>true</required>
 			</parameter>
 		</config-description>
 	</thing-type>
@@ -660,15 +606,13 @@
 			<channel id="healthy" typeId="healthy"/>
 		</channels>
 		<config-description>
-			<parameter name="node" type="integer" min="0" max="256">
+			<parameter name="node" type="integer" min="0" max="256" required="true">
 				<label>Node</label>
 				<description>Node</description>
-				<required>true</required>
 			</parameter>
-			<parameter name="slot" type="integer" min="0" max="256">
+			<parameter name="slot" type="integer" min="0" max="256" required="true">
 				<label>Slot</label>
 				<description>Slot</description>
-				<required>true</required>
 			</parameter>
 		</config-description>
 	</thing-type>
@@ -685,15 +629,13 @@
 			<channel id="healthy" typeId="healthy"/>
 		</channels>
 		<config-description>
-			<parameter name="node" type="integer" min="0" max="256">
+			<parameter name="node" type="integer" min="0" max="256" required="true">
 				<label>Node</label>
 				<description>Node</description>
-				<required>true</required>
 			</parameter>
-			<parameter name="slot" type="integer" min="0" max="256">
+			<parameter name="slot" type="integer" min="0" max="256" required="true">
 				<label>Slot</label>
 				<description>Slot</description>
-				<required>true</required>
 			</parameter>
 		</config-description>
 	</thing-type>
@@ -710,15 +652,13 @@
 			<channel id="healthy" typeId="healthy"/>
 		</channels>
 		<config-description>
-			<parameter name="node" type="integer" min="0" max="256">
+			<parameter name="node" type="integer" min="0" max="256" required="true">
 				<label>Node</label>
 				<description>Node</description>
-				<required>true</required>
 			</parameter>
-			<parameter name="slot" type="integer" min="0" max="256">
+			<parameter name="slot" type="integer" min="0" max="256" required="true">
 				<label>Slot</label>
 				<description>Slot</description>
-				<required>true</required>
 			</parameter>
 		</config-description>
 	</thing-type>
@@ -735,15 +675,13 @@
 			<channel id="healthy" typeId="healthy"/>
 		</channels>
 		<config-description>
-			<parameter name="node" type="integer" min="0" max="256">
+			<parameter name="node" type="integer" min="0" max="256" required="true">
 				<label>Node</label>
 				<description>Node</description>
-				<required>true</required>
 			</parameter>
-			<parameter name="slot" type="integer" min="0" max="256">
+			<parameter name="slot" type="integer" min="0" max="256" required="true">
 				<label>Slot</label>
 				<description>Slot</description>
-				<required>true</required>
 			</parameter>
 		</config-description>
 	</thing-type>
@@ -760,15 +698,13 @@
 			<channel id="healthy" typeId="healthy"/>
 		</channels>
 		<config-description>
-			<parameter name="node" type="integer" min="0" max="256">
+			<parameter name="node" type="integer" min="0" max="256" required="true">
 				<label>Node</label>
 				<description>Node</description>
-				<required>true</required>
 			</parameter>
-			<parameter name="slot" type="integer" min="0" max="256">
+			<parameter name="slot" type="integer" min="0" max="256" required="true">
 				<label>Slot</label>
 				<description>Slot</description>
-				<required>true</required>
 			</parameter>
 		</config-description>
 	</thing-type>
@@ -788,15 +724,13 @@
 			<property name="thingTypeVersion">1</property>
 		</properties>
 		<config-description>
-			<parameter name="node" type="integer" min="0" max="256">
+			<parameter name="node" type="integer" min="0" max="256" required="true">
 				<label>Node</label>
 				<description>Node</description>
-				<required>true</required>
 			</parameter>
-			<parameter name="slot" type="integer" min="0" max="256">
+			<parameter name="slot" type="integer" min="0" max="256" required="true">
 				<label>Slot</label>
 				<description>Slot</description>
-				<required>true</required>
 			</parameter>
 		</config-description>
 	</thing-type>
@@ -812,15 +746,13 @@
 			<channel id="lastStatusStored" typeId="lastStatusStored"/>
 		</channels>
 		<config-description>
-			<parameter name="node" type="integer" min="0" max="256">
+			<parameter name="node" type="integer" min="0" max="256" required="true">
 				<label>Node</label>
 				<description>Node</description>
-				<required>true</required>
 			</parameter>
-			<parameter name="slot" type="integer" min="0" max="256">
+			<parameter name="slot" type="integer" min="0" max="256" required="true">
 				<label>Slot</label>
 				<description>Slot</description>
-				<required>true</required>
 			</parameter>
 		</config-description>
 	</thing-type>
@@ -836,15 +768,13 @@
 			<channel id="lastStatusStored" typeId="lastStatusStored"/>
 		</channels>
 		<config-description>
-			<parameter name="node" type="integer" min="0" max="256">
+			<parameter name="node" type="integer" min="0" max="256" required="true">
 				<label>Node</label>
 				<description>Node</description>
-				<required>true</required>
 			</parameter>
-			<parameter name="slot" type="integer" min="0" max="256">
+			<parameter name="slot" type="integer" min="0" max="256" required="true">
 				<label>Slot</label>
 				<description>Slot</description>
-				<required>true</required>
 			</parameter>
 		</config-description>
 	</thing-type>
@@ -860,15 +790,13 @@
 			<channel id="lastStatusStored" typeId="lastStatusStored"/>
 		</channels>
 		<config-description>
-			<parameter name="node" type="integer" min="0" max="256">
+			<parameter name="node" type="integer" min="0" max="256" required="true">
 				<label>Node</label>
 				<description>Node</description>
-				<required>true</required>
 			</parameter>
-			<parameter name="slot" type="integer" min="0" max="256">
+			<parameter name="slot" type="integer" min="0" max="256" required="true">
 				<label>Slot</label>
 				<description>Slot</description>
-				<required>true</required>
 			</parameter>
 		</config-description>
 	</thing-type>
@@ -885,15 +813,13 @@
 			<channel id="healthy" typeId="healthy"/>
 		</channels>
 		<config-description>
-			<parameter name="node" type="integer" min="0" max="256">
+			<parameter name="node" type="integer" min="0" max="256" required="true">
 				<label>Node</label>
 				<description>Node</description>
-				<required>true</required>
 			</parameter>
-			<parameter name="slot" type="integer" min="0" max="256">
+			<parameter name="slot" type="integer" min="0" max="256" required="true">
 				<label>Slot</label>
 				<description>Slot</description>
-				<required>true</required>
 			</parameter>
 		</config-description>
 	</thing-type>
@@ -910,15 +836,13 @@
 			<channel id="healthy" typeId="healthy"/>
 		</channels>
 		<config-description>
-			<parameter name="node" type="integer" min="0" max="256">
+			<parameter name="node" type="integer" min="0" max="256" required="true">
 				<label>Node</label>
 				<description>Node</description>
-				<required>true</required>
 			</parameter>
-			<parameter name="slot" type="integer" min="0" max="256">
+			<parameter name="slot" type="integer" min="0" max="256" required="true">
 				<label>Slot</label>
 				<description>Slot</description>
-				<required>true</required>
 			</parameter>
 		</config-description>
 	</thing-type>
@@ -935,15 +859,13 @@
 			<channel id="healthy" typeId="healthy"/>
 		</channels>
 		<config-description>
-			<parameter name="node" type="integer" min="0" max="256">
+			<parameter name="node" type="integer" min="0" max="256" required="true">
 				<label>Node</label>
 				<description>Node</description>
-				<required>true</required>
 			</parameter>
-			<parameter name="slot" type="integer" min="0" max="256">
+			<parameter name="slot" type="integer" min="0" max="256" required="true">
 				<label>Slot</label>
 				<description>Slot</description>
-				<required>true</required>
 			</parameter>
 		</config-description>
 	</thing-type>
@@ -960,15 +882,13 @@
 			<channel id="healthy" typeId="healthy"/>
 		</channels>
 		<config-description>
-			<parameter name="node" type="integer" min="0" max="256">
+			<parameter name="node" type="integer" min="0" max="256" required="true">
 				<label>Node</label>
 				<description>Node</description>
-				<required>true</required>
 			</parameter>
-			<parameter name="slot" type="integer" min="0" max="256">
+			<parameter name="slot" type="integer" min="0" max="256" required="true">
 				<label>Slot</label>
 				<description>Slot</description>
-				<required>true</required>
 			</parameter>
 		</config-description>
 	</thing-type>
@@ -985,15 +905,13 @@
 			<channel id="healthy" typeId="healthy"/>
 		</channels>
 		<config-description>
-			<parameter name="node" type="integer" min="0" max="256">
+			<parameter name="node" type="integer" min="0" max="256" required="true">
 				<label>Node</label>
 				<description>Node</description>
-				<required>true</required>
 			</parameter>
-			<parameter name="slot" type="integer" min="0" max="256">
+			<parameter name="slot" type="integer" min="0" max="256" required="true">
 				<label>Slot</label>
 				<description>Slot</description>
-				<required>true</required>
 			</parameter>
 		</config-description>
 	</thing-type>
@@ -1011,15 +929,13 @@
 		</channels>
 		<representation-property>number</representation-property>
 		<config-description>
-			<parameter name="number" type="text">
+			<parameter name="number" type="text" required="true">
 				<label>Number</label>
 				<description>Topic Number</description>
-				<required>true</required>
 			</parameter>
-			<parameter name="variant" type="text">
+			<parameter name="variant" type="text" required="true">
 				<label>Variant</label>
 				<description>Topic Variant</description>
-				<required>true</required>
 			</parameter>
 		</config-description>
 	</thing-type>

--- a/bundles/org.openhab.binding.souliss/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.souliss/src/main/resources/OH-INF/thing/thing-types.xml
@@ -82,12 +82,12 @@
 				<advanced>true</advanced>
 			</parameter>
 
-			<parameter name="userIndex" type="integer" required="true" required="true">
+			<parameter name="userIndex" type="integer" required="true">
 				<label>User Index</label>
 				<description>User Index</description>
 				<default>70</default>
 			</parameter>
-			<parameter name="nodeIndex" type="integer" required="true" required="true">
+			<parameter name="nodeIndex" type="integer" required="true">
 				<label>Node Index</label>
 				<description>Node Index</description>
 				<default>120</default>

--- a/bundles/org.openhab.binding.unifiprotect/src/main/resources/OH-INF/config/config.xml
+++ b/bundles/org.openhab.binding.unifiprotect/src/main/resources/OH-INF/config/config.xml
@@ -5,24 +5,22 @@
 	xsi:schemaLocation="https://openhab.org/schemas/config-description/v1.0.0
 		https://openhab.org/schemas/config-description-1.0.0.xsd">
 	<config-description uri="binding:unifiprotect">
-		<parameter name="downloadBinaries" type="boolean">
+		<parameter name="downloadBinaries" type="boolean" required="true">
 			<label>Download Stream Binaries</label>
 			<description>Download the stream binaries for go2rtc and ffmpeg if not already present on the system PATH</description>
 			<default>true</default>
-			<required>true</required>
 		</parameter>
-		<parameter name="useStun" type="boolean">
+		<parameter name="useStun" type="boolean" required="true">
 			<label>Use STUN for external IP discovery</label>
 			<description>Use STUN for external IP discovery. This will allow camera streams to work behind NATs when outside your
 				local network (e.g. when using the openHAB cloud service). STUN will incur an approximately 5 second delay starting
 				the stream as it discovers your external IP.
 			</description>
 			<default>true</default>
-			<required>true</required>
 		</parameter>
 	</config-description>
 	<config-description uri="thing-type:unifiprotect:snapshot-config">
-		<parameter name="sequence" type="text" required="false">
+		<parameter name="sequence" type="text" required="true">
 			<label>Sequence</label>
 			<description>The order in which a snapshot is taken relative to the event or item state change. By default, a
 				snapshot is taken before the trigger event fires or item state updates so it's immediately available for use in
@@ -31,7 +29,6 @@
 				take a snapshot on a trigger event or item state update, you can set this to "none". Image items can also be updated
 				in rules using either the setImage action (`actions.HTTP.setImage`) or by sending a `REFRESH` command to the item.</description>
 			<default>before</default>
-			<required>true</required>
 			<options>
 				<option value="before">Take a snapshot before firing the trigger event or updating the item state.</option>
 				<option value="after">Take a snapshot after firing the trigger event or updating the item state.</option>
@@ -45,7 +42,6 @@
 			<description>The delay in milliseconds to wait before the contact is considered latched/closed after the last motion
 				event.</description>
 			<default>5000</default>
-			<required>false</required>
 		</parameter>
 	</config-description>
 </config-description:config-descriptions>

--- a/bundles/org.openhab.binding.vesync/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.vesync/src/main/resources/OH-INF/thing/thing-types.xml
@@ -15,15 +15,13 @@
 		</properties>
 
 		<config-description>
-			<parameter name="username" type="text">
+			<parameter name="username" type="text" required="true">
 				<context>email</context>
-				<required>true</required>
 				<label>Username</label>
 				<description>Name of a registered VeSync user, that allows to access the mobile application.</description>
 			</parameter>
-			<parameter name="password" type="text">
+			<parameter name="password" type="text" required="true">
 				<context>password</context>
-				<required>true</required>
 				<label>Password</label>
 				<description>Password for the registered VeSync username, that allows to access the mobile application.</description>
 			</parameter>

--- a/bundles/org.openhab.binding.wiz/src/main/resources/OH-INF/config/config.xml
+++ b/bundles/org.openhab.binding.wiz/src/main/resources/OH-INF/config/config.xml
@@ -8,13 +8,11 @@
 		<parameter name="macAddress" type="text" required="true">
 			<label>MAC Address</label>
 			<description>MAC address of the device</description>
-			<required>true</required>
 		</parameter>
 		<parameter name="ipAddress" type="text" required="true">
 			<label>IP Address</label>
 			<context>network-address</context>
 			<description>IP address of the device</description>
-			<required>true</required>
 		</parameter>
 		<parameter name="updateInterval" type="integer" min="5">
 			<label>Update Interval</label>

--- a/bundles/org.openhab.transform.rollershutterposition/src/main/resources/OH-INF/config/rollerShutterPosition.xml
+++ b/bundles/org.openhab.transform.rollershutterposition/src/main/resources/OH-INF/config/rollerShutterPosition.xml
@@ -8,7 +8,6 @@
 		<parameter name="uptime" type="decimal" required="true">
 			<label>Up Time</label>
 			<description>Time it takes for roller shutter to fully open (in seconds).</description>
-			<required>true</required>
 		</parameter>
 		<parameter name="downtime" type="decimal">
 			<label>Down Time</label>

--- a/bundles/org.openhab.voice.openaitts/src/main/resources/OH-INF/config/config.xml
+++ b/bundles/org.openhab.voice.openaitts/src/main/resources/OH-INF/config/config.xml
@@ -13,21 +13,18 @@
 			<label>TTS Configuration</label>
 			<description>Configure Text to Speech.</description>
 		</parameter-group>
-		<parameter name="apiKey" type="text" required="true" groupName="authentication">
+		<parameter name="apiKey" type="text" required="true" groupName="authentication" required="true">
 			<label>API Key</label>
-			<required>true</required>
 			<description>OpenAI API key.</description>
 			<context>password</context>
 		</parameter>
-		<parameter name="apiUrl" type="text" required="true" groupName="authentication">
+		<parameter name="apiUrl" type="text" required="true" groupName="authentication" required="true">
 			<label>API URL</label>
-			<required>true</required>
 			<description>TTS host API URL.</description>
 			<default>https://api.openai.com/v1/audio/speech</default>
 		</parameter>
-		<parameter name="model" type="text" required="true" groupName="tts">
+		<parameter name="model" type="text" required="true" groupName="tts" required="true">
 			<label>Model</label>
-			<required>true</required>
 			<description>ID of the model to use.</description>
 			<options>
 				<option value="tts-1">Standard TTS (fast)</option>

--- a/bundles/org.openhab.voice.openaitts/src/main/resources/OH-INF/config/config.xml
+++ b/bundles/org.openhab.voice.openaitts/src/main/resources/OH-INF/config/config.xml
@@ -13,17 +13,17 @@
 			<label>TTS Configuration</label>
 			<description>Configure Text to Speech.</description>
 		</parameter-group>
-		<parameter name="apiKey" type="text" required="true" groupName="authentication" required="true">
+		<parameter name="apiKey" type="text" required="true" groupName="authentication">
 			<label>API Key</label>
 			<description>OpenAI API key.</description>
 			<context>password</context>
 		</parameter>
-		<parameter name="apiUrl" type="text" required="true" groupName="authentication" required="true">
+		<parameter name="apiUrl" type="text" required="true" groupName="authentication">
 			<label>API URL</label>
 			<description>TTS host API URL.</description>
 			<default>https://api.openai.com/v1/audio/speech</default>
 		</parameter>
-		<parameter name="model" type="text" required="true" groupName="tts" required="true">
+		<parameter name="model" type="text" required="true" groupName="tts">
 			<label>Model</label>
 			<description>ID of the model to use.</description>
 			<options>


### PR DESCRIPTION
According to the [documentation](https://www.openhab.org/docs/developer/addons/config-xml.html#xml-structure-for-configuration-descriptions) the configuration description xml `required` **_element_** (element within the parameter) has been deprecated and should replaced by a `required` **_attribute_** (attribute on the parameter).

```
// DEPRECATED FORM
<parameter name="ipAddress" type="text" ... >
    ...
    <required>true</required>
</parameter>

// NEW FORM
<parameter name="ipAddress" type="text" ... required="true">
    ...
</parameter>
```

This PR cleans up the remaining few bindings that were still using the old deprecated form. It is a non breaking change without functional impact.

Note: there are a couple of addons that had both a `required` element and a `required` attribute -- _having contradictory values_ -- which have been set with `required="true"` ..

Signed-off-by: Andrew Fiddian-Green <software@whitebear.ch>
