### PR TITLE
[dmx] Remove unsupported 'context' element

### DIFF
--- a/bundles/org.openhab.binding.dmx/src/main/resources/OH-INF/thing/sacn-bridge.xml
+++ b/bundles/org.openhab.binding.dmx/src/main/resources/OH-INF/thing/sacn-bridge.xml
@@ -11,7 +11,6 @@
 		</channels>
 		<config-description>
 			<parameter name="mode" type="text" required="true">
-				<context></context>
 				<label>Transmission Mode</label>
 				<description>Set UDP mode to multicast (default)/unicast</description>
 				<options>


### PR DESCRIPTION
SAT fails after openhab/openhab-core#5372

See https://ci.openhab.org/job/openHAB-Addons/