### PR TITLE
[max] Remove unsupported 'context' element

### DIFF
--- a/bundles/org.openhab.binding.max/src/main/resources/OH-INF/thing/bridge.xml
+++ b/bundles/org.openhab.binding.max/src/main/resources/OH-INF/thing/bridge.xml
@@ -34,7 +34,6 @@
 			</parameter-group>
 			<!-- Trigger actions -->
 			<parameter-group name="actions">
-				<context></context>
 				<label>Actions</label>
 				<description>Action Buttons</description>
 			</parameter-group>


### PR DESCRIPTION
SAT fails after openhab/openhab-core#5372

See https://ci.openhab.org/job/openHAB-Addons/