### PR TITLE
[verisure] Fix NPE when API returns null gui field (#20324)

### DIFF
--- a/bundles/org.openhab.binding.verisure/pom.xml
+++ b/bundles/org.openhab.binding.verisure/pom.xml
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
 

--- a/bundles/org.openhab.binding.verisure/src/main/java/org/openhab/binding/verisure/internal/VerisureSession.java
+++ b/bundles/org.openhab.binding.verisure/src/main/java/org/openhab/binding/verisure/internal/VerisureSession.java
@@ -49,6 +49,7 @@ import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.openhab.binding.verisure.internal.dto.VerisureAlarmsDTO;
+import org.openhab.binding.verisure.internal.dto.VerisureBaseThingDTO.Gui;
 import org.openhab.binding.verisure.internal.dto.VerisureBatteryStatusDTO;
 import org.openhab.binding.verisure.internal.dto.VerisureBroadbandConnectionsDTO;
 import org.openhab.binding.verisure.internal.dto.VerisureClimatesDTO;
@@ -912,7 +913,8 @@ public class VerisureSession {
             if (climateList != null) {
                 climateList.forEach(climate -> {
                     // If thing is Mouse detection device, then skip it, but fetch temperature from it
-                    String type = climate.getDevice().getGui().getLabel();
+                    Gui gui = climate.getDevice().getGui();
+                    String type = gui != null ? gui.getLabel() : null;
                     if ("MOUSE".equals(type)) {
                         logger.debug("Mouse detection device!");
                         String deviceId = climate.getDevice().getDeviceLabel();

--- a/bundles/org.openhab.binding.verisure/src/main/java/org/openhab/binding/verisure/internal/dto/VerisureBaseThingDTO.java
+++ b/bundles/org.openhab.binding.verisure/src/main/java/org/openhab/binding/verisure/internal/dto/VerisureBaseThingDTO.java
@@ -411,7 +411,7 @@ public abstract class VerisureBaseThingDTO implements VerisureThingDTO {
 
         private @Nullable String deviceLabel;
         private @Nullable String area;
-        private Gui gui = new Gui();
+        private @Nullable Gui gui = new Gui();
         @SerializedName("__typename")
         private @Nullable String typename;
 
@@ -423,7 +423,7 @@ public abstract class VerisureBaseThingDTO implements VerisureThingDTO {
             return area;
         }
 
-        public Gui getGui() {
+        public @Nullable Gui getGui() {
             return gui;
         }
 
@@ -439,7 +439,8 @@ public abstract class VerisureBaseThingDTO implements VerisureThingDTO {
             result = prime * result + ((localArea == null) ? 0 : localArea.hashCode());
             String localDeviceLabel = deviceLabel;
             result = prime * result + ((localDeviceLabel == null) ? 0 : localDeviceLabel.hashCode());
-            result = prime * result + gui.hashCode();
+            Gui localGui = gui;
+            result = prime * result + ((localGui == null) ? 0 : localGui.hashCode());
             String localTypeName = typename;
             result = prime * result + ((localTypeName == null) ? 0 : localTypeName.hashCode());
             return result;
@@ -473,7 +474,12 @@ public abstract class VerisureBaseThingDTO implements VerisureThingDTO {
             } else if (!localDeviceLabel.equals(other.deviceLabel)) {
                 return false;
             }
-            if (!gui.equals(other.gui)) {
+            Gui localGui = gui;
+            if (localGui == null) {
+                if (other.gui != null) {
+                    return false;
+                }
+            } else if (!localGui.equals(other.gui)) {
                 return false;
             }
             String localTypeName = typename;

--- a/bundles/org.openhab.binding.verisure/src/main/java/org/openhab/binding/verisure/internal/dto/VerisureClimatesDTO.java
+++ b/bundles/org.openhab.binding.verisure/src/main/java/org/openhab/binding/verisure/internal/dto/VerisureClimatesDTO.java
@@ -41,7 +41,8 @@ public class VerisureClimatesDTO extends VerisureBaseThingDTO {
 
     @Override
     public ThingTypeUID getThingTypeUID() {
-        String type = getData().getInstallation().getClimates().get(0).getDevice().getGui().getLabel();
+        Gui gui = getData().getInstallation().getClimates().get(0).getDevice().getGui();
+        String type = gui != null ? gui.getLabel() : null;
         if ("SMOKE".equals(type)) {
             return THING_TYPE_SMOKEDETECTOR;
         } else if ("WATER".equals(type)) {

--- a/bundles/org.openhab.binding.verisure/src/main/java/org/openhab/binding/verisure/internal/handler/VerisureEventLogThingHandler.java
+++ b/bundles/org.openhab.binding.verisure/src/main/java/org/openhab/binding/verisure/internal/handler/VerisureEventLogThingHandler.java
@@ -27,6 +27,7 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.binding.verisure.internal.VerisureSession;
 import org.openhab.binding.verisure.internal.VerisureThingConfiguration;
 import org.openhab.binding.verisure.internal.dto.VerisureBaseThingDTO.Device;
+import org.openhab.binding.verisure.internal.dto.VerisureBaseThingDTO.Gui;
 import org.openhab.binding.verisure.internal.dto.VerisureEventLogDTO;
 import org.openhab.binding.verisure.internal.dto.VerisureEventLogDTO.EventLog;
 import org.openhab.binding.verisure.internal.dto.VerisureEventLogDTO.PagedList;
@@ -128,8 +129,9 @@ public class VerisureEventLogThingHandler extends VerisureThingHandler<VerisureE
                     triggerEventChannels(eventLog);
                 }
             case CHANNEL_LAST_EVENT_DEVICE_TYPE:
-                return device != null && device.getGui().getLabel() != null ? new StringType(device.getGui().getLabel())
-                        : UnDefType.NULL;
+                Gui gui = device != null ? device.getGui() : null;
+                String label = gui != null ? gui.getLabel() : null;
+                return label != null ? new StringType(label) : UnDefType.NULL;
             case CHANNEL_LAST_EVENT_TYPE:
                 String lastEventType = eventLog.getPagedList().get(0).getEventType();
                 return lastEventType != null ? new StringType(lastEventType) : UnDefType.NULL;

--- a/bundles/org.openhab.binding.verisure/src/main/java/org/openhab/binding/verisure/internal/handler/VerisureGatewayThingHandler.java
+++ b/bundles/org.openhab.binding.verisure/src/main/java/org/openhab/binding/verisure/internal/handler/VerisureGatewayThingHandler.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.Set;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.binding.verisure.internal.dto.VerisureBaseThingDTO.Gui;
 import org.openhab.binding.verisure.internal.dto.VerisureGatewayDTO;
 import org.openhab.binding.verisure.internal.dto.VerisureGatewayDTO.CommunicationState;
 import org.openhab.core.library.types.StringType;
@@ -89,7 +90,8 @@ public class VerisureGatewayThingHandler extends VerisureThingHandler<VerisureGa
                 String state = communicationState.getResult();
                 return state != null ? new StringType(state) : UnDefType.NULL;
             case CHANNEL_GATEWAY_MODEL:
-                String model = communicationState.getDevice().getGui().getLabel();
+                Gui gui = communicationState.getDevice().getGui();
+                String model = gui != null ? gui.getLabel() : null;
                 return model != null ? new StringType(model) : UnDefType.NULL;
             case CHANNEL_LOCATION:
                 String location = communicationState.getDevice().getArea();


### PR DESCRIPTION
## Summary
- Fix NullPointerException in `updateClimateStatus` when `Device.getGui()` returns null
- Make `Device.gui` field `@Nullable` and add null checks at all 4 call sites
- Update `Device.hashCode()` and `equals()` to handle null gui

Fixes #20324

## Root Cause
When the Verisure GraphQL API omits or nulls the `gui` field in the climate response, Gson overrides the Java default `new Gui()` with `null`. The code then calls `getGui().getLabel()` without null checking, causing an NPE that prevents all climate temperature updates.

## Pre-built JAR for testing
[Download org.openhab.binding.verisure-5.1.4-SNAPSHOT.jar](https://github.com/jannegpriv/openhab-addons/releases/download/v5.1.4-verisure-20324/org.openhab.binding.verisure-5.1.4-SNAPSHOT.jar)

Copy to your openHAB `addons/` folder to test.

## Note: main branch divergence
Commit 7541668f62 ([verisure] Fix HTTP 400 errors due to duplicate Content-Type headers - PR #19725) was merged to 5.1.x but was **never cherry-picked to main**. This means the Verisure binding on main is missing critical fixes including updated API server URLs. This NPE fix will also need to be applied to main separately, along with a cherry-pick of #19725.

## Test plan
- [x] Deployed patched JAR to production openHAB 5.1.1 on K3s
- [x] Verified no NPEs in logs
- [x] Verified climate temperatures reporting correctly
- [x] Verified binding compiles cleanly with spotless

Signed-off-by: Jan Gustafsson <jannegpriv@gmail.com>