### PR TITLE
[shelly] Fix DST issue

### DIFF
--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api1/Shelly1CoIoTVersion2.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api1/Shelly1CoIoTVersion2.java
@@ -21,6 +21,7 @@ import static org.openhab.binding.shelly.internal.ShellyBindingConstants.*;
 import static org.openhab.binding.shelly.internal.api1.Shelly1ApiJsonDTO.*;
 import static org.openhab.binding.shelly.internal.util.ShellyUtils.*;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -31,6 +32,7 @@ import org.openhab.binding.shelly.internal.api1.Shelly1CoapJSonDTO.CoIotDescrSen
 import org.openhab.binding.shelly.internal.api1.Shelly1CoapJSonDTO.CoIotSensor;
 import org.openhab.binding.shelly.internal.handler.ShellyColorUtils;
 import org.openhab.binding.shelly.internal.handler.ShellyThingInterface;
+import org.openhab.core.library.types.DateTimeType;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.library.types.OpenClosedType;
 import org.openhab.core.library.unit.SIUnits;
@@ -363,17 +365,17 @@ public class Shelly1CoIoTVersion2 extends Shelly1CoIoTProtocol implements Shelly
                 // {"I":6107,"T":"A","D":"motion","R":["0/1","-1"],"L":1},
                 updateChannel(updates, CHANNEL_GROUP_SENSOR, CHANNEL_SENSOR_MOTION, OnOffType.from(value == 1));
                 break;
-            case "3119": // Motion timestamp (timestamp os GMT, not adapted to the adapted timezone)
+            case "3119": // Motion timestamp (timestamp is GMT, not adapted to the adapted timezone)
                 // {"I":3119,"T":"S","D":"timestamp","U":"s","R":["U32","-1"],"L":1},
                 if (s.value != 0) {
                     updateChannel(updates, CHANNEL_GROUP_SENSOR, CHANNEL_SENSOR_MOTION_TS,
-                            getTimestamp(getString("GMT"), (long) s.value));
+                            new DateTimeType(Instant.ofEpochSecond((long) s.value)));
                 }
                 break;
-            case "3120": // motionActive (timestamp os GMT, not adapted to the adapted timezone)
+            case "3120": // motionActive (timestamp is GMT, not adapted to the adapted timezone)
                 // {"I":3120,"T":"S","D":"motionActive","R":["0/1","-1"],"L":1},
                 updateChannel(updates, CHANNEL_GROUP_SENSOR, CHANNEL_SENSOR_MOTION_ACT,
-                        getTimestamp("GMT", (long) s.value));
+                        new DateTimeType(Instant.ofEpochSecond((long) s.value)));
                 break;
 
             case "6108": // A, gas, none/mild/heavy/test or unknown

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/util/ShellyUtils.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/util/ShellyUtils.java
@@ -295,14 +295,14 @@ public class ShellyUtils {
     }
 
     public static DateTimeType getTimestamp() {
-        return new DateTimeType(ZonedDateTime.now().truncatedTo(ChronoUnit.SECONDS));
+        return new DateTimeType(Instant.now().truncatedTo(ChronoUnit.SECONDS));
     }
 
     public static DateTimeType getTimestamp(String zone, long timestamp) {
         try {
-            ZoneId zoneId = !zone.isEmpty() ? ZoneId.of(zone) : ZoneId.systemDefault();
-            ZonedDateTime zdt = ZonedDateTime.now(zoneId);
-            int delta = zdt.getOffset().getTotalSeconds();
+            ZoneId zoneId = zone.isEmpty() ? ZoneId.systemDefault() : ZoneId.of(zone);
+            Instant instant = Instant.ofEpochSecond(timestamp);
+            int delta = zoneId.getRules().getOffset(instant).getTotalSeconds();
             return new DateTimeType(Instant.ofEpochSecond(timestamp - delta));
         } catch (DateTimeException e) {
             // Unable to convert device's timezone, use system one

--- a/bundles/org.openhab.binding.shelly/src/test/java/org/openhab/binding/shelly/internal/util/ShellyUtilsTest.java
+++ b/bundles/org.openhab.binding.shelly/src/test/java/org/openhab/binding/shelly/internal/util/ShellyUtilsTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.shelly.internal.util;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
+import java.util.stream.Stream;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.openhab.core.library.types.DateTimeType;
+
+/**
+ * Tests for {@link ShellyUtils}.
+ *
+ * @author Jacob Laursen - Initial contribution
+ */
+@NonNullByDefault
+public class ShellyUtilsTest {
+    @ParameterizedTest
+    @MethodSource("provideTestCasesForGetTimestamp")
+    void getTimestamp(String zone, long timestamp, Instant expectedInstant) {
+        DateTimeType actual = ShellyUtils.getTimestamp(zone, timestamp);
+        DateTimeType expected = new DateTimeType(expectedInstant);
+        assertThat(actual, is(equalTo(expected)));
+    }
+
+    private static Stream<Arguments> provideTestCasesForGetTimestamp() {
+        return Stream.of( //
+                Arguments.of("UTC", 1772900449, Instant.parse("2026-03-07T16:20:49Z")), //
+                Arguments.of("Europe/Copenhagen", 1772900449, Instant.parse("2026-03-07T15:20:49Z")), //
+                Arguments.of("Europe/Copenhagen", 1783441249, Instant.parse("2026-07-07T14:20:49Z")), //
+                Arguments.of("", 1772900449,
+                        LocalDateTime.parse("2026-03-07T16:20:49").atZone(ZoneId.systemDefault()).toInstant()));
+    }
+
+    @Test
+    void getTimestampInvalidZoneFallsBackToNow() {
+        Instant before = Instant.now().truncatedTo(ChronoUnit.SECONDS);
+        DateTimeType actual = ShellyUtils.getTimestamp("_invalid", 123);
+        Instant actualInstant = actual.getInstant();
+        Instant after = Instant.now().truncatedTo(ChronoUnit.SECONDS);
+
+        assertThat(actualInstant, allOf(greaterThanOrEqualTo(before), lessThanOrEqualTo(after)));
+        assertThat(actualInstant.getNano(), is(0));
+    }
+}


### PR DESCRIPTION
This fixes two SAT warnings and a DST bug.

This testcase failed before the fix:
```java
Arguments.of("CET", 1783441249, Instant.parse("2026-07-07T14:20:49Z")), //
```

since the offset was determined from `now` rather than the provided timestamp.

I have preserved the strange concept of "local epoch", since otherwise the method wouldn't make sense at all. I assume this is concept actually implemented by the devices? Otherwise this could be further improved/simplified.

I'm also not sure why `getTimestamp()` truncates to seconds, but have preserved this as well.