### PR TITLE
[verisure] Fix `NullPointerException` for specific case in climate devices

### DIFF
--- a/bundles/org.openhab.binding.verisure/src/main/java/org/openhab/binding/verisure/internal/VerisureSession.java
+++ b/bundles/org.openhab.binding.verisure/src/main/java/org/openhab/binding/verisure/internal/VerisureSession.java
@@ -49,6 +49,7 @@ import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.openhab.binding.verisure.internal.dto.VerisureAlarmsDTO;
+import org.openhab.binding.verisure.internal.dto.VerisureBaseThingDTO.Gui;
 import org.openhab.binding.verisure.internal.dto.VerisureBatteryStatusDTO;
 import org.openhab.binding.verisure.internal.dto.VerisureBroadbandConnectionsDTO;
 import org.openhab.binding.verisure.internal.dto.VerisureClimatesDTO;
@@ -912,7 +913,8 @@ public class VerisureSession {
             if (climateList != null) {
                 climateList.forEach(climate -> {
                     // If thing is Mouse detection device, then skip it, but fetch temperature from it
-                    String type = climate.getDevice().getGui().getLabel();
+                    Gui gui = climate.getDevice().getGui();
+                    String type = gui != null ? gui.getLabel() : null;
                     if ("MOUSE".equals(type)) {
                         logger.debug("Mouse detection device!");
                         String deviceId = climate.getDevice().getDeviceLabel();

--- a/bundles/org.openhab.binding.verisure/src/main/java/org/openhab/binding/verisure/internal/dto/VerisureBaseThingDTO.java
+++ b/bundles/org.openhab.binding.verisure/src/main/java/org/openhab/binding/verisure/internal/dto/VerisureBaseThingDTO.java
@@ -411,7 +411,7 @@ public abstract class VerisureBaseThingDTO implements VerisureThingDTO {
 
         private @Nullable String deviceLabel;
         private @Nullable String area;
-        private Gui gui = new Gui();
+        private @Nullable Gui gui = new Gui();
         @SerializedName("__typename")
         private @Nullable String typename;
 
@@ -423,7 +423,7 @@ public abstract class VerisureBaseThingDTO implements VerisureThingDTO {
             return area;
         }
 
-        public Gui getGui() {
+        public @Nullable Gui getGui() {
             return gui;
         }
 
@@ -439,7 +439,8 @@ public abstract class VerisureBaseThingDTO implements VerisureThingDTO {
             result = prime * result + ((localArea == null) ? 0 : localArea.hashCode());
             String localDeviceLabel = deviceLabel;
             result = prime * result + ((localDeviceLabel == null) ? 0 : localDeviceLabel.hashCode());
-            result = prime * result + gui.hashCode();
+            Gui localGui = gui;
+            result = prime * result + ((localGui == null) ? 0 : localGui.hashCode());
             String localTypeName = typename;
             result = prime * result + ((localTypeName == null) ? 0 : localTypeName.hashCode());
             return result;
@@ -473,7 +474,12 @@ public abstract class VerisureBaseThingDTO implements VerisureThingDTO {
             } else if (!localDeviceLabel.equals(other.deviceLabel)) {
                 return false;
             }
-            if (!gui.equals(other.gui)) {
+            Gui localGui = gui;
+            if (localGui == null) {
+                if (other.gui != null) {
+                    return false;
+                }
+            } else if (!localGui.equals(other.gui)) {
                 return false;
             }
             String localTypeName = typename;

--- a/bundles/org.openhab.binding.verisure/src/main/java/org/openhab/binding/verisure/internal/dto/VerisureClimatesDTO.java
+++ b/bundles/org.openhab.binding.verisure/src/main/java/org/openhab/binding/verisure/internal/dto/VerisureClimatesDTO.java
@@ -41,7 +41,8 @@ public class VerisureClimatesDTO extends VerisureBaseThingDTO {
 
     @Override
     public ThingTypeUID getThingTypeUID() {
-        String type = getData().getInstallation().getClimates().get(0).getDevice().getGui().getLabel();
+        Gui gui = getData().getInstallation().getClimates().get(0).getDevice().getGui();
+        String type = gui != null ? gui.getLabel() : null;
         if ("SMOKE".equals(type)) {
             return THING_TYPE_SMOKEDETECTOR;
         } else if ("WATER".equals(type)) {

--- a/bundles/org.openhab.binding.verisure/src/main/java/org/openhab/binding/verisure/internal/handler/VerisureEventLogThingHandler.java
+++ b/bundles/org.openhab.binding.verisure/src/main/java/org/openhab/binding/verisure/internal/handler/VerisureEventLogThingHandler.java
@@ -128,6 +128,7 @@ public class VerisureEventLogThingHandler extends VerisureThingHandler<VerisureE
                 if (lastEventTime != 0) {
                     triggerEventChannels(eventLog);
                 }
+                return UnDefType.UNDEF;
             case CHANNEL_LAST_EVENT_DEVICE_TYPE:
                 Gui gui = device != null ? device.getGui() : null;
                 String label = gui != null ? gui.getLabel() : null;

--- a/bundles/org.openhab.binding.verisure/src/main/java/org/openhab/binding/verisure/internal/handler/VerisureEventLogThingHandler.java
+++ b/bundles/org.openhab.binding.verisure/src/main/java/org/openhab/binding/verisure/internal/handler/VerisureEventLogThingHandler.java
@@ -27,6 +27,7 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.binding.verisure.internal.VerisureSession;
 import org.openhab.binding.verisure.internal.VerisureThingConfiguration;
 import org.openhab.binding.verisure.internal.dto.VerisureBaseThingDTO.Device;
+import org.openhab.binding.verisure.internal.dto.VerisureBaseThingDTO.Gui;
 import org.openhab.binding.verisure.internal.dto.VerisureEventLogDTO;
 import org.openhab.binding.verisure.internal.dto.VerisureEventLogDTO.EventLog;
 import org.openhab.binding.verisure.internal.dto.VerisureEventLogDTO.PagedList;
@@ -128,8 +129,9 @@ public class VerisureEventLogThingHandler extends VerisureThingHandler<VerisureE
                     triggerEventChannels(eventLog);
                 }
             case CHANNEL_LAST_EVENT_DEVICE_TYPE:
-                return device != null && device.getGui().getLabel() != null ? new StringType(device.getGui().getLabel())
-                        : UnDefType.NULL;
+                Gui gui = device != null ? device.getGui() : null;
+                String label = gui != null ? gui.getLabel() : null;
+                return label != null ? new StringType(label) : UnDefType.NULL;
             case CHANNEL_LAST_EVENT_TYPE:
                 String lastEventType = eventLog.getPagedList().get(0).getEventType();
                 return lastEventType != null ? new StringType(lastEventType) : UnDefType.NULL;

--- a/bundles/org.openhab.binding.verisure/src/main/java/org/openhab/binding/verisure/internal/handler/VerisureEventLogThingHandler.java
+++ b/bundles/org.openhab.binding.verisure/src/main/java/org/openhab/binding/verisure/internal/handler/VerisureEventLogThingHandler.java
@@ -85,12 +85,22 @@ public class VerisureEventLogThingHandler extends VerisureThingHandler<VerisureE
     private void updateEventLogState(VerisureEventLogDTO eventLogJSON) {
         EventLog eventLog = eventLogJSON.getData().getInstallation().getEventLog();
         if (!eventLog.getPagedList().isEmpty()) {
-            getThing().getChannels().stream().map(Channel::getUID).filter(channelUID -> isLinked(channelUID))
+            // The last-event-time channel is handled separately via updateTimeStamp(), so exclude it from the
+            // generic loop to avoid setting it to UNDEF and then immediately overwriting it with the timestamp,
+            // which would produce two state updates/events per refresh.
+            getThing().getChannels().stream().map(Channel::getUID)
+                    .filter(channelUID -> isLinked(channelUID) && !CHANNEL_LAST_EVENT_TIME.equals(channelUID.getId()))
                     .forEach(channelUID -> {
                         State state = getValue(channelUID.getId(), eventLogJSON, eventLog);
                         updateState(channelUID, state);
                     });
             updateInstallationChannels(eventLogJSON);
+            // Trigger event channels before lastEventTime is updated below, so that events newer than the
+            // previous refresh are detected. Skipped on the first refresh (lastEventTime == 0) to avoid
+            // flooding trigger channels on startup.
+            if (lastEventTime != 0) {
+                triggerEventChannels(eventLog);
+            }
             String eventTime = eventLogJSON.getData().getInstallation().getEventLog().getPagedList().get(0)
                     .getEventTime();
             if (eventTime != null) {
@@ -124,11 +134,6 @@ public class VerisureEventLogThingHandler extends VerisureThingHandler<VerisureE
                 } else {
                     return UnDefType.NULL;
                 }
-            case CHANNEL_LAST_EVENT_TIME:
-                if (lastEventTime != 0) {
-                    triggerEventChannels(eventLog);
-                }
-                return UnDefType.UNDEF;
             case CHANNEL_LAST_EVENT_DEVICE_TYPE:
                 Gui gui = device != null ? device.getGui() : null;
                 String label = gui != null ? gui.getLabel() : null;

--- a/bundles/org.openhab.binding.verisure/src/main/java/org/openhab/binding/verisure/internal/handler/VerisureGatewayThingHandler.java
+++ b/bundles/org.openhab.binding.verisure/src/main/java/org/openhab/binding/verisure/internal/handler/VerisureGatewayThingHandler.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.Set;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.binding.verisure.internal.dto.VerisureBaseThingDTO.Gui;
 import org.openhab.binding.verisure.internal.dto.VerisureGatewayDTO;
 import org.openhab.binding.verisure.internal.dto.VerisureGatewayDTO.CommunicationState;
 import org.openhab.core.library.types.StringType;
@@ -89,7 +90,8 @@ public class VerisureGatewayThingHandler extends VerisureThingHandler<VerisureGa
                 String state = communicationState.getResult();
                 return state != null ? new StringType(state) : UnDefType.NULL;
             case CHANNEL_GATEWAY_MODEL:
-                String model = communicationState.getDevice().getGui().getLabel();
+                Gui gui = communicationState.getDevice().getGui();
+                String model = gui != null ? gui.getLabel() : null;
                 return model != null ? new StringType(model) : UnDefType.NULL;
             case CHANNEL_LOCATION:
                 String location = communicationState.getDevice().getArea();


### PR DESCRIPTION
## Summary
- Add null-safety checks for `Device.getGui()` which can return `null` when Gson deserializes API responses where the gui field is absent
- This caused a `NullPointerException` in `updateClimateStatus`, preventing all climate temperature updates

Fixes #20324

Supersedes #20328 (which was incorrectly targeted at 5.1.x)

Signed-off-by: Jan Gustafsson <jannegpriv@gmail.com>