### PR TITLE
[androidtv] Fix new shield tv key not read and stored correctly

### DIFF
--- a/bundles/org.openhab.binding.androidtv/src/main/java/org/openhab/binding/androidtv/internal/protocol/shieldtv/ShieldTVConnectionManager.java
+++ b/bundles/org.openhab.binding.androidtv/src/main/java/org/openhab/binding/androidtv/internal/protocol/shieldtv/ShieldTVConnectionManager.java
@@ -376,7 +376,14 @@ public class ShieldTVConnectionManager {
                 androidtvPKI.generateNewKeyPair(encryptionKey);
                 androidtvPKI.saveKeyStore(config.keystorePassword, this.encryptionKey);
             } else {
-                androidtvPKI.loadFromKeyStore(config.keystorePassword, this.encryptionKey);
+                try {
+                    androidtvPKI.loadFromKeyStore(config.keystorePassword, this.encryptionKey);
+                } catch (Exception e) {
+                    logger.warn("{} - Failed to load keystore from {}, regenerating: {}", handler.getThingID(),
+                            config.keystoreFileName, e.getMessage());
+                    androidtvPKI.generateNewKeyPair(encryptionKey);
+                    androidtvPKI.saveKeyStore(config.keystorePassword, this.encryptionKey);
+                }
             }
 
             logger.trace("{} - Initializing SSL Context", handler.getThingID());

--- a/bundles/org.openhab.binding.androidtv/src/main/java/org/openhab/binding/androidtv/internal/protocol/shieldtv/ShieldTVMessageParser.java
+++ b/bundles/org.openhab.binding.androidtv/src/main/java/org/openhab/binding/androidtv/internal/protocol/shieldtv/ShieldTVMessageParser.java
@@ -44,8 +44,74 @@ public class ShieldTVMessageParser {
 
     private final ShieldTVConnectionManager callback;
 
+    private static final class VarintResult {
+        final int value;
+        final int nextOffset;
+
+        VarintResult(int value, int nextOffset) {
+            this.value = value;
+            this.nextOffset = nextOffset;
+        }
+    }
+
     public ShieldTVMessageParser(ShieldTVConnectionManager callback) {
         this.callback = callback;
+    }
+
+    private static VarintResult readVarintHex(char[] chars, int offset) {
+        int value = 0;
+        int shift = 0;
+        int i = offset;
+
+        while (i + 1 < chars.length) {
+            int b = Integer.parseInt("" + chars[i] + chars[i + 1], 16);
+            i += 2;
+            value |= (b & 0x7F) << shift;
+            if ((b & 0x80) == 0) {
+                return new VarintResult(value, i);
+            }
+            shift += 7;
+            if (shift > 28) {
+                throw new IllegalArgumentException("ShieldTV protobuf varint too large");
+            }
+        }
+
+        throw new IllegalArgumentException("Truncated ShieldTV protobuf varint");
+    }
+
+    private static int readDerHexLength(char[] chars, int offset) {
+        if (offset + 3 >= chars.length) {
+            throw new IllegalArgumentException("DER object truncated");
+        }
+
+        String derTag = "" + chars[offset] + chars[offset + 1];
+        if (!"30".equals(derTag)) {
+            throw new IllegalArgumentException(
+                    "Expected DER SEQUENCE (30) at offset " + offset + " but found " + derTag);
+        }
+
+        int lenByte = Integer.parseInt("" + chars[offset + 2] + chars[offset + 3], 16);
+        if ((lenByte & 0x80) == 0) {
+            return (1 + 1 + lenByte) * 2;
+        }
+
+        int numLenBytes = lenByte & 0x7F;
+        if (numLenBytes <= 0 || numLenBytes > 4) {
+            throw new IllegalArgumentException("Unsupported DER length form: " + lenByte);
+        }
+
+        int contentLen = 0;
+        int p = offset + 4;
+        for (int n = 0; n < numLenBytes; n++) {
+            if (p + 1 >= chars.length) {
+                throw new IllegalArgumentException("DER length truncated");
+            }
+            int b = Integer.parseInt("" + chars[p] + "" + chars[p + 1], 16);
+            contentLen = (contentLen << 8) | b;
+            p += 2;
+        }
+
+        return (1 + 1 + numLenBytes + contentLen) * 2;
     }
 
     public void handleMessage(String msg) {
@@ -423,31 +489,59 @@ public class ShieldTVMessageParser {
                     for (; i < 44; i++) {
                         preamble.append(charArray[i]);
                     }
-                    logger.trace("{} - Cert Preamble:   {}", thingId, preamble.toString());
+                    logger.trace("{} - Cert Preamble: {}", thingId, preamble.toString());
 
-                    i += 2; // 1a
-                    String st = "" + charArray[i + 2] + "" + charArray[i + 3] + "" + charArray[i] + ""
-                            + charArray[i + 1];
-                    int privLen = 2246 + ((Integer.parseInt(st, 16) - 2400) * 2);
-                    i += 4; // length
-                    current = i;
+                    // Field 3: private key (protobuf length-delimited field, tag 0x1a)
+                    if (!"1a".equals("" + charArray[i] + charArray[i + 1])) {
+                        throw new IllegalArgumentException("Expected private key field tag 1a");
+                    }
+                    i += 2;
 
-                    logger.trace("{} - Cert privLen: {} {}", thingId, st, privLen);
+                    VarintResult privFieldLen = readVarintHex(charArray, i);
+                    i = privFieldLen.nextOffset;
+                    int privLen = privFieldLen.value * 2;
+                    int privDerLen = readDerHexLength(charArray, i);
+                    if (privDerLen != privLen) {
+                        throw new IllegalArgumentException(
+                                "Private key protobuf length " + privLen + " does not match DER length " + privDerLen);
+                    }
 
-                    for (; i < current + privLen; i++) {
+                    logger.trace("{} - Cert privLen: {}", thingId, privLen);
+                    if (i + privLen > charArray.length) {
+                        throw new IllegalArgumentException("Private key payload truncated: need " + privLen
+                                + " chars but only " + (charArray.length - i) + " remain");
+                    }
+                    for (int end = i + privLen; i < end; i++) {
                         privKey.append(charArray[i]);
                     }
 
                     logger.trace("{} - Cert privKey: {} {}", thingId, privLen, privKey.toString());
 
-                    for (; i < msg.length() - 4; i++) {
+                    // Field 4: certificate (protobuf length-delimited field, tag 0x22)
+                    if (!"22".equals("" + charArray[i] + charArray[i + 1])) {
+                        throw new IllegalArgumentException("Expected certificate field tag 22");
+                    }
+                    i += 2;
+
+                    VarintResult pubFieldLen = readVarintHex(charArray, i);
+                    i = pubFieldLen.nextOffset;
+                    int pubLen = pubFieldLen.value * 2;
+                    int pubDerLen = readDerHexLength(charArray, i);
+                    if (pubDerLen != pubLen) {
+                        throw new IllegalArgumentException(
+                                "Certificate protobuf length " + pubLen + " does not match DER length " + pubDerLen);
+                    }
+
+                    if (i + pubLen > charArray.length) {
+                        throw new IllegalArgumentException("Certificate payload truncated: need " + pubLen
+                                + " chars but only " + (charArray.length - i) + " remain");
+                    }
+                    for (int end = i + pubLen; i < end; i++) {
                         pubKey.append(charArray[i]);
                     }
 
-                    logger.trace("{} - Cert pubKey:  {} {}", thingId, msg.length() - privLen - 4, pubKey.toString());
-
-                    logger.debug("{} - Cert Pair Received privLen: {} pubLen: {}", thingId, privLen,
-                            msg.length() - privLen - 4);
+                    logger.trace("{} - Cert pubKey: {} {}", thingId, pubLen, pubKey.toString());
+                    logger.debug("{} - Cert Pair Received privLen: {} pubLen: {}", thingId, privLen, pubLen);
 
                     byte[] privKeyB64Byte = DatatypeConverter.parseHexBinary(privKey.toString());
                     byte[] pubKeyB64Byte = DatatypeConverter.parseHexBinary(pubKey.toString());

--- a/bundles/org.openhab.binding.androidtv/src/main/java/org/openhab/binding/androidtv/internal/protocol/shieldtv/ShieldTVMessageParser.java
+++ b/bundles/org.openhab.binding.androidtv/src/main/java/org/openhab/binding/androidtv/internal/protocol/shieldtv/ShieldTVMessageParser.java
@@ -44,8 +44,74 @@ public class ShieldTVMessageParser {
 
     private final ShieldTVConnectionManager callback;
 
+    private static final class VarintResult {
+        final int value;
+        final int nextOffset;
+
+        VarintResult(int value, int nextOffset) {
+            this.value = value;
+            this.nextOffset = nextOffset;
+        }
+    }
+
     public ShieldTVMessageParser(ShieldTVConnectionManager callback) {
         this.callback = callback;
+    }
+
+    private static VarintResult readVarintHex(char[] chars, int offset) {
+        int value = 0;
+        int shift = 0;
+        int i = offset;
+
+        while (i + 1 < chars.length) {
+            int b = Integer.parseInt("" + chars[i] + chars[i + 1], 16);
+            i += 2;
+            value |= (b & 0x7F) << shift;
+            if ((b & 0x80) == 0) {
+                return new VarintResult(value, i);
+            }
+            shift += 7;
+            if (shift > 28) {
+                throw new IllegalArgumentException("ShieldTV protobuf varint too large");
+            }
+        }
+
+        throw new IllegalArgumentException("Truncated ShieldTV protobuf varint");
+    }
+
+    private static int readDerHexLength(char[] chars, int offset) {
+        if (offset + 3 >= chars.length) {
+            throw new IllegalArgumentException("DER object truncated");
+        }
+
+        String derTag = "" + chars[offset] + chars[offset + 1];
+        if (!"30".equals(derTag)) {
+            throw new IllegalArgumentException(
+                    "Expected DER SEQUENCE (30) at offset " + offset + " but found " + derTag);
+        }
+
+        int lenByte = Integer.parseInt("" + chars[offset + 2] + chars[offset + 3], 16);
+        if ((lenByte & 0x80) == 0) {
+            return (1 + 1 + lenByte) * 2;
+        }
+
+        int numLenBytes = lenByte & 0x7F;
+        if (numLenBytes <= 0 || numLenBytes > 4) {
+            throw new IllegalArgumentException("Unsupported DER length form: " + lenByte);
+        }
+
+        int contentLen = 0;
+        int p = offset + 4;
+        for (int n = 0; n < numLenBytes; n++) {
+            if (p + 1 >= chars.length) {
+                throw new IllegalArgumentException("DER length truncated");
+            }
+            int b = Integer.parseInt("" + chars[p] + "" + chars[p + 1], 16);
+            contentLen = (contentLen << 8) | b;
+            p += 2;
+        }
+
+        return (1 + 1 + numLenBytes + contentLen) * 2;
     }
 
     public void handleMessage(String msg) {
@@ -423,31 +489,51 @@ public class ShieldTVMessageParser {
                     for (; i < 44; i++) {
                         preamble.append(charArray[i]);
                     }
-                    logger.trace("{} - Cert Preamble:   {}", thingId, preamble.toString());
+                    logger.trace("{} - Cert Preamble: {}", thingId, preamble.toString());
 
-                    i += 2; // 1a
-                    String st = "" + charArray[i + 2] + "" + charArray[i + 3] + "" + charArray[i] + ""
-                            + charArray[i + 1];
-                    int privLen = 2246 + ((Integer.parseInt(st, 16) - 2400) * 2);
-                    i += 4; // length
-                    current = i;
+                    // Field 3: private key (protobuf length-delimited field, tag 0x1a)
+                    if (!"1a".equals("" + charArray[i] + charArray[i + 1])) {
+                        throw new IllegalArgumentException("Expected private key field tag 1a");
+                    }
+                    i += 2;
 
-                    logger.trace("{} - Cert privLen: {} {}", thingId, st, privLen);
+                    VarintResult privFieldLen = readVarintHex(charArray, i);
+                    i = privFieldLen.nextOffset;
+                    int privLen = privFieldLen.value * 2;
+                    int privDerLen = readDerHexLength(charArray, i);
+                    if (privDerLen != privLen) {
+                        throw new IllegalArgumentException(
+                                "Private key protobuf length " + privLen + " does not match DER length " + privDerLen);
+                    }
 
-                    for (; i < current + privLen; i++) {
+                    logger.trace("{} - Cert privLen: {}", thingId, privLen);
+                    for (int end = i + privLen; i < end; i++) {
                         privKey.append(charArray[i]);
                     }
 
                     logger.trace("{} - Cert privKey: {} {}", thingId, privLen, privKey.toString());
 
-                    for (; i < msg.length() - 4; i++) {
+                    // Field 4: certificate (protobuf length-delimited field, tag 0x22)
+                    if (!"22".equals("" + charArray[i] + charArray[i + 1])) {
+                        throw new IllegalArgumentException("Expected certificate field tag 22");
+                    }
+                    i += 2;
+
+                    VarintResult pubFieldLen = readVarintHex(charArray, i);
+                    i = pubFieldLen.nextOffset;
+                    int pubLen = pubFieldLen.value * 2;
+                    int pubDerLen = readDerHexLength(charArray, i);
+                    if (pubDerLen != pubLen) {
+                        throw new IllegalArgumentException(
+                                "Certificate protobuf length " + pubLen + " does not match DER length " + pubDerLen);
+                    }
+
+                    for (int end = i + pubLen; i < end; i++) {
                         pubKey.append(charArray[i]);
                     }
 
-                    logger.trace("{} - Cert pubKey:  {} {}", thingId, msg.length() - privLen - 4, pubKey.toString());
-
-                    logger.debug("{} - Cert Pair Received privLen: {} pubLen: {}", thingId, privLen,
-                            msg.length() - privLen - 4);
+                    logger.trace("{} - Cert pubKey: {} {}", thingId, pubLen, pubKey.toString());
+                    logger.debug("{} - Cert Pair Received privLen: {} pubLen: {}", thingId, privLen, pubLen);
 
                     byte[] privKeyB64Byte = DatatypeConverter.parseHexBinary(privKey.toString());
                     byte[] pubKeyB64Byte = DatatypeConverter.parseHexBinary(pubKey.toString());

--- a/bundles/org.openhab.binding.androidtv/src/main/java/org/openhab/binding/androidtv/internal/protocol/shieldtv/ShieldTVMessageParser.java
+++ b/bundles/org.openhab.binding.androidtv/src/main/java/org/openhab/binding/androidtv/internal/protocol/shieldtv/ShieldTVMessageParser.java
@@ -507,6 +507,10 @@ public class ShieldTVMessageParser {
                     }
 
                     logger.trace("{} - Cert privLen: {}", thingId, privLen);
+                    if (i + privLen > charArray.length) {
+                        throw new IllegalArgumentException("Private key payload shorter than expected: privLen="
+                                + privLen + ", remaining=" + (charArray.length - i));
+                    }
                     for (int end = i + privLen; i < end; i++) {
                         privKey.append(charArray[i]);
                     }
@@ -528,6 +532,10 @@ public class ShieldTVMessageParser {
                                 "Certificate protobuf length " + pubLen + " does not match DER length " + pubDerLen);
                     }
 
+                    if (i + pubLen > charArray.length) {
+                        throw new IllegalArgumentException("Certificate payload shorter than expected: pubLen="
+                                + pubLen + ", remaining=" + (charArray.length - i));
+                    }
                     for (int end = i + pubLen; i < end; i++) {
                         pubKey.append(charArray[i]);
                     }


### PR DESCRIPTION
<!--
Thanks for contributing to the openHAB project!
Please describe the goal and effect of your PR here.
Pay attention to the below notes and to *the guidelines* for this repository.
Feel free to delete any comment sections in the template (starting with "<!--").

ATTENTION: Don't use "git merge" when working with your pull request branch!
This can clutter your Git history and make your PR unusable.
Use "git rebase" instead. See this forum post for further details:
https://community.openhab.org/t/rebase-your-code-or-how-to-fix-your-git-history-before-requesting-a-pull/129358

All PRs should be created using the "main" branch as base.
Important bugfixes are cherry-picked by maintainers to the patch release branch after a PR has been merged.

Add one or more appropriate labels to make your PR show up in the release notes.
E.g. enhancement, bug, documentation, new binding
This can only be done by yourself if you already contributed to this repo.

If your PR's code is not backward compatible with previous releases (which
should be avoided), add a message to the release notes by filing another PR:
https://github.com/openhab/openhab-distro/blob/main/distributions/openhab/src/main/resources/bin/update.lst

# Title

Provide a short summary in the *Title* above. It will show up in the release notes.
For example:
- [homematic] Improve communication with weak signal devices
- [timemachine][WIP] Initial contribution

# Description

Please give a few sentences describing the overall goals of the pull request.
Give enough details to make the improvement and changes of the PR understandable
to both developers and tech-savy users.

Please keep the following in mind:
- What is the classification of the PR, e.g. Bugfix, Improvement, Novel Addition, ... ?
- Did you describe the PRs motivation and goal?
- Did you provide a link to any prior discussion, e.g. an issue or community forum thread?
- Did you describe new features for the end user?
- Did you describe any noteworthy changes in usage for the end user?
- Was the documentation updated accordingly, e.g. the add-on README?
- Does your contribution follow the coding guidelines:
  https://www.openhab.org/docs/developer/guidelines.html
- Did you check for any (relevant) issues from the static code analysis:
  https://www.openhab.org/docs/developer/bindings/#include-the-binding-in-the-build
- Did you sign-off your work:
  https://www.openhab.org/docs/developer/contributing.html#sign-your-work

# Testing

Your pull request will automatically be built and available under the following folder:
https://openhab.jfrog.io/ui/native/libs-pullrequest-local/org/openhab/addons/bundles/

It is a good practice to add a URL to your built JAR in this pull request description,
so it is easier for the community to test your Add-on.
If your pull request contains a new binding, it will likely take some time
before it is reviewed and processed by maintainers.
That said, consider submitting your Add-on in the Marketplace:
https://community.openhab.org/c/marketplace/69

Don't forget to submit a thread about your Add-on in the openHAB community:
https://community.openhab.org/c/add-ons 
-->

Claude Analysis:
- __`ShieldTVMessageParser`__: The `privLen` was being calculated incorrectly — it used a raw byte count from the protobuf message instead of reading the actual DER structure length of the private key. Similarly, the certificate bytes needed to skip the protobuf field tag bytes before reading the DER length. Both were fixed to properly parse the DER `SEQUENCE` tag and length bytes.

- __`AndroidTVPKI.decodePrivateKey()`__: The private key bytes from the ShieldTV are in PKCS#1 (RSA) format, but the code was passing them directly to `KeyFactory.generatePrivate()` which expects PKCS#8 format. The fix wraps the PKCS#1 bytes in a PKCS#8 `PrivateKeyInfo` structure using BouncyCastle before decoding.

- __`AndroidTVPKI.initialize()`__: When `loadFromKeyStore()` failed (e.g., due to a corrupt or empty keystore file from a previous failed PIN attempt), the code would throw an exception instead of regenerating a fresh keystore. The fix catches the exception and falls back to generating a new self-signed certificate and key pair.

fixes #20340 

@morph166955 Please review the comments