### PR TITLE
[shelly] Cleaner thing handler registration

### DIFF
--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/ShellyHandlerFactory.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/ShellyHandlerFactory.java
@@ -155,13 +155,10 @@ public class ShellyHandlerFactory extends BaseThingHandlerFactory {
                     webSocketClient);
         }
 
-        if (handler != null) {
-            String uid = thing.getUID().getAsString();
-            thingTable.addThing(uid, handler);
-            logger.debug("Thing handler for uid {} added, total things = {}", uid, thingTable.size());
+        if (handler == null) {
+            logger.debug("Unable to create Thing Handler instance!");
         }
-        logger.debug("Unable to create Thing Handler instance!");
-        return null;
+        return handler;
     }
 
     /**

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/handler/ShellyBaseHandler.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/handler/ShellyBaseHandler.java
@@ -190,7 +190,10 @@ public abstract class ShellyBaseHandler extends BaseThingHandler
             boolean start = false;
             try {
                 if (initializeThingConfig()) {
-                    logger.debug("{}: Config: {}", thingName, config);
+                    String uid = thing.getUID().getAsString();
+                    thingTable.addThing(uid, this);
+                    logger.debug("Thing handler for uid {} added, total things = {}", uid, thingTable.size());
+
                     start = initializeThing();
                 }
             } catch (ShellyApiException e) {
@@ -1086,6 +1089,7 @@ public abstract class ShellyBaseHandler extends BaseThingHandler
         skipCount = config.updateInterval / UPDATE_STATUS_INTERVAL_SECONDS;
         logger.trace("{}: updateInterval = {}s -> skipCount = {}", thingName, config.updateInterval, skipCount);
 
+        logger.debug("{}: Config: {}", thingName, config);
         return true;
     }
 


### PR DESCRIPTION
Small change to handler creation. The thing handler now registers itself to the thingTable on first initialization rather than getting registered by the handler factory. This is cleaner and might prevent a timing issue when thingHandler.find() is called before the factory completes and registers-

