### PR TITLE
[pihole] Discrepencies between dashboard and channels

### DIFF
--- a/bundles/org.openhab.binding.pihole/src/main/java/org/openhab/binding/pihole/internal/PiHoleActions.java
+++ b/bundles/org.openhab.binding.pihole/src/main/java/org/openhab/binding/pihole/internal/PiHoleActions.java
@@ -67,9 +67,9 @@ public class PiHoleActions implements ThingActions {
 
     @RuleAction(label = "@text/action.disable.label", description = "@text/action.disable.description")
     public void disableBlocking(
-            @ActionInput(name = "time", label = "@text/action.disable.timeLabel", description = "@text/action.disable.timeDescription") long time)
+            @ActionInput(name = "time", label = "@text/action.disable.timeLabel", description = "@text/action.disable.timeDescription") Number time)
             throws PiHoleException {
-        disableBlocking(time, null);
+        disableBlocking(time.longValue(), null);
     }
 
     public static void disableBlocking(@Nullable ThingActions actions, long time) throws PiHoleException {

--- a/bundles/org.openhab.binding.pihole/src/main/java/org/openhab/binding/pihole/internal/rest/JettyAdminServiceV6.java
+++ b/bundles/org.openhab.binding.pihole/src/main/java/org/openhab/binding/pihole/internal/rest/JettyAdminServiceV6.java
@@ -61,7 +61,6 @@ public class JettyAdminServiceV6 extends AdminService {
     private final URI databaseSummaryURI;
     private final URI historyClientsURI;
     private final URI configURI;
-    private final URI clientsURI;
     private final String tokenJson;
 
     private @Nullable String sid;
@@ -76,7 +75,6 @@ public class JettyAdminServiceV6 extends AdminService {
         configURI = apiUriBuilder.clone().path("config").build();
         dnsBlockingURI = apiUriBuilder.clone().path("dns").path("blocking").build();
         historyClientsURI = apiUriBuilder.clone().path("history").path("clients").build();
-        clientsURI = apiUriBuilder.clone().path("clients").build();
 
         UriBuilder statsUriBuilder = apiUriBuilder.clone().path("stats");
         statsSummaryURI = statsUriBuilder.clone().path("summary").build();

--- a/bundles/org.openhab.binding.pihole/src/main/java/org/openhab/binding/pihole/internal/rest/JettyAdminServiceV6.java
+++ b/bundles/org.openhab.binding.pihole/src/main/java/org/openhab/binding/pihole/internal/rest/JettyAdminServiceV6.java
@@ -61,11 +61,11 @@ public class JettyAdminServiceV6 extends AdminService {
     private final URI databaseSummaryURI;
     private final URI historyClientsURI;
     private final URI configURI;
+    private final URI clientsURI;
     private final String tokenJson;
 
     private @Nullable String sid;
     private @Nullable Instant sessionValidity;
-    private @Nullable Instant midnightUtc;
 
     public JettyAdminServiceV6(String token, URI baseUrl, HttpClient client, Gson gson) {
         super(client, gson);
@@ -76,6 +76,7 @@ public class JettyAdminServiceV6 extends AdminService {
         configURI = apiUriBuilder.clone().path("config").build();
         dnsBlockingURI = apiUriBuilder.clone().path("dns").path("blocking").build();
         historyClientsURI = apiUriBuilder.clone().path("history").path("clients").build();
+        clientsURI = apiUriBuilder.clone().path("clients").build();
 
         UriBuilder statsUriBuilder = apiUriBuilder.clone().path("stats");
         statsSummaryURI = statsUriBuilder.clone().path("summary").build();
@@ -110,18 +111,6 @@ public class JettyAdminServiceV6 extends AdminService {
         return updateSid();
     }
 
-    private long getTodayMidnight() {
-        Instant now = Instant.now();
-        Instant local = midnightUtc;
-
-        if (local == null || now.minus(1, ChronoUnit.DAYS).isAfter(local)) {
-            local = now.truncatedTo(ChronoUnit.DAYS);
-            midnightUtc = local;
-        }
-
-        return local.getEpochSecond();
-    }
-
     @Override
     public Optional<DnsStatistics> summary() throws PiHoleException {
         logger.debug("Building the as if it was a v5 API");
@@ -132,9 +121,12 @@ public class JettyAdminServiceV6 extends AdminService {
 
         DnsBlockingAnswer blockingAnswer = get(dnsBlockingURI, DnsBlockingAnswer.class);
 
-        long todayMidnight = getTodayMidnight();
-        StatDatabaseSummary statDatabase = get(databaseSummaryURI, StatDatabaseSummary.class, "from",
-                Long.toString(todayMidnight), "until", Long.toString(todayMidnight + 24 * 60 * 60));
+        Instant now = Instant.now();
+        String oneDayAgo = Long.toString(now.minus(24, ChronoUnit.HOURS).getEpochSecond());
+        String toNow = Long.toString(now.getEpochSecond());
+
+        StatDatabaseSummary statDatabase = get(databaseSummaryURI, StatDatabaseSummary.class, "from", oneDayAgo,
+                "until", toNow);
 
         HistoryClients historyClients = get(historyClientsURI, HistoryClients.class, "N", "0");
         ConfigAnswer configAnswer = get(configURI, ConfigAnswer.class);
@@ -143,12 +135,13 @@ public class JettyAdminServiceV6 extends AdminService {
 
         DnsStatistics translated = new DnsStatistics(gravity.domainsBeingBlocked(), statDatabase.sumQueries(),
                 statDatabase.sumBlocked(), statDatabase.percentBlocked(), statQueries.uniqueDomains(),
-                statQueries.forwarded(), statQueries.cached(), historyClients.clients().size(), null,
-                statQueries.types().all(), replies.unknown(), replies.nodata(), replies.nxdomain(), replies.cname(),
-                replies.ip(), replies.domain(), replies.rrname(), replies.servfail(), replies.refused(),
-                replies.notimp(), replies.other(), replies.dnssec(), replies.none(), replies.blob(), replies.all(),
-                configAnswer.config().misc().privacylevel(), blockingAnswer.blocking(), new GravityLastUpdated(
-                        configAnswer.config().files().gravity() != null, gravity.lastUpdate(), relative));
+                statQueries.forwarded(), statQueries.cached(), historyClients.clients().size(),
+                statAnswer.clients().active(), statQueries.types().all(), replies.unknown(), replies.nodata(),
+                replies.nxdomain(), replies.cname(), replies.ip(), replies.domain(), replies.rrname(),
+                replies.servfail(), replies.refused(), replies.notimp(), replies.other(), replies.dnssec(),
+                replies.none(), replies.blob(), replies.all(), configAnswer.config().misc().privacylevel(),
+                blockingAnswer.blocking(), new GravityLastUpdated(configAnswer.config().files().gravity() != null,
+                        gravity.lastUpdate(), relative));
 
         return Optional.of(translated);
     }

--- a/bundles/org.openhab.binding.pihole/src/main/java/org/openhab/binding/pihole/internal/rest/model/v6/StatAnswer.java
+++ b/bundles/org.openhab.binding.pihole/src/main/java/org/openhab/binding/pihole/internal/rest/model/v6/StatAnswer.java
@@ -22,8 +22,8 @@ import com.google.gson.annotations.SerializedName;
  * @author Gaël L'hopital - Initial contribution
  */
 @NonNullByDefault
-public record StatAnswer(Queries queries, Clients client, Gravity gravity, double took) {
-    record Clients(int active, int total) {
+public record StatAnswer(Queries queries, Clients clients, Gravity gravity, double took) {
+    public record Clients(int active, int total) {
 
     }
 

--- a/bundles/org.openhab.binding.pihole/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.binding.pihole/src/main/resources/OH-INF/addon/addon.xml
@@ -6,6 +6,6 @@
 	<type>binding</type>
 	<name>Pi-hole Binding</name>
 	<description>This is the binding for Pi-hole.</description>
-	<connection>cloud</connection>
+	<connection>local</connection>
 
 </addon:addon>

--- a/bundles/org.openhab.binding.pihole/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.pihole/src/main/resources/OH-INF/thing/thing-types.xml
@@ -115,9 +115,11 @@
 			</channel>
 			<channel id="enabled" typeId="enabled-channel"/>
 			<channel id="disable-enable" typeId="disable-enable-channel"/>
+			<channel id="gravity-file-exists" typeId="gravity-file-exists-channel"/>
+			<channel id="gravity-last-update" typeId="gravity-last-update-channel"/>
 		</channels>
 		<properties>
-			<property name="thingTypeVersion">2</property>
+			<property name="thingTypeVersion">3</property>
 		</properties>
 
 		<config-description>

--- a/bundles/org.openhab.binding.pihole/src/main/resources/OH-INF/update/update.xml
+++ b/bundles/org.openhab.binding.pihole/src/main/resources/OH-INF/update/update.xml
@@ -20,4 +20,14 @@
 			</update-channel>
 		</instruction-set>
 	</thing-type>
+	<thing-type uid="pihole:server">
+		<instruction-set targetVersion="3">
+			<add-channel id="gravity-file-exists">
+				<type>pihole:gravity-file-exists-channel</type>
+			</add-channel>
+			<add-channel id="gravity-last-update">
+				<type>pihole:gravity-last-update-channel</type>
+			</add-channel>
+		</instruction-set>
+	</thing-type>
 </update:update-descriptions>


### PR DESCRIPTION
Solves #20381 

- Discrepency on `ads_percentage_today` : dashboard displays it on the past 24h, while binding worked 'since midnight'. Corrected.
- `unique_clients` was not provided by the binding.
- Fixes actions failing from UI
- Reintroduce missing channels `gravity-last-update` and `gravity-file-exists`