### PR TITLE
[shelly] Fix broken handler factory

### DIFF
--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/ShellyHandlerFactory.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/ShellyHandlerFactory.java
@@ -159,6 +159,7 @@ public class ShellyHandlerFactory extends BaseThingHandlerFactory {
             String uid = thing.getUID().getAsString();
             thingTable.addThing(uid, handler);
             logger.debug("Thing handler for uid {} added, total things = {}", uid, thingTable.size());
+            return handler;
         }
         logger.debug("Unable to create Thing Handler instance!");
         return null;


### PR DESCRIPTION
This is a hotfix for last PR to make sure that a handler != null is returned when thing handler was created by the handler factory.