### PR TITLE
[intesis] Correctly handles empty enum message

### DIFF
--- a/bundles/org.openhab.binding.intesis/src/main/java/org/openhab/binding/intesis/internal/api/IntesisBoxMessage.java
+++ b/bundles/org.openhab.binding.intesis/src/main/java/org/openhab/binding/intesis/internal/api/IntesisBoxMessage.java
@@ -64,6 +64,9 @@ public class IntesisBoxMessage {
     }
 
     public List<String> getLimitsValue() {
+        if (value.length() <= 2) {
+            return List.of();
+        }
         return Arrays.asList(value.substring(1, value.length() - 1).split(","));
     }
 

--- a/bundles/org.openhab.binding.intesis/src/main/java/org/openhab/binding/intesis/internal/handler/IntesisBoxHandler.java
+++ b/bundles/org.openhab.binding.intesis/src/main/java/org/openhab/binding/intesis/internal/handler/IntesisBoxHandler.java
@@ -297,7 +297,7 @@ public class IntesisBoxHandler extends BaseThingHandler implements IntesisBoxCha
                         logger.trace("Property target temperatures {} added", message.getValue());
                         properties.put("targetTemperature limits", "[" + minTemp + "," + maxTemp + "]");
                         addChannel(CHANNEL_TYPE_TARGETTEMP, "Number:Temperature");
-                    } else {
+                    } else if (message.getLimitsValue().size() > 0) {
                         switch (function) {
                             case "MODE":
                                 properties.put("supported modes", message.getValue());
@@ -320,6 +320,9 @@ public class IntesisBoxHandler extends BaseThingHandler implements IntesisBoxCha
                                 addChannel(CHANNEL_TYPE_VANESLR, "String");
                                 break;
                         }
+                    } else {
+                        logger.trace("Property {} limits {} not added (due to missing limits)", function,
+                                message.getValue());
                     }
                     updateProperties(properties);
                     break;


### PR DESCRIPTION
This Bugfix PR handles the situation where an Intesis box returns an empty list of states for a command. For example, mine would return:

```LIMIT:VANELR,[]```

This triggers a bug in IntesisMessage which returns a one element list of values with the single element of an empty string (rather than an empty list). There is also no handling for where there are no values (which in this case should ignore the command and it's not available).