### PR TITLE
[evcc] Migrate vehicle Thing property

### DIFF
--- a/bundles/org.openhab.binding.evcc/src/main/java/org/openhab/binding/evcc/internal/handler/EvccVehicleHandler.java
+++ b/bundles/org.openhab.binding.evcc/src/main/java/org/openhab/binding/evcc/internal/handler/EvccVehicleHandler.java
@@ -19,6 +19,7 @@ import java.util.Optional;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.core.config.core.Configuration;
 import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.Thing;
 import org.openhab.core.thing.ThingStatus;
@@ -76,6 +77,22 @@ public class EvccVehicleHandler extends EvccBaseThingHandler {
 
     @Override
     public void initialize() {
+        Configuration config = getConfig();
+
+        Object oldId = config.get("id");
+        Object newId = config.get(PROPERTY_VEHICLE_ID);
+
+        if (oldId != null && newId == null) {
+            String migrated = oldId.toString();
+            config.put(PROPERTY_VEHICLE_ID, migrated);
+            config.remove("id");
+
+            updateConfiguration(config);
+            logger.info("Migrated evcc vehicle Thing property 'id' -> 'vehicleId'");
+            updateStatus(ThingStatus.UNINITIALIZED);
+            return;
+        }
+
         super.initialize();
         Optional.ofNullable(bridgeHandler).ifPresent(handler -> {
             endpoint = String.join("/", handler.getBaseURL(), API_PATH_VEHICLES);

--- a/bundles/org.openhab.binding.evcc/src/main/java/org/openhab/binding/evcc/internal/handler/EvccVehicleHandler.java
+++ b/bundles/org.openhab.binding.evcc/src/main/java/org/openhab/binding/evcc/internal/handler/EvccVehicleHandler.java
@@ -18,7 +18,6 @@ import java.util.Locale;
 import java.util.Optional;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.config.core.Configuration;
 import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.Thing;
@@ -43,13 +42,10 @@ public class EvccVehicleHandler extends EvccBaseThingHandler {
 
     private final Logger logger = LoggerFactory.getLogger(EvccVehicleHandler.class);
 
-    private final @Nullable String vehicleId;
-
     private String endpoint = "";
 
     public EvccVehicleHandler(Thing thing, ChannelTypeRegistry channelTypeRegistry) {
         super(thing, channelTypeRegistry);
-        vehicleId = getPropertyOrConfigValue(PROPERTY_VEHICLE_ID);
         type = PROPERTY_TYPE_VEHICLE;
     }
 
@@ -61,7 +57,7 @@ public class EvccVehicleHandler extends EvccBaseThingHandler {
             if (value.contains(" ")) {
                 value = value.substring(0, state.toString().indexOf(" "));
             }
-            String url = endpoint + "/" + vehicleId + "/" + datapoint + "/" + value;
+            String url = endpoint + "/" + getPropertyOrConfigValue(PROPERTY_VEHICLE_ID) + "/" + datapoint + "/" + value;
             logger.debug("Sending command to this url: {}", url);
             performApiRequest(url, POST, JsonNull.INSTANCE);
         } else {
@@ -71,7 +67,7 @@ public class EvccVehicleHandler extends EvccBaseThingHandler {
 
     @Override
     public void prepareApiResponseForChannelStateUpdate(JsonObject state) {
-        state = state.getAsJsonObject(JSON_KEY_VEHICLES).getAsJsonObject(vehicleId);
+        state = state.getAsJsonObject(JSON_KEY_VEHICLES).getAsJsonObject(getPropertyOrConfigValue(PROPERTY_VEHICLE_ID));
         updateStatesFromApiResponse(state);
     }
 
@@ -79,16 +75,20 @@ public class EvccVehicleHandler extends EvccBaseThingHandler {
     public void initialize() {
         Configuration config = getConfig();
 
-        Object oldId = config.get("id");
+        Object oldId = config.get(PROPERTY_ID);
         Object newId = config.get(PROPERTY_VEHICLE_ID);
 
         if (oldId != null && newId == null) {
             String migrated = oldId.toString();
             config.put(PROPERTY_VEHICLE_ID, migrated);
-            config.remove("id");
+            config.remove(PROPERTY_ID);
 
             updateConfiguration(config);
             logger.info("Migrated evcc vehicle Thing property 'id' -> 'vehicleId'");
+        }
+
+        if (getPropertyOrConfigValue(PROPERTY_VEHICLE_ID).isEmpty()) {
+            logger.warn("No vehicle ID given");
             updateStatus(ThingStatus.UNINITIALIZED);
             return;
         }
@@ -102,14 +102,15 @@ public class EvccVehicleHandler extends EvccBaseThingHandler {
                 return;
             }
 
-            JsonObject state = stateOpt.getAsJsonObject(JSON_KEY_VEHICLES).getAsJsonObject(vehicleId);
+            JsonObject state = stateOpt.getAsJsonObject(JSON_KEY_VEHICLES)
+                    .getAsJsonObject(getPropertyOrConfigValue(PROPERTY_VEHICLE_ID));
             commonInitialize(state);
         });
     }
 
     @Override
     public JsonObject getStateFromCachedState(JsonObject state) {
-        return state.has(JSON_KEY_VEHICLES) ? state.getAsJsonObject(JSON_KEY_VEHICLES).getAsJsonObject(vehicleId)
-                : new JsonObject();
+        return state.has(JSON_KEY_VEHICLES) ? state.getAsJsonObject(JSON_KEY_VEHICLES)
+                .getAsJsonObject(getPropertyOrConfigValue(PROPERTY_VEHICLE_ID)) : new JsonObject();
     }
 }

--- a/bundles/org.openhab.binding.evcc/src/main/java/org/openhab/binding/evcc/internal/handler/EvccVehicleHandler.java
+++ b/bundles/org.openhab.binding.evcc/src/main/java/org/openhab/binding/evcc/internal/handler/EvccVehicleHandler.java
@@ -73,13 +73,20 @@ public class EvccVehicleHandler extends EvccBaseThingHandler {
 
     @Override
     public void initialize() {
-        Configuration config = getConfig();
+        Configuration config = thing.getConfiguration();
 
         Object oldId = config.get(PROPERTY_ID);
         Object newId = config.get(PROPERTY_VEHICLE_ID);
 
+        if (newId == null) {
+            System.out.println("newID is null");
+        } else {
+            System.out.println(newId.toString());
+        }
+
         if (oldId != null && newId == null) {
             String migrated = oldId.toString();
+
             config.put(PROPERTY_VEHICLE_ID, migrated);
             config.remove(PROPERTY_ID);
 

--- a/bundles/org.openhab.binding.evcc/src/main/java/org/openhab/binding/evcc/internal/handler/EvccVehicleHandler.java
+++ b/bundles/org.openhab.binding.evcc/src/main/java/org/openhab/binding/evcc/internal/handler/EvccVehicleHandler.java
@@ -78,7 +78,7 @@ public class EvccVehicleHandler extends EvccBaseThingHandler {
         Object oldId = config.get(PROPERTY_ID);
         Object newId = config.get(PROPERTY_VEHICLE_ID);
 
-        if (oldId != null && newId == null) {
+        if (oldId != null && (newId == null || newId.toString().isBlank())) {
             String migrated = oldId.toString();
 
             config.put(PROPERTY_VEHICLE_ID, migrated);
@@ -86,11 +86,14 @@ public class EvccVehicleHandler extends EvccBaseThingHandler {
 
             updateConfiguration(config);
             logger.info("Migrated evcc vehicle Thing property 'id' -> 'vehicleId'");
+        } else if (oldId != null && newId != null) {
+            config.remove(PROPERTY_ID);
+            updateConfiguration(config);
         }
 
         if (getPropertyOrConfigValue(PROPERTY_VEHICLE_ID).isEmpty()) {
             logger.warn("No vehicle ID given");
-            updateStatus(ThingStatus.UNINITIALIZED);
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR);
             return;
         }
 

--- a/bundles/org.openhab.binding.evcc/src/main/java/org/openhab/binding/evcc/internal/handler/EvccVehicleHandler.java
+++ b/bundles/org.openhab.binding.evcc/src/main/java/org/openhab/binding/evcc/internal/handler/EvccVehicleHandler.java
@@ -78,12 +78,6 @@ public class EvccVehicleHandler extends EvccBaseThingHandler {
         Object oldId = config.get(PROPERTY_ID);
         Object newId = config.get(PROPERTY_VEHICLE_ID);
 
-        if (newId == null) {
-            System.out.println("newID is null");
-        } else {
-            System.out.println(newId.toString());
-        }
-
         if (oldId != null && newId == null) {
             String migrated = oldId.toString();
 

--- a/bundles/org.openhab.binding.evcc/src/test/java/org/openhab/binding/evcc/internal/handler/EvccVehicleHandlerTest.java
+++ b/bundles/org.openhab.binding.evcc/src/test/java/org/openhab/binding/evcc/internal/handler/EvccVehicleHandlerTest.java
@@ -12,7 +12,7 @@
  */
 package org.openhab.binding.evcc.internal.handler;
 
-import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 import static org.mockito.Mockito.when;
 import static org.openhab.binding.evcc.internal.EvccBindingConstants.PROPERTY_ID;
@@ -110,11 +110,11 @@ public class EvccVehicleHandlerTest extends AbstractThingHandlerTestClass<EvccVe
 
     @Test
     public void testMigrationFromIdToVehicleId() {
-        Configuration config = mock(Configuration.class);
-        when(config.get(PROPERTY_ID)).thenReturn("old_vehicle_id");
-        when(config.get(PROPERTY_VEHICLE_ID)).thenReturn(null);
+        Configuration config = new Configuration();
+        config.put(PROPERTY_ID, "vehicle_1");
 
         when(thing.getConfiguration()).thenReturn(config);
+        when(thing.getProperties()).thenReturn(Map.of("type", "vehicle"));
 
         handler = spy(createHandler());
         handler.bridgeHandler = mock(EvccBridgeHandler.class);
@@ -123,12 +123,9 @@ public class EvccVehicleHandlerTest extends AbstractThingHandlerTestClass<EvccVe
 
         handler.initialize();
 
-        verify(config).put(PROPERTY_VEHICLE_ID, "old_vehicle_id");
-
-        verify(config).remove(PROPERTY_ID);
-
+        assertEquals("vehicle_1", config.get(PROPERTY_VEHICLE_ID));
+        assertNull(config.get(PROPERTY_ID));
         assertSame(config, lastUpdatedConfiguration);
-
         assertSame(ThingStatus.ONLINE, lastThingStatus);
     }
 }

--- a/bundles/org.openhab.binding.evcc/src/test/java/org/openhab/binding/evcc/internal/handler/EvccVehicleHandlerTest.java
+++ b/bundles/org.openhab.binding.evcc/src/test/java/org/openhab/binding/evcc/internal/handler/EvccVehicleHandlerTest.java
@@ -15,6 +15,7 @@ package org.openhab.binding.evcc.internal.handler;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.mockito.Mockito.*;
 import static org.mockito.Mockito.when;
+import static org.openhab.binding.evcc.internal.EvccBindingConstants.PROPERTY_ID;
 import static org.openhab.binding.evcc.internal.EvccBindingConstants.PROPERTY_INDEX;
 import static org.openhab.binding.evcc.internal.EvccBindingConstants.PROPERTY_VEHICLE_ID;
 
@@ -41,6 +42,8 @@ import org.openhab.core.types.State;
  */
 @NonNullByDefault
 public class EvccVehicleHandlerTest extends AbstractThingHandlerTestClass<EvccVehicleHandler> {
+
+    private @Nullable Configuration lastUpdatedConfiguration;
 
     @Override
     protected EvccVehicleHandler createHandler() {
@@ -74,6 +77,11 @@ public class EvccVehicleHandlerTest extends AbstractThingHandlerTestClass<EvccVe
             @Override
             protected void updateState(ChannelUID channelUID, State state) {
             }
+
+            @Override
+            public void updateConfiguration(Configuration configuration) {
+                lastUpdatedConfiguration = configuration;
+            }
         };
     }
 
@@ -97,6 +105,30 @@ public class EvccVehicleHandlerTest extends AbstractThingHandlerTestClass<EvccVe
     @Test
     public void testInitializeWithBridgeHandlerWithValidState() {
         handler.initialize();
+        assertSame(ThingStatus.ONLINE, lastThingStatus);
+    }
+
+    @Test
+    public void testMigrationFromIdToVehicleId() {
+        Configuration config = mock(Configuration.class);
+        when(config.get(PROPERTY_ID)).thenReturn("old_vehicle_id");
+        when(config.get(PROPERTY_VEHICLE_ID)).thenReturn(null);
+
+        when(thing.getConfiguration()).thenReturn(config);
+
+        handler = spy(createHandler());
+        handler.bridgeHandler = mock(EvccBridgeHandler.class);
+
+        when(handler.bridgeHandler.getCachedEvccState()).thenReturn(exampleResponse);
+
+        handler.initialize();
+
+        verify(config).put(PROPERTY_VEHICLE_ID, "old_vehicle_id");
+
+        verify(config).remove(PROPERTY_ID);
+
+        assertSame(config, lastUpdatedConfiguration);
+
         assertSame(ThingStatus.ONLINE, lastThingStatus);
     }
 }


### PR DESCRIPTION
## Breaking Change
The EVCC vehicle Thing configuration has renamed the `id` property to `vehicleId`.
Existing Things using the old property name are automatically migrated during
initialization. No user action is required.
