### PR TITLE
[shelly] Fix thing lookup for inbound Gen2+ if FQDN name is used as device address

### DIFF
--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/handler/ShellyBaseHandler.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/handler/ShellyBaseHandler.java
@@ -177,7 +177,8 @@ public abstract class ShellyBaseHandler extends BaseThingHandler
     @Override
     public boolean checkRepresentation(String key) {
         return key.equalsIgnoreCase(getUID()) || key.equalsIgnoreCase(config.deviceAddress)
-                || key.equalsIgnoreCase(config.realm) || key.equalsIgnoreCase(getThingName());
+                || key.equalsIgnoreCase(config.deviceIp) || key.equalsIgnoreCase(config.realm)
+                || key.equalsIgnoreCase(getThingName());
     }
 
     /**


### PR DESCRIPTION
- Add deviceIp to checkRepresentation for proper thing matching when things are added via DNS names.

fixes issue described in #20418.