### PR TITLE
[viessmann] Fix parsing of unit Seconds

### DIFF
--- a/bundles/org.openhab.binding.viessmann/src/main/java/org/openhab/binding/viessmann/internal/ViessmannBindingConstants.java
+++ b/bundles/org.openhab.binding.viessmann/src/main/java/org/openhab/binding/viessmann/internal/ViessmannBindingConstants.java
@@ -76,6 +76,7 @@ public class ViessmannBindingConstants {
             entry("power-kilowattHour", Units.KILOWATT_HOUR.toString()), //
             entry("heat-kilowattHour", Units.KILOWATT_HOUR.toString()), //
             entry("percent", Units.PERCENT.toString()), //
+            entry("seconds", Units.SECOND.toString()), //
             entry("minute", Units.MINUTE.toString()), //
             entry("hour", Units.HOUR.toString()), //
             entry("hours", Units.HOUR.toString()), //

--- a/bundles/org.openhab.binding.viessmann/src/main/java/org/openhab/binding/viessmann/internal/handler/DeviceHandler.java
+++ b/bundles/org.openhab.binding.viessmann/src/main/java/org/openhab/binding/viessmann/internal/handler/DeviceHandler.java
@@ -1497,8 +1497,10 @@ public class DeviceHandler extends ViessmannThingHandler {
         if (channelType.isBlank() || "object".equals(channelType)) {
             channelType = "string";
         }
-        if ("meter".equals(msg.getUnit()) || "degree".equals(msg.getUnit())) {
-            channelType = msg.getUnit();
+
+        String unit = msg.getUnit();
+        if ("meter".equals(unit) || "degree".equals(unit) || "seconds".equals(unit)) {
+            channelType = unit;
         }
 
         List<String> com = msg.getAllCommands();

--- a/bundles/org.openhab.binding.viessmann/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.viessmann/src/main/resources/OH-INF/thing/thing-types.xml
@@ -453,6 +453,17 @@
 		<state pattern="%d %unit%" readOnly="true"/>
 	</channel-type>
 
+	<channel-type id="seconds">
+		<item-type>Number:Time</item-type>
+		<label>Seconds</label>
+		<category>Time</category>
+		<tags>
+			<tag>Status</tag>
+			<tag>Duration</tag>
+		</tags>
+		<state pattern="%d %unit%" readOnly="true"/>
+	</channel-type>
+
 	<channel-type id="percent">
 		<item-type>Number:Dimensionless</item-type>
 		<label>Percentage</label>


### PR DESCRIPTION
Fixes unknown unit **seconds** reported here: https://community.openhab.org/t/viessmann-binding-5-0-0-0-6-0-0-0/165352/105
