### PR TITLE
[jsscripting] Implement debugger support

### DIFF
--- a/bundles/org.openhab.automation.jsscripting/src/main/feature/feature.xml
+++ b/bundles/org.openhab.automation.jsscripting/src/main/feature/feature.xml
@@ -7,14 +7,17 @@
 		<feature>openhab-runtime-base</feature>
 		<bundle dependency="true" start-level="78">mvn:org.openhab.osgiify/org.graalvm.js.js-language/25.0.1</bundle>
 		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.js.js-scriptengine/25.0.1</bundle>
-		<bundle dependency="true" start-level="78">mvn:org.openhab.osgiify/org.graalvm.regex.regex/25.0.1</bundle>
 		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.polyglot.polyglot/25.0.1</bundle>
+		<bundle dependency="true" start-level="78">mvn:org.openhab.osgiify/org.graalvm.regex.regex/25.0.1</bundle>
 		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.sdk.collections/25.0.1</bundle>
 		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.sdk.jniutils/25.0.1</bundle>
 		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.sdk.nativeimage/25.0.1</bundle>
 		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.sdk.word/25.0.1</bundle>
 		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.shadowed.icu4j/25.0.1</bundle>
+		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.shadowed.json/25.0.1</bundle>
 		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.shadowed.xz/25.0.1</bundle>
+		<bundle dependency="true" start-level="78">mvn:org.openhab.osgiify/org.graalvm.tools.chromeinspector-tool/25.0.1</bundle>
+		<bundle dependency="true" start-level="78">mvn:org.openhab.osgiify/org.graalvm.tools.profiler-tool/25.0.1</bundle>
 		<bundle dependency="true" start-level="79">mvn:org.openhab.osgiify/org.graalvm.truffle.truffle-api/25.0.1</bundle>
 		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.truffle.truffle-compiler/25.0.1</bundle>
 		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.truffle.truffle-runtime/25.0.1</bundle>

--- a/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/GraalJSScriptEngineConfiguration.java
+++ b/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/GraalJSScriptEngineConfiguration.java
@@ -33,16 +33,22 @@ public class GraalJSScriptEngineConfiguration {
     private static final String CFG_SCRIPT_CONDITION_WRAPPER_ENABLED = "scriptConditionWrapperEnabled";
     private static final String CFG_EVENT_CONVERSION_ENABLED = "eventConversionEnabled";
     private static final String CFG_DEPENDENCY_TRACKING_ENABLED = "dependencyTrackingEnabled";
+    private static final String CFG_DEBUGGER_ENABLED = "debuggerEnabled";
+    private static final String CFG_DEBUGGER_PORT = "debuggerPort";
 
     private static final int INJECTION_ENABLED_FOR_SCRIPT_MODULES_ONLY = 1;
     private static final int INJECTION_ENABLED_FOR_SCRIPT_MODULES_AND_TRANSFORMATIONS = 2;
     private static final int INJECTION_ENABLED_FOR_ALL_SCRIPTS = 3;
+
+    private static final int DEBUGGER_PORT_DEFAULT = 9229;
 
     private int injectionEnabled = INJECTION_ENABLED_FOR_ALL_SCRIPTS;
     private boolean injectionCachingEnabled = true;
     private boolean scriptConditionWrapperEnabled = false;
     private boolean eventConversionEnabled = true;
     private boolean dependencyTrackingEnabled = true;
+    private boolean debuggerEnabled = false;
+    private int debuggerPort = DEBUGGER_PORT_DEFAULT;
 
     /**
      * Create a new configuration instance from the given parameters.
@@ -63,6 +69,8 @@ public class GraalJSScriptEngineConfiguration {
         boolean oldDependencyTrackingEnabled = dependencyTrackingEnabled;
         boolean oldScriptConditionWrapperEnabled = scriptConditionWrapperEnabled;
         boolean oldEventConversionEnabled = eventConversionEnabled;
+        boolean oldDebuggerEnabled = debuggerEnabled;
+        int oldDebuggerPort = debuggerPort;
 
         this.update(config);
 
@@ -91,6 +99,12 @@ public class GraalJSScriptEngineConfiguration {
                         "Disabled event conversion for JavaScript Scripting. Please resave your scripts to apply this change.");
             }
         }
+        if (oldDebuggerEnabled != debuggerEnabled) {
+            logger.warn("{} debugger for JavaScript Scripting. Restart openHAB to apply this change.",
+                    debuggerEnabled ? "Enabled" : "Disabled");
+        } else if (oldDebuggerPort != debuggerPort) {
+            logger.warn("Reconfigured debugger for JavaScript Scripting. Restart openHAB to apply this change.");
+        }
     }
 
     /**
@@ -111,6 +125,8 @@ public class GraalJSScriptEngineConfiguration {
                 true);
         dependencyTrackingEnabled = ConfigParser.valueAsOrElse(config.get(CFG_DEPENDENCY_TRACKING_ENABLED),
                 Boolean.class, true);
+        debuggerEnabled = ConfigParser.valueAsOrElse(config.get(CFG_DEBUGGER_ENABLED), Boolean.class, false);
+        debuggerPort = ConfigParser.valueAsOrElse(config.get(CFG_DEBUGGER_PORT), Integer.class, DEBUGGER_PORT_DEFAULT);
     }
 
     /**
@@ -162,5 +178,13 @@ public class GraalJSScriptEngineConfiguration {
 
     public boolean isDependencyTrackingEnabled() {
         return dependencyTrackingEnabled;
+    }
+
+    public boolean isDebuggerEnabled() {
+        return debuggerEnabled;
+    }
+
+    public int getDebuggerPort() {
+        return debuggerPort;
     }
 }

--- a/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/GraalJSScriptEngineFactory.java
+++ b/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/GraalJSScriptEngineFactory.java
@@ -24,6 +24,7 @@ import org.eclipse.jdt.annotation.Nullable;
 import org.graalvm.polyglot.Engine;
 import org.graalvm.polyglot.Language;
 import org.openhab.automation.jsscripting.internal.fs.watch.JSDependencyTracker;
+import org.openhab.automation.jsscripting.internal.util.ThreadLocalSlf4jOutputStream;
 import org.openhab.core.OpenHAB;
 import org.openhab.core.automation.module.script.ScriptDependencyTracker;
 import org.openhab.core.automation.module.script.ScriptEngineFactory;
@@ -115,10 +116,11 @@ public class GraalJSScriptEngineFactory implements ScriptEngineFactory {
                 .getLogger(GraalJSScriptEngineFactory.class.getPackageName() + ".org.graalvm.polyglot.Engine");
         return Engine.newBuilder().allowExperimentalOptions(true) //
                 .option("engine.WarnInterpreterOnly", "false") //
-                .out(new Slf4jOutputStream(engineLogger, Level.DEBUG)) //
-                // Note: Due to a bug in GraalVM, info messages are logged to the err stream, so hide it for now
-                // https://github.com/oracle/graal/issues/13222
-                .err(new Slf4jOutputStream(engineLogger, Level.DEBUG));
+                .out(new ThreadLocalSlf4jOutputStream(engineLogger, Level.DEBUG)) //
+                // Note: Due to a bug in GraalVM, info messages are logged to the err stream, so hide it until the fix
+                // is available. FTR: https://github.com/oracle/graal/issues/13222
+                // TODO: Increase level to WARN when upgrading GraalVM
+                .err(new ThreadLocalSlf4jOutputStream(engineLogger, Level.DEBUG));
     }
 
     @Deactivate

--- a/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/GraalJSScriptEngineFactory.java
+++ b/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/GraalJSScriptEngineFactory.java
@@ -83,7 +83,6 @@ public class GraalJSScriptEngineFactory implements ScriptEngineFactory {
         this.configuration = new GraalJSScriptEngineConfiguration(config);
 
         if (configuration.isDebuggerEnabled()) {
-            logger.info("Debugger support is enabled for JavaScript Scripting.");
             Engine.Builder engineBuilder = createEngineBuilder();
             engineBuilder //
                     .option("inspect", "0.0.0.0:" + configuration.getDebuggerPort()) //
@@ -100,6 +99,7 @@ public class GraalJSScriptEngineFactory implements ScriptEngineFactory {
                         e);
                 engine = createEngineBuilder().build();
             }
+            logger.info("Debugger support is enabled for JavaScript Scripting.");
             this.engine = engine;
         } else {
             this.engine = createEngineBuilder().build();

--- a/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/GraalJSScriptEngineFactory.java
+++ b/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/GraalJSScriptEngineFactory.java
@@ -31,6 +31,7 @@ import org.openhab.core.config.core.ConfigurableService;
 import org.osgi.framework.Constants;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Modified;
 import org.osgi.service.component.annotations.Reference;
 import org.slf4j.Logger;
@@ -81,26 +82,46 @@ public class GraalJSScriptEngineFactory implements ScriptEngineFactory {
         this.jsScriptServiceUtil = jsScriptServiceUtil;
         this.configuration = new GraalJSScriptEngineConfiguration(config);
 
-        Logger engineLogger = LoggerFactory
-                .getLogger(GraalJSScriptEngineFactory.class.getPackageName() + ".org.graalvm.polyglot.Engine");
-        Engine.Builder engineBuilder = Engine.newBuilder().allowExperimentalOptions(true) //
-                .option("engine.WarnInterpreterOnly", "false") //
-                .out(new Slf4jOutputStream(engineLogger, Level.DEBUG)) //
-                .err(new Slf4jOutputStream(engineLogger, Level.DEBUG));
         if (configuration.isDebuggerEnabled()) {
-            logger.info("Enabling JavaScript debugger support.");
+            logger.info("Debugger support is enabled for JavaScript Scripting.");
+            Engine.Builder engineBuilder = createEngineBuilder();
             engineBuilder //
                     .option("inspect", "0.0.0.0:" + configuration.getDebuggerPort()) //
                     .option("inspect.Suspend", "false") // Don't pause at startup waiting for debugger to attach
                     .option("inspect.WaitAttached", "false") // Don't block code execution waiting for debugger to
                                                              // attach
                     .option("inspect.Secure", "false"); // Disable TLS
+            Engine engine;
+            try {
+                engine = engineBuilder.build();
+            } catch (RuntimeException e) {
+                logger.error(
+                        "Failed to initialize Graal JavaScript engine with debugger support. Continuing without debugger support.",
+                        e);
+                engine = createEngineBuilder().build();
+            }
+            this.engine = engine;
+        } else {
+            this.engine = createEngineBuilder().build();
         }
-        this.engine = engineBuilder.build();
 
         if (getLanguage() == null) {
             logger.error(LANG_NOT_INITIALIZED_MSG);
         }
+    }
+
+    private Engine.Builder createEngineBuilder() {
+        Logger engineLogger = LoggerFactory
+                .getLogger(GraalJSScriptEngineFactory.class.getPackageName() + ".org.graalvm.polyglot.Engine");
+        return Engine.newBuilder().allowExperimentalOptions(true) //
+                .option("engine.WarnInterpreterOnly", "false") //
+                .out(new Slf4jOutputStream(engineLogger, Level.DEBUG)) //
+                .err(new Slf4jOutputStream(engineLogger, Level.DEBUG));
+    }
+
+    @Deactivate
+    public void dispose() {
+        this.engine.close();
     }
 
     @Modified

--- a/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/GraalJSScriptEngineFactory.java
+++ b/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/GraalJSScriptEngineFactory.java
@@ -35,6 +35,7 @@ import org.osgi.service.component.annotations.Modified;
 import org.osgi.service.component.annotations.Reference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.event.Level;
 
 /**
  * An implementation of {@link ScriptEngineFactory} with customizations for GraalJS ScriptEngines.
@@ -80,8 +81,12 @@ public class GraalJSScriptEngineFactory implements ScriptEngineFactory {
         this.jsScriptServiceUtil = jsScriptServiceUtil;
         this.configuration = new GraalJSScriptEngineConfiguration(config);
 
-        Engine.Builder engineBuilder = Engine.newBuilder().allowExperimentalOptions(true)
-                .option("engine.WarnInterpreterOnly", "false");
+        Logger engineLogger = LoggerFactory
+                .getLogger(GraalJSScriptEngineFactory.class.getPackageName() + ".org.graalvm.polyglot.Engine");
+        Engine.Builder engineBuilder = Engine.newBuilder().allowExperimentalOptions(true) //
+                .option("engine.WarnInterpreterOnly", "false") //
+                .out(new Slf4jOutputStream(engineLogger, Level.DEBUG)) //
+                .err(new Slf4jOutputStream(engineLogger, Level.DEBUG));
         if (configuration.isDebuggerEnabled()) {
             logger.info("Enabling JavaScript debugger support.");
             engineBuilder //

--- a/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/GraalJSScriptEngineFactory.java
+++ b/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/GraalJSScriptEngineFactory.java
@@ -21,6 +21,8 @@ import javax.script.ScriptEngine;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
+import org.graalvm.polyglot.Engine;
+import org.graalvm.polyglot.Language;
 import org.openhab.automation.jsscripting.internal.fs.watch.JSDependencyTracker;
 import org.openhab.core.OpenHAB;
 import org.openhab.core.automation.module.script.ScriptDependencyTracker;
@@ -39,10 +41,11 @@ import org.slf4j.LoggerFactory;
  *
  * @author Jonathan Gilbert - Initial contribution
  * @author Dan Cunningham - Script injections
+ * @author Florian Hotze - Debugger support
  */
 @Component(service = ScriptEngineFactory.class, configurationPid = "org.openhab.jsscripting", property = Constants.SERVICE_PID
         + "=org.openhab.jsscripting")
-@ConfigurableService(category = "automation", label = "JS Scripting", description_uri = "automation:jsscripting")
+@ConfigurableService(category = "automation", label = "JavaScript Scripting", description_uri = "automation:jsscripting")
 @NonNullByDefault
 public class GraalJSScriptEngineFactory implements ScriptEngineFactory {
     public static final Path JS_DEFAULT_PATH = Paths.get(OpenHAB.getConfigFolder(), "automation", "js");
@@ -60,6 +63,10 @@ public class GraalJSScriptEngineFactory implements ScriptEngineFactory {
 
     private final Logger logger = LoggerFactory.getLogger(GraalJSScriptEngineFactory.class);
     private final GraalJSScriptEngineConfiguration configuration;
+    /**
+     * Shared Polyglot {@link Engine} instance to be used by all instances of {@link OpenhabGraalJSScriptEngine}.
+     */
+    private final Engine engine;
 
     private final JSScriptServiceUtil jsScriptServiceUtil;
     private final JSDependencyTracker jsDependencyTracker;
@@ -73,7 +80,20 @@ public class GraalJSScriptEngineFactory implements ScriptEngineFactory {
         this.jsScriptServiceUtil = jsScriptServiceUtil;
         this.configuration = new GraalJSScriptEngineConfiguration(config);
 
-        if (OpenhabGraalJSScriptEngine.getLanguage() == null) {
+        Engine.Builder engineBuilder = Engine.newBuilder().allowExperimentalOptions(true)
+                .option("engine.WarnInterpreterOnly", "false");
+        if (configuration.isDebuggerEnabled()) {
+            logger.info("Enabling JavaScript debugger support.");
+            engineBuilder //
+                    .option("inspect", "0.0.0.0:" + configuration.getDebuggerPort()) //
+                    .option("inspect.Suspend", "false") // Don't pause at startup waiting for debugger to attach
+                    .option("inspect.WaitAttached", "false") // Don't block code execution waiting for debugger to
+                                                             // attach
+                    .option("inspect.Secure", "false"); // Disable TLS
+        }
+        this.engine = engineBuilder.build();
+
+        if (getLanguage() == null) {
             logger.error(LANG_NOT_INITIALIZED_MSG);
         }
     }
@@ -98,16 +118,25 @@ public class GraalJSScriptEngineFactory implements ScriptEngineFactory {
         if (!SCRIPT_TYPES.contains(scriptType)) {
             return null;
         }
-        if (OpenhabGraalJSScriptEngine.getLanguage() == null) {
+        if (getLanguage() == null) {
             logger.error(LANG_NOT_INITIALIZED_MSG);
             return null;
         }
         return new DebuggingGraalScriptEngine<>(
-                new OpenhabGraalJSScriptEngine(configuration, jsScriptServiceUtil, jsDependencyTracker));
+                new OpenhabGraalJSScriptEngine(configuration, engine, jsScriptServiceUtil, jsDependencyTracker));
     }
 
     @Override
     public @Nullable ScriptDependencyTracker getDependencyTracker() {
         return jsDependencyTracker;
+    }
+
+    /**
+     * Gets the Graal language of {@link OpenhabGraalJSScriptEngine}.
+     *
+     * @return the Graal language of {@link OpenhabGraalJSScriptEngine} or {@code null} if not available
+     */
+    private @Nullable Language getLanguage() {
+        return engine.getLanguages().get(OpenhabGraalJSScriptEngine.LANGUAGE_ID);
     }
 }

--- a/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/GraalJSScriptEngineFactory.java
+++ b/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/GraalJSScriptEngineFactory.java
@@ -116,6 +116,8 @@ public class GraalJSScriptEngineFactory implements ScriptEngineFactory {
         return Engine.newBuilder().allowExperimentalOptions(true) //
                 .option("engine.WarnInterpreterOnly", "false") //
                 .out(new Slf4jOutputStream(engineLogger, Level.DEBUG)) //
+                // Note: Due to a bug in GraalVM, info messages are logged to the err stream, so hide it for now
+                // https://github.com/oracle/graal/issues/13222
                 .err(new Slf4jOutputStream(engineLogger, Level.DEBUG));
     }
 

--- a/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/OpenhabGraalJSScriptEngine.java
+++ b/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/OpenhabGraalJSScriptEngine.java
@@ -49,7 +49,6 @@ import org.eclipse.jdt.annotation.Nullable;
 import org.graalvm.polyglot.Context;
 import org.graalvm.polyglot.Engine;
 import org.graalvm.polyglot.HostAccess;
-import org.graalvm.polyglot.Language;
 import org.graalvm.polyglot.Source;
 import org.graalvm.polyglot.Value;
 import org.graalvm.polyglot.io.IOAccess;
@@ -86,7 +85,7 @@ public class OpenhabGraalJSScriptEngine
         implements Lock {
 
     // see private constant GraalJSScriptEngine.ID
-    private static final String LANGUAGE_ID = "js";
+    static final String LANGUAGE_ID = "js";
 
     private static final Source GLOBAL_SOURCE;
     static {
@@ -125,9 +124,6 @@ public class OpenhabGraalJSScriptEngine
         File cachePath = Path.of(OpenHAB.getUserDataFolder(), "cache", "org.graalvm.polyglot").toFile();
         System.setProperty("polyglot.engine.userResourceCache", cachePath.getAbsolutePath());
     }
-    /** Shared Polyglot {@link Engine} across all instances of {@link OpenhabGraalJSScriptEngine} */
-    private static final Engine ENGINE = Engine.newBuilder().allowExperimentalOptions(true)
-            .option("engine.WarnInterpreterOnly", "false").build();
     /** Provides unlimited host access as well as custom translations from JS to Java Objects */
     private static final HostAccess HOST_ACCESS = HostAccess.newBuilder(HostAccess.ALL)
             // Translate JS-Joda ZonedDateTime to java.time.ZonedDateTime
@@ -176,13 +172,13 @@ public class OpenhabGraalJSScriptEngine
      * Creates an implementation of ScriptEngine {@code (& Invocable)}, wrapping the contained engine,
      * that tracks the script lifecycle and provides hooks for scripts to do so too.
      */
-    public OpenhabGraalJSScriptEngine(GraalJSScriptEngineConfiguration configuration,
+    public OpenhabGraalJSScriptEngine(GraalJSScriptEngineConfiguration configuration, Engine engine,
             JSScriptServiceUtil jsScriptServiceUtil, JSDependencyTracker jsDependencyTracker) {
         super(null); // delegate depends on fields not yet initialized, so we cannot set it immediately
         this.configuration = configuration;
         this.jsRuntimeFeatures = jsScriptServiceUtil.getJSRuntimeFeatures(lock);
 
-        delegate = GraalJSScriptEngine.create(ENGINE, Context.newBuilder(LANGUAGE_ID) //
+        delegate = GraalJSScriptEngine.create(engine, Context.newBuilder(LANGUAGE_ID) //
                 .allowIO(IOAccess.newBuilder() //
                         .fileSystem(new DelegatingFileSystem(FileSystems.getDefault().provider()) {
                             @Override
@@ -602,14 +598,5 @@ public class OpenhabGraalJSScriptEngine
     @Override
     public Condition newCondition() {
         return lock.newCondition();
-    }
-
-    /**
-     * Gets the Graal language of {@link OpenhabGraalJSScriptEngine}.
-     * 
-     * @return the Graal language of {@link OpenhabGraalJSScriptEngine} or {@code null} if not available
-     */
-    public static @Nullable Language getLanguage() {
-        return ENGINE.getLanguages().get(LANGUAGE_ID);
     }
 }

--- a/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/OpenhabGraalJSScriptEngine.java
+++ b/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/OpenhabGraalJSScriptEngine.java
@@ -68,6 +68,7 @@ import org.openhab.core.items.Item;
 import org.openhab.core.library.types.QuantityType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.event.Level;
 
 import com.oracle.truffle.js.scriptengine.GraalJSScriptEngine;
 
@@ -178,6 +179,8 @@ public class OpenhabGraalJSScriptEngine
         this.configuration = configuration;
         this.jsRuntimeFeatures = jsScriptServiceUtil.getJSRuntimeFeatures(lock);
 
+        Logger contextLogger = LoggerFactory
+                .getLogger(OpenhabGraalJSScriptEngine.class.getPackageName() + ".org.graalvm.polyglot.Context");
         delegate = GraalJSScriptEngine.create(engine, Context.newBuilder(LANGUAGE_ID) //
                 .allowIO(IOAccess.newBuilder() //
                         .fileSystem(new DelegatingFileSystem(FileSystems.getDefault().provider()) {
@@ -253,6 +256,9 @@ public class OpenhabGraalJSScriptEngine
                 .hostClassLoader(getClass().getClassLoader()) //
                 // allow experimental options
                 .allowExperimentalOptions(true) //
+                // redirect OutputStreams from System to Log4j
+                .out(new Slf4jOutputStream(contextLogger, Level.DEBUG)) //
+                .err(new Slf4jOutputStream(contextLogger, Level.DEBUG)) //
                 // choose the path to look for CommonJS module (i.e. node_modules)
                 .option("js.commonjs-require-cwd", jsDependencyTracker.getLibraryPath().toString()) //
                 // enable Nashorn compat mode as openhab-js relies on accessors, see

--- a/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/OpenhabGraalJSScriptEngine.java
+++ b/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/OpenhabGraalJSScriptEngine.java
@@ -256,7 +256,7 @@ public class OpenhabGraalJSScriptEngine
                 .hostClassLoader(getClass().getClassLoader()) //
                 // allow experimental options
                 .allowExperimentalOptions(true) //
-                // redirect OutputStreams from System to Log4j
+                // redirect context's out/err streams to SLF4J
                 .out(new Slf4jOutputStream(contextLogger, Level.DEBUG)) //
                 .err(new Slf4jOutputStream(contextLogger, Level.DEBUG)) //
                 // choose the path to look for CommonJS module (i.e. node_modules)

--- a/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/OpenhabGraalJSScriptEngine.java
+++ b/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/OpenhabGraalJSScriptEngine.java
@@ -59,6 +59,7 @@ import org.openhab.automation.jsscripting.internal.fs.watch.JSDependencyTracker;
 import org.openhab.automation.jsscripting.internal.scope.ScriptExtensionModuleProvider;
 import org.openhab.automation.jsscripting.internal.scriptengine.InvocationInterceptingScriptEngineWithInvocableAndCompilableAndAutoCloseable;
 import org.openhab.automation.jsscripting.internal.scriptengine.helper.LifecycleTracker;
+import org.openhab.automation.jsscripting.internal.util.Slf4jOutputStream;
 import org.openhab.core.OpenHAB;
 import org.openhab.core.automation.module.script.ScriptExtensionAccessor;
 import org.openhab.core.automation.module.script.internal.handler.AbstractScriptModuleHandler;

--- a/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/OpenhabGraalJSScriptEngine.java
+++ b/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/OpenhabGraalJSScriptEngine.java
@@ -258,7 +258,7 @@ public class OpenhabGraalJSScriptEngine
                 .allowExperimentalOptions(true) //
                 // redirect context's out/err streams to SLF4J
                 .out(new Slf4jOutputStream(contextLogger, Level.DEBUG)) //
-                .err(new Slf4jOutputStream(contextLogger, Level.DEBUG)) //
+                .err(new Slf4jOutputStream(contextLogger, Level.WARN)) //
                 // choose the path to look for CommonJS module (i.e. node_modules)
                 .option("js.commonjs-require-cwd", jsDependencyTracker.getLibraryPath().toString()) //
                 // enable Nashorn compat mode as openhab-js relies on accessors, see

--- a/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/OpenhabGraalJSScriptEngine.java
+++ b/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/OpenhabGraalJSScriptEngine.java
@@ -57,6 +57,7 @@ import org.openhab.automation.jsscripting.internal.fs.DelegatingFileSystem;
 import org.openhab.automation.jsscripting.internal.fs.PrefixedSeekableByteChannel;
 import org.openhab.automation.jsscripting.internal.fs.ReadOnlySeekableByteArrayChannel;
 import org.openhab.automation.jsscripting.internal.fs.watch.JSDependencyTracker;
+import org.openhab.automation.jsscripting.internal.scope.ScriptExtensionModuleProvider;
 import org.openhab.automation.jsscripting.internal.scriptengine.InvocationInterceptingScriptEngineWithInvocableAndCompilableAndAutoCloseable;
 import org.openhab.automation.jsscripting.internal.scriptengine.helper.LifecycleTracker;
 import org.openhab.core.OpenHAB;

--- a/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/Slf4jOutputStream.java
+++ b/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/Slf4jOutputStream.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.automation.jsscripting.internal;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.slf4j.Logger;
+import org.slf4j.event.Level;
+
+/**
+ * A {@link OutputStream} implementation that redirects to SLF4J logging.
+ *
+ * @author Florian Hotze - Initial contribution
+ */
+@NonNullByDefault
+class Slf4jOutputStream extends OutputStream {
+    private final Logger logger;
+    private final Level level;
+    private final ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+
+    public Slf4jOutputStream(Logger logger, Level level) {
+        this.logger = logger;
+        this.level = level;
+    }
+
+    @Override
+    public void write(int b) {
+        if (b == '\n') {
+            flushToLogger();
+        } else {
+            buffer.write(b);
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        flushToLogger();
+        super.close();
+    }
+
+    private void flushToLogger() {
+        if (buffer.size() > 0) {
+            logger.atLevel(level).log(buffer.toString());
+            buffer.reset();
+        }
+    }
+}

--- a/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/Slf4jOutputStream.java
+++ b/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/Slf4jOutputStream.java
@@ -39,7 +39,7 @@ class Slf4jOutputStream extends OutputStream {
     @Override
     public void write(int b) {
         if (b == '\n') {
-            flushToLogger();
+            flush();
         } else {
             buffer.write(b);
         }
@@ -47,11 +47,12 @@ class Slf4jOutputStream extends OutputStream {
 
     @Override
     public void close() throws IOException {
-        flushToLogger();
+        flush();
         super.close();
     }
 
-    private void flushToLogger() {
+    @Override
+    public void flush() {
         if (buffer.size() > 0) {
             logger.atLevel(level).log(buffer.toString());
             buffer.reset();

--- a/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/scope/ModuleLocator.java
+++ b/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/scope/ModuleLocator.java
@@ -10,7 +10,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-package org.openhab.automation.jsscripting.internal;
+package org.openhab.automation.jsscripting.internal.scope;
 
 import java.util.Optional;
 

--- a/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/scope/ScriptExtensionModuleProvider.java
+++ b/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/scope/ScriptExtensionModuleProvider.java
@@ -10,7 +10,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-package org.openhab.automation.jsscripting.internal;
+package org.openhab.automation.jsscripting.internal.scope;
 
 import java.io.IOException;
 import java.util.HashMap;

--- a/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/util/Slf4jOutputStream.java
+++ b/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/util/Slf4jOutputStream.java
@@ -10,7 +10,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-package org.openhab.automation.jsscripting.internal;
+package org.openhab.automation.jsscripting.internal.util;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -26,7 +26,7 @@ import org.slf4j.event.Level;
  * @author Florian Hotze - Initial contribution
  */
 @NonNullByDefault
-class Slf4jOutputStream extends OutputStream {
+public class Slf4jOutputStream extends OutputStream {
     private final Logger logger;
     private final Level level;
     private final ByteArrayOutputStream buffer = new ByteArrayOutputStream();
@@ -36,26 +36,32 @@ class Slf4jOutputStream extends OutputStream {
         this.level = level;
     }
 
+    protected ByteArrayOutputStream getBuffer() {
+        return buffer;
+    }
+
     @Override
     public void write(int b) {
         if (b == '\n') {
             flush();
         } else {
-            buffer.write(b);
+            getBuffer().write(b);
+        }
+    }
+
+    @Override
+    public void flush() {
+        var buffer = getBuffer();
+        if (buffer.size() > 0) {
+            logger.atLevel(level).log(buffer.toString());
+            buffer.reset();
         }
     }
 
     @Override
     public void close() throws IOException {
         flush();
+        getBuffer().close();
         super.close();
-    }
-
-    @Override
-    public void flush() {
-        if (buffer.size() > 0) {
-            logger.atLevel(level).log(buffer.toString());
-            buffer.reset();
-        }
     }
 }

--- a/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/util/ThreadLocalSlf4jOutputStream.java
+++ b/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/util/ThreadLocalSlf4jOutputStream.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.automation.jsscripting.internal.util;
+
+import java.io.ByteArrayOutputStream;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.slf4j.Logger;
+import org.slf4j.event.Level;
+
+/**
+ * {@link Slf4jOutputStream} version using a {@link ThreadLocal} buffer.
+ *
+ * @author Florian Hotze - Initial contribution
+ */
+@NonNullByDefault
+public class ThreadLocalSlf4jOutputStream extends Slf4jOutputStream {
+    private final ThreadLocal<ByteArrayOutputStream> buffer = ThreadLocal.withInitial(ByteArrayOutputStream::new);
+
+    public ThreadLocalSlf4jOutputStream(Logger logger, Level level) {
+        super(logger, level);
+    }
+
+    @Override
+    protected ByteArrayOutputStream getBuffer() {
+        return buffer.get();
+    }
+}

--- a/bundles/org.openhab.automation.jsscripting/src/main/resources/OH-INF/config/config.xml
+++ b/bundles/org.openhab.automation.jsscripting/src/main/resources/OH-INF/config/config.xml
@@ -76,7 +76,7 @@
 		<parameter name="debuggerEnabled" type="boolean" required="true" groupName="debugger">
 			<label>Enable Debugger</label>
 			<description><![CDATA[
-			Enables Chrome Debugger support for JavaScript. This allows to attach any debugger compatible with the <a href="https://chromedevtools.github.io/devtools-protocol/">Chrome DevTools Protocol</a>, such as Chrome's Developer Tools or Visual Studio Code.
+			Enables Chrome Debugger support for JavaScript. This allows attaching any debugger compatible with the <a href="https://chromedevtools.github.io/devtools-protocol/">Chrome DevTools Protocol</a>, such as Chrome's Developer Tools or Visual Studio Code.
 			]]>
 			</description>
 			<default>false</default>

--- a/bundles/org.openhab.automation.jsscripting/src/main/resources/OH-INF/config/config.xml
+++ b/bundles/org.openhab.automation.jsscripting/src/main/resources/OH-INF/config/config.xml
@@ -7,14 +7,17 @@
 	<config-description uri="automation:jsscripting">
 		<parameter-group name="environment">
 			<label>JavaScript Environment</label>
-			<description>This group defines JavaScript's environment.</description>
 		</parameter-group>
 
 		<parameter-group name="system">
 			<label>System Behavior</label>
-			<description>This group defines JavaScript's system behavior.</description>
 		</parameter-group>
 
+		<parameter-group name="debugger">
+			<label>Debugger Support</label>
+		</parameter-group>
+
+		<!-- Environment -->
 		<parameter name="injectionEnabledV2" type="integer" required="true" min="0" max="3" groupName="environment">
 			<label>Inject Global Variables from Helper Library</label>
 			<description><![CDATA[
@@ -50,6 +53,7 @@
 			<advanced>true</advanced>
 		</parameter>
 
+		<!-- System Behaviour -->
 		<parameter name="injectionCachingEnabled" type="boolean" required="true" groupName="system">
 			<label>Cache openHAB JavaScript Library Injection</label>
 			<description><![CDATA[
@@ -65,6 +69,23 @@
 				your scripts to reload until you can test it. Please note that changing this setting only applies to scripts loaded
 				after the change.</description>
 			<default>true</default>
+			<advanced>true</advanced>
+		</parameter>
+
+		<!-- Debugger -->
+		<parameter name="debuggerEnabled" type="boolean" required="true" groupName="debugger">
+			<label>Enable Debugger</label>
+			<description><![CDATA[
+			Enables Chrome Debugger support for JavaScript. This allows to attach any debugger compatible with the <a href="https://chromedevtools.github.io/devtools-protocol/">Chrome DevTools Protocol</a>, such as Chrome's Developer Tools or Visual Studio Code.
+			]]>
+			</description>
+			<default>false</default>
+			<advanced>true</advanced>
+		</parameter>
+		<parameter name="debuggerPort" type="integer" required="true" min="1024" max="49151" groupName="debugger">
+			<label>Debugger Port</label>
+			<description>The port to bind the debugger to.</description>
+			<default>9229</default>
 			<advanced>true</advanced>
 		</parameter>
 	</config-description>

--- a/bundles/org.openhab.automation.jsscripting/src/main/resources/OH-INF/i18n/jsscripting.properties
+++ b/bundles/org.openhab.automation.jsscripting/src/main/resources/OH-INF/i18n/jsscripting.properties
@@ -6,7 +6,7 @@ addon.jsscripting.description = This adds a JS (ECMAScript-2024) script engine.
 # add-on config
 
 automation.config.jsscripting.debuggerEnabled.label = Enable Debugger
-automation.config.jsscripting.debuggerEnabled.description = Enables Chrome Debugger support for JavaScript. This allows to attach any debugger compatible with the <a href="https://chromedevtools.github.io/devtools-protocol/">Chrome DevTools Protocol</a>, such as Chrome's Developer Tools or Visual Studio Code.
+automation.config.jsscripting.debuggerEnabled.description = Enables Chrome Debugger support for JavaScript. This allows attaching any debugger compatible with the <a href="https://chromedevtools.github.io/devtools-protocol/">Chrome DevTools Protocol</a>, such as Chrome's Developer Tools or Visual Studio Code.
 automation.config.jsscripting.debuggerPort.label = Debugger Port
 automation.config.jsscripting.debuggerPort.description = The port to bind the debugger to.
 automation.config.jsscripting.dependencyTrackingEnabled.label = Enable Dependency Tracking

--- a/bundles/org.openhab.automation.jsscripting/src/main/resources/OH-INF/i18n/jsscripting.properties
+++ b/bundles/org.openhab.automation.jsscripting/src/main/resources/OH-INF/i18n/jsscripting.properties
@@ -5,14 +5,17 @@ addon.jsscripting.description = This adds a JS (ECMAScript-2024) script engine.
 
 # add-on config
 
+automation.config.jsscripting.debuggerEnabled.label = Enable Debugger
+automation.config.jsscripting.debuggerEnabled.description = Enables Chrome Debugger support for JavaScript. This allows to attach any debugger compatible with the <a href="https://chromedevtools.github.io/devtools-protocol/">Chrome DevTools Protocol</a>, such as Chrome's Developer Tools or Visual Studio Code.
+automation.config.jsscripting.debuggerPort.label = Debugger Port
+automation.config.jsscripting.debuggerPort.description = The port to bind the debugger to.
 automation.config.jsscripting.dependencyTrackingEnabled.label = Enable Dependency Tracking
 automation.config.jsscripting.dependencyTrackingEnabled.description = Dependency tracking allows your scripts to automatically reload when one of its dependencies is updated. You may want to disable dependency tracking if you plan on editing or updating a shared library, but don't want all your scripts to reload until you can test it. Please note that changing this setting only applies to scripts loaded after the change.
 automation.config.jsscripting.eventConversionEnabled.label = Convert Event from Java to JavaScript type in Script Actions & Script Conditions scripts
 automation.config.jsscripting.eventConversionEnabled.description = Converting the event data from Java to JavaScript types in Script Actions &amp; Script Conditions allows working with event data in a native JS way without special handling for Java types.<br> With this option enabled, the event data available in Script Actions &amp; Script Conditions is all JS types and the same as in rules created from script files.<br> Please note that this option <strong>requires auto-injection enabled at least for Script Actions &amp; Script Conditions</strong>.
+automation.config.jsscripting.group.debugger.label = Debugger Support
 automation.config.jsscripting.group.environment.label = JavaScript Environment
-automation.config.jsscripting.group.environment.description = This group defines JavaScript's environment.
 automation.config.jsscripting.group.system.label = System Behavior
-automation.config.jsscripting.group.system.description = This group defines JavaScript's system behavior.
 automation.config.jsscripting.injectionCachingEnabled.label = Cache openHAB JavaScript Library Injection
 automation.config.jsscripting.injectionCachingEnabled.description = Cache the openHAB JavaScript library injection for optimal performance.<br> Disable this option to allow loading the library from the local user configuration directory "automation/js/node_modules". Disabling caching may increase script loading times, especially on less powerful systems.
 automation.config.jsscripting.injectionEnabledV2.label = Inject Global Variables from Helper Library


### PR DESCRIPTION
Resolves #17415.

### Description

Implements support for enabling the GraalVM Chrome Debugger support (see https://www.graalvm.org/latest/tools/chrome-debugger/), so a Chrome DevTools Protocol compatible debugger, e.g. VS Code, can be attached to JavaScript scripts.

The debugger can be enabled and the debugger port can be configured through the advanced add-on settings, requiring an openHAB restart to become effective.

Chrome Debugger support is provided by the `org.graalvm.tools.chromeinspector-tool`, which is added as feature dependency together with its dependencies `org.graalvm.shadowed.json` and `org.graalvm.tools.profiler-tool`.
These dependencies are available as OSGi bundles have OSGi's ServiceLoader mediator properly configured, so no bad-practise like `Fragment-Bundle` has to be used.

### Review Notes

I'd recommend reviewing this PR by each individual commit, this should make review easier.

### Testing

An example VS Code launch configuration to connect to openHAB on localhost:

```json
{
    "version": "0.2.0",
    "configurations": [
        {
            "type": "node",
            "request": "attach",
            "name": "Attach to openHAB JavaScript Scripting",
            "address": "127.0.0.1",
            "port": 9229,
            "localRoot": "/etc/openhab/automation/js",
            "remoteRoot": "/etc/openhab/automation/js",
            "sourceMaps": false,
            "restart": true,
            "timeout": 30000,
            "continueOnAttach": true
        }
    ]
}
```

### To-Dos

- [ ] Documentation => Documentation lives in openhab-js repository, will be added there and then synced here.