### PR TITLE
[pythonscripting] Implement debugger support

### DIFF
--- a/bundles/org.openhab.automation.pythonscripting/README.md
+++ b/bundles/org.openhab.automation.pythonscripting/README.md
@@ -117,6 +117,19 @@ If you use the marketplace version of this Add-on, it is necessary to use the co
 # For tips and instructions, please refer to <a href="https://www.graalvm.org/latest/reference-manual/python/Modern-Python-on-JVM">Jython Migration Guide</a>.
 #
 #org.openhab.automation.pythonscripting:jythonEmulation = false
+
+# Enable debugger
+#
+# Enables Chrome Debugger support for Python Script. This allows to attach any debugger compatible with the 
+# <a href="https://chromedevtools.github.io/devtools-protocol/">Chrome DevTools Protocol</a>, such as Chrome's Developer Tools or Visual Studio Code.
+#
+#org.openhab.automation.pythonscripting:debuggerEnabled = false
+
+# Debugger port
+#
+# The port to bind the debugger to.
+#
+#org.openhab.automation.pythonscripting:debuggerPort = 9229
 ```
 
 ### Console

--- a/bundles/org.openhab.automation.pythonscripting/README.md
+++ b/bundles/org.openhab.automation.pythonscripting/README.md
@@ -120,7 +120,7 @@ If you use the marketplace version of this Add-on, it is necessary to use the co
 
 # Enable debugger
 #
-# Enables Chrome Debugger support for Python Script. This allows to attach any debugger compatible with the 
+# Enables Chrome Debugger support for Python Scripting. This allows you to attach any debugger compatible with the 
 # <a href="https://chromedevtools.github.io/devtools-protocol/">Chrome DevTools Protocol</a>, such as Chrome's Developer Tools or Visual Studio Code.
 #
 #org.openhab.automation.pythonscripting:debuggerEnabled = false

--- a/bundles/org.openhab.automation.pythonscripting/README.md
+++ b/bundles/org.openhab.automation.pythonscripting/README.md
@@ -129,7 +129,7 @@ If you use the marketplace version of this Add-on, it is necessary to use the co
 #
 # The port to bind the debugger to.
 #
-#org.openhab.automation.pythonscripting:debuggerPort = 9229
+#org.openhab.automation.pythonscripting:debuggerPort = 9230
 ```
 
 ### Console

--- a/bundles/org.openhab.automation.pythonscripting/src/main/feature/feature.xml
+++ b/bundles/org.openhab.automation.pythonscripting/src/main/feature/feature.xml
@@ -12,13 +12,12 @@
 		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.llvm.llvm-api/25.0.1</bundle>
 		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.shadowed.json/25.0.1</bundle>
 		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.shadowed.xz/25.0.1</bundle>
-		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.tools.profiler-tool/25.0.1</bundle>
 		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.polyglot.polyglot/25.0.1</bundle>
 		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.truffle.truffle-runtime/25.0.1</bundle>
 		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.truffle.truffle-compiler/25.0.1</bundle>
 		<bundle dependency="true" start-level="78">mvn:org.openhab.osgiify/org.graalvm.regex.regex/25.0.1</bundle>
-        <bundle dependency="true" start-level="78">mvn:org.openhab.osgiify/org.graalvm.tools.chromeinspector-tool/25.0.1</bundle>
-        <bundle dependency="true" start-level="78">mvn:org.openhab.osgiify/org.graalvm.tools.profiler-tool/25.0.1</bundle>
+		<bundle dependency="true" start-level="78">mvn:org.openhab.osgiify/org.graalvm.tools.chromeinspector-tool/25.0.1</bundle>
+		<bundle dependency="true" start-level="78">mvn:org.openhab.osgiify/org.graalvm.tools.profiler-tool/25.0.1</bundle>
 		<bundle dependency="true" start-level="78">mvn:org.openhab.osgiify/org.graalvm.python.python-resources/25.0.1</bundle>
 		<bundle dependency="true" start-level="78">mvn:org.openhab.osgiify/org.graalvm.python.python-language/25.0.1</bundle>
 		<bundle dependency="true" start-level="78">mvn:org.openhab.osgiify/org.graalvm.truffle.truffle-nfi/25.0.1</bundle>

--- a/bundles/org.openhab.automation.pythonscripting/src/main/feature/feature.xml
+++ b/bundles/org.openhab.automation.pythonscripting/src/main/feature/feature.xml
@@ -17,6 +17,8 @@
 		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.truffle.truffle-runtime/25.0.1</bundle>
 		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.truffle.truffle-compiler/25.0.1</bundle>
 		<bundle dependency="true" start-level="78">mvn:org.openhab.osgiify/org.graalvm.regex.regex/25.0.1</bundle>
+        <bundle dependency="true" start-level="78">mvn:org.openhab.osgiify/org.graalvm.tools.chromeinspector-tool/25.0.1</bundle>
+        <bundle dependency="true" start-level="78">mvn:org.openhab.osgiify/org.graalvm.tools.profiler-tool/25.0.1</bundle>
 		<bundle dependency="true" start-level="78">mvn:org.openhab.osgiify/org.graalvm.python.python-resources/25.0.1</bundle>
 		<bundle dependency="true" start-level="78">mvn:org.openhab.osgiify/org.graalvm.python.python-language/25.0.1</bundle>
 		<bundle dependency="true" start-level="78">mvn:org.openhab.osgiify/org.graalvm.truffle.truffle-nfi/25.0.1</bundle>

--- a/bundles/org.openhab.automation.pythonscripting/src/main/java/org/openhab/automation/pythonscripting/internal/PythonScriptEngine.java
+++ b/bundles/org.openhab.automation.pythonscripting/src/main/java/org/openhab/automation/pythonscripting/internal/PythonScriptEngine.java
@@ -51,7 +51,7 @@ import org.graalvm.polyglot.Value;
 import org.graalvm.polyglot.io.IOAccess;
 import org.openhab.automation.pythonscripting.internal.context.ContextInput;
 import org.openhab.automation.pythonscripting.internal.context.ContextOutput;
-import org.openhab.automation.pythonscripting.internal.context.ContextOutputLogger;
+import org.openhab.automation.pythonscripting.internal.context.ThreadLocalContextOutputLogger;
 import org.openhab.automation.pythonscripting.internal.fs.DelegatingFileSystem;
 import org.openhab.automation.pythonscripting.internal.provider.LifecycleTracker;
 import org.openhab.automation.pythonscripting.internal.provider.ScriptExtensionModuleProvider;
@@ -157,15 +157,13 @@ public class PythonScriptEngine extends InvocationInterceptingPythonScriptEngine
     /**
      * Creates an implementation of ScriptEngine {@code (& Invocable)}, wrapping the contained engine,
      * that tracks the script lifecycle and provides hooks for scripts to do so too.
-     *
-     * @param engine
      */
     public PythonScriptEngine(PythonScriptEngineConfiguration pythonScriptEngineConfiguration, Engine engine,
             PythonScriptEngineFactory pythonScriptEngineFactory) {
         this.pythonScriptEngineConfiguration = pythonScriptEngineConfiguration;
 
-        this.scriptOutputStream = new ContextOutput(new ContextOutputLogger(logger, Level.INFO));
-        this.scriptErrorStream = new ContextOutput(new ContextOutputLogger(logger, Level.ERROR));
+        this.scriptOutputStream = new ContextOutput(new ThreadLocalContextOutputLogger(logger, Level.INFO));
+        this.scriptErrorStream = new ContextOutput(new ThreadLocalContextOutputLogger(logger, Level.ERROR));
         this.scriptInputStream = new ContextInput(null);
 
         this.lifecycleTracker = new LifecycleTracker();
@@ -504,8 +502,8 @@ public class PythonScriptEngine extends InvocationInterceptingPythonScriptEngine
 
         Logger scriptLogger = LoggerFactory.getLogger("org.openhab.automation.pythonscripting." + identifier);
 
-        scriptOutputStream.setOutputStream(new ContextOutputLogger(scriptLogger, Level.INFO));
-        scriptErrorStream.setOutputStream(new ContextOutputLogger(scriptLogger, Level.ERROR));
+        scriptOutputStream.setOutputStream(new ThreadLocalContextOutputLogger(scriptLogger, Level.INFO));
+        scriptErrorStream.setOutputStream(new ThreadLocalContextOutputLogger(scriptLogger, Level.ERROR));
     }
 
     private String stringifyThrowable(Throwable throwable) {

--- a/bundles/org.openhab.automation.pythonscripting/src/main/java/org/openhab/automation/pythonscripting/internal/PythonScriptEngine.java
+++ b/bundles/org.openhab.automation.pythonscripting/src/main/java/org/openhab/automation/pythonscripting/internal/PythonScriptEngine.java
@@ -45,7 +45,6 @@ import org.eclipse.jdt.annotation.Nullable;
 import org.graalvm.polyglot.Context;
 import org.graalvm.polyglot.Engine;
 import org.graalvm.polyglot.HostAccess;
-import org.graalvm.polyglot.Language;
 import org.graalvm.polyglot.PolyglotException;
 import org.graalvm.polyglot.Source;
 import org.graalvm.polyglot.Value;
@@ -83,8 +82,6 @@ public class PythonScriptEngine extends InvocationInterceptingPythonScriptEngine
     public static final String CONTEXT_KEY_ENGINE_LOGGER_INPUT = "ctx.engine-logger-input";
     private static final String CONTEXT_KEY_SCRIPT_FILENAME = "javax.script.filename";
 
-    private static final String PYTHON_OPTION_ENGINE_WARNINTERPRETERONLY = "engine.WarnInterpreterOnly";
-
     private static final String SYSTEM_PROPERTY_ATTACH_LIBRARY_FAILURE_ACTION = "polyglotimpl.AttachLibraryFailureAction";
 
     private static final String PYTHON_OPTION_PYTHONPATH = "python.PythonPath";
@@ -105,11 +102,6 @@ public class PythonScriptEngine extends InvocationInterceptingPythonScriptEngine
     private static final int STACK_TRACE_LENGTH = 5;
 
     private static final String LOGGER_INIT_NAME = "__logger_init__";
-
-    /** Shared Polyglot {@link Engine} across all instances of {@link PythonScriptEngine} */
-    private static Engine engine = Engine.newBuilder()
-            // disable warning about fallback runtime (is only available in graalvm)
-            .option(PYTHON_OPTION_ENGINE_WARNINTERPRETERONLY, Boolean.toString(false)).build();
 
     static {
         // disable warning about missing TruffleAttach library (is only available in graalvm)
@@ -165,8 +157,10 @@ public class PythonScriptEngine extends InvocationInterceptingPythonScriptEngine
     /**
      * Creates an implementation of ScriptEngine {@code (& Invocable)}, wrapping the contained engine,
      * that tracks the script lifecycle and provides hooks for scripts to do so too.
+     *
+     * @param engine
      */
-    public PythonScriptEngine(PythonScriptEngineConfiguration pythonScriptEngineConfiguration,
+    public PythonScriptEngine(PythonScriptEngineConfiguration pythonScriptEngineConfiguration, Engine engine,
             PythonScriptEngineFactory pythonScriptEngineFactory) {
         this.pythonScriptEngineConfiguration = pythonScriptEngineConfiguration;
 
@@ -630,9 +624,5 @@ public class PythonScriptEngine extends InvocationInterceptingPythonScriptEngine
                 + (!value.hasMember("tzinfo") || value.getMember("tzinfo").isNull()
                         ? OffsetDateTime.now().getOffset().getId()
                         : ""));
-    }
-
-    public static @Nullable Language getLanguage() {
-        return engine.getLanguages().get(GraalPythonScriptEngine.LANGUAGE_ID);
     }
 }

--- a/bundles/org.openhab.automation.pythonscripting/src/main/java/org/openhab/automation/pythonscripting/internal/PythonScriptEngine.java
+++ b/bundles/org.openhab.automation.pythonscripting/src/main/java/org/openhab/automation/pythonscripting/internal/PythonScriptEngine.java
@@ -82,8 +82,6 @@ public class PythonScriptEngine extends InvocationInterceptingPythonScriptEngine
     public static final String CONTEXT_KEY_ENGINE_LOGGER_INPUT = "ctx.engine-logger-input";
     private static final String CONTEXT_KEY_SCRIPT_FILENAME = "javax.script.filename";
 
-    private static final String SYSTEM_PROPERTY_ATTACH_LIBRARY_FAILURE_ACTION = "polyglotimpl.AttachLibraryFailureAction";
-
     private static final String PYTHON_OPTION_PYTHONPATH = "python.PythonPath";
     private static final String PYTHON_OPTION_EMULATEJYTHON = "python.EmulateJython";
     private static final String PYTHON_OPTION_POSIXMODULEBACKEND = "python.PosixModuleBackend";
@@ -102,11 +100,6 @@ public class PythonScriptEngine extends InvocationInterceptingPythonScriptEngine
     private static final int STACK_TRACE_LENGTH = 5;
 
     private static final String LOGGER_INIT_NAME = "__logger_init__";
-
-    static {
-        // disable warning about missing TruffleAttach library (is only available in graalvm)
-        System.getProperties().setProperty(SYSTEM_PROPERTY_ATTACH_LIBRARY_FAILURE_ACTION, "ignore");
-    }
 
     // private static final boolean isPosix = FileSystems.getDefault().supportedFileAttributeViews().contains("posix");
 

--- a/bundles/org.openhab.automation.pythonscripting/src/main/java/org/openhab/automation/pythonscripting/internal/PythonScriptEngineConfiguration.java
+++ b/bundles/org.openhab.automation.pythonscripting/src/main/java/org/openhab/automation/pythonscripting/internal/PythonScriptEngineConfiguration.java
@@ -67,7 +67,7 @@ public class PythonScriptEngineConfiguration {
     private static final int INJECTION_ENABLED_FOR_SCRIPT_MODULES_AND_TRANSFORMATIONS = 3;
     private static final int INJECTION_ENABLED_FOR_ALL_SCRIPTS = 4;
 
-    private static final int DEBUGGER_PORT_DEFAULT = 9229;
+    private static final int DEBUGGER_PORT_DEFAULT = 9230;
 
     // The variable names must match the configuration keys in config.xml
     public static class PythonScriptingConfiguration {
@@ -75,8 +75,8 @@ public class PythonScriptEngineConfiguration {
         public boolean dependencyTrackingEnabled = true;
         public boolean cachingEnabled = true;
         public boolean jythonEmulation = false;
-        private boolean debuggerEnabled = false;
-        private int debuggerPort = DEBUGGER_PORT_DEFAULT;
+        public boolean debuggerEnabled = false;
+        public int debuggerPort = DEBUGGER_PORT_DEFAULT;
         public String pipModules = "";
     }
 

--- a/bundles/org.openhab.automation.pythonscripting/src/main/java/org/openhab/automation/pythonscripting/internal/PythonScriptEngineConfiguration.java
+++ b/bundles/org.openhab.automation.pythonscripting/src/main/java/org/openhab/automation/pythonscripting/internal/PythonScriptEngineConfiguration.java
@@ -67,12 +67,16 @@ public class PythonScriptEngineConfiguration {
     private static final int INJECTION_ENABLED_FOR_SCRIPT_MODULES_AND_TRANSFORMATIONS = 3;
     private static final int INJECTION_ENABLED_FOR_ALL_SCRIPTS = 4;
 
+    private static final int DEBUGGER_PORT_DEFAULT = 9229;
+
     // The variable names must match the configuration keys in config.xml
     public static class PythonScriptingConfiguration {
         public int injectionEnabled = INJECTION_ENABLED_FOR_SCRIPT_MODULES_ONLY;
         public boolean dependencyTrackingEnabled = true;
         public boolean cachingEnabled = true;
         public boolean jythonEmulation = false;
+        private boolean debuggerEnabled = false;
+        private int debuggerPort = DEBUGGER_PORT_DEFAULT;
         public String pipModules = "";
     }
 
@@ -153,21 +157,30 @@ public class PythonScriptEngineConfiguration {
     public void modified(Map<String, Object> config, PythonScriptEngineFactory factory) {
         int oldInjectionEnabled = configuration.injectionEnabled;
         boolean oldDependencyTrackingEnabled = isDependencyTrackingEnabled();
-
         String oldPipModules = configuration.pipModules;
+        boolean oldDebuggerEnabled = configuration.debuggerEnabled;
+        int oldDebuggerPort = configuration.debuggerPort;
+
         configuration = new Configuration(config).as(PythonScriptingConfiguration.class);
+
         if (!oldPipModules.equals(configuration.pipModules)) {
             PythonScriptEngineHelper.initPipModules(this, factory);
         }
 
         if (oldInjectionEnabled != configuration.injectionEnabled) {
-            logger.info(
+            logger.warn(
                     "Changed helper module setting for Python Scripting. Please resave your python scripts to apply this change.");
         }
         if (oldDependencyTrackingEnabled != isDependencyTrackingEnabled()) {
-            logger.info(
+            logger.warn(
                     "{} dependency tracking for Python Scripting. Please resave your python scripts to apply this change.",
                     isDependencyTrackingEnabled() ? "Enabled" : "Disabled");
+        }
+        if (oldDebuggerEnabled != configuration.debuggerEnabled) {
+            logger.warn("{} debugger for Python Scripting. Restart openHAB to apply this change.",
+                    configuration.debuggerEnabled ? "Enabled" : "Disabled");
+        } else if (oldDebuggerPort != configuration.debuggerPort) {
+            logger.warn("Reconfigured debugger for Python Scripting. Restart openHAB to apply this change.");
         }
     }
 
@@ -201,6 +214,14 @@ public class PythonScriptEngineConfiguration {
 
     public boolean isJythonEmulation() {
         return configuration.jythonEmulation;
+    }
+
+    public boolean isDebuggerEnabled() {
+        return configuration.debuggerEnabled;
+    }
+
+    public int getDebuggerPort() {
+        return configuration.debuggerPort;
     }
 
     public String getPIPModules() {

--- a/bundles/org.openhab.automation.pythonscripting/src/main/java/org/openhab/automation/pythonscripting/internal/PythonScriptEngineConfiguration.java
+++ b/bundles/org.openhab.automation.pythonscripting/src/main/java/org/openhab/automation/pythonscripting/internal/PythonScriptEngineConfiguration.java
@@ -48,7 +48,7 @@ public class PythonScriptEngineConfiguration {
     private final Logger logger = LoggerFactory.getLogger(PythonScriptEngineConfiguration.class);
 
     private static final String SYSTEM_PROPERTY_POLYGLOT_ENGINE_USERRESOURCECACHE = "polyglot.engine.userResourceCache";
-
+    private static final String SYSTEM_PROPERTY_ATTACH_LIBRARY_FAILURE_ACTION = "polyglotimpl.AttachLibraryFailureAction";
     private static final String SYSTEM_PROPERTY_JAVA_IO_TMPDIR = "java.io.tmpdir";
 
     public static final String PATH_SEPARATOR = FileSystems.getDefault().getSeparator();
@@ -98,6 +98,11 @@ public class PythonScriptEngineConfiguration {
         return Version.parse(version != null && version.startsWith("v") ? version.substring(1) : version);
     }
 
+    static {
+        // disable warning about missing TruffleAttach library (is only available in graalvm)
+        System.getProperties().setProperty(SYSTEM_PROPERTY_ATTACH_LIBRARY_FAILURE_ACTION, "ignore");
+    }
+
     @Activate
     public PythonScriptEngineConfiguration(Map<String, Object> config) {
         Path userdataDir = Paths.get(OpenHAB.getUserDataFolder());
@@ -127,6 +132,7 @@ public class PythonScriptEngineConfiguration {
         Properties props = System.getProperties();
         props.setProperty(SYSTEM_PROPERTY_POLYGLOT_ENGINE_USERRESOURCECACHE,
                 userdataDir.resolve("cache").resolve("org.graalvm.polyglot").toString());
+        props.setProperty(SYSTEM_PROPERTY_ATTACH_LIBRARY_FAILURE_ACTION, "ignore");
 
         String packageName = PythonScriptEngineConfiguration.class.getPackageName();
         packageName = packageName.substring(0, packageName.lastIndexOf("."));

--- a/bundles/org.openhab.automation.pythonscripting/src/main/java/org/openhab/automation/pythonscripting/internal/PythonScriptEngineFactory.java
+++ b/bundles/org.openhab.automation.pythonscripting/src/main/java/org/openhab/automation/pythonscripting/internal/PythonScriptEngineFactory.java
@@ -98,13 +98,13 @@ public class PythonScriptEngineFactory implements ScriptEngineFactory, ScriptEng
             Engine engine;
             try {
                 engine = engineBuilder.build();
+                logger.info("Debugger support is enabled for Python Scripting.");
             } catch (RuntimeException e) {
                 logger.error(
                         "Failed to initialize Graal Python engine with debugger support. Continuing without debugger support.",
                         e);
                 engine = createEngineBuilder().build();
             }
-            logger.info("Debugger support is enabled for Python Scripting.");
             this.engine = engine;
         } else {
             this.engine = createEngineBuilder().build();

--- a/bundles/org.openhab.automation.pythonscripting/src/main/java/org/openhab/automation/pythonscripting/internal/PythonScriptEngineFactory.java
+++ b/bundles/org.openhab.automation.pythonscripting/src/main/java/org/openhab/automation/pythonscripting/internal/PythonScriptEngineFactory.java
@@ -98,7 +98,8 @@ public class PythonScriptEngineFactory implements ScriptEngineFactory, ScriptEng
             Engine engine;
             try {
                 engine = engineBuilder.build();
-                logger.info("Debugger support is enabled for Python Scripting.");
+                logger.info("Debugger support is enabled for Python Scripting on port {}",
+                        configuration.getDebuggerPort());
             } catch (RuntimeException e) {
                 logger.error(
                         "Failed to initialize Graal Python engine with debugger support. Continuing without debugger support.",

--- a/bundles/org.openhab.automation.pythonscripting/src/main/java/org/openhab/automation/pythonscripting/internal/PythonScriptEngineFactory.java
+++ b/bundles/org.openhab.automation.pythonscripting/src/main/java/org/openhab/automation/pythonscripting/internal/PythonScriptEngineFactory.java
@@ -86,23 +86,39 @@ public class PythonScriptEngineFactory implements ScriptEngineFactory, ScriptEng
         this.configuration = new PythonScriptEngineConfiguration(config);
         this.configuration.init(this);
 
-        Engine.Builder engineBuilder = Engine.newBuilder().allowExperimentalOptions(true) //
-                .option(PYTHON_OPTION_ENGINE_WARNINTERPRETERONLY, Boolean.toString(false));
+        Engine.Builder engineBuilder = createEngineBuilder();
         if (configuration.isDebuggerEnabled()) {
-            logger.info("Enabling Python debugger support.");
             engineBuilder //
                     .option("inspect", "0.0.0.0:" + configuration.getDebuggerPort()) //
                     .option("inspect.Suspend", "false") // Don't pause at startup waiting for debugger to attach
                     .option("inspect.WaitAttached", "false") // Don't block code execution waiting for debugger to
                                                              // attach
                     .option("inspect.Secure", "false"); // Disable TLS
+
+            Engine engine;
+            try {
+                engine = engineBuilder.build();
+            } catch (RuntimeException e) {
+                logger.error(
+                        "Failed to initialize Graal Python engine with debugger support. Continuing without debugger support.",
+                        e);
+                engine = createEngineBuilder().build();
+            }
+            logger.info("Debugger support is enabled for Python Scripting.");
+            this.engine = engine;
+        } else {
+            this.engine = createEngineBuilder().build();
         }
-        this.engine = engineBuilder.build();
 
         if (getLanguage() == null) {
             logger.error(
                     "Graal Python language not initialized. Restart openHAB to initialize available Graal languages properly.");
         }
+    }
+
+    private Engine.Builder createEngineBuilder() {
+        return Engine.newBuilder().allowExperimentalOptions(true) //
+                .option(PYTHON_OPTION_ENGINE_WARNINTERPRETERONLY, Boolean.toString(false));
     }
 
     @Deactivate

--- a/bundles/org.openhab.automation.pythonscripting/src/main/java/org/openhab/automation/pythonscripting/internal/PythonScriptEngineFactory.java
+++ b/bundles/org.openhab.automation.pythonscripting/src/main/java/org/openhab/automation/pythonscripting/internal/PythonScriptEngineFactory.java
@@ -23,8 +23,10 @@ import javax.script.ScriptEngine;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
+import org.graalvm.polyglot.Engine;
 import org.graalvm.polyglot.Language;
 import org.openhab.automation.pythonscripting.internal.fs.PythonDependencyTracker;
+import org.openhab.automation.pythonscripting.internal.scriptengine.graal.GraalPythonScriptEngine;
 import org.openhab.automation.pythonscripting.internal.scriptengine.graal.GraalPythonScriptEngine.ScriptEngineProvider;
 import org.openhab.core.automation.module.script.ScriptDependencyTracker;
 import org.openhab.core.automation.module.script.ScriptEngineFactory;
@@ -60,18 +62,17 @@ public class PythonScriptEngineFactory implements ScriptEngineFactory, ScriptEng
     private final PythonDependencyTracker pythonDependencyTracker;
     private final PythonScriptEngineConfiguration configuration;
 
-    private final @Nullable Language language;
+    private static final String PYTHON_OPTION_ENGINE_WARNINTERPRETERONLY = "engine.WarnInterpreterOnly";
+
+    /**
+     * Shared Polyglot {@link Engine} instance to be used by all instances of {@link PythonScriptEngine}.
+     */
+    private final Engine engine;
 
     @Activate
     public PythonScriptEngineFactory(final @Reference PythonDependencyTracker pythonDependencyTracker,
             final @Reference TimeZoneProvider timeZoneProvider, Map<String, Object> config) {
         logger.debug("Loading PythonScriptEngineFactory");
-
-        this.language = PythonScriptEngine.getLanguage();
-        if (this.language == null) {
-            logger.error(
-                    "Graal Python language not initialized. Restart openHAB to initialize available Graal languages properly.");
-        }
 
         String defaultTimezone = ZoneId.systemDefault().getId();
         String providerTimezone = timeZoneProvider.getTimeZone().getId();
@@ -84,6 +85,24 @@ public class PythonScriptEngineFactory implements ScriptEngineFactory, ScriptEng
         this.pythonDependencyTracker = pythonDependencyTracker;
         this.configuration = new PythonScriptEngineConfiguration(config);
         this.configuration.init(this);
+
+        Engine.Builder engineBuilder = Engine.newBuilder().allowExperimentalOptions(true) //
+                .option(PYTHON_OPTION_ENGINE_WARNINTERPRETERONLY, Boolean.toString(false));
+        if (configuration.isDebuggerEnabled()) {
+            logger.info("Enabling Python debugger support.");
+            engineBuilder //
+                    .option("inspect", "0.0.0.0:" + configuration.getDebuggerPort()) //
+                    .option("inspect.Suspend", "false") // Don't pause at startup waiting for debugger to attach
+                    .option("inspect.WaitAttached", "false") // Don't block code execution waiting for debugger to
+                                                             // attach
+                    .option("inspect.Secure", "false"); // Disable TLS
+        }
+        this.engine = engineBuilder.build();
+
+        if (getLanguage() == null) {
+            logger.error(
+                    "Graal Python language not initialized. Restart openHAB to initialize available Graal languages properly.");
+        }
     }
 
     @Deactivate
@@ -127,10 +146,10 @@ public class PythonScriptEngineFactory implements ScriptEngineFactory, ScriptEng
 
     @Override
     public @Nullable ScriptEngine createScriptEngine() {
-        if (language == null) {
+        if (getLanguage() == null) {
             return null;
         }
-        return new PythonScriptEngine(configuration, this);
+        return new PythonScriptEngine(configuration, engine, this);
     }
 
     @Override
@@ -140,5 +159,14 @@ public class PythonScriptEngineFactory implements ScriptEngineFactory, ScriptEng
 
     public PythonScriptEngineConfiguration getConfiguration() {
         return this.configuration;
+    }
+
+    /**
+     * Gets the Graal language of {@link PythonScriptEngine}.
+     *
+     * @return the Graal language of {@link PythonScriptEngine} or {@code null} if not available
+     */
+    public @Nullable Language getLanguage() {
+        return engine.getLanguages().get(GraalPythonScriptEngine.LANGUAGE_ID);
     }
 }

--- a/bundles/org.openhab.automation.pythonscripting/src/main/java/org/openhab/automation/pythonscripting/internal/console/PythonConsoleCommandExtension.java
+++ b/bundles/org.openhab.automation.pythonscripting/src/main/java/org/openhab/automation/pythonscripting/internal/console/PythonConsoleCommandExtension.java
@@ -174,7 +174,8 @@ public class PythonConsoleCommandExtension extends AbstractConsoleCommandExtensi
     }
 
     private void info(Console console) {
-        new InfoCmd(pythonScriptEngineConfiguration, console).show(configDescriptionRegistry);
+        new InfoCmd(pythonScriptEngineConfiguration, console, this.pythonScriptEngineFactory.getLanguage())
+                .show(configDescriptionRegistry);
     }
 
     private void startConsole(Console console, String[] args) {

--- a/bundles/org.openhab.automation.pythonscripting/src/main/java/org/openhab/automation/pythonscripting/internal/console/handler/InfoCmd.java
+++ b/bundles/org.openhab.automation.pythonscripting/src/main/java/org/openhab/automation/pythonscripting/internal/console/handler/InfoCmd.java
@@ -20,8 +20,8 @@ import java.util.List;
 import java.util.Map;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.graalvm.polyglot.Language;
-import org.openhab.automation.pythonscripting.internal.PythonScriptEngine;
 import org.openhab.automation.pythonscripting.internal.PythonScriptEngineConfiguration;
 import org.openhab.automation.pythonscripting.internal.PythonScriptEngineFactory;
 import org.openhab.core.config.core.ConfigDescription;
@@ -38,10 +38,12 @@ import org.openhab.core.io.console.Console;
 public class InfoCmd {
     private final PythonScriptEngineConfiguration config;
     private final Console console;
+    private final @Nullable Language language;
 
-    public InfoCmd(PythonScriptEngineConfiguration config, Console console) {
+    public InfoCmd(PythonScriptEngineConfiguration config, Console console, @Nullable Language language) {
         this.config = config;
         this.console = console;
+        this.language = language;
     }
 
     public void show(ConfigDescriptionRegistry registry) {
@@ -50,7 +52,6 @@ public class InfoCmd {
         console.println("  Runtime:");
         console.println("    Bundle version: " + config.getBundleVersion());
         console.println("    GraalVM version: " + config.getGraalVersion());
-        Language language = PythonScriptEngine.getLanguage();
         console.println("    Python version: " + (language != null ? language.getVersion() : "unavailable"));
         Version version = config.getInstalledHelperLibVersion();
         console.println("    Helper lib version: " + (version != null ? version.toString() : "disabled"));

--- a/bundles/org.openhab.automation.pythonscripting/src/main/java/org/openhab/automation/pythonscripting/internal/context/ContextOutputLogger.java
+++ b/bundles/org.openhab.automation.pythonscripting/src/main/java/org/openhab/automation/pythonscripting/internal/context/ContextOutputLogger.java
@@ -12,6 +12,8 @@
  */
 package org.openhab.automation.pythonscripting.internal.context;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.io.OutputStream;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -25,79 +27,41 @@ import org.slf4j.event.Level;
  */
 @NonNullByDefault
 public class ContextOutputLogger extends OutputStream {
-    private static final int DEFAULT_BUFFER_LENGTH = 2048;
-    private static final String LINE_SEPARATOR = System.lineSeparator();
-    private static final int LINE_SEPARATOR_SIZE = LINE_SEPARATOR.length();
-
-    private int bufLength;
-    private byte[] buf;
-    private int count;
-
-    private Logger logger;
-    private Level level;
+    private final Logger logger;
+    private final Level level;
+    private final ByteArrayOutputStream buffer = new ByteArrayOutputStream();
 
     public ContextOutputLogger(Logger logger, Level level) {
         this.logger = logger;
         this.level = level;
+    }
 
-        bufLength = DEFAULT_BUFFER_LENGTH;
-        buf = new byte[DEFAULT_BUFFER_LENGTH];
-        count = 0;
+    protected ByteArrayOutputStream getBuffer() {
+        return buffer;
     }
 
     @Override
     public void write(int b) {
-        // don't log nulls
-        if (b == 0) {
-            return;
+        if (b == '\n') {
+            flush();
+        } else {
+            getBuffer().write(b);
         }
-
-        if (count == bufLength) {
-            growBuffer();
-        }
-
-        buf[count] = (byte) b;
-        count++;
     }
 
     @Override
     public void flush() {
-        if (count == 0) {
-            return;
+        var buffer = getBuffer();
+        if (buffer.size() > 0) {
+            logger.atLevel(level).log(buffer.toString());
+            buffer.reset();
         }
-
-        // don't print out blank lines;
-        if (count == LINE_SEPARATOR_SIZE) {
-            if (((char) buf[0]) == LINE_SEPARATOR.charAt(0)
-                    && ((count == 1) || ((count == 2) && ((char) buf[1]) == LINE_SEPARATOR.charAt(1)))) {
-                reset();
-                return;
-            }
-        } else if (count > LINE_SEPARATOR_SIZE) {
-            // remove linebreaks at the end
-            if (((char) buf[count - 1]) == LINE_SEPARATOR.charAt(LINE_SEPARATOR_SIZE - 1)
-                    && ((LINE_SEPARATOR_SIZE == 1) || ((LINE_SEPARATOR_SIZE == 2)
-                            && ((char) buf[count - 1]) == LINE_SEPARATOR.charAt(LINE_SEPARATOR_SIZE - 2)))) {
-                count -= LINE_SEPARATOR_SIZE;
-            }
-        }
-
-        final byte[] line = new byte[count];
-        System.arraycopy(buf, 0, line, 0, count);
-        logger.atLevel(level).log(new String(line));
-        reset();
     }
 
-    private void growBuffer() {
-        final int newBufLength = bufLength + DEFAULT_BUFFER_LENGTH;
-        final byte[] newBuf = new byte[newBufLength];
-        System.arraycopy(buf, 0, newBuf, 0, bufLength);
-        buf = newBuf;
-        bufLength = newBufLength;
-    }
-
-    private void reset() {
-        // don't shrink buffer. assuming that if it grew that it will likely grow similarly again
-        count = 0;
+    @Override
+    public void close() throws IOException {
+        flush();
+        getBuffer().close();
+        super.close();
     }
 }

--- a/bundles/org.openhab.automation.pythonscripting/src/main/java/org/openhab/automation/pythonscripting/internal/context/ThreadLocalContextOutputLogger.java
+++ b/bundles/org.openhab.automation.pythonscripting/src/main/java/org/openhab/automation/pythonscripting/internal/context/ThreadLocalContextOutputLogger.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.automation.pythonscripting.internal.context;
+
+import java.io.ByteArrayOutputStream;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.slf4j.Logger;
+import org.slf4j.event.Level;
+
+/**
+ * {@link ContextOutputLogger} version using a {@link ThreadLocal} buffer.
+ *
+ * @author Holger Hees - Initial contribution
+ */
+@NonNullByDefault
+public class ThreadLocalContextOutputLogger extends ContextOutputLogger {
+    private final ThreadLocal<ByteArrayOutputStream> buffer = ThreadLocal.withInitial(ByteArrayOutputStream::new);
+
+    public ThreadLocalContextOutputLogger(Logger logger, Level level) {
+        super(logger, level);
+    }
+
+    @Override
+    protected ByteArrayOutputStream getBuffer() {
+        return buffer.get();
+    }
+}

--- a/bundles/org.openhab.automation.pythonscripting/src/main/resources/OH-INF/config/config.xml
+++ b/bundles/org.openhab.automation.pythonscripting/src/main/resources/OH-INF/config/config.xml
@@ -80,7 +80,7 @@
 		<parameter name="debuggerEnabled" type="boolean" required="true" groupName="debugger">
 			<label>Enable Debugger</label>
 			<description><![CDATA[
-			Enables Chrome Debugger support for Python Script. This allows to attach any debugger compatible with the <a href="https://chromedevtools.github.io/devtools-protocol/">Chrome DevTools Protocol</a>, such as Chrome's Developer Tools or Visual Studio Code.
+			Enables Chrome Debugger support for Python Scripting. This allows you to attach any debugger compatible with the <a href="https://chromedevtools.github.io/devtools-protocol/">Chrome DevTools Protocol</a>, such as Chrome's Developer Tools or Visual Studio Code.
 			]]>
 			</description>
 			<default>false</default>

--- a/bundles/org.openhab.automation.pythonscripting/src/main/resources/OH-INF/config/config.xml
+++ b/bundles/org.openhab.automation.pythonscripting/src/main/resources/OH-INF/config/config.xml
@@ -16,6 +16,11 @@
 			<advanced>true</advanced>
 		</parameter-group>
 
+		<parameter-group name="debugger">
+			<label>Debugger Support</label>
+		</parameter-group>
+
+		<!-- Environment -->
 		<parameter name="injectionEnabled" type="integer" required="true" min="0" max="4" groupName="environment">
 			<label>Activate openHAB Python helper module and inject scope and helper objects into rules.</label>
 			<description><![CDATA[
@@ -32,6 +37,8 @@
 			</options>
 			<default>2</default>
 		</parameter>
+
+		<!-- System Behaviour -->
 		<parameter name="pipModules" type="text" required="false" groupName="system">
 			<label>Python pip modules (requires a manually configured venv)</label>
 			<description><![CDATA[
@@ -66,6 +73,23 @@
 			For tips and instructions, please refer to <a href="https://www.graalvm.org/latest/reference-manual/python/Modern-Python-on-JVM">Jython Migration Guide</a>.
 			]]></description>
 			<default>false</default>
+			<advanced>true</advanced>
+		</parameter>
+
+		<!-- Debugger -->
+		<parameter name="debuggerEnabled" type="boolean" required="true" groupName="debugger">
+			<label>Enable Debugger</label>
+			<description><![CDATA[
+			Enables Chrome Debugger support for Python Script. This allows to attach any debugger compatible with the <a href="https://chromedevtools.github.io/devtools-protocol/">Chrome DevTools Protocol</a>, such as Chrome's Developer Tools or Visual Studio Code.
+			]]>
+			</description>
+			<default>false</default>
+			<advanced>true</advanced>
+		</parameter>
+		<parameter name="debuggerPort" type="integer" required="true" min="1024" max="49151" groupName="debugger">
+			<label>Debugger Port</label>
+			<description>The port to bind the debugger to.</description>
+			<default>9229</default>
 			<advanced>true</advanced>
 		</parameter>
 	</config-description>

--- a/bundles/org.openhab.automation.pythonscripting/src/main/resources/OH-INF/config/config.xml
+++ b/bundles/org.openhab.automation.pythonscripting/src/main/resources/OH-INF/config/config.xml
@@ -89,7 +89,7 @@
 		<parameter name="debuggerPort" type="integer" required="true" min="1024" max="49151" groupName="debugger">
 			<label>Debugger Port</label>
 			<description>The port to bind the debugger to.</description>
-			<default>9229</default>
+			<default>9230</default>
 			<advanced>true</advanced>
 		</parameter>
 	</config-description>

--- a/bundles/org.openhab.automation.pythonscripting/src/main/resources/OH-INF/i18n/pythonscripting.properties
+++ b/bundles/org.openhab.automation.pythonscripting/src/main/resources/OH-INF/i18n/pythonscripting.properties
@@ -8,7 +8,7 @@ addon.pythonscripting.description = This adds a Python 3.x script engine.
 automation.config.pythonscripting.cachingEnabled.label = Cache compiled openHAB Python modules (.pyc files)
 automation.config.pythonscripting.cachingEnabled.description = Cache the openHAB python modules for improved startup performance.<br> Disabling this option will result in slower startup performance, because scripts have to be recompiled on every startup.
 automation.config.pythonscripting.debuggerEnabled.label = Enable Debugger
-automation.config.pythonscripting.debuggerEnabled.description = Enables Chrome Debugger support for Python Script. This allows to attach any debugger compatible with the <a href="https://chromedevtools.github.io/devtools-protocol/">Chrome DevTools Protocol</a>, such as Chrome's Developer Tools or Visual Studio Code.
+automation.config.pythonscripting.debuggerEnabled.description = Enables Chrome Debugger support for Python Scripting. This allows you to attach any debugger compatible with the <a href="https://chromedevtools.github.io/devtools-protocol/">Chrome DevTools Protocol</a>, such as Chrome's Developer Tools or Visual Studio Code.
 automation.config.pythonscripting.debuggerPort.label = Debugger Port
 automation.config.pythonscripting.debuggerPort.description = The port to bind the debugger to.
 automation.config.pythonscripting.dependencyTrackingEnabled.label = Enable dependency tracking

--- a/bundles/org.openhab.automation.pythonscripting/src/main/resources/OH-INF/i18n/pythonscripting.properties
+++ b/bundles/org.openhab.automation.pythonscripting/src/main/resources/OH-INF/i18n/pythonscripting.properties
@@ -7,8 +7,13 @@ addon.pythonscripting.description = This adds a Python 3.x script engine.
 
 automation.config.pythonscripting.cachingEnabled.label = Cache compiled openHAB Python modules (.pyc files)
 automation.config.pythonscripting.cachingEnabled.description = Cache the openHAB python modules for improved startup performance.<br> Disabling this option will result in slower startup performance, because scripts have to be recompiled on every startup.
+automation.config.pythonscripting.debuggerEnabled.label = Enable Debugger
+automation.config.pythonscripting.debuggerEnabled.description = Enables Chrome Debugger support for Python Script. This allows to attach any debugger compatible with the <a href="https://chromedevtools.github.io/devtools-protocol/">Chrome DevTools Protocol</a>, such as Chrome's Developer Tools or Visual Studio Code.
+automation.config.pythonscripting.debuggerPort.label = Debugger Port
+automation.config.pythonscripting.debuggerPort.description = The port to bind the debugger to.
 automation.config.pythonscripting.dependencyTrackingEnabled.label = Enable dependency tracking
 automation.config.pythonscripting.dependencyTrackingEnabled.description = Dependency tracking allows your scripts to automatically reload when one of its dependencies is updated. You may want to disable dependency tracking if you plan on editing or updating a shared library, but don't want all your scripts to reload until you can test it.
+automation.config.pythonscripting.group.debugger.label = Debugger Support
 automation.config.pythonscripting.group.environment.label = Python Environment
 automation.config.pythonscripting.group.environment.description = This group defines Python's environment.
 automation.config.pythonscripting.group.system.label = System Behavior


### PR DESCRIPTION
Implements support for enabling the GraalVM Chrome Debugger support (see https://www.graalvm.org/latest/tools/chrome-debugger/), so a Chrome DevTools Protocol compatible debugger, e.g. VS Code, can be attached to JavaScript scripts.

The debugger can be enabled and the debugger port can be configured through the advanced add-on settings, requiring an openHAB restart to become effective.

Chrome Debugger support is provided by the org.graalvm.tools.chromeinspector-tool, which is added as feature dependency together with its dependencies org.graalvm.shadowed.json and org.graalvm.tools.profiler-tool.
These dependencies are available as OSGi bundles have OSGi's ServiceLoader mediator properly configured, so no bad-practise like Fragment-Bundle has to be used.

This pull request is more or less the same as https://github.com/openhab/openhab-addons/pull/20440 , but this time for python.