### PR TITLE
[shelly] Sync access to ShellyDeviceStats (thread safety)

### DIFF
--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/handler/ShellyBaseHandler.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/handler/ShellyBaseHandler.java
@@ -55,7 +55,7 @@ import org.openhab.binding.shelly.internal.config.ShellyBindingConfiguration;
 import org.openhab.binding.shelly.internal.config.ShellyThingConfiguration;
 import org.openhab.binding.shelly.internal.discovery.ShellyBasicDiscoveryService;
 import org.openhab.binding.shelly.internal.discovery.ShellyThingCreator;
-import org.openhab.binding.shelly.internal.handler.ShellyDeviceStats.Alarm;
+import org.openhab.binding.shelly.internal.handler.ShellyDeviceStats.ShellyDeviceAlarm;
 import org.openhab.binding.shelly.internal.provider.ShellyChannelDefinitions;
 import org.openhab.binding.shelly.internal.provider.ShellyTranslationProvider;
 import org.openhab.binding.shelly.internal.util.ShellyChannelCache;
@@ -836,7 +836,7 @@ public abstract class ShellyBaseHandler extends BaseThingHandler
         String channelId = mkChannelId(CHANNEL_GROUP_DEV_STATUS, CHANNEL_DEVST_ALARM);
         State value = cache.getValue(channelId);
         String lastAlarmMsg = value != UnDefType.NULL ? value.toString() : "";
-        Alarm lastAlarm = stats.lastAlarm.get();
+        ShellyDeviceAlarm lastAlarm = stats.lastAlarm.get();
 
         if (force || !lastAlarmMsg.equals(event) || (lastAlarmMsg.equals(event)
                 && (lastAlarm == null || now() > lastAlarm.timeStamp() + HEALTH_CHECK_INTERVAL_SEC))) {
@@ -861,7 +861,7 @@ public abstract class ShellyBaseHandler extends BaseThingHandler
                     logger.debug("{}: {}", thingName, messages.get("event.triggered", event));
                     triggerChannel(channelId, event);
                     cache.updateChannel(channelId, getStringType(event.toUpperCase(Locale.ROOT)));
-                    lastAlarm = new Alarm(event, (long) now());
+                    lastAlarm = new ShellyDeviceAlarm(event, (long) now());
                     stats.lastAlarm.set(lastAlarm);
                     stats.alarms.incrementAndGet();
             }

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/handler/ShellyBaseHandler.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/handler/ShellyBaseHandler.java
@@ -763,7 +763,7 @@ public abstract class ShellyBaseHandler extends BaseThingHandler
 
         if (api.isInitialized()) {
             stats.timeoutErrors.set(api.getTimeoutErrors());
-            stats.timeoutsRecorvered.set(api.getTimeoutsRecovered());
+            stats.timeoutsRecovered.set(api.getTimeoutsRecovered());
         }
         stats.remainingWatchdog.set(watchdog > 0 ? (long) (now() - watchdog) : 0);
 

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/handler/ShellyBaseHandler.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/handler/ShellyBaseHandler.java
@@ -55,6 +55,7 @@ import org.openhab.binding.shelly.internal.config.ShellyBindingConfiguration;
 import org.openhab.binding.shelly.internal.config.ShellyThingConfiguration;
 import org.openhab.binding.shelly.internal.discovery.ShellyBasicDiscoveryService;
 import org.openhab.binding.shelly.internal.discovery.ShellyThingCreator;
+import org.openhab.binding.shelly.internal.handler.ShellyDeviceStats.Alarm;
 import org.openhab.binding.shelly.internal.provider.ShellyChannelDefinitions;
 import org.openhab.binding.shelly.internal.provider.ShellyTranslationProvider;
 import org.openhab.binding.shelly.internal.util.ShellyChannelCache;
@@ -834,10 +835,11 @@ public abstract class ShellyBaseHandler extends BaseThingHandler
     public void postEvent(String event, boolean force) {
         String channelId = mkChannelId(CHANNEL_GROUP_DEV_STATUS, CHANNEL_DEVST_ALARM);
         State value = cache.getValue(channelId);
-        String lastAlarm = value != UnDefType.NULL ? value.toString() : "";
+        String lastAlarmMsg = value != UnDefType.NULL ? value.toString() : "";
+        Alarm lastAlarm = stats.lastAlarm.get();
 
-        if (force || !lastAlarm.equals(event)
-                || (lastAlarm.equals(event) && now() > stats.lastAlarmTs.get() + HEALTH_CHECK_INTERVAL_SEC)) {
+        if (force || !lastAlarmMsg.equals(event) || (lastAlarmMsg.equals(event)
+                && (lastAlarm == null || now() > lastAlarm.timeStamp() + HEALTH_CHECK_INTERVAL_SEC))) {
             switch (event.toUpperCase(Locale.ROOT)) {
                 case "":
                 case "0": // DW2 1.8
@@ -852,14 +854,15 @@ public abstract class ShellyBaseHandler extends BaseThingHandler
                 case Shelly2ApiJsonDTO.SHELLY2_EVENT_OTADONE:
                 case SHELLY_EVENT_ROLLER_CALIB:
                     logger.debug("{}: {}", thingName, messages.get("event.filtered", event));
+                    break;
                 case ALARM_TYPE_NONE:
                     break;
                 default:
                     logger.debug("{}: {}", thingName, messages.get("event.triggered", event));
                     triggerChannel(channelId, event);
                     cache.updateChannel(channelId, getStringType(event.toUpperCase(Locale.ROOT)));
-                    stats.lastAlarm.set(event);
-                    stats.lastAlarmTs.set((long) now());
+                    lastAlarm = new Alarm(event, (long) now());
+                    stats.lastAlarm.set(lastAlarm);
                     stats.alarms.incrementAndGet();
             }
         }

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/handler/ShellyBaseHandler.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/handler/ShellyBaseHandler.java
@@ -567,7 +567,7 @@ public abstract class ShellyBaseHandler extends BaseThingHandler
                 profile.updateFromStatus(status);
                 if (restarted) {
                     logger.debug("{}: Device restart #{} detected", thingName, stats.restarts);
-                    stats.restarts++;
+                    stats.restarts.incrementAndGet();
                     postEvent(ALARM_TYPE_RESTARTED, true);
                 }
 
@@ -730,7 +730,7 @@ public abstract class ShellyBaseHandler extends BaseThingHandler
     private boolean isWatchdogExpired() {
         double delta = now() - watchdog;
         if ((watchdog > 0) && (delta > profile.updatePeriod)) {
-            stats.remainingWatchdog = (long) delta;
+            stats.remainingWatchdog.set((long) delta);
             return true;
         }
         return false;
@@ -759,13 +759,13 @@ public abstract class ShellyBaseHandler extends BaseThingHandler
 
         // Update uptime and WiFi, internal temp
         ShellyComponents.updateDeviceStatus(this, status);
-        stats.wifiRssi = status.wifiSta != null && status.wifiSta.rssi != null ? status.wifiSta.rssi : 0;
+        stats.wifiRssi.set(status.wifiSta != null && status.wifiSta.rssi != null ? status.wifiSta.rssi : 0);
 
         if (api.isInitialized()) {
-            stats.timeoutErrors = api.getTimeoutErrors();
-            stats.timeoutsRecorvered = api.getTimeoutsRecovered();
+            stats.timeoutErrors.set(api.getTimeoutErrors());
+            stats.timeoutsRecorvered.set(api.getTimeoutsRecovered());
         }
-        stats.remainingWatchdog = watchdog > 0 ? (long) (now() - watchdog) : 0;
+        stats.remainingWatchdog.set(watchdog > 0 ? (long) (now() - watchdog) : 0);
 
         // Check various device indicators like overheating
         if (checkRestarted(status)) {
@@ -781,13 +781,13 @@ public abstract class ShellyBaseHandler extends BaseThingHandler
         State internalTemp = getChannelValue(CHANNEL_GROUP_DEV_STATUS, CHANNEL_DEVST_ITEMP);
         if (internalTemp instanceof Number number) {
             int temp = number.intValue();
-            if (temp > stats.maxInternalTemp) {
-                stats.maxInternalTemp = temp;
+            if (temp > stats.maxInternalTemp.get()) {
+                stats.maxInternalTemp.set(temp);
             }
         }
 
         if (status.uptime != null) {
-            stats.lastUptime = getLong(status.uptime);
+            stats.lastUptime.set(getLong(status.uptime));
         }
 
         if (!alarm.isEmpty()) {
@@ -797,12 +797,12 @@ public abstract class ShellyBaseHandler extends BaseThingHandler
 
     @Override
     public void incProtMessages() {
-        stats.protocolMessages++;
+        stats.protocolMessages.incrementAndGet();
     }
 
     @Override
     public void incProtErrors() {
-        stats.protocolErrors++;
+        stats.protocolErrors.incrementAndGet();
     }
 
     /**
@@ -813,7 +813,7 @@ public abstract class ShellyBaseHandler extends BaseThingHandler
 
     private boolean checkRestarted(ShellySettingsStatus status) {
         if (profile.isInitialized() && profile.alwaysOn /* exclude battery powered devices */
-                && (status.uptime != null && status.uptime < stats.lastUptime
+                && (status.uptime != null && status.uptime < stats.lastUptime.get()
                         || (profile.status.update != null && !getString(profile.status.update.oldVersion).isEmpty()
                                 && !status.update.oldVersion.equals(profile.status.update.oldVersion)))) {
             logger.debug("{}: Device has been restarted, uptime={}/{}, firmware={}/{}", thingName, stats.lastUptime,
@@ -837,7 +837,7 @@ public abstract class ShellyBaseHandler extends BaseThingHandler
         String lastAlarm = value != UnDefType.NULL ? value.toString() : "";
 
         if (force || !lastAlarm.equals(event)
-                || (lastAlarm.equals(event) && now() > stats.lastAlarmTs + HEALTH_CHECK_INTERVAL_SEC)) {
+                || (lastAlarm.equals(event) && now() > stats.lastAlarmTs.get() + HEALTH_CHECK_INTERVAL_SEC)) {
             switch (event.toUpperCase(Locale.ROOT)) {
                 case "":
                 case "0": // DW2 1.8
@@ -858,9 +858,9 @@ public abstract class ShellyBaseHandler extends BaseThingHandler
                     logger.debug("{}: {}", thingName, messages.get("event.triggered", event));
                     triggerChannel(channelId, event);
                     cache.updateChannel(channelId, getStringType(event.toUpperCase(Locale.ROOT)));
-                    stats.lastAlarm = event;
-                    stats.lastAlarmTs = (long) now();
-                    stats.alarms++;
+                    stats.lastAlarm.set(event);
+                    stats.lastAlarmTs.set((long) now());
+                    stats.alarms.incrementAndGet();
             }
         }
     }

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/handler/ShellyDeviceStats.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/handler/ShellyDeviceStats.java
@@ -30,7 +30,7 @@ import org.openhab.binding.shelly.internal.util.ShellyUtils;
 @NonNullByDefault
 public class ShellyDeviceStats {
 
-    public record Alarm(String message, long timeStamp) {
+    public record ShellyDeviceAlarm(String message, long timeStamp) {
     }
 
     public final AtomicLong lastUptime = new AtomicLong(0);
@@ -39,7 +39,7 @@ public class ShellyDeviceStats {
     public final AtomicInteger timeoutsRecovered = new AtomicInteger(0);
     public final AtomicLong remainingWatchdog = new AtomicLong(0);
     public final AtomicLong alarms = new AtomicLong(0);
-    public final AtomicReference<@Nullable Alarm> lastAlarm = new AtomicReference<>();
+    public final AtomicReference<@Nullable ShellyDeviceAlarm> lastAlarm = new AtomicReference<>();
     public final AtomicLong protocolMessages = new AtomicLong(0);
     public final AtomicInteger protocolErrors = new AtomicInteger(0);
     public final AtomicInteger wifiRssi = new AtomicInteger(0);
@@ -53,7 +53,7 @@ public class ShellyDeviceStats {
         prop.put("timeoutsRecovered", String.valueOf(timeoutsRecovered));
         prop.put("remainingWatchdog", String.valueOf(remainingWatchdog));
         prop.put("alarmCount", String.valueOf(alarms));
-        Alarm alarm = lastAlarm.get();
+        ShellyDeviceAlarm alarm = lastAlarm.get();
         if (alarm != null) {
             prop.put("lastAlarm", alarm.message);
             prop.put("lastAlarmTs", ShellyUtils.convertTimestamp(alarm.timeStamp));

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/handler/ShellyDeviceStats.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/handler/ShellyDeviceStats.java
@@ -19,6 +19,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.shelly.internal.util.ShellyUtils;
 
 /***
@@ -28,14 +29,17 @@ import org.openhab.binding.shelly.internal.util.ShellyUtils;
  */
 @NonNullByDefault
 public class ShellyDeviceStats {
+
+    public record Alarm(String message, long timeStamp) {
+    }
+
     public final AtomicLong lastUptime = new AtomicLong(0);
     public final AtomicLong restarts = new AtomicLong(0);
     public final AtomicInteger timeoutErrors = new AtomicInteger(0);
     public final AtomicInteger timeoutsRecovered = new AtomicInteger(0);
     public final AtomicLong remainingWatchdog = new AtomicLong(0);
     public final AtomicLong alarms = new AtomicLong(0);
-    public final AtomicReference<String> lastAlarm = new AtomicReference<>("");
-    public final AtomicLong lastAlarmTs = new AtomicLong(0);
+    public final AtomicReference<@Nullable Alarm> lastAlarm = new AtomicReference<>();
     public final AtomicLong protocolMessages = new AtomicLong(0);
     public final AtomicInteger protocolErrors = new AtomicInteger(0);
     public final AtomicInteger wifiRssi = new AtomicInteger(0);
@@ -49,8 +53,11 @@ public class ShellyDeviceStats {
         prop.put("timeoutsRecovered", String.valueOf(timeoutsRecovered));
         prop.put("remainingWatchdog", String.valueOf(remainingWatchdog));
         prop.put("alarmCount", String.valueOf(alarms));
-        prop.put("lastAlarm", lastAlarm.get());
-        prop.put("lastAlarmTs", ShellyUtils.convertTimestamp(lastAlarmTs.get()));
+        Alarm alarm = lastAlarm.get();
+        if (alarm != null) {
+            prop.put("lastAlarm", alarm.message);
+            prop.put("lastAlarmTs", ShellyUtils.convertTimestamp(alarm.timeStamp));
+        }
         prop.put("protocolMessages", String.valueOf(protocolMessages));
         prop.put("protocolErrors", String.valueOf(protocolErrors));
         prop.put("wifiRssi", String.valueOf(wifiRssi));

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/handler/ShellyDeviceStats.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/handler/ShellyDeviceStats.java
@@ -14,6 +14,9 @@ package org.openhab.binding.shelly.internal.handler;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.binding.shelly.internal.util.ShellyUtils;
@@ -25,18 +28,18 @@ import org.openhab.binding.shelly.internal.util.ShellyUtils;
  */
 @NonNullByDefault
 public class ShellyDeviceStats {
-    public long lastUptime = 0;
-    public long restarts = 0;
-    public long timeoutErrors = 0;
-    public long timeoutsRecorvered = 0;
-    public long remainingWatchdog = 0;
-    public long alarms = 0;
-    public String lastAlarm = "";
-    public long lastAlarmTs = 0;
-    public long protocolMessages = 0;
-    public long protocolErrors = 0;
-    public int wifiRssi = 0;
-    public int maxInternalTemp = 0;
+    public AtomicLong lastUptime = new AtomicLong(0);
+    public AtomicLong restarts = new AtomicLong(0);
+    public AtomicInteger timeoutErrors = new AtomicInteger(0);
+    public AtomicInteger timeoutsRecorvered = new AtomicInteger(0);
+    public AtomicLong remainingWatchdog = new AtomicLong(0);
+    public AtomicLong alarms = new AtomicLong(0);
+    public AtomicReference<String> lastAlarm = new AtomicReference<>("");
+    public AtomicLong lastAlarmTs = new AtomicLong(0);
+    public AtomicLong protocolMessages = new AtomicLong(0);
+    public AtomicInteger protocolErrors = new AtomicInteger(0);
+    public AtomicInteger wifiRssi = new AtomicInteger(0);
+    public AtomicInteger maxInternalTemp = new AtomicInteger(0);
 
     public Map<String, String> asProperties() {
         Map<String, String> prop = new HashMap<>();
@@ -46,11 +49,12 @@ public class ShellyDeviceStats {
         prop.put("timeoutsRecovered", String.valueOf(timeoutsRecorvered));
         prop.put("remainingWatchdog", String.valueOf(remainingWatchdog));
         prop.put("alarmCount", String.valueOf(alarms));
-        prop.put("lastAlarm", lastAlarm);
-        prop.put("lastAlarmTs", ShellyUtils.convertTimestamp(lastAlarmTs));
+        prop.put("lastAlarm", lastAlarm.get());
+        prop.put("lastAlarmTs", ShellyUtils.convertTimestamp(lastAlarmTs.get()));
         prop.put("protocolMessages", String.valueOf(protocolMessages));
         prop.put("protocolErrors", String.valueOf(protocolErrors));
         prop.put("wifiRssi", String.valueOf(wifiRssi));
+        prop.put("maxInternalTemp", String.valueOf(maxInternalTemp.get()));
         return prop;
     }
 }

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/handler/ShellyDeviceStats.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/handler/ShellyDeviceStats.java
@@ -28,25 +28,25 @@ import org.openhab.binding.shelly.internal.util.ShellyUtils;
  */
 @NonNullByDefault
 public class ShellyDeviceStats {
-    public AtomicLong lastUptime = new AtomicLong(0);
-    public AtomicLong restarts = new AtomicLong(0);
-    public AtomicInteger timeoutErrors = new AtomicInteger(0);
-    public AtomicInteger timeoutsRecorvered = new AtomicInteger(0);
-    public AtomicLong remainingWatchdog = new AtomicLong(0);
-    public AtomicLong alarms = new AtomicLong(0);
-    public AtomicReference<String> lastAlarm = new AtomicReference<>("");
-    public AtomicLong lastAlarmTs = new AtomicLong(0);
-    public AtomicLong protocolMessages = new AtomicLong(0);
-    public AtomicInteger protocolErrors = new AtomicInteger(0);
-    public AtomicInteger wifiRssi = new AtomicInteger(0);
-    public AtomicInteger maxInternalTemp = new AtomicInteger(0);
+    public final AtomicLong lastUptime = new AtomicLong(0);
+    public final AtomicLong restarts = new AtomicLong(0);
+    public final AtomicInteger timeoutErrors = new AtomicInteger(0);
+    public final AtomicInteger timeoutsRecovered = new AtomicInteger(0);
+    public final AtomicLong remainingWatchdog = new AtomicLong(0);
+    public final AtomicLong alarms = new AtomicLong(0);
+    public final AtomicReference<String> lastAlarm = new AtomicReference<>("");
+    public final AtomicLong lastAlarmTs = new AtomicLong(0);
+    public final AtomicLong protocolMessages = new AtomicLong(0);
+    public final AtomicInteger protocolErrors = new AtomicInteger(0);
+    public final AtomicInteger wifiRssi = new AtomicInteger(0);
+    public final AtomicInteger maxInternalTemp = new AtomicInteger(0);
 
     public Map<String, String> asProperties() {
         Map<String, String> prop = new HashMap<>();
         prop.put("lastUptime", String.valueOf(lastUptime));
         prop.put("deviceRestarts", String.valueOf(restarts));
         prop.put("timeoutErrors", String.valueOf(timeoutErrors));
-        prop.put("timeoutsRecovered", String.valueOf(timeoutsRecorvered));
+        prop.put("timeoutsRecovered", String.valueOf(timeoutsRecovered));
         prop.put("remainingWatchdog", String.valueOf(remainingWatchdog));
         prop.put("alarmCount", String.valueOf(alarms));
         prop.put("lastAlarm", lastAlarm.get());

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/manager/ShellyManagerOverviewPage.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/manager/ShellyManagerOverviewPage.java
@@ -31,7 +31,7 @@ import org.openhab.binding.shelly.internal.api.ShellyApiException;
 import org.openhab.binding.shelly.internal.api.ShellyDeviceProfile;
 import org.openhab.binding.shelly.internal.config.ShellyThingConfiguration;
 import org.openhab.binding.shelly.internal.handler.ShellyDeviceStats;
-import org.openhab.binding.shelly.internal.handler.ShellyDeviceStats.Alarm;
+import org.openhab.binding.shelly.internal.handler.ShellyDeviceStats.ShellyDeviceAlarm;
 import org.openhab.binding.shelly.internal.handler.ShellyManagerInterface;
 import org.openhab.binding.shelly.internal.provider.ShellyTranslationProvider;
 import org.openhab.binding.shelly.internal.util.ShellyVersionDTO;
@@ -283,7 +283,7 @@ public class ShellyManagerOverviewPage extends ShellyManagerPage {
             }
         }
 
-        Alarm lastAlarm = stats.lastAlarm.get();
+        ShellyDeviceAlarm lastAlarm = stats.lastAlarm.get();
         if (lastAlarm != null && lastAlarm.message().equalsIgnoreCase(ALARM_TYPE_RESTARTED)) {
             result.put("Device Alarm", ALARM_TYPE_RESTARTED + " (" + convertTimestamp(lastAlarm.timeStamp()) + ")");
         }

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/manager/ShellyManagerOverviewPage.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/manager/ShellyManagerOverviewPage.java
@@ -31,6 +31,7 @@ import org.openhab.binding.shelly.internal.api.ShellyApiException;
 import org.openhab.binding.shelly.internal.api.ShellyDeviceProfile;
 import org.openhab.binding.shelly.internal.config.ShellyThingConfiguration;
 import org.openhab.binding.shelly.internal.handler.ShellyDeviceStats;
+import org.openhab.binding.shelly.internal.handler.ShellyDeviceStats.Alarm;
 import org.openhab.binding.shelly.internal.handler.ShellyManagerInterface;
 import org.openhab.binding.shelly.internal.provider.ShellyTranslationProvider;
 import org.openhab.binding.shelly.internal.util.ShellyVersionDTO;
@@ -282,14 +283,9 @@ public class ShellyManagerOverviewPage extends ShellyManagerPage {
             }
         }
 
-        String lastAlarm;
-        long lastAlarmTs;
-        synchronized (this) {
-            lastAlarm = stats.lastAlarm.get();
-            lastAlarmTs = stats.lastAlarmTs.get();
-        }
-        if (lastAlarm.equalsIgnoreCase(ALARM_TYPE_RESTARTED)) {
-            result.put("Device Alarm", ALARM_TYPE_RESTARTED + " (" + convertTimestamp(lastAlarmTs) + ")");
+        Alarm lastAlarm = stats.lastAlarm.get();
+        if (lastAlarm != null && lastAlarm.message().equalsIgnoreCase(ALARM_TYPE_RESTARTED)) {
+            result.put("Device Alarm", ALARM_TYPE_RESTARTED + " (" + convertTimestamp(lastAlarm.timeStamp()) + ")");
         }
 
         if (getBool(profile.status.overtemperature)) {

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/manager/ShellyManagerOverviewPage.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/manager/ShellyManagerOverviewPage.java
@@ -282,8 +282,8 @@ public class ShellyManagerOverviewPage extends ShellyManagerPage {
             }
         }
 
-        if (stats.lastAlarm.equalsIgnoreCase(ALARM_TYPE_RESTARTED)) {
-            result.put("Device Alarm", ALARM_TYPE_RESTARTED + " (" + convertTimestamp(stats.lastAlarmTs) + ")");
+        if (stats.lastAlarm.get().equalsIgnoreCase(ALARM_TYPE_RESTARTED)) {
+            result.put("Device Alarm", ALARM_TYPE_RESTARTED + " (" + convertTimestamp(stats.lastAlarmTs.get()) + ")");
         }
         if (getBool(profile.status.overtemperature)) {
             result.put("Device Alarm", ALARM_TYPE_OVERTEMP);
@@ -306,9 +306,9 @@ public class ShellyManagerOverviewPage extends ShellyManagerPage {
             if ((config.eventsCoIoT) && (profile.settings.coiot != null)) {
                 if ((profile.settings.coiot.enabled != null) && !profile.settings.coiot.enabled) {
                     result.put("CoIoT Status", "COIOT_DISABLED");
-                } else if (stats.protocolMessages == 0) {
+                } else if (stats.protocolMessages.get() == 0) {
                     result.put("CoIoT Discovery", "NO_COIOT_DISCOVERY");
-                } else if (stats.protocolMessages < 2) {
+                } else if (stats.protocolMessages.get() < 2) {
                     result.put("CoIoT Multicast", "NO_COIOT_MULTICAST");
                 }
             }

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/manager/ShellyManagerOverviewPage.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/manager/ShellyManagerOverviewPage.java
@@ -282,9 +282,16 @@ public class ShellyManagerOverviewPage extends ShellyManagerPage {
             }
         }
 
-        if (stats.lastAlarm.get().equalsIgnoreCase(ALARM_TYPE_RESTARTED)) {
-            result.put("Device Alarm", ALARM_TYPE_RESTARTED + " (" + convertTimestamp(stats.lastAlarmTs.get()) + ")");
+        String lastAlarm;
+        long lastAlarmTs;
+        synchronized (this) {
+            lastAlarm = stats.lastAlarm.get();
+            lastAlarmTs = stats.lastAlarmTs.get();
         }
+        if (lastAlarm.equalsIgnoreCase(ALARM_TYPE_RESTARTED)) {
+            result.put("Device Alarm", ALARM_TYPE_RESTARTED + " (" + convertTimestamp(lastAlarmTs) + ")");
+        }
+
         if (getBool(profile.status.overtemperature)) {
             result.put("Device Alarm", ALARM_TYPE_OVERTEMP);
         }
@@ -303,13 +310,16 @@ public class ShellyManagerOverviewPage extends ShellyManagerPage {
             }
         }
         if (profile.alwaysOn && (status == ThingStatus.ONLINE)) {
-            if ((config.eventsCoIoT) && (profile.settings.coiot != null)) {
-                if ((profile.settings.coiot.enabled != null) && !profile.settings.coiot.enabled) {
+            if (config.eventsCoIoT && profile.settings.coiot != null) {
+                if (profile.settings.coiot.enabled != null && !profile.settings.coiot.enabled) {
                     result.put("CoIoT Status", "COIOT_DISABLED");
-                } else if (stats.protocolMessages.get() == 0) {
-                    result.put("CoIoT Discovery", "NO_COIOT_DISCOVERY");
-                } else if (stats.protocolMessages.get() < 2) {
-                    result.put("CoIoT Multicast", "NO_COIOT_MULTICAST");
+                } else {
+                    long protocolMessages = stats.protocolMessages.get();
+                    if (protocolMessages == 0) {
+                        result.put("CoIoT Discovery", "NO_COIOT_DISCOVERY");
+                    } else if (protocolMessages < 2) {
+                        result.put("CoIoT Multicast", "NO_COIOT_MULTICAST");
+                    }
                 }
             }
         }

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/manager/ShellyManagerPage.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/manager/ShellyManagerPage.java
@@ -266,8 +266,9 @@ public class ShellyManagerPage {
                 (tz.isEmpty() ? "n/a" : tz) + ", auto-detect: " + getBool(profile.settings.tzautodetect));
         properties.put(ATTRIBUTE_ACTIONS_SKIPPED,
                 profile.status.astats != null ? String.valueOf(profile.status.astats.skipped) : "n/a");
-        properties.put(ATTRIBUTE_MAX_ITEMP, stats.maxInternalTemp.get() > 0 ? stats.maxInternalTemp + " °C" : "n/a");
-        if (stats.maxInternalTemp.get() == 0) {
+        int maxInternalTemp = stats.maxInternalTemp.get();
+        properties.put(ATTRIBUTE_MAX_ITEMP, maxInternalTemp > 0 ? maxInternalTemp + " °C" : "n/a");
+        if (maxInternalTemp == 0) {
             properties.replace(CHANNEL_DEVST_ITEMP, "n/a");
         }
 

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/manager/ShellyManagerPage.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/manager/ShellyManagerPage.java
@@ -266,8 +266,8 @@ public class ShellyManagerPage {
                 (tz.isEmpty() ? "n/a" : tz) + ", auto-detect: " + getBool(profile.settings.tzautodetect));
         properties.put(ATTRIBUTE_ACTIONS_SKIPPED,
                 profile.status.astats != null ? String.valueOf(profile.status.astats.skipped) : "n/a");
-        properties.put(ATTRIBUTE_MAX_ITEMP, stats.maxInternalTemp > 0 ? stats.maxInternalTemp + " °C" : "n/a");
-        if (stats.maxInternalTemp == 0) {
+        properties.put(ATTRIBUTE_MAX_ITEMP, stats.maxInternalTemp.get() > 0 ? stats.maxInternalTemp + " °C" : "n/a");
+        if (stats.maxInternalTemp.get() == 0) {
             properties.replace(CHANNEL_DEVST_ITEMP, "n/a");
         }
 


### PR DESCRIPTION
This PR adds synchronization for the device stats using AtomicInteger/Long, so not every access needs to be synchronized explicitly. This improves thread-safety, because stats are updated from thing handler, event handler etc. 