### PR TITLE
[electroluxappliance] Fix sendCommand() rejecting HTTP 202 Accepted responses

### DIFF
--- a/bundles/org.openhab.binding.electroluxappliance/src/main/java/org/openhab/binding/electroluxappliance/internal/api/ElectroluxGroupAPI.java
+++ b/bundles/org.openhab.binding.electroluxappliance/src/main/java/org/openhab/binding/electroluxappliance/internal/api/ElectroluxGroupAPI.java
@@ -432,7 +432,7 @@ public class ElectroluxGroupAPI {
                     String content = response.getContentAsString();
                     logger.trace("API response: {}", content);
 
-                    if (response.getStatus() != HttpStatus.OK_200) {
+                    if (!HttpStatus.isSuccess(response.getStatus())) {
                         logger.debug("sendCommand failed, HTTP status: {}", response.getStatus());
                         refreshToken();
                     } else {


### PR DESCRIPTION
## Problem
`ElectroluxGroupAPI.sendCommand()` checks for HTTP 200 OK exclusively:

    if (response.getStatus() != HttpStatus.OK_200)

The Electrolux API returns HTTP 202 Accepted for successful commands. This causes the method to treat every successful command as a failure, triggering a token refresh and retrying up to 3 times. The device receives the command up to 3 times per user action.

## Fix
Replace the strict 200 check with `HttpStatus.isSuccess()` which accepts any 2xx status code:

    if (!HttpStatus.isSuccess(response.getStatus()))

## Related
Fixes #20446