### PR TITLE
[hue] Support Zigbee Green Power connectivity state

### DIFF
--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/Clip2ThingHandler.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/Clip2ThingHandler.java
@@ -1142,6 +1142,7 @@ public class Clip2ThingHandler extends BaseThingHandler {
                 updateState(CHANNEL_2_TEMPERATURE_ENABLED, resource.getEnabledState(), fullUpdate);
                 break;
 
+            case ZGP_CONNECTIVITY:
             case ZIGBEE_CONNECTIVITY:
                 updateConnectivityState(resource);
                 break;


### PR DESCRIPTION
This PR supports monitoring the connectivity state of devices that communicate via Zigbee  Green Power; whereby `zgp_connectivity` resources are essentially an exact analog (synonym) of the already supported `zigbee_connectivity` resources.

Signed-off-by: Andrew Fiddian-Green <software@whitebear.ch>
