### PR TITLE
[shelly] Do not create WebSocket for Gen2 battery devices

### DIFF
--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api/ShellyDeviceProfile.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api/ShellyDeviceProfile.java
@@ -122,7 +122,8 @@ public class ShellyDeviceProfile {
 
     public Map<String, String> irCodes = new HashMap<>(); // Sense: list of stored IR codes
 
-    public ShellyDeviceProfile() {
+    public ShellyDeviceProfile(ThingTypeUID thingTypeUID) {
+        initFromThingType(thingTypeUID);
     }
 
     public ShellyDeviceProfile initialize(ThingTypeUID thingTypeUID, String jsonIn, ShellySettingsDevice device)

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api/ShellyHttpClient.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api/ShellyHttpClient.java
@@ -13,6 +13,7 @@
 package org.openhab.binding.shelly.internal.api;
 
 import static org.openhab.binding.shelly.internal.ShellyBindingConstants.SHELLY_API_TIMEOUT_MS;
+import static org.openhab.binding.shelly.internal.ShellyDevices.THING_TYPE_SHELLYUNKNOWN;
 import static org.openhab.binding.shelly.internal.api1.Shelly1ApiJsonDTO.*;
 import static org.openhab.binding.shelly.internal.api2.Shelly2ApiJsonDTO.*;
 import static org.openhab.binding.shelly.internal.util.ShellyUtils.*;
@@ -70,7 +71,7 @@ public class ShellyHttpClient {
     protected final Gson gson = new Gson();
     protected int timeoutErrors = 0;
     protected int timeoutsRecovered = 0;
-    private final ShellyDeviceProfile profile;
+    protected final ShellyDeviceProfile profile;
     protected boolean basicAuth = false;
 
     public ShellyHttpClient(String thingName, ShellyThingInterface thing) {
@@ -84,7 +85,7 @@ public class ShellyHttpClient {
         this.thingName = thingName;
         this.config = config;
         this.httpClient = httpClient;
-        this.profile = new ShellyDeviceProfile();
+        this.profile = new ShellyDeviceProfile(THING_TYPE_SHELLYUNKNOWN);
     }
 
     public void setConfig(String thingName, ShellyThingConfiguration config) {

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api1/Shelly1HttpApi.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api1/Shelly1HttpApi.java
@@ -64,11 +64,9 @@ import com.google.gson.JsonSyntaxException;
 @NonNullByDefault
 public class Shelly1HttpApi extends ShellyHttpClient implements ShellyApiInterface {
     private final Logger logger = LoggerFactory.getLogger(Shelly1HttpApi.class);
-    private final ShellyDeviceProfile profile;
 
     public Shelly1HttpApi(String thingName, ShellyThingInterface thing) {
         super(thingName, thing);
-        profile = thing.getProfile();
     }
 
     /**
@@ -80,7 +78,6 @@ public class Shelly1HttpApi extends ShellyHttpClient implements ShellyApiInterfa
      */
     public Shelly1HttpApi(String thingName, ShellyThingConfiguration config, HttpClient httpClient) {
         super(thingName, config, httpClient);
-        this.profile = new ShellyDeviceProfile();
     }
 
     @Override

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/Shelly2ApiClient.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/Shelly2ApiClient.java
@@ -23,7 +23,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Random;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -106,7 +105,6 @@ import org.slf4j.LoggerFactory;
 @NonNullByDefault
 public class Shelly2ApiClient extends ShellyHttpClient implements ShellyDiscoveryInterface {
     private final Logger logger = LoggerFactory.getLogger(Shelly2ApiClient.class);
-    protected final Random random = new Random();
     protected final ShellyStatusRelay relayStatus = new ShellyStatusRelay();
     protected final ShellyStatusSensor sensorData = new ShellyStatusSensor();
     protected final ArrayList<ShellyRollerStatus> rollerStatus = new ArrayList<>();

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/Shelly2ApiClient.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/Shelly2ApiClient.java
@@ -213,8 +213,6 @@ public class Shelly2ApiClient extends ShellyHttpClient implements ShellyDiscover
          * first, and then takes only the extra steps that depends on other methods in Shelly2ApiRpc.
          */
 
-        ShellyDeviceProfile profile = thing != null ? getProfile() : new ShellyDeviceProfile();
-
         if (devInfo != null) {
             profile.device = devInfo;
         }

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/Shelly2ApiRpc.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/Shelly2ApiRpc.java
@@ -157,7 +157,7 @@ public class Shelly2ApiRpc extends Shelly2ApiClient implements ShellyApiInterfac
                 rpcSocket.disconnect();
             }
 
-            rpcSocket = new Shelly2RpcSocket(thingName, thingTable, config.getDeviceIp(), client, scheduler);
+            rpcSocket = new Shelly2RpcSocket(thingName, thingTable, config.deviceIp, client, scheduler);
             rpcSocket.addMessageHandler(this);
             this.rpcSocket = rpcSocket;
         }

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/Shelly2ApiRpc.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/Shelly2ApiRpc.java
@@ -111,6 +111,7 @@ public class Shelly2ApiRpc extends Shelly2ApiClient implements ShellyApiInterfac
     private final ShellyThingTable thingTable;
 
     protected volatile boolean initialized = false;
+    protected volatile boolean alwaysOn = false;
     private @Nullable Shelly2RpcSocket rpcSocket;
     private @Nullable Shelly2AuthChallenge authInfo;
     private final WebSocketClient client;
@@ -139,18 +140,28 @@ public class Shelly2ApiRpc extends Shelly2ApiClient implements ShellyApiInterfac
     @Override
     public void initialize(String thingName, ShellyThingConfiguration config) throws ShellyApiException {
         setConfig(thingName, config);
+        alwaysOn = getProfile().alwaysOn;
+
         if (initialized) {
             logger.debug("{}: Disconnect Rpc Socket on initialize", thingName);
             disconnect();
         }
-        Shelly2RpcSocket rpcSocket = this.rpcSocket;
-        if (rpcSocket != null) {
-            rpcSocket.disconnect();
+
+        if (getProfile().alwaysOn) {
+            if (initialized) {
+                logger.debug("{}: Disconnect Rpc Socket on initialize", thingName);
+                disconnect();
+            }
+            Shelly2RpcSocket rpcSocket = this.rpcSocket;
+            if (rpcSocket != null) {
+                rpcSocket.disconnect();
+            }
+
+            rpcSocket = new Shelly2RpcSocket(thingName, thingTable, config.getDeviceIp(), client, scheduler);
+            rpcSocket.addMessageHandler(this);
+            this.rpcSocket = rpcSocket;
         }
 
-        rpcSocket = new Shelly2RpcSocket(thingName, thingTable, config.deviceIp, client, scheduler);
-        rpcSocket.addMessageHandler(this);
-        this.rpcSocket = rpcSocket;
         initialized = true;
     }
 
@@ -339,14 +350,14 @@ public class Shelly2ApiRpc extends Shelly2ApiClient implements ShellyApiInterfac
             profile.settings.ledPowerDisable = "off".equals(getString(dc.led.powerLed));
         }
 
-        if (!profile.initialized && profile.alwaysOn) {
+        if (!profile.initialized && alwaysOn) {
             getStatus(); // make sure profile.status is initialized (e.g,. relay/meter status)
             asyncApiRequest(SHELLYRPC_METHOD_GETSTATUS); // request periodic status updates from device
         }
         profile.initialized = true;
 
         try {
-            if (profile.alwaysOn && dc.ble != null) {
+            if (alwaysOn && dc.ble != null) {
                 logger.debug("{}: BLU Gateway support is {} for this device", thingName,
                         config.enableBluGateway ? "enabled" : "disabled");
                 if (config.enableBluGateway) {
@@ -768,7 +779,7 @@ public class Shelly2ApiRpc extends Shelly2ApiClient implements ShellyApiInterfac
             logger.debug("{}: WebSocket connection closed, status = {}/{}", thingName, statusCode, reason);
             if ("Bye".equalsIgnoreCase(reason)) {
                 logger.debug("{}: Device went to sleep mode or was restarted", thingName);
-            } else if (statusCode == StatusCode.ABNORMAL && getProfile().alwaysOn) {
+            } else if (statusCode == StatusCode.ABNORMAL && alwaysOn) {
                 // e.g. device rebooted
                 if (getThing().getThingStatusDetail() != ThingStatusDetail.DUTY_CYCLE) {
                     thingOffline("WebSocket connection closed abnormally");
@@ -790,7 +801,7 @@ public class Shelly2ApiRpc extends Shelly2ApiClient implements ShellyApiInterfac
             }
         }
         ShellyThingInterface thing = this.thing;
-        if (thing != null && thing.getProfile().alwaysOn) {
+        if (thing != null && alwaysOn) {
             thingOffline("WebSocket error");
         }
     }

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/Shelly2ApiRpc.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/Shelly2ApiRpc.java
@@ -770,11 +770,11 @@ public class Shelly2ApiRpc extends Shelly2ApiClient implements ShellyApiInterfac
     }
 
     @Override
-    public void onClose(int statusCode, String description) {
+    public void onClose(boolean inbound, int statusCode, String description) {
         try {
             String reason = getString(description);
             logger.debug("{}: WebSocket connection closed, status = {}/{}", thingName, statusCode, reason);
-            if ("Bye".equalsIgnoreCase(reason)) {
+            if ("Bye".equalsIgnoreCase(reason) || inbound) {
                 logger.debug("{}: Device went to sleep mode or was restarted", thingName);
             } else if (statusCode == StatusCode.ABNORMAL && alwaysOn) {
                 // e.g. device rebooted

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/Shelly2ApiRpc.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/Shelly2ApiRpc.java
@@ -138,25 +138,14 @@ public class Shelly2ApiRpc extends Shelly2ApiClient implements ShellyApiInterfac
     }
 
     @Override
-    public void initialize(String thingName, ShellyThingConfiguration config) throws ShellyApiException {
+    public synchronized void initialize(String thingName, ShellyThingConfiguration config) throws ShellyApiException {
         setConfig(thingName, config);
 
         alwaysOn = getProfile().alwaysOn;
         if (alwaysOn) {
-            if (initialized) {
-                if (logger.isDebugEnabled()) {
-                    logger.debug("{}: Disconnect Rpc Socket on initialize", thingName);
-                }
-                disconnect();
-            }
-            Shelly2RpcSocket rpcSocket = this.rpcSocket;
-            if (rpcSocket != null) {
-                rpcSocket.disconnect();
-            }
-
+            disconnect();
             rpcSocket = new Shelly2RpcSocket(thingName, thingTable, config.deviceIp, client, scheduler);
             rpcSocket.addMessageHandler(this);
-            this.rpcSocket = rpcSocket;
         }
 
         initialized = true;

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/Shelly2ApiRpc.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/Shelly2ApiRpc.java
@@ -140,16 +140,13 @@ public class Shelly2ApiRpc extends Shelly2ApiClient implements ShellyApiInterfac
     @Override
     public void initialize(String thingName, ShellyThingConfiguration config) throws ShellyApiException {
         setConfig(thingName, config);
+
         alwaysOn = getProfile().alwaysOn;
-
-        if (initialized) {
-            logger.debug("{}: Disconnect Rpc Socket on initialize", thingName);
-            disconnect();
-        }
-
-        if (getProfile().alwaysOn) {
+        if (alwaysOn) {
             if (initialized) {
-                logger.debug("{}: Disconnect Rpc Socket on initialize", thingName);
+                if (logger.isDebugEnabled()) {
+                    logger.debug("{}: Disconnect Rpc Socket on initialize", thingName);
+                }
                 disconnect();
             }
             Shelly2RpcSocket rpcSocket = this.rpcSocket;

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/Shelly2ApiRpc.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/Shelly2ApiRpc.java
@@ -111,7 +111,7 @@ public class Shelly2ApiRpc extends Shelly2ApiClient implements ShellyApiInterfac
     private final ShellyThingTable thingTable;
 
     protected volatile boolean initialized = false;
-    protected volatile boolean alwaysOn = false;
+    protected final boolean alwaysOn;
     private @Nullable Shelly2RpcSocket rpcSocket;
     private @Nullable Shelly2AuthChallenge authInfo;
     private final WebSocketClient client;
@@ -135,13 +135,13 @@ public class Shelly2ApiRpc extends Shelly2ApiClient implements ShellyApiInterfac
         this.thingTable = thingTable;
         this.client = webSocketClient;
         this.scheduler = scheduler;
+        this.alwaysOn = profile.alwaysOn;
     }
 
     @Override
-    public synchronized void initialize(String thingName, ShellyThingConfiguration config) throws ShellyApiException {
+    public void initialize(String thingName, ShellyThingConfiguration config) throws ShellyApiException {
         setConfig(thingName, config);
 
-        alwaysOn = getProfile().alwaysOn;
         if (alwaysOn) {
             disconnect();
             rpcSocket = new Shelly2RpcSocket(thingName, thingTable, config.deviceIp, client, scheduler);

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/Shelly2ApiRpc.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/Shelly2ApiRpc.java
@@ -180,7 +180,12 @@ public class Shelly2ApiRpc extends Shelly2ApiClient implements ShellyApiInterfac
     @Override
     public ShellyDeviceProfile getDeviceProfile(ThingTypeUID thingTypeUID, @Nullable ShellySettingsDevice devInfo)
             throws ShellyApiException {
-        ShellyDeviceProfile profile = thing != null ? getProfile() : new ShellyDeviceProfile();
+        if (thing == null) {
+            int i = 1;
+        }
+        ShellyDeviceProfile profile = thing != null ? getProfile() : new ShellyDeviceProfile(thingTypeUID);
+
+        profile.initFromThingType(thingTypeUID);
 
         if (devInfo != null) {
             profile.device = devInfo;

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/Shelly2ApiRpc.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/Shelly2ApiRpc.java
@@ -180,12 +180,7 @@ public class Shelly2ApiRpc extends Shelly2ApiClient implements ShellyApiInterfac
     @Override
     public ShellyDeviceProfile getDeviceProfile(ThingTypeUID thingTypeUID, @Nullable ShellySettingsDevice devInfo)
             throws ShellyApiException {
-        if (thing == null) {
-            int i = 1;
-        }
         ShellyDeviceProfile profile = thing != null ? getProfile() : new ShellyDeviceProfile(thingTypeUID);
-
-        profile.initFromThingType(thingTypeUID);
 
         if (devInfo != null) {
             profile.device = devInfo;

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/Shelly2EventServlet.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/Shelly2EventServlet.java
@@ -134,8 +134,10 @@ public class Shelly2EventServlet extends WebSocketServlet {
 
         @Override
         public Object createWebSocket(@Nullable ServletUpgradeRequest req, @Nullable ServletUpgradeResponse resp) {
-            String host = req != null ? req.getRemoteHostName() : "";
-            logger.debug("WebSocket: Inbound servlet request from {}", host);
+            if (logger.isDebugEnabled()) {
+                String host = req != null ? req.getRemoteHostName() : "";
+                logger.debug("WebSocket: Inbound servlet request from {}", host);
+            }
             return new Shelly2RpcSocket(thingTable, true, webSocketClient, scheduler);
         }
     }

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/Shelly2EventServlet.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/Shelly2EventServlet.java
@@ -134,7 +134,8 @@ public class Shelly2EventServlet extends WebSocketServlet {
 
         @Override
         public Object createWebSocket(@Nullable ServletUpgradeRequest req, @Nullable ServletUpgradeResponse resp) {
-            logger.debug("WebSocket: Create socket from servlet");
+            String host = req != null ? req.getRemoteHostName() : "";
+            logger.debug("WebSocket: Inbound servlet request from {}", host);
             return new Shelly2RpcSocket(thingTable, true, webSocketClient, scheduler);
         }
     }

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/Shelly2EventServlet.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/Shelly2EventServlet.java
@@ -135,8 +135,7 @@ public class Shelly2EventServlet extends WebSocketServlet {
         @Override
         public Object createWebSocket(@Nullable ServletUpgradeRequest req, @Nullable ServletUpgradeResponse resp) {
             if (logger.isDebugEnabled()) {
-                String host = req != null ? req.getRemoteHostName() : "";
-                logger.debug("WebSocket: Inbound servlet request from {}", host);
+                logger.debug("WebSocket: Inbound servlet request from {}", req != null ? req.getRemoteHostName() : "");
             }
             return new Shelly2RpcSocket(thingTable, true, webSocketClient, scheduler);
         }

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/Shelly2RpcSocket.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/Shelly2RpcSocket.java
@@ -200,6 +200,7 @@ public class Shelly2RpcSocket implements WriteCallback {
         ShellyThingInterface thing;
         try {
             thing = thingTable.getThing(deviceIp);
+            thingName = thing.getThingName();
         } catch (IllegalArgumentException e) { // unknown thing
             logger.debug("{}: RPC connection error for {} (unknown/disabled thing? - {}), closing socket", thingName,
                     deviceIp, e.getMessage(), e);

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/Shelly2RpcSocket.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/Shelly2RpcSocket.java
@@ -418,12 +418,8 @@ public class Shelly2RpcSocket implements WriteCallback {
             cleanup();
         }
 
-        if (inbound) {
-            // Ignore disconnect: Device establishes the socket, sends NotifyxFullStatus and disconnects
-            return;
-        }
         if (handler != null) {
-            handler.onClose(statusCode, reason);
+            handler.onClose(inbound, statusCode, reason);
         }
     }
 

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/Shelly2RpctInterface.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/Shelly2RpctInterface.java
@@ -32,7 +32,7 @@ public interface Shelly2RpctInterface {
 
     void onPong();
 
-    void onClose(int statusCode, String reason);
+    void onClose(boolean inbound, int statusCode, String reason);
 
     void onError(Throwable cause);
 }

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/ShellyBluApi.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/ShellyBluApi.java
@@ -74,7 +74,6 @@ public class ShellyBluApi extends Shelly2ApiRpc {
             WebSocketClient webSocketClient, ScheduledExecutorService scheduler) {
         super(thingName, thingTable, thing, webSocketClient, scheduler);
 
-        ShellyDeviceProfile profile = thing.getProfile();
         ThingTypeUID uid = thing.getThing().getThingTypeUID();
         profile.initializeInputs(uid, SHELLY_BTNT_MOMENTARY);
         deviceStatus = profile.status;

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/ShellyBluApi.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/ShellyBluApi.java
@@ -110,7 +110,7 @@ public class ShellyBluApi extends Shelly2ApiRpc {
     @Override
     public ShellyDeviceProfile getDeviceProfile(ThingTypeUID thingTypeUID, @Nullable ShellySettingsDevice devInfo)
             throws ShellyApiException {
-        ShellyDeviceProfile profile = thing != null ? getProfile() : new ShellyDeviceProfile();
+        ShellyDeviceProfile profile = thing != null ? getProfile() : new ShellyDeviceProfile(thingTypeUID);
 
         if (devInfo != null) {
             profile.device = devInfo;

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/discovery/ShellyBasicDiscoveryService.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/discovery/ShellyBasicDiscoveryService.java
@@ -20,7 +20,6 @@ import static org.openhab.core.thing.Thing.*;
 import java.util.HashMap;
 import java.util.Hashtable;
 import java.util.Map;
-import java.util.TreeMap;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
@@ -125,7 +124,7 @@ public class ShellyBasicDiscoveryService extends AbstractDiscoveryService {
         String name = hostname; // will become the realm for auth response
         String deviceName = "";
         String thingType = "";
-        Map<String, String> properties = new TreeMap<>();
+        Map<String, String> properties = new HashMap<>();
 
         try {
             ShellyThingConfiguration config = fillConfig(bindingConfig, ipAddress, name);

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/discovery/ShellyBasicDiscoveryService.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/discovery/ShellyBasicDiscoveryService.java
@@ -17,6 +17,7 @@ import static org.openhab.binding.shelly.internal.ShellyDevices.*;
 import static org.openhab.binding.shelly.internal.util.ShellyUtils.*;
 import static org.openhab.core.thing.Thing.*;
 
+import java.util.HashMap;
 import java.util.Hashtable;
 import java.util.Map;
 import java.util.TreeMap;
@@ -124,7 +125,7 @@ public class ShellyBasicDiscoveryService extends AbstractDiscoveryService {
         String name = hostname; // will become the realm for auth response
         String deviceName = "";
         String thingType = "";
-        Map<String, Object> properties = new TreeMap<>();
+        Map<String, String> properties = new TreeMap<>();
 
         try {
             ShellyThingConfiguration config = fillConfig(bindingConfig, ipAddress, name);
@@ -184,8 +185,8 @@ public class ShellyBasicDiscoveryService extends AbstractDiscoveryService {
             String thingLabel = deviceName.isEmpty() ? name + " - " + ipAddress
                     : deviceName + " (" + name + "@" + ipAddress + ")";
             logger.debug("{}: Adding Thing to Inbox (type {}, model {}, mode={})", name, thingType, model, mode);
-            return DiscoveryResultBuilder.create(thingUID).withProperties(properties).withLabel(thingLabel)
-                    .withRepresentationProperty(PROPERTY_SERVICE_NAME).build();
+            return DiscoveryResultBuilder.create(thingUID).withProperties(new HashMap<>(properties))
+                    .withLabel(thingLabel).withRepresentationProperty(PROPERTY_SERVICE_NAME).build();
         }
 
         return null;
@@ -202,7 +203,7 @@ public class ShellyBasicDiscoveryService extends AbstractDiscoveryService {
         return config;
     }
 
-    private static void addProperty(Map<String, Object> properties, String key, @Nullable String value) {
+    private static void addProperty(Map<String, String> properties, String key, @Nullable String value) {
         properties.put(key, value != null ? value : "");
     }
 }

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/handler/ShellyBaseHandler.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/handler/ShellyBaseHandler.java
@@ -21,10 +21,10 @@ import static org.openhab.core.thing.Thing.*;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.TreeMap;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
@@ -104,7 +104,7 @@ public abstract class ShellyBaseHandler extends BaseThingHandler
 
     private ShellyBindingConfiguration bindingConfig;
     protected ShellyThingConfiguration config = new ShellyThingConfiguration();
-    protected ShellyDeviceProfile profile = new ShellyDeviceProfile(); // init empty profile to avoid NPE
+    protected ShellyDeviceProfile profile;
     private ShellyDeviceStats stats = new ShellyDeviceStats();
     private @Nullable Shelly1CoapHandler coap;
 
@@ -158,6 +158,7 @@ public abstract class ShellyBaseHandler extends BaseThingHandler
 
         // Create thing handler depending on device generation
         ThingTypeUID thingTypeUID = thing.getThingTypeUID();
+        profile = new ShellyDeviceProfile(thingTypeUID);
         blu = ShellyDeviceProfile.isBluSeries(thingTypeUID);
         gen2 = ShellyDeviceProfile.isGeneration2(thingTypeUID);
         if (blu) {
@@ -167,9 +168,7 @@ public abstract class ShellyBaseHandler extends BaseThingHandler
         } else {
             this.api = new Shelly1HttpApi(thingName, this);
         }
-        if (gen2) {
-            config.eventsCoIoT = false;
-        }
+
         if (config.eventsCoIoT) {
             this.coap = new Shelly1CoapHandler(this, coapServer);
         }
@@ -695,10 +694,6 @@ public abstract class ShellyBaseHandler extends BaseThingHandler
     @Override
     public void setThingOnline() {
         if (!isThingOnline()) {
-            if (!profile.isInitialized()) {
-                // First time wake-up from a battery powered sensor device
-                profile.initFromThingType(thing.getThingTypeUID());
-            }
             updateStatus(ThingStatus.ONLINE);
 
             // request 3 updates in a row (during the first 2+3*3 sec)
@@ -1396,7 +1391,7 @@ public abstract class ShellyBaseHandler extends BaseThingHandler
      * @param status the /status result
      */
     public void updateProperties(ShellyDeviceProfile profile, ShellySettingsStatus status) {
-        Map<String, Object> properties = fillDeviceProperties(profile);
+        Map<String, String> properties = fillDeviceProperties(profile);
         String deviceName = getString(profile.settings.name);
         properties.put(PROPERTY_SERVICE_NAME, config.realm);
         properties.put(PROPERTY_DEV_AUTH, getBool(profile.device.auth) ? "yes" : "no");
@@ -1416,11 +1411,7 @@ public abstract class ShellyBaseHandler extends BaseThingHandler
         }
         properties.put(PROPERTY_COIOTAUTO, String.valueOf(autoCoIoT));
 
-        Map<String, String> thingProperties = new TreeMap<>();
-        for (Map.Entry<String, Object> property : properties.entrySet()) {
-            thingProperties.put(property.getKey(), (String) property.getValue());
-        }
-        flushProperties(thingProperties);
+        flushProperties(properties);
     }
 
     /**
@@ -1432,24 +1423,14 @@ public abstract class ShellyBaseHandler extends BaseThingHandler
     @Override
     public void updateProperties(String key, String value) {
         Map<String, String> thingProperties = editProperties();
-        if (thingProperties.containsKey(key)) {
-            thingProperties.replace(key, value);
-        } else {
-            thingProperties.put(key, value);
-        }
+        thingProperties.put(key, value);
         updateProperties(thingProperties);
         logger.trace("{}: Properties updated", thingName);
     }
 
     public void flushProperties(Map<String, String> propertyUpdates) {
         Map<String, String> thingProperties = editProperties();
-        for (Map.Entry<String, String> property : propertyUpdates.entrySet()) {
-            if (thingProperties.containsKey(property.getKey())) {
-                thingProperties.replace(property.getKey(), property.getValue());
-            } else {
-                thingProperties.put(property.getKey(), property.getValue());
-            }
-        }
+        thingProperties.putAll(propertyUpdates);
         updateProperties(thingProperties);
     }
 
@@ -1471,8 +1452,8 @@ public abstract class ShellyBaseHandler extends BaseThingHandler
      * @param profile Property Map to full
      * @return a full property map
      */
-    public static Map<String, Object> fillDeviceProperties(ShellyDeviceProfile profile) {
-        Map<String, Object> properties = new TreeMap<>();
+    public static Map<String, String> fillDeviceProperties(ShellyDeviceProfile profile) {
+        Map<String, String> properties = new HashMap<>();
         properties.put(PROPERTY_VENDOR, VENDOR);
         if (profile.isInitialized()) {
             properties.put(PROPERTY_MODEL_ID, getString(profile.device.type));

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/handler/ShellyBaseHandler.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/handler/ShellyBaseHandler.java
@@ -307,7 +307,7 @@ public abstract class ShellyBaseHandler extends BaseThingHandler
             return false;
         }
 
-        if (profile.alwaysOn || !profile.isInitialized() &&!isThingOnline()) {
+        if (profile.alwaysOn || !profile.isInitialized() && !isThingOnline()) {
             ThingStatusDetail detail = getThingStatusDetail();
             if (detail != ThingStatusDetail.DUTY_CYCLE) {
                 updateStatus(ThingStatus.ONLINE, ThingStatusDetail.CONFIGURATION_PENDING,

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/handler/ShellyBaseHandler.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/handler/ShellyBaseHandler.java
@@ -307,7 +307,7 @@ public abstract class ShellyBaseHandler extends BaseThingHandler
             return false;
         }
 
-        if (profile.alwaysOn || !profile.isInitialized()) {
+        if (profile.alwaysOn || !profile.isInitialized() &&!isThingOnline()) {
             ThingStatusDetail detail = getThingStatusDetail();
             if (detail != ThingStatusDetail.DUTY_CYCLE) {
                 updateStatus(ThingStatus.ONLINE, ThingStatusDetail.CONFIGURATION_PENDING,
@@ -695,6 +695,10 @@ public abstract class ShellyBaseHandler extends BaseThingHandler
     @Override
     public void setThingOnline() {
         if (!isThingOnline()) {
+            if (!profile.isInitialized()) {
+                // First time wake-up from a battery powered sensor device
+                profile.initFromThingType(thing.getThingTypeUID());
+            }
             updateStatus(ThingStatus.ONLINE);
 
             // request 3 updates in a row (during the first 2+3*3 sec)

--- a/bundles/org.openhab.binding.shelly/src/test/java/org/openhab/binding/shelly/internal/api/ShellyDeviceProfileTest.java
+++ b/bundles/org.openhab.binding.shelly/src/test/java/org/openhab/binding/shelly/internal/api/ShellyDeviceProfileTest.java
@@ -150,7 +150,7 @@ public class ShellyDeviceProfileTest {
     @MethodSource("provideTestCasesForGetControlGroup")
     void getControlGroup(ThingTypeUID thingTypeUID, String mode, int numRollers, int numOutputs, int numLights,
             int index, String expectedControlGroup) throws ShellyApiException {
-        ShellyDeviceProfile deviceProfile = new ShellyDeviceProfile();
+        ShellyDeviceProfile deviceProfile = new ShellyDeviceProfile(thingTypeUID);
         ShellySettingsGlobal settingsGlobal = new ShellySettingsGlobal();
         ShellySettingsDevice settingsDevice = new ShellySettingsDevice();
 
@@ -201,7 +201,7 @@ public class ShellyDeviceProfileTest {
 
     @Test
     void updateFromStatusHasRelays() {
-        ShellyDeviceProfile deviceProfile = new ShellyDeviceProfile();
+        ShellyDeviceProfile deviceProfile = new ShellyDeviceProfile(THING_TYPE_SHELLYUNKNOWN);
         deviceProfile.hasRelays = true;
         deviceProfile.numInputs = -1;
 
@@ -216,7 +216,7 @@ public class ShellyDeviceProfileTest {
 
     @Test
     void updateFromStatusHasRelaysNoInputs() {
-        ShellyDeviceProfile deviceProfile = new ShellyDeviceProfile();
+        ShellyDeviceProfile deviceProfile = new ShellyDeviceProfile(THING_TYPE_SHELLYUNKNOWN);
         deviceProfile.hasRelays = true;
         deviceProfile.numInputs = -1;
 
@@ -228,7 +228,7 @@ public class ShellyDeviceProfileTest {
 
     @Test
     void updateFromStatusInput() {
-        ShellyDeviceProfile deviceProfile = new ShellyDeviceProfile();
+        ShellyDeviceProfile deviceProfile = new ShellyDeviceProfile(THING_TYPE_SHELLYUNKNOWN);
         deviceProfile.hasRelays = false;
         deviceProfile.numInputs = -1;
 
@@ -241,7 +241,7 @@ public class ShellyDeviceProfileTest {
 
     @Test
     void updateFromStatusNoInput() {
-        ShellyDeviceProfile deviceProfile = new ShellyDeviceProfile();
+        ShellyDeviceProfile deviceProfile = new ShellyDeviceProfile(THING_TYPE_SHELLYUNKNOWN);
         deviceProfile.hasRelays = false;
         deviceProfile.numInputs = -1;
 


### PR DESCRIPTION
For Gen2 devices the WS logic is flipped
- The binding must not try to create a WS connection (because device is usually in sleep mode)
- The device will create an inbound WS connection to report events, this is handled by Shelly2EventServlet
- The binding setups the callback url mapping to the servlet at initialization time (not for alwaysOn devices)
