### PR TITLE
[senseenergy] Implement dirty on senseDevices to limit number of thing updates

### DIFF
--- a/bundles/org.openhab.binding.senseenergy/src/main/java/org/openhab/binding/senseenergy/internal/api/SenseEnergyWebSocket.java
+++ b/bundles/org.openhab.binding.senseenergy/src/main/java/org/openhab/binding/senseenergy/internal/api/SenseEnergyWebSocket.java
@@ -158,14 +158,11 @@ public class SenseEnergyWebSocket implements WebSocketListener {
             return;
         }
 
-        logger.debug("onWebSocketText");
-
         try {
             JsonObject jsonResponse = JsonParser.parseString(message).getAsJsonObject();
             String type = jsonResponse.get("type").getAsString();
 
             if ("realtime_update".equals(type)) {
-                logger.trace("realtime_update: {}", jsonResponse);
                 SenseEnergyWebSocketRealtimeUpdate update = gson.fromJson(jsonResponse.getAsJsonObject("payload"),
                         SenseEnergyWebSocketRealtimeUpdate.class);
                 if (update != null) {

--- a/bundles/org.openhab.binding.senseenergy/src/main/java/org/openhab/binding/senseenergy/internal/api/dto/SenseEnergyApiDevice.java
+++ b/bundles/org.openhab.binding.senseenergy/src/main/java/org/openhab/binding/senseenergy/internal/api/dto/SenseEnergyApiDevice.java
@@ -22,4 +22,31 @@ public class SenseEnergyApiDevice {
     public String name;
     public String icon;
     public SenseEnergyApiDeviceTags tags;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        SenseEnergyApiDevice that = (SenseEnergyApiDevice) o;
+        if (id != null ? !id.equals(that.id) : that.id != null)
+            return false;
+        if (name != null ? !name.equals(that.name) : that.name != null)
+            return false;
+        if (icon != null ? !icon.equals(that.icon) : that.icon != null)
+            return false;
+        if (tags != null ? !tags.equals(that.tags) : that.tags != null)
+            return false;
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = id != null ? id.hashCode() : 0;
+        result = 31 * result + (name != null ? name.hashCode() : 0);
+        result = 31 * result + (icon != null ? icon.hashCode() : 0);
+        result = 31 * result + (tags != null ? tags.hashCode() : 0);
+        return result;
+    }
 }

--- a/bundles/org.openhab.binding.senseenergy/src/main/java/org/openhab/binding/senseenergy/internal/api/dto/SenseEnergyApiDevice.java
+++ b/bundles/org.openhab.binding.senseenergy/src/main/java/org/openhab/binding/senseenergy/internal/api/dto/SenseEnergyApiDevice.java
@@ -12,6 +12,10 @@
  */
 package org.openhab.binding.senseenergy.internal.api.dto;
 
+import java.util.Objects;
+
+import org.eclipse.jdt.annotation.Nullable;
+
 /**
  * The {@link SenseEnergyApiDevice } is the dto for the api sense discovered devices
  *
@@ -24,29 +28,20 @@ public class SenseEnergyApiDevice {
     public SenseEnergyApiDeviceTags tags;
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o)
+    public boolean equals(@Nullable Object o) {
+        if (this == o) {
             return true;
-        if (o == null || getClass() != o.getClass())
+        }
+        if (o == null || getClass() != o.getClass()) {
             return false;
+        }
         SenseEnergyApiDevice that = (SenseEnergyApiDevice) o;
-        if (id != null ? !id.equals(that.id) : that.id != null)
-            return false;
-        if (name != null ? !name.equals(that.name) : that.name != null)
-            return false;
-        if (icon != null ? !icon.equals(that.icon) : that.icon != null)
-            return false;
-        if (tags != null ? !tags.equals(that.tags) : that.tags != null)
-            return false;
-        return true;
+        return Objects.equals(id, that.id) && Objects.equals(name, that.name) && Objects.equals(icon, that.icon)
+                && Objects.equals(tags, that.tags);
     }
 
     @Override
     public int hashCode() {
-        int result = id != null ? id.hashCode() : 0;
-        result = 31 * result + (name != null ? name.hashCode() : 0);
-        result = 31 * result + (icon != null ? icon.hashCode() : 0);
-        result = 31 * result + (tags != null ? tags.hashCode() : 0);
-        return result;
+        return Objects.hash(id, name, icon, tags);
     }
 }

--- a/bundles/org.openhab.binding.senseenergy/src/main/java/org/openhab/binding/senseenergy/internal/api/dto/SenseEnergyApiDeviceTags.java
+++ b/bundles/org.openhab.binding.senseenergy/src/main/java/org/openhab/binding/senseenergy/internal/api/dto/SenseEnergyApiDeviceTags.java
@@ -12,6 +12,10 @@
  */
 package org.openhab.binding.senseenergy.internal.api.dto;
 
+import java.util.Objects;
+
+import org.eclipse.jdt.annotation.Nullable;
+
 import com.google.gson.annotations.SerializedName;
 
 /**
@@ -37,32 +41,20 @@ public class SenseEnergyApiDeviceTags {
     public boolean ssiEnabled;
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o)
+    public boolean equals(@Nullable Object o) {
+        if (this == o) {
             return true;
-        if (o == null || getClass() != o.getClass())
+        }
+        if (o == null || getClass() != o.getClass()) {
             return false;
+        }
         SenseEnergyApiDeviceTags that = (SenseEnergyApiDeviceTags) o;
-        if (userDeleted != that.userDeleted)
-            return false;
-        if (alwaysOn != that.alwaysOn)
-            return false;
-        if (ssiEnabled != that.ssiEnabled)
-            return false;
-        if (stage != that.stage)
-            return false;
-        if (deviceID != null ? !deviceID.equals(that.deviceID) : that.deviceID != null)
-            return false;
-        return true;
+        return userDeleted == that.userDeleted && alwaysOn == that.alwaysOn && ssiEnabled == that.ssiEnabled
+                && Objects.equals(stage, that.stage) && Objects.equals(deviceID, that.deviceID);
     }
 
     @Override
     public int hashCode() {
-        int result = stage != null ? stage.hashCode() : 0;
-        result = 31 * result + (userDeleted ? 1 : 0);
-        result = 31 * result + (alwaysOn ? 1 : 0);
-        result = 31 * result + (deviceID != null ? deviceID.hashCode() : 0);
-        result = 31 * result + (ssiEnabled ? 1 : 0);
-        return result;
+        return Objects.hash(stage, userDeleted, alwaysOn, deviceID, ssiEnabled);
     }
 }

--- a/bundles/org.openhab.binding.senseenergy/src/main/java/org/openhab/binding/senseenergy/internal/api/dto/SenseEnergyApiDeviceTags.java
+++ b/bundles/org.openhab.binding.senseenergy/src/main/java/org/openhab/binding/senseenergy/internal/api/dto/SenseEnergyApiDeviceTags.java
@@ -35,4 +35,34 @@ public class SenseEnergyApiDeviceTags {
     public String deviceID;
     @SerializedName("SSIEnabled")
     public boolean ssiEnabled;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        SenseEnergyApiDeviceTags that = (SenseEnergyApiDeviceTags) o;
+        if (userDeleted != that.userDeleted)
+            return false;
+        if (alwaysOn != that.alwaysOn)
+            return false;
+        if (ssiEnabled != that.ssiEnabled)
+            return false;
+        if (stage != that.stage)
+            return false;
+        if (deviceID != null ? !deviceID.equals(that.deviceID) : that.deviceID != null)
+            return false;
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = stage != null ? stage.hashCode() : 0;
+        result = 31 * result + (userDeleted ? 1 : 0);
+        result = 31 * result + (alwaysOn ? 1 : 0);
+        result = 31 * result + (deviceID != null ? deviceID.hashCode() : 0);
+        result = 31 * result + (ssiEnabled ? 1 : 0);
+        return result;
+    }
 }

--- a/bundles/org.openhab.binding.senseenergy/src/main/java/org/openhab/binding/senseenergy/internal/handler/SenseEnergyMonitorHandler.java
+++ b/bundles/org.openhab.binding.senseenergy/src/main/java/org/openhab/binding/senseenergy/internal/handler/SenseEnergyMonitorHandler.java
@@ -117,6 +117,7 @@ public class SenseEnergyMonitorHandler extends BaseBridgeHandler
 
     // Map of all device types from the api
     private Map<String, SenseEnergyApiDevice> senseDevices = Collections.emptyMap();
+    private boolean senseDevicesDirty = false;
     // DeviceTypes deduced from the senseDevices
     private Map<String, DeviceType> senseDevicesType = new HashMap<String, DeviceType>();
     // Keep track of which devices are on so we can send trigger when devices are turned on/off
@@ -366,14 +367,24 @@ public class SenseEnergyMonitorHandler extends BaseBridgeHandler
      */
     private void refreshDevices() {
         logger.trace("refreshDevices");
-        try {
-            senseDevices = getApi().getDevices(id);
+        Map<String, SenseEnergyApiDevice> newSenseDevices = Collections.emptyMap();
 
-            senseDevices.entrySet().stream() //
+        try {
+            newSenseDevices = getApi().getDevices(id);
+
+            newSenseDevices.entrySet().stream() //
                     .filter(e -> !senseDevicesType.containsKey(e.getKey())) //
                     .forEach(e -> senseDevicesType.put(e.getKey(), deduceDeviceType(e.getValue())));
         } catch (SenseEnergyApiException e) {
             handleApiException(e);
+        }
+
+        if (!newSenseDevices.equals(senseDevices)) {
+            senseDevices = newSenseDevices;
+            senseDevicesDirty = true;
+            logger.debug("Device list updated, device count: {}", senseDevices.size());
+        } else {
+            logger.trace("Device list refreshed but no change detected");
         }
     }
 
@@ -388,10 +399,14 @@ public class SenseEnergyMonitorHandler extends BaseBridgeHandler
                 .requireNonNull(channelGroupTypeRegistry.getChannelGroupType(CHANNEL_GROUP_TYPE_DEVICE_TEMPLATE));
         List<ChannelDefinition> channelDefinitions = channelGroupType.getChannelDefinitions();
 
+        if (!senseDevicesDirty) {
+            return;
+        }
+
         Set<String> senseIDs = new HashSet<>(senseDevices.keySet());
         senseIDs.remove("solar"); // don't create solar as a separate channel
 
-        logger.trace("Reconciling channels with Sense device, channel count: {}", senseIDs.size());
+        logger.debug("Reconciling channels with Sense device, channel count: {}", senseIDs.size());
 
         boolean channelsUpdated = false;
         ThingBuilder localBuilder = (thingBuilder != null) ? thingBuilder : editThing();
@@ -433,6 +448,7 @@ public class SenseEnergyMonitorHandler extends BaseBridgeHandler
         if (thingBuilder == null) {
             updateThing(localBuilder.build());
         }
+        senseDevicesDirty = false;
 
         if (channelsUpdated) {
             triggerChannel(new ChannelUID(getThing().getUID(), CHANNEL_GROUP_GENERAL, CHANNEL_DEVICES_UPDATED_TRIGGER));

--- a/bundles/org.openhab.binding.senseenergy/src/main/java/org/openhab/binding/senseenergy/internal/handler/SenseEnergyMonitorHandler.java
+++ b/bundles/org.openhab.binding.senseenergy/src/main/java/org/openhab/binding/senseenergy/internal/handler/SenseEnergyMonitorHandler.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
 import javax.measure.Unit;
@@ -42,6 +43,7 @@ import org.openhab.binding.senseenergy.internal.api.SenseEnergyDatagramListener;
 import org.openhab.binding.senseenergy.internal.api.SenseEnergyWebSocket;
 import org.openhab.binding.senseenergy.internal.api.SenseEnergyWebSocketListener;
 import org.openhab.binding.senseenergy.internal.api.dto.SenseEnergyApiDevice;
+import org.openhab.binding.senseenergy.internal.api.dto.SenseEnergyApiDeviceTags;
 import org.openhab.binding.senseenergy.internal.api.dto.SenseEnergyApiMonitor;
 import org.openhab.binding.senseenergy.internal.api.dto.SenseEnergyApiMonitorInfo;
 import org.openhab.binding.senseenergy.internal.api.dto.SenseEnergyApiMonitorStatus;
@@ -117,7 +119,7 @@ public class SenseEnergyMonitorHandler extends BaseBridgeHandler
 
     // Map of all device types from the api
     private Map<String, SenseEnergyApiDevice> senseDevices = Collections.emptyMap();
-    private boolean senseDevicesDirty = false;
+    private final AtomicBoolean senseDevicesDirty = new AtomicBoolean(false);
     // DeviceTypes deduced from the senseDevices
     private Map<String, DeviceType> senseDevicesType = new HashMap<String, DeviceType>();
     // Keep track of which devices are on so we can send trigger when devices are turned on/off
@@ -188,6 +190,7 @@ public class SenseEnergyMonitorHandler extends BaseBridgeHandler
         }
 
         reconcileDiscoveredDeviceChannels(thingBuilder);
+        senseDevicesDirty.set(false);
         updateThing(thingBuilder.build());
         updateProperties();
 
@@ -216,9 +219,8 @@ public class SenseEnergyMonitorHandler extends BaseBridgeHandler
 
         logger.trace("SenseEnergyMonitorHandler: heartbeat");
         refreshDevices();
-        if (senseDevicesDirty) {
+        if (senseDevicesDirty.getAndSet(false)) {
             reconcileDiscoveredDeviceChannels(null);
-            senseDevicesDirty = false;
         }
 
         if (!webSocket.isRunning()) {
@@ -357,11 +359,17 @@ public class SenseEnergyMonitorHandler extends BaseBridgeHandler
      * @return The deduced DeviceType.
      */
     private DeviceType deduceDeviceType(SenseEnergyApiDevice apiDevice) {
-        if (!apiDevice.tags.ssiEnabled) {
+        SenseEnergyApiDeviceTags tags = apiDevice.tags;
+        if (tags == null || !tags.ssiEnabled) {
             return DeviceType.DISCOVERED_DEVICE;
         }
 
-        SenseEnergyProxyDeviceHandler proxyHandler = getProxyDeviceByMAC(apiDevice.tags.deviceID);
+        String deviceId = tags.deviceID;
+        if (deviceId == null) {
+            return DeviceType.SELF_REPORTING_DEVICE;
+        }
+
+        SenseEnergyProxyDeviceHandler proxyHandler = getProxyDeviceByMAC(deviceId);
         return (proxyHandler != null) ? DeviceType.PROXY_DEVICE : DeviceType.SELF_REPORTING_DEVICE;
     }
 
@@ -385,7 +393,7 @@ public class SenseEnergyMonitorHandler extends BaseBridgeHandler
 
         if (!newSenseDevices.equals(senseDevices)) {
             senseDevices = newSenseDevices;
-            senseDevicesDirty = true;
+            senseDevicesDirty.set(true);
             logger.debug("Device list updated, device count: {}", senseDevices.size());
         } else {
             logger.trace("Device list refreshed but no change detected");
@@ -445,10 +453,9 @@ public class SenseEnergyMonitorHandler extends BaseBridgeHandler
             }
         }
 
-        if (thingBuilder == null) {
+        if (thingBuilder == null && channelsUpdated) {
             updateThing(localBuilder.build());
         }
-        senseDevicesDirty = false;
 
         if (channelsUpdated) {
             triggerChannel(new ChannelUID(getThing().getUID(), CHANNEL_GROUP_GENERAL, CHANNEL_DEVICES_UPDATED_TRIGGER));
@@ -696,7 +703,8 @@ public class SenseEnergyMonitorHandler extends BaseBridgeHandler
 
             // check if device channels need to be updated because there is a new device
             if (!senseDevices.containsKey(device.id)) {
-                reconcileDiscoveredDeviceChannels(null);
+                // Defer reconciliation to heartbeat thread to avoid cross-thread channel mutation.
+                senseDevicesDirty.set(true);
             }
 
             DeviceType deviceType = senseDevicesType.getOrDefault(device.id, DeviceType.DISCOVERED_DEVICE);

--- a/bundles/org.openhab.binding.senseenergy/src/main/java/org/openhab/binding/senseenergy/internal/handler/SenseEnergyMonitorHandler.java
+++ b/bundles/org.openhab.binding.senseenergy/src/main/java/org/openhab/binding/senseenergy/internal/handler/SenseEnergyMonitorHandler.java
@@ -216,7 +216,10 @@ public class SenseEnergyMonitorHandler extends BaseBridgeHandler
 
         logger.trace("SenseEnergyMonitorHandler: heartbeat");
         refreshDevices();
-        reconcileDiscoveredDeviceChannels(null);
+        if (senseDevicesDirty) {
+            reconcileDiscoveredDeviceChannels(null);
+            senseDevicesDirty = false;
+        }
 
         if (!webSocket.isRunning()) {
             logger.debug("heartbeat: webSocket not running");
@@ -377,6 +380,7 @@ public class SenseEnergyMonitorHandler extends BaseBridgeHandler
                     .forEach(e -> senseDevicesType.put(e.getKey(), deduceDeviceType(e.getValue())));
         } catch (SenseEnergyApiException e) {
             handleApiException(e);
+            return;
         }
 
         if (!newSenseDevices.equals(senseDevices)) {
@@ -398,10 +402,6 @@ public class SenseEnergyMonitorHandler extends BaseBridgeHandler
         ChannelGroupType channelGroupType = Objects
                 .requireNonNull(channelGroupTypeRegistry.getChannelGroupType(CHANNEL_GROUP_TYPE_DEVICE_TEMPLATE));
         List<ChannelDefinition> channelDefinitions = channelGroupType.getChannelDefinitions();
-
-        if (!senseDevicesDirty) {
-            return;
-        }
 
         Set<String> senseIDs = new HashSet<>(senseDevices.keySet());
         senseIDs.remove("solar"); // don't create solar as a separate channel


### PR DESCRIPTION
Currently, when the monitor thing reconciles channels, it always calls editThing/updateThing - this causes issue with the UI as the updated event is triggered even if no channels are updated.

This change will only ever call those if there are real changes to the devices from the sense API.