### PR TITLE
[openhabcloud] Add webhook service

### DIFF
--- a/bundles/org.openhab.io.openhabcloud/src/main/java/org/openhab/io/openhabcloud/WebhookService.java
+++ b/bundles/org.openhab.io.openhabcloud/src/main/java/org/openhab/io/openhabcloud/WebhookService.java
@@ -27,7 +27,7 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
  * Usage example:
  *
  * <pre>
- * {@code @Reference}(cardinality = ReferenceCardinality.OPTIONAL, policy = ReferencePolicy.DYNAMIC)
+ * {@code @Reference(cardinality = ReferenceCardinality.OPTIONAL, policy = ReferencePolicy.DYNAMIC)}
  * protected void setWebhookService(WebhookService service) {
  *     this.webhookService = service;
  * }

--- a/bundles/org.openhab.io.openhabcloud/src/main/java/org/openhab/io/openhabcloud/internal/CloudClient.java
+++ b/bundles/org.openhab.io.openhabcloud/src/main/java/org/openhab/io/openhabcloud/internal/CloudClient.java
@@ -906,6 +906,10 @@ public class CloudClient {
             data.put("localPath", localPath);
             socket.emit(eventName, data, (io.socket.client.Ack) args -> {
                 try {
+                    if (args == null || args.length == 0 || !(args[0] instanceof JSONObject)) {
+                        future.completeExceptionally(new IOException("Missing or invalid response from openHAB Cloud"));
+                        return;
+                    }
                     JSONObject response = (JSONObject) args[0];
                     if (response.optBoolean("success")) {
                         future.complete(successHandler.apply(response));

--- a/bundles/org.openhab.io.openhabcloud/src/main/java/org/openhab/io/openhabcloud/internal/CloudService.java
+++ b/bundles/org.openhab.io.openhabcloud/src/main/java/org/openhab/io/openhabcloud/internal/CloudService.java
@@ -330,6 +330,10 @@ public class CloudService implements ActionService, CloudClientListener, EventSu
     @Override
     public CompletableFuture<String> requestWebhook(String localPath) {
         CompletableFuture<String> future = new CompletableFuture<>();
+        if (localPath.isBlank() || !localPath.startsWith("/")) {
+            future.completeExceptionally(new IllegalArgumentException("localPath must start with '/'"));
+            return future;
+        }
         if (cloudClient != null && cloudClient.isConnected()) {
             cloudClient.registerWebhook(localPath, future);
         } else {
@@ -341,6 +345,10 @@ public class CloudService implements ActionService, CloudClientListener, EventSu
     @Override
     public CompletableFuture<Void> removeWebhook(String localPath) {
         CompletableFuture<Void> future = new CompletableFuture<>();
+        if (localPath.isBlank() || !localPath.startsWith("/")) {
+            future.completeExceptionally(new IllegalArgumentException("localPath must start with '/'"));
+            return future;
+        }
         if (cloudClient != null && cloudClient.isConnected()) {
             cloudClient.removeWebhook(localPath, future);
         } else {


### PR DESCRIPTION
This supports a new feature of the cloud service that allows bindings to register webooks for 3rd parties to call.  I will submit another binding (Twilio) which will optionally utilize this. 

The flow is a binding registers a local path, say `/somebinding/foo`.  The cloud service will generate a URL like `https://myopenhab.org/api/hooks/{uuid}`, where the UUID is generated for just this local path.  It also has a 30 day TTL, so if the binding does not refresh it, it will go away.  The binding can then use this cloud URL to register for 3rd part apps.  Binding developers are still responsible for validating requests, thats out of the control for the cloud binding.