### PR TITLE
Fix Maven build output

### DIFF
--- a/.github/scripts/maven-build
+++ b/.github/scripts/maven-build
@@ -58,10 +58,10 @@ function mvnp() {
   local padding=$(bc -l <<< "scale=0;2*(l($reactor_size)/l(10)+1)")
   local command=(bash ./mvnw "$@")
 
-  "${command[@]}" 2>&1 | \ # execute, redirect stderr to stdout
-    tee "$BUILD_LOG" | \ # write output to log
-    stdbuf -oL grep -aE '^\[INFO\] Building .+ \[.+\]$' | \ # filter progress
-    stdbuf -o0 sed -uE 's/^\[INFO\] Building (.*[^ ])[ ]+\[([0-9]+\/[0-9]+)\]$/\2| \1/' | \ # prefix project name with progress
+  "${command[@]}" 2>&1 | # execute, redirect stderr to stdout
+    tee "$BUILD_LOG" | # write output to log
+    stdbuf -oL grep -aE '^\[INFO\] Building .+ \[.+\]$' | # filter progress
+    stdbuf -o0 sed -uE 's/^\[INFO\] Building (.*[^ ])[ ]+\[([0-9]+\/[0-9]+)\]$/\2| \1/' | # prefix project name with progress
     stdbuf -o0 sed -e :a -e "s/^.\{1,${padding}\}|/ &/;ta" # right align progress with padding
 
   # Exit code of Maven is the first command in the pipeline


### PR DESCRIPTION
The output doesn't show because of errors:

```
+ ./mvnw clean verify -B -T 1.5C -U

./.github/scripts/maven-build: line 61:  #: command not found
./.github/scripts/maven-build: line 62:  #: command not found
./.github/scripts/maven-build: line 63:  #: command not found
./.github/scripts/maven-build: line 64:  #: command not found

sed: -e expression #1, char 1: unknown command: `,'
```

Caused by #19010