### PR TITLE
[intesis] Improve limits handling

### DIFF
--- a/bundles/org.openhab.binding.intesis/src/main/java/org/openhab/binding/intesis/internal/api/IntesisBoxMessage.java
+++ b/bundles/org.openhab.binding.intesis/src/main/java/org/openhab/binding/intesis/internal/api/IntesisBoxMessage.java
@@ -71,7 +71,7 @@ public class IntesisBoxMessage {
     }
 
     public static @Nullable IntesisBoxMessage parse(String message) {
-        Matcher m = REGEX.matcher(message);
+        Matcher m = REGEX.matcher(message.trim());
         if (!m.find()) {
             return null;
         }

--- a/bundles/org.openhab.binding.intesis/src/main/java/org/openhab/binding/intesis/internal/api/IntesisBoxSocketApi.java
+++ b/bundles/org.openhab.binding.intesis/src/main/java/org/openhab/binding/intesis/internal/api/IntesisBoxSocketApi.java
@@ -168,10 +168,10 @@ public class IntesisBoxSocketApi {
         return message;
     }
 
-    public void readMessage(String message) {
+    public void readMessage(@Nullable String message) {
         IntesisBoxChangeListener listener = this.changeListener;
 
-        if (listener != null && !message.isEmpty()) {
+        if (listener != null && message != null && !message.isEmpty()) {
             listener.messageReceived(message);
         }
     }

--- a/bundles/org.openhab.binding.intesis/src/main/java/org/openhab/binding/intesis/internal/handler/IntesisBoxHandler.java
+++ b/bundles/org.openhab.binding.intesis/src/main/java/org/openhab/binding/intesis/internal/handler/IntesisBoxHandler.java
@@ -174,7 +174,9 @@ public class IntesisBoxHandler extends BaseThingHandler implements IntesisBoxCha
                     if (celsiusTemperature != null) {
                         double doubleValue = celsiusTemperature.doubleValue();
                         logger.trace("targetTemp double value = {}", doubleValue);
-                        doubleValue = Math.max(minTemp, Math.min(maxTemp, doubleValue));
+                        if (maxTemp > minTemp) {
+                            doubleValue = Math.max(minTemp, Math.min(maxTemp, doubleValue));
+                        }
                         value = String.format("%.0f", doubleValue * 10);
                         function = "SETPTEMP";
                         logger.trace("targetTemp raw string = {}", value);
@@ -297,7 +299,7 @@ public class IntesisBoxHandler extends BaseThingHandler implements IntesisBoxCha
                         logger.trace("Property target temperatures {} added", message.getValue());
                         properties.put("targetTemperature limits", "[" + minTemp + "," + maxTemp + "]");
                         addChannel(CHANNEL_TYPE_TARGETTEMP, "Number:Temperature");
-                    } else if (message.getLimitsValue().size() > 0) {
+                    } else if (!message.getLimitsValue().isEmpty()) {
                         switch (function) {
                             case "MODE":
                                 properties.put("supported modes", message.getValue());


### PR DESCRIPTION
# [intesis] Improved limits detection and handling

This improves the robustness of handling LIMITS responses on IntesisBox connections.

The changes are fairly simple, however prevent failures which occurred with my intesisbox due to failing to correctly handle temperature limit responses (fixed), then subsequently failing to send temperate requests due to limits still being at zero (also fixed).