### PR TITLE
Remove all `super();` calls

### DIFF
--- a/bundles/org.openhab.binding.enocean/src/main/java/org/openhab/binding/enocean/internal/eep/A5_07/A5_07_01.java
+++ b/bundles/org.openhab.binding.enocean/src/main/java/org/openhab/binding/enocean/internal/eep/A5_07/A5_07_01.java
@@ -46,7 +46,6 @@ public class A5_07_01 extends A5_07 {
     private static final byte DB0_DEFAULT = 0x09;
 
     public A5_07_01() {
-        super();
     }
 
     public A5_07_01(ERP1Message packet) {

--- a/bundles/org.openhab.binding.mideaac/src/main/java/org/openhab/binding/mideaac/internal/security/Decryption8370Result.java
+++ b/bundles/org.openhab.binding.mideaac/src/main/java/org/openhab/binding/mideaac/internal/security/Decryption8370Result.java
@@ -52,7 +52,6 @@ public class Decryption8370Result {
      * @param buffer buffer
      */
     public Decryption8370Result(ArrayList<byte[]> responses, byte[] buffer) {
-        super();
         this.responses = responses;
         this.buffer = buffer;
     }

--- a/bundles/org.openhab.binding.modbus.stiebeleltron/src/main/java/org/openhab/binding/modbus/stiebeleltron/internal/dto/EnergyRuntimeBlockAllWpm.java
+++ b/bundles/org.openhab.binding.modbus.stiebeleltron/src/main/java/org/openhab/binding/modbus/stiebeleltron/internal/dto/EnergyRuntimeBlockAllWpm.java
@@ -66,7 +66,6 @@ public class EnergyRuntimeBlockAllWpm extends EnergyBlock {
     public HeatPumpEnergyRuntimeInfo[] heatPumps;
 
     public EnergyRuntimeBlockAllWpm(int heatpumpCount) {
-        super();
         this.heatPumps = new HeatPumpEnergyRuntimeInfo[heatpumpCount];
         for (int i = 0; i < heatpumpCount; i++) {
             this.heatPumps[i] = new HeatPumpEnergyRuntimeInfo();

--- a/bundles/org.openhab.binding.modbus.stiebeleltron/src/main/java/org/openhab/binding/modbus/stiebeleltron/internal/dto/SystemInformationBlockAllWpm.java
+++ b/bundles/org.openhab.binding.modbus.stiebeleltron/src/main/java/org/openhab/binding/modbus/stiebeleltron/internal/dto/SystemInformationBlockAllWpm.java
@@ -78,7 +78,6 @@ public class SystemInformationBlockAllWpm extends SystemInformationBlock {
     public HeatPumpInfo[] heatPumps;
 
     public SystemInformationBlockAllWpm(int nrOfHps) {
-        super();
         heatPumps = new HeatPumpInfo[nrOfHps];
         for (int i = 0; i < heatPumps.length; i++) {
             heatPumps[i] = new HeatPumpInfo();

--- a/bundles/org.openhab.binding.sedif/src/main/java/org/openhab/binding/sedif/internal/types/CommunicationFailedException.java
+++ b/bundles/org.openhab.binding.sedif/src/main/java/org/openhab/binding/sedif/internal/types/CommunicationFailedException.java
@@ -24,7 +24,6 @@ public class CommunicationFailedException extends SedifException {
     private static final long serialVersionUID = 3703839284673384018L;
 
     public CommunicationFailedException() {
-        super();
     }
 
     public CommunicationFailedException(String message) {

--- a/bundles/org.openhab.binding.sedif/src/main/java/org/openhab/binding/sedif/internal/types/InvalidSessionException.java
+++ b/bundles/org.openhab.binding.sedif/src/main/java/org/openhab/binding/sedif/internal/types/InvalidSessionException.java
@@ -24,7 +24,6 @@ public class InvalidSessionException extends SedifException {
     private static final long serialVersionUID = 3703839284673384018L;
 
     public InvalidSessionException() {
-        super();
     }
 
     public InvalidSessionException(String message) {

--- a/bundles/org.openhab.binding.sedif/src/main/java/org/openhab/binding/sedif/internal/types/SedifException.java
+++ b/bundles/org.openhab.binding.sedif/src/main/java/org/openhab/binding/sedif/internal/types/SedifException.java
@@ -24,7 +24,6 @@ public class SedifException extends Exception {
     private static final long serialVersionUID = 3703839284673384018L;
 
     public SedifException() {
-        super();
     }
 
     public SedifException(String message) {

--- a/bundles/org.openhab.binding.solarforecast/src/test/java/org/openhab/binding/solarforecast/CallbackMock.java
+++ b/bundles/org.openhab.binding.solarforecast/src/test/java/org/openhab/binding/solarforecast/CallbackMock.java
@@ -60,7 +60,6 @@ public class CallbackMock implements ThingHandlerCallback {
     volatile ThingStatusInfo currentStatusInfo = new ThingStatusInfo(ThingStatus.UNKNOWN, ThingStatusDetail.NONE, null);
 
     public CallbackMock() {
-        super();
     }
 
     public void clear() {
@@ -70,7 +69,6 @@ public class CallbackMock implements ThingHandlerCallback {
     }
 
     public CallbackMock(String name) {
-        super();
         this.name = name;
     }
 


### PR DESCRIPTION
by calling:
>  sed -i "/super();/d" $(git grep -l "super();")

From The Java Tutorials > [Using the Keyword super](https://docs.oracle.com/javase/tutorial/java/IandI/super.html):

>  If a constructor does not explicitly invoke a superclass constructor, the Java compiler automatically inserts a call to the no-argument constructor of the superclass.

Similar to https://github.com/openhab/openhab-addons/pull/19279.