### PR TITLE
Fix Markdown lint when having spaces in path

### DIFF
--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -818,7 +818,7 @@
             <phase>validate</phase>
             <configuration>
               <workingDirectory>${project.basedir}</workingDirectory>
-              <arguments>exec --yes markdownlint-cli2 -- **/*.md !**/target/** !**/node_modules/** --config ${maven.multiModuleProjectDirectory}/.github/markdownlint.yaml</arguments>
+              <arguments>exec --yes markdownlint-cli2 -- **/*.md !**/target/** !**/node_modules/** --config "${maven.multiModuleProjectDirectory}/.github/markdownlint.yaml"</arguments>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
This fixes this error on `mvn clean install` from a path having spaces in it:
```text
[INFO] Running 'npm exec --yes markdownlint-cli2 -- **/*.md !**/target/** !**/node_modules/** --config C:\Users\Jacob Laursen\Development\jlaur\openhab-addons/.github/markdownlint.yaml' in C:\Users\Jacob Laursen\Development\jlaur\openhab-addons\bundles\org.openhab.automation.pidcontroller
[INFO] markdownlint-cli2 v0.22.0 (markdownlint v0.40.0)
[INFO] Error: Unable to use configuration file 'C:/Users/Jacob'; Configuration file should be one of the supported names (e.g., '.markdownlint-cli2.jsonc') or a prefix with a supported name (e.g., 'example.markdownlint-cli2.jsonc') or have a supported extension (e.g., jsonc, json, yaml, yml, cjs, mjs).
[INFO]     at throwForConfigurationFile (file:///C:/Users/Jacob%20Laursen/AppData/Local/npm-cache/_npx/3c2a9ea6c4b6e0a2/node_modules/markdownlint-cli2/markdownlint-cli2.mjs:48:9)
[INFO]     at readOptionsOrConfig (file:///C:/Users/Jacob%20Laursen/AppData/Local/npm-cache/_npx/3c2a9ea6c4b6e0a2/node_modules/markdownlint-cli2/markdownlint-cli2.mjs:169:5)
[INFO]     at main (file:///C:/Users/Jacob%20Laursen/AppData/Local/npm-cache/_npx/3c2a9ea6c4b6e0a2/node_modules/markdownlint-cli2/markdownlint-cli2.mjs:926:27)
[INFO]     ... 3 lines matching cause stack trace ...
[INFO]     at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:117:5) {
[INFO]   [cause]: Error: Configuration file should be one of the supported names (e.g., '.markdownlint-cli2.jsonc') or a prefix with a supported name (e.g., 'example.markdownlint-cli2.jsonc') or have a supported extension (e.g., jsonc, json, yaml, yml, cjs, mjs).
[INFO]       at readOptionsOrConfig (file:///C:/Users/Jacob%20Laursen/AppData/Local/npm-cache/_npx/3c2a9ea6c4b6e0a2/node_modules/markdownlint-cli2/markdownlint-cli2.mjs:161:13)
[INFO]       at main (file:///C:/Users/Jacob%20Laursen/AppData/Local/npm-cache/_npx/3c2a9ea6c4b6e0a2/node_modules/markdownlint-cli2/markdownlint-cli2.mjs:926:27)
[INFO]       at file:///C:/Users/Jacob%20Laursen/AppData/Local/npm-cache/_npx/3c2a9ea6c4b6e0a2/node_modules/markdownlint-cli2/markdownlint-cli2-bin.mjs:14:28
[INFO]       at ModuleJob.run (node:internal/modules/esm/module_job:329:25)
[INFO]       at async onImport.tracePromise.__proto__ (node:internal/modules/esm/loader:644:26)
[INFO]       at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:117:5)
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  58.721 s
[INFO] Finished at: 2026-04-02T18:45:25+02:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal com.github.eirslett:frontend-maven-plugin:2.0.0:npm (markdownlint) on project org.openhab.automation.pidcontroller: Failed to run task: 'npm exec --yes markdownlint-cli2 -- **/*.md !**/target/** !**/node_modules/** --config C:\Users\Jacob Laursen\Development\jlaur\openhab-addons/.github/markdownlint.yaml' failed. org.apache.commons.exec.ExecuteException: Process exited with an error: 2 (Exit value: 2) -> [Help 1]
```

Regression of #19010