### PR TITLE
[dahuadoor] Add HTTPS support

### DIFF
--- a/bundles/org.openhab.binding.dahuadoor/README.md
+++ b/bundles/org.openhab.binding.dahuadoor/README.md
@@ -24,12 +24,12 @@ Devices in a different subnet or VLAN will not be found automatically and must b
 
 Single-button outdoor station.
 
-| Parameter    | Type    | Required | Default | Description                                                                  |
-| ------------ | ------- | -------- | ------- | ---------------------------------------------------------------------------- |
-| hostname     | text    | Yes      |         | Hostname or IP address of the device (e.g., 192.168.1.100)                   |
-| username     | text    | Yes      |         | Username to access the device                                                |
-| password     | text    | Yes      |         | Password to access the device                                                |
-| snapshotPath | text    | Yes      |         | Linux path where image files are stored (e.g., /var/lib/openhab/door-images) |
+| Parameter    | Type    | Required | Default | Description                                                                                                                                                              |
+| ------------ | ------- | -------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| hostname     | text    | Yes      |         | Hostname or IP address of the device (e.g., 192.168.1.100)                                                                                                               |
+| username     | text    | Yes      |         | Username to access the device                                                                                                                                            |
+| password     | text    | Yes      |         | Password to access the device                                                                                                                                            |
+| snapshotPath | text    | Yes      |         | Linux path where image files are stored (e.g., /var/lib/openhab/door-images)                                                                                             |
 | useHttps     | boolean | No       | false   | Use HTTPS (port 443) for snapshot and door-open requests. Enable if the device has HTTPS turned on in its network settings. When disabled, plain HTTP (port 80) is used. |
 
 **Note:** Windows paths are not currently supported.
@@ -43,8 +43,6 @@ If you have exported the device certificate as `ca.crt`, import it with:
 keytool -importcert -alias dahua-door -file ca.crt \
     -keystore "$JAVA_HOME/lib/security/cacerts" -storepass changeit
 ```
-
-Connection errors are logged at ERROR level.
 
 ## Channels
 

--- a/bundles/org.openhab.binding.dahuadoor/README.md
+++ b/bundles/org.openhab.binding.dahuadoor/README.md
@@ -24,14 +24,27 @@ Devices in a different subnet or VLAN will not be found automatically and must b
 
 Single-button outdoor station.
 
-| Parameter    | Type | Required | Description                                                                  |
-| ------------ | ---- | -------- | ---------------------------------------------------------------------------- |
-| hostname     | text | Yes      | Hostname or IP address of the device (e.g., 192.168.1.100)                   |
-| username     | text | Yes      | Username to access the device                                                |
-| password     | text | Yes      | Password to access the device                                                |
-| snapshotPath | text | Yes      | Linux path where image files are stored (e.g., /var/lib/openhab/door-images) |
+| Parameter    | Type    | Required | Default | Description                                                                  |
+| ------------ | ------- | -------- | ------- | ---------------------------------------------------------------------------- |
+| hostname     | text    | Yes      |         | Hostname or IP address of the device (e.g., 192.168.1.100)                   |
+| username     | text    | Yes      |         | Username to access the device                                                |
+| password     | text    | Yes      |         | Password to access the device                                                |
+| snapshotPath | text    | Yes      |         | Linux path where image files are stored (e.g., /var/lib/openhab/door-images) |
+| useHttps     | boolean | No       | false   | Use HTTPS (port 443) for snapshot and door-open requests. Enable if the device has HTTPS turned on in its network settings. When disabled, plain HTTP (port 80) is used. |
 
 **Note:** Windows paths are not currently supported.
+
+**Note on HTTPS:**
+To use HTTPS for snapshot retrieval and door-open commands, set `useHttps=true` and enable HTTPS on the device.
+Dahua devices typically use a self-signed certificate, which must be imported into the Java truststore of the machine running openHAB.
+If you have exported the device certificate as `ca.crt`, import it with:
+
+```shell
+keytool -importcert -alias dahua-door -file ca.crt \
+    -keystore "$JAVA_HOME/lib/security/cacerts" -storepass changeit
+```
+
+Connection errors are logged at ERROR level.
 
 ## Channels
 
@@ -69,7 +82,8 @@ Thing dahuadoor:vto2202:frontdoor "Front Door Station" @ "Entrance" [
     hostname="192.168.1.100",
     username="admin",
     password="password123",
-    snapshotPath="/var/lib/openhab/door-images"
+    snapshotPath="/var/lib/openhab/door-images",
+    useHttps=false
 ]
 ```
 
@@ -105,7 +119,8 @@ Thing dahuadoor:vto3211:entrance "Entrance Station" @ "Entrance" [
     hostname="192.168.1.101",
     username="admin",
     password="password123",
-    snapshotPath="/var/lib/openhab/door-images"
+    snapshotPath="/var/lib/openhab/door-images",
+    useHttps=false
 ]
 ```
 

--- a/bundles/org.openhab.binding.dahuadoor/pom.xml
+++ b/bundles/org.openhab.binding.dahuadoor/pom.xml
@@ -19,6 +19,7 @@
          bcprov + bctls are unpacked into the bundle (embed-dependencies).
          Without this exclusion Karaf would try to resolve them as external deps. -->
     <bnd.importpackage>!org.bouncycastle.*</bnd.importpackage>
+    <bouncycastle.version>1.83</bouncycastle.version>
   </properties>
 
   <dependencies>
@@ -28,17 +29,19 @@
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcprov-jdk18on</artifactId>
-      <version>1.83</version>
+      <version>${bouncycastle.version}</version>
+      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bctls-jdk18on</artifactId>
-      <version>1.83</version>
+      <version>${bouncycastle.version}</version>
+      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcutil-jdk18on</artifactId>
-      <version>1.83</version>
+      <version>${bouncycastle.version}</version>
     </dependency>
   </dependencies>
 

--- a/bundles/org.openhab.binding.dahuadoor/pom.xml
+++ b/bundles/org.openhab.binding.dahuadoor/pom.xml
@@ -14,4 +14,32 @@
 
   <name>openHAB Add-ons :: Bundles :: DahuaDoor Binding</name>
 
+  <properties>
+    <!-- Exclude embedded Bouncy Castle packages from OSGi Import-Package.
+         bcprov + bctls are unpacked into the bundle (embed-dependencies).
+         Without this exclusion Karaf would try to resolve them as external deps. -->
+    <bnd.importpackage>!org.bouncycastle.*</bnd.importpackage>
+  </properties>
+
+  <dependencies>
+    <!-- Bouncy Castle JSSE: provides TLS_RSA_WITH_AES_256_GCM_SHA384 which was
+         removed from Java 21's built-in TLS implementation but is required by
+         Dahua firmware. Embedded into the bundle via embed-dependencies mechanism. -->
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcprov-jdk18on</artifactId>
+      <version>1.83</version>
+    </dependency>
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bctls-jdk18on</artifactId>
+      <version>1.83</version>
+    </dependency>
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcutil-jdk18on</artifactId>
+      <version>1.83</version>
+    </dependency>
+  </dependencies>
+
 </project>

--- a/bundles/org.openhab.binding.dahuadoor/src/main/java/org/openhab/binding/dahuadoor/internal/DahuaDoorBaseHandler.java
+++ b/bundles/org.openhab.binding.dahuadoor/src/main/java/org/openhab/binding/dahuadoor/internal/DahuaDoorBaseHandler.java
@@ -562,7 +562,7 @@ public abstract class DahuaDoorBaseHandler extends BaseThingHandler implements D
     }
 
     protected void handleVTOCall() {
-        logger.debug("Event Call from VTO - subclass should override this method");
+        logger.debug("Event Call from VTO");
     }
 
     /**

--- a/bundles/org.openhab.binding.dahuadoor/src/main/java/org/openhab/binding/dahuadoor/internal/DahuaDoorBaseHandler.java
+++ b/bundles/org.openhab.binding.dahuadoor/src/main/java/org/openhab/binding/dahuadoor/internal/DahuaDoorBaseHandler.java
@@ -113,8 +113,8 @@ public abstract class DahuaDoorBaseHandler extends BaseThingHandler implements D
             return;
         }
 
-        client = new DahuaEventClient(localConfig.hostname, localConfig.username, localConfig.password, this,
-                this::errorInformer);
+        client = new DahuaEventClient(localConfig.hostname, localConfig.username, localConfig.password,
+                localConfig.useHttps, this, this::errorInformer);
 
         // Set status to UNKNOWN - will be set to ONLINE when first DHIP event is received
         updateStatus(ThingStatus.UNKNOWN);

--- a/bundles/org.openhab.binding.dahuadoor/src/main/java/org/openhab/binding/dahuadoor/internal/DahuaDoorConfiguration.java
+++ b/bundles/org.openhab.binding.dahuadoor/src/main/java/org/openhab/binding/dahuadoor/internal/DahuaDoorConfiguration.java
@@ -30,4 +30,5 @@ public class DahuaDoorConfiguration {
     public String username = "";
     public String password = "";
     public String snapshotPath = "";
+    public boolean useHttps = false;
 }

--- a/bundles/org.openhab.binding.dahuadoor/src/main/java/org/openhab/binding/dahuadoor/internal/DahuaVto2202Handler.java
+++ b/bundles/org.openhab.binding.dahuadoor/src/main/java/org/openhab/binding/dahuadoor/internal/DahuaVto2202Handler.java
@@ -35,22 +35,18 @@ public class DahuaVto2202Handler extends DahuaDoorBaseHandler {
     @Override
     protected void handleInvite(JsonObject eventList, JsonObject eventData) {
         logger.debug("Event Invite from VTO2202 (single button)");
-        // VTO2202 has only one button, always use lockNumber 1
         onButtonPressed(1);
     }
 
     @Override
     protected void handleVTOCall() {
-        logger.debug("Event Call from VTO2202 (single button)");
-        // VTO2202 has only one button, always use lockNumber 1
-        onButtonPressed(1);
     }
 
     @Override
     protected void onButtonPressed(int lockNumber) {
         logger.debug("Button pressed on VTO2202 (lockNumber ignored, single button)");
 
-        // Trigger bell button channel synchronously (fast, no blocking)
+        // Trigger bell button channel
         Channel channel = this.getThing().getChannel(DahuaDoorBindingConstants.CHANNEL_BELL_BUTTON);
         if (channel == null) {
             logger.warn("Bell button channel not found");
@@ -68,11 +64,8 @@ public class DahuaVto2202Handler extends DahuaDoorBaseHandler {
         scheduler.submit(() -> {
             byte[] buffer = localClient.requestImage();
             if (buffer != null && buffer.length > 0) {
-                // Update image channel
                 RawType image = new RawType(buffer, "image/jpeg");
                 updateState(DahuaDoorBindingConstants.CHANNEL_DOOR_IMAGE, image);
-
-                // Save snapshot
                 saveSnapshot(buffer);
             } else {
                 logger.warn("Received empty or null image buffer from VTO2202");

--- a/bundles/org.openhab.binding.dahuadoor/src/main/java/org/openhab/binding/dahuadoor/internal/DahuaVto2202Handler.java
+++ b/bundles/org.openhab.binding.dahuadoor/src/main/java/org/openhab/binding/dahuadoor/internal/DahuaVto2202Handler.java
@@ -35,18 +35,15 @@ public class DahuaVto2202Handler extends DahuaDoorBaseHandler {
     @Override
     protected void handleInvite(JsonObject eventList, JsonObject eventData) {
         logger.debug("Event Invite from VTO2202 (single button)");
+        // VTO2202 has only one button, always use lockNumber 1
         onButtonPressed(1);
-    }
-
-    @Override
-    protected void handleVTOCall() {
     }
 
     @Override
     protected void onButtonPressed(int lockNumber) {
         logger.debug("Button pressed on VTO2202 (lockNumber ignored, single button)");
 
-        // Trigger bell button channel
+        // Trigger bell button channel synchronously (fast, no blocking)
         Channel channel = this.getThing().getChannel(DahuaDoorBindingConstants.CHANNEL_BELL_BUTTON);
         if (channel == null) {
             logger.warn("Bell button channel not found");
@@ -64,8 +61,11 @@ public class DahuaVto2202Handler extends DahuaDoorBaseHandler {
         scheduler.submit(() -> {
             byte[] buffer = localClient.requestImage();
             if (buffer != null && buffer.length > 0) {
+                // Update image channel
                 RawType image = new RawType(buffer, "image/jpeg");
                 updateState(DahuaDoorBindingConstants.CHANNEL_DOOR_IMAGE, image);
+
+                // Save snapshot
                 saveSnapshot(buffer);
             } else {
                 logger.warn("Received empty or null image buffer from VTO2202");

--- a/bundles/org.openhab.binding.dahuadoor/src/main/java/org/openhab/binding/dahuadoor/internal/DahuaVto3211Handler.java
+++ b/bundles/org.openhab.binding.dahuadoor/src/main/java/org/openhab/binding/dahuadoor/internal/DahuaVto3211Handler.java
@@ -51,13 +51,6 @@ public class DahuaVto3211Handler extends DahuaDoorBaseHandler {
     }
 
     @Override
-    protected void handleVTOCall() {
-        logger.debug("Event Call from VTO3211 (dual button) - no LockNum available, defaulting to button 1");
-        // VTOCall events don't contain LockNum, default to button 1
-        onButtonPressed(1);
-    }
-
-    @Override
     protected void onButtonPressed(int lockNumber) {
         logger.debug("Button {} pressed on VTO3211", lockNumber);
 

--- a/bundles/org.openhab.binding.dahuadoor/src/main/java/org/openhab/binding/dahuadoor/internal/dahuaeventhandler/DahuaEventClient.java
+++ b/bundles/org.openhab.binding.dahuadoor/src/main/java/org/openhab/binding/dahuadoor/internal/dahuaeventhandler/DahuaEventClient.java
@@ -45,6 +45,7 @@ import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.bouncycastle.jsse.provider.BouncyCastleJsseProvider;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.jetty.http.HttpStatus;
 import org.openhab.core.common.ThreadPoolManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -124,6 +125,8 @@ public class DahuaEventClient implements Runnable {
         logger.debug("Requesting snapshot from {}", host);
         try {
             return sendSnapshotRequest(SNAPSHOT_PATH);
+        } catch (DahuaHttpRedirectException e) {
+            errorInformer.accept(e.getRedirectMessage());
         } catch (Exception e) {
             logger.warn("Could not retrieve snapshot from {}", host, e);
         }
@@ -139,6 +142,8 @@ public class DahuaEventClient implements Runnable {
         try {
             String path = "/cgi-bin/accessControl.cgi?action=openDoor&UserID=101&Type=Remote&channel=" + doorNo;
             sendOpenDoorRequest(path);
+        } catch (DahuaHttpRedirectException e) {
+            errorInformer.accept(e.getRedirectMessage());
         } catch (Exception e) {
             logger.warn("Could not open door {} on {}", doorNo, host, e);
         }
@@ -162,20 +167,19 @@ public class DahuaEventClient implements Runnable {
                     socket.setSoTimeout(HTTP_TIMEOUT_MS);
                     writeHttpGet(socket.getOutputStream(), path, null, false);
                     SnapshotHttpResponse response = parseSnapshotResponse(socket.getInputStream());
-                    if (response.statusCode == 200) {
+                    if (response.statusCode == HttpStatus.OK_200) {
                         logger.debug("Snapshot OK: {} bytes from {}", response.body.length, host);
                         return response.body;
                     }
-                    if (response.statusCode == 401) {
+                    if (response.statusCode == HttpStatus.UNAUTHORIZED_401) {
                         String challenge = response.headers.get("www-authenticate");
                         if (challenge != null) {
                             digestHeader = createDigestAuthorizationHeader(challenge, path);
                         }
                     } else {
-                        if (response.statusCode == 302) {
-                            logger.error(
-                                    "Snapshot request to {} redirected (HTTP 302) - device may require HTTPS; enable 'Use HTTPS' in the thing configuration",
-                                    host);
+                        if (response.statusCode == HttpStatus.MOVED_TEMPORARILY_302) {
+                            throw new DahuaHttpRedirectException("Snapshot request to " + host
+                                    + " redirected (HTTP 302) - device may require HTTPS; enable 'Use HTTPS' in the thing configuration");
                         } else {
                             logger.warn("Snapshot request to {} failed with unexpected HTTP status {}", host,
                                     response.statusCode);
@@ -194,14 +198,13 @@ public class DahuaEventClient implements Runnable {
                         authSocket.setSoTimeout(HTTP_TIMEOUT_MS);
                         writeHttpGet(authSocket.getOutputStream(), path, digestHeader, false);
                         SnapshotHttpResponse authResponse = parseSnapshotResponse(authSocket.getInputStream());
-                        if (authResponse.statusCode == 200) {
+                        if (authResponse.statusCode == HttpStatus.OK_200) {
                             logger.debug("Snapshot OK: {} bytes from {}", authResponse.body.length, host);
                             return authResponse.body;
                         }
-                        if (authResponse.statusCode == 302) {
-                            logger.error(
-                                    "Snapshot request to {} redirected (HTTP 302) - device may require HTTPS; enable 'Use HTTPS' in the thing configuration",
-                                    host);
+                        if (authResponse.statusCode == HttpStatus.MOVED_TEMPORARILY_302) {
+                            throw new DahuaHttpRedirectException("Snapshot request to " + host
+                                    + " redirected (HTTP 302) - device may require HTTPS; enable 'Use HTTPS' in the thing configuration");
                         } else {
                             logger.warn("Authenticated snapshot request to {} failed with unexpected HTTP status {}",
                                     host, authResponse.statusCode);
@@ -211,12 +214,20 @@ public class DahuaEventClient implements Runnable {
                 }
                 logger.debug("Snapshot request failed: no Digest challenge received from {}", host);
                 return null;
-            } catch (Exception e) {
+            } catch (InterruptedException ie) {
+                Thread.currentThread().interrupt();
+                return null;
+            } catch (IOException e) {
                 if (attempt < maxAttempts - 1) {
                     long delayMs = 750L * (1 << attempt); // 750 ms, 1.5 s
                     logger.debug("Snapshot attempt {}/{} via {} to {} failed ({}), retrying in {} ms", attempt + 1,
                             maxAttempts, useHttps ? "HTTPS" : "HTTP", host, e.getMessage(), delayMs);
-                    Thread.sleep(delayMs);
+                    try {
+                        Thread.sleep(delayMs);
+                    } catch (InterruptedException ie) {
+                        Thread.currentThread().interrupt();
+                        return null;
+                    }
                 } else {
                     throw e;
                 }
@@ -240,20 +251,19 @@ public class DahuaEventClient implements Runnable {
                     socket.setSoTimeout(HTTP_TIMEOUT_MS);
                     writeHttpGet(socket.getOutputStream(), path, null, false);
                     OpenDoorHttpResponse response = parseOpenDoorResponse(socket.getInputStream());
-                    if (response.statusCode == 200) {
+                    if (response.statusCode == HttpStatus.OK_200) {
                         logger.debug("Open Door Success");
                         return;
                     }
-                    if (response.statusCode == 401) {
+                    if (response.statusCode == HttpStatus.UNAUTHORIZED_401) {
                         String challenge = response.wwwAuthenticate;
                         if (challenge != null) {
                             digestHeader = createDigestAuthorizationHeader(challenge, path);
                         }
                     } else {
-                        if (response.statusCode == 302) {
-                            logger.error(
-                                    "Open door request to {} redirected (HTTP 302) - device may require HTTPS; enable 'Use HTTPS' in the thing configuration",
-                                    host);
+                        if (response.statusCode == HttpStatus.MOVED_TEMPORARILY_302) {
+                            throw new DahuaHttpRedirectException("Open door request to " + host
+                                    + " redirected (HTTP 302) - device may require HTTPS; enable 'Use HTTPS' in the thing configuration");
                         } else {
                             logger.warn("Open door request to {} failed with unexpected HTTP status {}", host,
                                     response.statusCode);
@@ -269,12 +279,11 @@ public class DahuaEventClient implements Runnable {
                         authSocket.setSoTimeout(HTTP_TIMEOUT_MS);
                         writeHttpGet(authSocket.getOutputStream(), path, digestHeader, false);
                         OpenDoorHttpResponse authResponse = parseOpenDoorResponse(authSocket.getInputStream());
-                        if (authResponse.statusCode == 200) {
+                        if (authResponse.statusCode == HttpStatus.OK_200) {
                             logger.debug("Open Door Success (with authentication)");
-                        } else if (authResponse.statusCode == 302) {
-                            logger.error(
-                                    "Open door request to {} redirected (HTTP 302) - device may require HTTPS; enable 'Use HTTPS' in the thing configuration",
-                                    host);
+                        } else if (authResponse.statusCode == HttpStatus.MOVED_TEMPORARILY_302) {
+                            throw new DahuaHttpRedirectException("Open door request to " + host
+                                    + " redirected (HTTP 302) - device may require HTTPS; enable 'Use HTTPS' in the thing configuration");
                         } else {
                             logger.warn("Open door request to {} failed with unexpected HTTP status {}", host,
                                     authResponse.statusCode);
@@ -284,12 +293,20 @@ public class DahuaEventClient implements Runnable {
                 }
                 logger.debug("Open door request failed: no Digest challenge received from {}", host);
                 return;
-            } catch (Exception e) {
+            } catch (InterruptedException ie) {
+                Thread.currentThread().interrupt();
+                return;
+            } catch (IOException e) {
                 if (attempt < maxAttempts - 1) {
                     long delayMs = 750L * (1 << attempt); // 750 ms, 1.5 s
                     logger.debug("Open door attempt {}/{} via {} to {} failed ({}), retrying in {} ms", attempt + 1,
                             maxAttempts, useHttps ? "HTTPS" : "HTTP", host, e.getMessage(), delayMs);
-                    Thread.sleep(delayMs);
+                    try {
+                        Thread.sleep(delayMs);
+                    } catch (InterruptedException ie) {
+                        Thread.currentThread().interrupt();
+                        return;
+                    }
                 } else {
                     throw e;
                 }
@@ -340,8 +357,9 @@ public class DahuaEventClient implements Runnable {
 
     /**
      * Builds the BCJSSE {@link SSLSocketFactory} once at class load time.
-     * Registers BouncyCastle providers if not already present so that
-     * TLS_RSA_WITH_AES_256_GCM_SHA384 (removed from Java 21 built-in TLS) is available.
+     * Uses directly instantiated BouncyCastle provider instances with the {@link SSLContext},
+     * without registering them globally, so that TLS_RSA_WITH_AES_256_GCM_SHA384 (removed from
+     * Java 21 built-in TLS) is available.
      */
     private static SSLSocketFactory buildBcSslSocketFactory() {
         // Use our embedded BouncyCastleJsseProvider instance directly (not via the global
@@ -566,7 +584,7 @@ public class DahuaEventClient implements Runnable {
             try {
                 return Integer.parseInt(parts[1]);
             } catch (NumberFormatException e) {
-                // ignore
+                logger.trace("Could not parse HTTP status code from status line: {}", statusLine);
             }
         }
         return 0;

--- a/bundles/org.openhab.binding.dahuadoor/src/main/java/org/openhab/binding/dahuadoor/internal/dahuaeventhandler/DahuaEventClient.java
+++ b/bundles/org.openhab.binding.dahuadoor/src/main/java/org/openhab/binding/dahuadoor/internal/dahuaeventhandler/DahuaEventClient.java
@@ -24,10 +24,11 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
 import java.security.KeyManagementException;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
-import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -38,8 +39,7 @@ import java.util.function.Consumer;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLSocket;
 import javax.net.ssl.SSLSocketFactory;
-import javax.net.ssl.TrustManager;
-import javax.net.ssl.X509TrustManager;
+import javax.net.ssl.TrustManagerFactory;
 
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.bouncycastle.jsse.provider.BouncyCastleJsseProvider;
@@ -362,35 +362,32 @@ public class DahuaEventClient implements Runnable {
      * Java 21 built-in TLS) is available.
      */
     private static SSLSocketFactory buildBcSslSocketFactory() {
-        // Use our embedded BouncyCastleJsseProvider instance directly (not via the global
-        // Security registry). Karaf may already have a bctls bundle installed; if we looked up
-        // "BCJSSE" from Security we might get that foreign provider, whose internal classes
-        // (e.g. SSLSocketUtil) can't be loaded by our bundle's ClassLoader → NoClassDefFoundError.
-        // By passing the Provider instance to SSLContext.getInstance() we stay entirely within
-        // our embedded BC classes regardless of what other BC bundles Karaf has loaded.
+        // Use our embedded BouncyCastleJsseProvider instance directly for both the TrustManager
+        // and the SSLContext (not via the global Security registry).
+        //
+        // Why not TrustManagerFactory.getInstance(alg) / Security.getProviders() approach:
+        // - JCA provider selection uses the global registry; Karaf globally registers its own
+        // bctls bundle's BouncyCastleJsseProvider at higher priority than SunJSSE.
+        // - Using Karaf's globally-registered BCJSSE factory fails with NoClassDefFoundError
+        // (ProvTrustManagerFactorySpi is in Karaf's bundle, invisible to our classloader).
+        // - Using SunJSSE's X509TrustManagerImpl fails because BCJSSE passes authType "KE:RSA"
+        // to checkServerTrusted(); SunJSSE does not recognise that format → certificate_unknown.
+        //
+        // Solution: supply our local embedded bcjsse instance as the explicit Provider to both
+        // TrustManagerFactory.getInstance() and SSLContext.getInstance(). Class loading then
+        // goes through bcjsse's own classloader (our embedded classes), not Karaf's bundle.
+        // BCJSSE's trust manager also speaks BCJSSE's own authType format natively.
         ClassLoader savedCl = Thread.currentThread().getContextClassLoader();
         try {
             Thread.currentThread().setContextClassLoader(BouncyCastleJsseProvider.class.getClassLoader());
             BouncyCastleJsseProvider bcjsse = new BouncyCastleJsseProvider(new BouncyCastleProvider());
+            TrustManagerFactory tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm(),
+                    bcjsse);
+            tmf.init((KeyStore) null);
             SSLContext ctx = SSLContext.getInstance("TLS", bcjsse);
-            ctx.init(null, new TrustManager[] { new X509TrustManager() {
-                @Override
-                public void checkClientTrusted(final X509Certificate @Nullable [] chain,
-                        final @Nullable String authType) {
-                }
-
-                @Override
-                public void checkServerTrusted(final X509Certificate @Nullable [] chain,
-                        final @Nullable String authType) {
-                }
-
-                @Override
-                public X509Certificate[] getAcceptedIssuers() {
-                    return new X509Certificate[0];
-                }
-            } }, SECURE_RANDOM);
+            ctx.init(null, tmf.getTrustManagers(), SECURE_RANDOM);
             return ctx.getSocketFactory();
-        } catch (NoSuchAlgorithmException | KeyManagementException e) {
+        } catch (NoSuchAlgorithmException | KeyManagementException | KeyStoreException e) {
             throw new IllegalStateException("Failed to initialize BCJSSE SSL context", e);
         } finally {
             Thread.currentThread().setContextClassLoader(savedCl);

--- a/bundles/org.openhab.binding.dahuadoor/src/main/java/org/openhab/binding/dahuadoor/internal/dahuaeventhandler/DahuaEventClient.java
+++ b/bundles/org.openhab.binding.dahuadoor/src/main/java/org/openhab/binding/dahuadoor/internal/dahuaeventhandler/DahuaEventClient.java
@@ -16,14 +16,18 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.net.ConnectException;
 import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.net.SocketTimeoutException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
+import java.security.KeyManagementException;
 import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
+import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -31,6 +35,14 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.function.Consumer;
 
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSocket;
+import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.jsse.provider.BouncyCastleJsseProvider;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.common.ThreadPoolManager;
@@ -69,18 +81,24 @@ public class DahuaEventClient implements Runnable {
     private Consumer<String> errorInformer;
     private ByteBuffer residualBuffer = ByteBuffer.allocate(0); // Buffer for incomplete frames across reads
 
-    private static final int HTTP_TIMEOUT_SECONDS = 10;
+    private static final int HTTP_TIMEOUT_MS = 750;
     private static final String SNAPSHOT_PATH = "/cgi-bin/snapshot.cgi";
     private static final SecureRandom SECURE_RANDOM = new SecureRandom();
+    private static final SSLSocketFactory BC_SSL_SOCKET_FACTORY = buildBcSslSocketFactory();
 
-    public DahuaEventClient(String host, String username, String password, DHIPEventListener eventListener,
-            Consumer<String> errorInformer) {
+    /** Whether to use HTTPS (port 443) or HTTP (port 80) for snapshot and door-open requests. */
+    private final boolean httpsAvailable;
+
+    public DahuaEventClient(String host, String username, String password, boolean useHttps,
+            DHIPEventListener eventListener, Consumer<String> errorInformer) {
         this.host = host;
         this.username = username;
         this.password = password;
         this.eventListener = eventListener;
         this.errorInformer = errorInformer;
         this.execThread = true;
+        this.httpsAvailable = useHttps;
+        logger.debug("HTTPS {} for {}", useHttps ? "enabled" : "disabled", host);
         ThreadPoolManager.getPool("binding.dahuadoor").submit(this);
     }
 
@@ -103,26 +121,9 @@ public class DahuaEventClient implements Runnable {
      * @return JPEG image bytes, or null if the request failed
      */
     public byte @Nullable [] requestImage() {
+        logger.debug("Requesting snapshot from {}", host);
         try {
-            SnapshotHttpResponse response = sendSnapshotRequest(null);
-            if (response.statusCode == 200) {
-                return response.body;
-            }
-            if (response.statusCode == 401) {
-                String challenge = response.headers.get("www-authenticate");
-                if (challenge != null) {
-                    String digestHeader = createDigestAuthorizationHeader(challenge, SNAPSHOT_PATH);
-                    if (digestHeader != null) {
-                        SnapshotHttpResponse authResponse = sendSnapshotRequest(digestHeader);
-                        if (authResponse.statusCode == 200) {
-                            return authResponse.body;
-                        }
-                        logger.debug("Authenticated snapshot request failed with HTTP status {} from {}",
-                                authResponse.statusCode, host);
-                    }
-                }
-            }
-            logger.debug("Snapshot request failed with HTTP status {} from {}", response.statusCode, host);
+            return sendSnapshotRequest(SNAPSHOT_PATH);
         } catch (Exception e) {
             logger.warn("Could not retrieve snapshot from {}", host, e);
         }
@@ -137,169 +138,269 @@ public class DahuaEventClient implements Runnable {
     public void openDoor(int doorNo) {
         try {
             String path = "/cgi-bin/accessControl.cgi?action=openDoor&UserID=101&Type=Remote&channel=" + doorNo;
-            OpenDoorHttpResponse response = sendOpenDoorRequest(path, null);
-            if (response.statusCode == 200) {
-                logger.debug("Open Door Success");
-            } else if (response.statusCode == 401) {
-                String challenge = response.wwwAuthenticate;
-                if (challenge != null) {
-                    String digestHeader = createDigestAuthorizationHeader(challenge, path);
-                    if (digestHeader != null) {
-                        OpenDoorHttpResponse authResponse = sendOpenDoorRequest(path, digestHeader);
-                        if (authResponse.statusCode == 200) {
-                            logger.debug("Open Door Success (with authentication)");
-                        } else {
-                            logger.debug("Open door request failed with HTTP status {} for door {} on {}",
-                                    authResponse.statusCode, doorNo, host);
-                        }
-                    }
-                } else {
-                    logger.debug("Open door request failed with HTTP status {} for door {} on {}", response.statusCode,
-                            doorNo, host);
-                }
-            } else {
-                logger.debug("Open door request failed with HTTP status {} for door {} on {}", response.statusCode,
-                        doorNo, host);
-            }
+            sendOpenDoorRequest(path);
         } catch (Exception e) {
             logger.warn("Could not open door {} on {}", doorNo, host, e);
         }
     }
 
-    private SnapshotHttpResponse sendSnapshotRequest(@Nullable String authorizationHeader) throws Exception {
-        try (Socket socket = new Socket()) {
-            socket.connect(new InetSocketAddress(host, 80), HTTP_TIMEOUT_SECONDS * 1000);
-            socket.setSoTimeout(HTTP_TIMEOUT_SECONDS * 1000);
-            StringBuilder request = new StringBuilder();
-            request.append("GET ").append(SNAPSHOT_PATH).append(" HTTP/1.1\r\n");
-            request.append("Host: ").append(host).append("\r\n");
-            request.append("Connection: close\r\n");
-            request.append("Accept: */*\r\n");
-            if (authorizationHeader != null) {
-                request.append("Authorization: ").append(authorizationHeader).append("\r\n");
-            }
-            request.append("\r\n");
-            OutputStream outputStream = socket.getOutputStream();
-            outputStream.write(request.toString().getBytes(StandardCharsets.ISO_8859_1));
-            outputStream.flush();
-            byte[] rawResponse = readHttpResponse(socket.getInputStream());
-            return parseSnapshotResponse(rawResponse);
-        }
-    }
-
-    private OpenDoorHttpResponse sendOpenDoorRequest(String path, @Nullable String authorizationHeader)
-            throws Exception {
-        try (Socket socket = new Socket()) {
-            socket.connect(new InetSocketAddress(host, 80), HTTP_TIMEOUT_SECONDS * 1000);
-            socket.setSoTimeout(HTTP_TIMEOUT_SECONDS * 1000);
-            StringBuilder request = new StringBuilder();
-            request.append("GET ").append(path).append(" HTTP/1.1\r\n");
-            request.append("Host: ").append(host).append("\r\n");
-            request.append("Connection: close\r\n");
-            if (authorizationHeader != null) {
-                request.append("Authorization: ").append(authorizationHeader).append("\r\n");
-            }
-            request.append("\r\n");
-            OutputStream outputStream = socket.getOutputStream();
-            outputStream.write(request.toString().getBytes(StandardCharsets.ISO_8859_1));
-            outputStream.flush();
-            byte[] rawResponse = readHttpResponse(socket.getInputStream());
-            return parseOpenDoorResponse(rawResponse);
-        }
-    }
-
-    private byte[] readHttpResponse(InputStream inputStream) throws Exception {
-        ByteArrayOutputStream headerStream = new ByteArrayOutputStream();
-        int state = 0;
-        while (true) {
-            int next = inputStream.read();
-            if (next == -1) {
-                break;
-            }
-            headerStream.write(next);
-            if (state == 0 && next == '\r') {
-                state = 1;
-            } else if (state == 1 && next == '\n') {
-                state = 2;
-            } else if (state == 2 && next == '\r') {
-                state = 3;
-            } else if (state == 3 && next == '\n') {
-                break;
-            } else {
-                state = 0;
-            }
-        }
-        byte[] headerBytes = headerStream.toByteArray();
-        int contentLength = extractContentLength(headerBytes);
-        ByteArrayOutputStream responseStream = new ByteArrayOutputStream();
-        responseStream.write(headerBytes);
-        byte[] buffer = new byte[4096];
-        if (contentLength >= 0) {
-            int remaining = contentLength;
-            while (remaining > 0) {
-                int read = inputStream.read(buffer, 0, Math.min(buffer.length, remaining));
-                if (read == -1) {
-                    break;
-                }
-                responseStream.write(buffer, 0, read);
-                remaining -= read;
-            }
-        } else {
-            while (true) {
-                try {
-                    int read = inputStream.read(buffer);
-                    if (read == -1) {
-                        break;
+    /**
+     * Sends a snapshot request with Digest auth.
+     * Uses HTTPS or HTTP based on the cached {@link #httpsAvailable} flag.
+     * Step 1: open connection, get 401 + challenge, close connection.
+     * Step 2: open fresh connection, send authenticated request.
+     */
+    private byte @Nullable [] sendSnapshotRequest(String path) throws Exception {
+        boolean useHttps = httpsAvailable;
+        int port = useHttps ? 443 : 80;
+        int maxAttempts = 3;
+        for (int attempt = 0; attempt < maxAttempts; attempt++) {
+            try {
+                // Step 1: unauthenticated request — get 401 + Digest challenge, then close socket
+                String digestHeader = null;
+                try (Socket socket = useHttps ? buildTlsSocket(port) : plainSocket(port)) {
+                    socket.setSoTimeout(HTTP_TIMEOUT_MS);
+                    writeHttpGet(socket.getOutputStream(), path, null, false);
+                    SnapshotHttpResponse response = parseSnapshotResponse(socket.getInputStream());
+                    if (response.statusCode == 200) {
+                        logger.debug("Snapshot OK: {} bytes from {}", response.body.length, host);
+                        return response.body;
                     }
-                    responseStream.write(buffer, 0, read);
-                } catch (SocketTimeoutException e) {
-                    logger.debug("Snapshot response read timed out without Content-Length; using partial body");
-                    break;
+                    if (response.statusCode == 401) {
+                        String challenge = response.headers.get("www-authenticate");
+                        if (challenge != null) {
+                            digestHeader = createDigestAuthorizationHeader(challenge, path);
+                        }
+                    } else {
+                        if (response.statusCode == 302) {
+                            logger.error(
+                                    "Snapshot request to {} redirected (HTTP 302) - device may require HTTPS; enable 'Use HTTPS' in the thing configuration",
+                                    host);
+                        } else {
+                            logger.warn("Snapshot request to {} failed with unexpected HTTP status {}", host,
+                                    response.statusCode);
+                        }
+                        return null;
+                    }
+                }
+                // First socket is now fully closed before opening the second.
+                // Brief pause to let the device finish processing the TLS close_notify and
+                // free its connection slot before we open the authenticated connection.
+                Thread.sleep(300);
+
+                // Step 2: authenticated request on a fresh connection
+                if (digestHeader != null) {
+                    try (Socket authSocket = useHttps ? buildTlsSocket(port) : plainSocket(port)) {
+                        authSocket.setSoTimeout(HTTP_TIMEOUT_MS);
+                        writeHttpGet(authSocket.getOutputStream(), path, digestHeader, false);
+                        SnapshotHttpResponse authResponse = parseSnapshotResponse(authSocket.getInputStream());
+                        if (authResponse.statusCode == 200) {
+                            logger.debug("Snapshot OK: {} bytes from {}", authResponse.body.length, host);
+                            return authResponse.body;
+                        }
+                        if (authResponse.statusCode == 302) {
+                            logger.error(
+                                    "Snapshot request to {} redirected (HTTP 302) - device may require HTTPS; enable 'Use HTTPS' in the thing configuration",
+                                    host);
+                        } else {
+                            logger.warn("Authenticated snapshot request to {} failed with unexpected HTTP status {}",
+                                    host, authResponse.statusCode);
+                        }
+                        return null;
+                    }
+                }
+                logger.debug("Snapshot request failed: no Digest challenge received from {}", host);
+                return null;
+            } catch (Exception e) {
+                if (attempt < maxAttempts - 1) {
+                    long delayMs = 750L * (1 << attempt); // 750 ms, 1.5 s
+                    logger.debug("Snapshot attempt {}/{} via {} to {} failed ({}), retrying in {} ms", attempt + 1,
+                            maxAttempts, useHttps ? "HTTPS" : "HTTP", host, e.getMessage(), delayMs);
+                    Thread.sleep(delayMs);
+                } else {
+                    throw e;
                 }
             }
         }
-        return responseStream.toByteArray();
+        throw new IOException("All snapshot attempts failed for " + host);
     }
 
-    private int extractContentLength(byte[] headerBytes) {
-        String headerText = new String(headerBytes, StandardCharsets.ISO_8859_1);
-        for (String line : headerText.split("\\r\\n")) {
-            if (line.regionMatches(true, 0, "Content-Length:", 0, "Content-Length:".length())) {
-                try {
-                    return Integer.parseInt(line.substring("Content-Length:".length()).trim());
-                } catch (NumberFormatException e) {
-                    return -1;
+    /**
+     * Sends an open-door request with Digest auth.
+     * Same sequential two-connection pattern as sendSnapshotRequest.
+     */
+    private void sendOpenDoorRequest(String path) throws Exception {
+        boolean useHttps = httpsAvailable;
+        int port = useHttps ? 443 : 80;
+        int maxAttempts = 3;
+        for (int attempt = 0; attempt < maxAttempts; attempt++) {
+            try {
+                String digestHeader = null;
+                try (Socket socket = useHttps ? buildTlsSocket(port) : plainSocket(port)) {
+                    socket.setSoTimeout(HTTP_TIMEOUT_MS);
+                    writeHttpGet(socket.getOutputStream(), path, null, false);
+                    OpenDoorHttpResponse response = parseOpenDoorResponse(socket.getInputStream());
+                    if (response.statusCode == 200) {
+                        logger.debug("Open Door Success");
+                        return;
+                    }
+                    if (response.statusCode == 401) {
+                        String challenge = response.wwwAuthenticate;
+                        if (challenge != null) {
+                            digestHeader = createDigestAuthorizationHeader(challenge, path);
+                        }
+                    } else {
+                        if (response.statusCode == 302) {
+                            logger.error(
+                                    "Open door request to {} redirected (HTTP 302) - device may require HTTPS; enable 'Use HTTPS' in the thing configuration",
+                                    host);
+                        } else {
+                            logger.warn("Open door request to {} failed with unexpected HTTP status {}", host,
+                                    response.statusCode);
+                        }
+                        return;
+                    }
+                }
+                // First socket is now fully closed before opening the second
+                Thread.sleep(300);
+
+                if (digestHeader != null) {
+                    try (Socket authSocket = useHttps ? buildTlsSocket(port) : plainSocket(port)) {
+                        authSocket.setSoTimeout(HTTP_TIMEOUT_MS);
+                        writeHttpGet(authSocket.getOutputStream(), path, digestHeader, false);
+                        OpenDoorHttpResponse authResponse = parseOpenDoorResponse(authSocket.getInputStream());
+                        if (authResponse.statusCode == 200) {
+                            logger.debug("Open Door Success (with authentication)");
+                        } else if (authResponse.statusCode == 302) {
+                            logger.error(
+                                    "Open door request to {} redirected (HTTP 302) - device may require HTTPS; enable 'Use HTTPS' in the thing configuration",
+                                    host);
+                        } else {
+                            logger.warn("Open door request to {} failed with unexpected HTTP status {}", host,
+                                    authResponse.statusCode);
+                        }
+                        return;
+                    }
+                }
+                logger.debug("Open door request failed: no Digest challenge received from {}", host);
+                return;
+            } catch (Exception e) {
+                if (attempt < maxAttempts - 1) {
+                    long delayMs = 750L * (1 << attempt); // 750 ms, 1.5 s
+                    logger.debug("Open door attempt {}/{} via {} to {} failed ({}), retrying in {} ms", attempt + 1,
+                            maxAttempts, useHttps ? "HTTPS" : "HTTP", host, e.getMessage(), delayMs);
+                    Thread.sleep(delayMs);
+                } else {
+                    throw e;
                 }
             }
         }
-        return -1;
+        throw new IOException("All open door attempts failed for " + host);
     }
 
-    private SnapshotHttpResponse parseSnapshotResponse(byte[] rawResponse) {
-        int headerEnd = -1;
-        for (int i = 0; i < rawResponse.length - 3; i++) {
-            if (rawResponse[i] == '\r' && rawResponse[i + 1] == '\n' && rawResponse[i + 2] == '\r'
-                    && rawResponse[i + 3] == '\n') {
-                headerEnd = i + 4;
-                break;
-            }
+    private Socket plainSocket(int port) throws IOException {
+        Socket socket = new Socket();
+        socket.connect(new InetSocketAddress(host, port), HTTP_TIMEOUT_MS);
+        return socket;
+    }
+
+    private Socket buildTlsSocket(int port) throws IOException {
+        // Dahua firmware uses TLS_RSA_WITH_AES_256_GCM_SHA384, removed from Java 21 built-in TLS.
+        // BCJSSE supports this cipher and provides standard SSLSocket close() semantics:
+        // graceful TLS close_notify + TCP FIN (no TCP RST), which is required for the device
+        // to immediately accept the next connection for the authenticated request.
+        //
+        // OSGi/Karaf may already have a BCJSSE bundle installed whose class loader differs from our
+        // embedded copy. BCJSSE loads internal classes (e.g. SSLSocketUtil) via the thread context
+        // class loader. We temporarily set it to our embedded BouncyCastleJsseProvider's class
+        // loader so that BCJSSE's internal class lookups stay within our bundle.
+        Socket tcpSocket = new Socket();
+        ClassLoader savedCl = Thread.currentThread().getContextClassLoader();
+        try {
+            Thread.currentThread().setContextClassLoader(BouncyCastleJsseProvider.class.getClassLoader());
+            tcpSocket.connect(new InetSocketAddress(host, port), HTTP_TIMEOUT_MS);
+            SSLSocket sslSocket = (SSLSocket) BC_SSL_SOCKET_FACTORY.createSocket(tcpSocket, host, port, true);
+            sslSocket.setSoTimeout(HTTP_TIMEOUT_MS);
+            sslSocket.setEnabledProtocols(new String[] { "TLSv1.2" });
+            sslSocket.setEnabledCipherSuites(new String[] { "TLS_RSA_WITH_AES_256_GCM_SHA384" });
+            sslSocket.startHandshake();
+            logger.debug("BCJSSE TLS connected to {}:{} using TLS_RSA_WITH_AES_256_GCM_SHA384", host, port);
+            return sslSocket;
+        } catch (ConnectException e) {
+            // Port unreachable: re-throw directly so callers can detect it without unwrapping
+            tcpSocket.close();
+            throw e;
+        } catch (Exception e) {
+            tcpSocket.close();
+            throw new IOException("TLS handshake failed to " + host + ":" + port + ": " + e.getMessage(), e);
+        } finally {
+            Thread.currentThread().setContextClassLoader(savedCl);
         }
+    }
+
+    /**
+     * Builds the BCJSSE {@link SSLSocketFactory} once at class load time.
+     * Registers BouncyCastle providers if not already present so that
+     * TLS_RSA_WITH_AES_256_GCM_SHA384 (removed from Java 21 built-in TLS) is available.
+     */
+    private static SSLSocketFactory buildBcSslSocketFactory() {
+        // Use our embedded BouncyCastleJsseProvider instance directly (not via the global
+        // Security registry). Karaf may already have a bctls bundle installed; if we looked up
+        // "BCJSSE" from Security we might get that foreign provider, whose internal classes
+        // (e.g. SSLSocketUtil) can't be loaded by our bundle's ClassLoader → NoClassDefFoundError.
+        // By passing the Provider instance to SSLContext.getInstance() we stay entirely within
+        // our embedded BC classes regardless of what other BC bundles Karaf has loaded.
+        ClassLoader savedCl = Thread.currentThread().getContextClassLoader();
+        try {
+            Thread.currentThread().setContextClassLoader(BouncyCastleJsseProvider.class.getClassLoader());
+            BouncyCastleJsseProvider bcjsse = new BouncyCastleJsseProvider(new BouncyCastleProvider());
+            SSLContext ctx = SSLContext.getInstance("TLS", bcjsse);
+            ctx.init(null, new TrustManager[] { new X509TrustManager() {
+                @Override
+                public void checkClientTrusted(final X509Certificate @Nullable [] chain,
+                        final @Nullable String authType) {
+                }
+
+                @Override
+                public void checkServerTrusted(final X509Certificate @Nullable [] chain,
+                        final @Nullable String authType) {
+                }
+
+                @Override
+                public X509Certificate[] getAcceptedIssuers() {
+                    return new X509Certificate[0];
+                }
+            } }, SECURE_RANDOM);
+            return ctx.getSocketFactory();
+        } catch (NoSuchAlgorithmException | KeyManagementException e) {
+            throw new IllegalStateException("Failed to initialize BCJSSE SSL context", e);
+        } finally {
+            Thread.currentThread().setContextClassLoader(savedCl);
+        }
+    }
+
+    private void writeHttpGet(OutputStream out, String path, @Nullable String authorizationHeader, boolean keepAlive)
+            throws IOException {
+        StringBuilder req = new StringBuilder();
+        req.append("GET ").append(path).append(" HTTP/1.1\r\n");
+        req.append("Host: ").append(host).append("\r\n");
+        if (authorizationHeader != null) {
+            req.append("Authorization: ").append(authorizationHeader).append("\r\n");
+        }
+        req.append("Connection: ").append(keepAlive ? "keep-alive" : "close").append("\r\n\r\n");
+        out.write(req.toString().getBytes(StandardCharsets.US_ASCII));
+        out.flush();
+    }
+
+    private SnapshotHttpResponse parseSnapshotResponse(InputStream in) throws IOException {
+        byte[] raw = readHttpResponse(in);
+        int headerEnd = findHeaderEnd(raw);
         if (headerEnd < 0) {
             return new SnapshotHttpResponse(0, Map.of(), new byte[0]);
         }
-        String headerText = new String(rawResponse, 0, headerEnd, StandardCharsets.ISO_8859_1);
-        String[] lines = headerText.split("\\r\\n");
-        int statusCode = 0;
-        if (lines.length > 0) {
-            String[] statusParts = lines[0].split(" ");
-            if (statusParts.length > 1) {
-                try {
-                    statusCode = Integer.parseInt(statusParts[1]);
-                } catch (NumberFormatException e) {
-                    statusCode = 0;
-                }
-            }
-        }
+        String headerSection = new String(raw, 0, headerEnd, StandardCharsets.US_ASCII);
+        String[] lines = headerSection.split("\r\n");
+        int statusCode = parseStatusCode(lines[0]);
         Map<String, String> headers = new HashMap<>();
         for (int i = 1; i < lines.length; i++) {
             int colon = lines[i].indexOf(':');
@@ -308,32 +409,167 @@ public class DahuaEventClient implements Runnable {
                         lines[i].substring(colon + 1).trim());
             }
         }
-        byte[] body = Arrays.copyOfRange(rawResponse, headerEnd, rawResponse.length);
+        byte[] body = Arrays.copyOfRange(raw, headerEnd + 4, raw.length);
         return new SnapshotHttpResponse(statusCode, headers, body);
     }
 
-    private OpenDoorHttpResponse parseOpenDoorResponse(byte[] rawResponse) {
-        String headerText = new String(rawResponse, StandardCharsets.ISO_8859_1);
-        String[] lines = headerText.split("\\r\\n");
-        int statusCode = 0;
-        if (lines.length > 0) {
-            String[] statusParts = lines[0].split(" ");
-            if (statusParts.length > 1) {
-                try {
-                    statusCode = Integer.parseInt(statusParts[1]);
-                } catch (NumberFormatException e) {
-                    statusCode = 0;
-                }
-            }
+    private OpenDoorHttpResponse parseOpenDoorResponse(InputStream in) throws IOException {
+        byte[] raw = readHttpResponse(in);
+        int headerEnd = findHeaderEnd(raw);
+        if (headerEnd < 0) {
+            return new OpenDoorHttpResponse(0, null);
         }
+        String headerSection = new String(raw, 0, headerEnd, StandardCharsets.US_ASCII);
+        String[] lines = headerSection.split("\r\n");
+        int statusCode = parseStatusCode(lines[0]);
         String wwwAuthenticate = null;
         for (int i = 1; i < lines.length; i++) {
-            if (lines[i].regionMatches(true, 0, "WWW-Authenticate:", 0, "WWW-Authenticate:".length())) {
-                wwwAuthenticate = lines[i].substring("WWW-Authenticate:".length()).trim();
+            int colon = lines[i].indexOf(':');
+            if (colon > 0 && "www-authenticate".equals(lines[i].substring(0, colon).trim().toLowerCase(Locale.ROOT))) {
+                wwwAuthenticate = lines[i].substring(colon + 1).trim();
                 break;
             }
         }
         return new OpenDoorHttpResponse(statusCode, wwwAuthenticate);
+    }
+
+    /**
+     * Reads an HTTP response in a TLS-safe way: reads headers until the blank line,
+     * then reads the body via Content-Length or chunked transfer encoding.
+     * Avoids waiting for EOF/close_notify which old Dahua firmware may never send.
+     */
+    private byte[] readHttpResponse(InputStream in) throws IOException {
+        // Read byte-by-byte until \r\n\r\n (end of headers)
+        ByteArrayOutputStream headerBuf = new ByteArrayOutputStream(4096);
+        int b;
+        int last4 = 0;
+        while ((b = in.read()) != -1) {
+            headerBuf.write(b);
+            last4 = ((last4 << 8) | b) & 0xFFFFFFFF;
+            if (last4 == 0x0D0A0D0A) { // \r\n\r\n
+                break;
+            }
+            if (headerBuf.size() > 65536) {
+                break; // safety limit
+            }
+        }
+        byte[] headerBytes = headerBuf.toByteArray();
+        String headerSection = new String(headerBytes, StandardCharsets.US_ASCII);
+        // Check for chunked transfer encoding
+        boolean isChunked = false;
+        int contentLength = -1;
+        for (String line : headerSection.split("\r\n")) {
+            String lower = line.toLowerCase(Locale.ROOT);
+            if (lower.startsWith("transfer-encoding:") && lower.contains("chunked")) {
+                isChunked = true;
+            } else if (lower.startsWith("content-length:")) {
+                try {
+                    contentLength = Integer.parseInt(line.substring(15).trim());
+                } catch (NumberFormatException e) {
+                    // ignore malformed header
+                }
+            }
+        }
+
+        ByteArrayOutputStream result = new ByteArrayOutputStream(headerBytes.length + Math.max(contentLength, 0));
+        result.write(headerBytes);
+
+        if (isChunked) {
+            // Read chunked body: each chunk is preceded by hex size line
+            byte[] chunkBody = readChunkedBody(in);
+            result.write(chunkBody);
+        } else if (contentLength > 0) {
+            // Read exactly contentLength bytes
+            byte[] body = new byte[contentLength];
+            int offset = 0;
+            while (offset < contentLength) {
+                int n = in.read(body, offset, contentLength - offset);
+                if (n == -1) {
+                    break;
+                }
+                offset += n;
+            }
+            result.write(body, 0, offset);
+        }
+        return result.toByteArray();
+    }
+
+    private byte[] readChunkedBody(InputStream in) throws IOException {
+        ByteArrayOutputStream body = new ByteArrayOutputStream(65536);
+        byte[] lineBuf = new byte[64];
+        while (true) {
+            // Read chunk size line (hex digits followed by \r\n)
+            int lineLen = 0;
+            int prev = 0;
+            int cur;
+            while ((cur = in.read()) != -1) {
+                if (prev == '\r' && cur == '\n') {
+                    break;
+                }
+                if (cur != '\r') {
+                    if (lineLen < lineBuf.length) {
+                        lineBuf[lineLen++] = (byte) cur;
+                    }
+                }
+                prev = cur;
+            }
+            if (lineLen == 0) {
+                break;
+            }
+            String sizeLine = new String(lineBuf, 0, lineLen, StandardCharsets.US_ASCII).trim();
+            // Strip chunk extensions (e.g. "1a;extension")
+            int semi = sizeLine.indexOf(';');
+            if (semi >= 0) {
+                sizeLine = sizeLine.substring(0, semi).trim();
+            }
+            int chunkSize;
+            try {
+                chunkSize = Integer.parseInt(sizeLine, 16);
+            } catch (NumberFormatException e) {
+                break;
+            }
+            if (chunkSize == 0) {
+                // Last chunk — consume trailing \r\n
+                in.read();
+                in.read();
+                break;
+            }
+            byte[] chunk = new byte[chunkSize];
+            int offset = 0;
+            while (offset < chunkSize) {
+                int n = in.read(chunk, offset, chunkSize - offset);
+                if (n == -1) {
+                    break;
+                }
+                offset += n;
+            }
+            body.write(chunk, 0, offset);
+            // Consume trailing \r\n after chunk data
+            in.read();
+            in.read();
+        }
+        return body.toByteArray();
+    }
+
+    private int findHeaderEnd(byte[] data) {
+        for (int i = 0; i < data.length - 3; i++) {
+            if (data[i] == '\r' && data[i + 1] == '\n' && data[i + 2] == '\r' && data[i + 3] == '\n') {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    private int parseStatusCode(String statusLine) {
+        String[] parts = statusLine.split(" ", 3);
+        if (parts.length >= 2) {
+            try {
+                return Integer.parseInt(parts[1]);
+            } catch (NumberFormatException e) {
+                // ignore
+            }
+        }
+        return 0;
     }
 
     private @Nullable String createDigestAuthorizationHeader(String challenge, String requestPath) throws Exception {

--- a/bundles/org.openhab.binding.dahuadoor/src/main/java/org/openhab/binding/dahuadoor/internal/dahuaeventhandler/DahuaHttpRedirectException.java
+++ b/bundles/org.openhab.binding.dahuadoor/src/main/java/org/openhab/binding/dahuadoor/internal/dahuaeventhandler/DahuaHttpRedirectException.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.dahuadoor.internal.dahuaeventhandler;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * Thrown when the device responds with an HTTP 302 redirect, which indicates a protocol mismatch
+ * (e.g. device requires HTTPS but the binding is configured to use plain HTTP).
+ * This is a permanent misconfiguration and should take the Thing offline.
+ *
+ * @author Sven Schad - Initial contribution
+ */
+@NonNullByDefault
+public class DahuaHttpRedirectException extends Exception {
+
+    private static final long serialVersionUID = 1L;
+
+    private final String redirectMessage;
+
+    public DahuaHttpRedirectException(String message) {
+        super(message);
+        this.redirectMessage = message;
+    }
+
+    public String getRedirectMessage() {
+        return redirectMessage;
+    }
+}

--- a/bundles/org.openhab.binding.dahuadoor/src/main/resources/OH-INF/i18n/dahuadoor.properties
+++ b/bundles/org.openhab.binding.dahuadoor/src/main/resources/OH-INF/i18n/dahuadoor.properties
@@ -34,6 +34,8 @@ thing-type.config.dahuadoor.vto2202.password.label = Password
 thing-type.config.dahuadoor.vto2202.password.description = Password to access the device
 thing-type.config.dahuadoor.vto2202.snapshotPath.label = Snapshot Path
 thing-type.config.dahuadoor.vto2202.snapshotPath.description = Path where snapshots will be saved (e.g., /var/lib/openhab/door-images)
+thing-type.config.dahuadoor.vto2202.useHttps.label = Use HTTPS
+thing-type.config.dahuadoor.vto2202.useHttps.description = Use HTTPS (port 443) for snapshot and door-open requests. Enable if the device has HTTPS turned on. Disable for plain HTTP (port 80).
 thing-type.config.dahuadoor.vto2202.username.label = Username
 thing-type.config.dahuadoor.vto2202.username.description = Username to access the device
 thing-type.config.dahuadoor.vto3211.hostname.label = Hostname
@@ -42,6 +44,8 @@ thing-type.config.dahuadoor.vto3211.password.label = Password
 thing-type.config.dahuadoor.vto3211.password.description = Password to access the device
 thing-type.config.dahuadoor.vto3211.snapshotPath.label = Snapshot Path
 thing-type.config.dahuadoor.vto3211.snapshotPath.description = Path where snapshots will be saved (e.g., /var/lib/openhab/door-images)
+thing-type.config.dahuadoor.vto3211.useHttps.label = Use HTTPS
+thing-type.config.dahuadoor.vto3211.useHttps.description = Use HTTPS (port 443) for snapshot and door-open requests. Enable if the device has HTTPS turned on. Disable for plain HTTP (port 80).
 thing-type.config.dahuadoor.vto3211.username.label = Username
 thing-type.config.dahuadoor.vto3211.username.description = Username to access the device
 

--- a/bundles/org.openhab.binding.dahuadoor/src/main/resources/OH-INF/thing/vto2202.xml
+++ b/bundles/org.openhab.binding.dahuadoor/src/main/resources/OH-INF/thing/vto2202.xml
@@ -43,14 +43,11 @@
 				<label>Snapshot Path</label>
 				<description>Path where snapshots will be saved (e.g., /var/lib/openhab/door-images)</description>
 			</parameter>
-			<parameter name="tlsVersion" type="text">
-				<label>TLS Version</label>
-				<description>TLS version for HTTPS snapshot requests</description>
-				<options>
-					<option value="auto">Auto (TLS 1.2, legacy cipher)</option>
-					<option value="TLSv1.3">TLS 1.3</option>
-				</options>
-				<default>auto</default>
+			<parameter name="useHttps" type="boolean">
+				<label>Use HTTPS</label>
+				<description>Use HTTPS (port 443) for snapshot and door-open requests. Enable if the device has HTTPS turned on.
+					Disable for plain HTTP (port 80).</description>
+				<default>false</default>
 			</parameter>
 		</config-description>
 	</thing-type>

--- a/bundles/org.openhab.binding.dahuadoor/src/main/resources/OH-INF/thing/vto3211.xml
+++ b/bundles/org.openhab.binding.dahuadoor/src/main/resources/OH-INF/thing/vto3211.xml
@@ -57,14 +57,11 @@
 				<label>Snapshot Path</label>
 				<description>Path where snapshots will be saved (e.g., /var/lib/openhab/door-images)</description>
 			</parameter>
-			<parameter name="tlsVersion" type="text">
-				<label>TLS Version</label>
-				<description>TLS version for HTTPS snapshot requests</description>
-				<options>
-					<option value="auto">Auto (TLS 1.2, legacy cipher)</option>
-					<option value="TLSv1.3">TLS 1.3</option>
-				</options>
-				<default>auto</default>
+			<parameter name="useHttps" type="boolean">
+				<label>Use HTTPS</label>
+				<description>Use HTTPS (port 443) for snapshot and door-open requests. Enable if the device has HTTPS turned on.
+					Disable for plain HTTP (port 80).</description>
+				<default>false</default>
 			</parameter>
 		</config-description>
 	</thing-type>


### PR DESCRIPTION
# Description

**Classification:** Novel Addition (Enhancement to existing binding)

This PR adds HTTPS support to the DahuaDoor binding (initially
contributed in #20172).

Dahua VTO devices can be configured to require HTTPS (port 443).
Java 21 dropped support for the legacy cipher
TLS_RSA_WITH_AES_256_GCM_SHA384 used by these devices, so HTTPS is
implemented via Bouncy Castle JSSE (BCJSSE). An OSGi ClassLoader fix
ensures the provider is available at runtime inside the OSGi container.

A new `useHttps` configuration parameter (default: `false`) controls
the behaviour. When enabled, all snapshot and door-open requests are
sent over HTTPS. HTTP 302 redirects are logged at ERROR level to help
users identify when the setting needs to be enabled.

The README has been updated with the new parameter, a note on HTTPS,
and the `keytool` command required to import the device certificate
into the Java truststore.

# Testing

Tested on a VTO2202 with HTTPS enabled and a self-signed certificate
imported into the Java truststore. Snapshot retrieval and door-open
commands work correctly. Plain HTTP (useHttps=false) continues to work
unchanged.