### PR TITLE
[heos] Fix `RuntimeException` during initialization

### DIFF
--- a/bundles/org.openhab.binding.heos/src/main/java/org/openhab/binding/heos/internal/handler/HeosBridgeHandler.java
+++ b/bundles/org.openhab.binding.heos/src/main/java/org/openhab/binding/heos/internal/handler/HeosBridgeHandler.java
@@ -219,7 +219,7 @@ public class HeosBridgeHandler extends BaseBridgeHandler implements HeosEventLis
                     }
                 }
             } catch (HeosNotFoundException e) {
-                logger.debug("SKipping handler which reported not found", e);
+                logger.debug("Skipping handler which reported not found", e);
             }
         }
     }

--- a/bundles/org.openhab.binding.heos/src/main/java/org/openhab/binding/heos/internal/handler/HeosGroupHandler.java
+++ b/bundles/org.openhab.binding.heos/src/main/java/org/openhab/binding/heos/internal/handler/HeosGroupHandler.java
@@ -122,11 +122,11 @@ public class HeosGroupHandler extends HeosThingBaseHandler {
 
     @Override
     public String getId() throws HeosNotFoundException {
-        String localGroupId = this.gid;
-        if (localGroupId == null) {
+        String gid = this.gid;
+        if (gid == null) {
             throw new HeosNotFoundException();
         }
-        return localGroupId;
+        return gid;
     }
 
     public String getGroupMemberHash() {
@@ -155,10 +155,10 @@ public class HeosGroupHandler extends HeosThingBaseHandler {
             return;
         }
 
-        String localGid = this.gid;
+        String gid = this.gid;
         String eventGroupId = eventObject.getAttribute(HeosCommunicationAttribute.GROUP_ID);
         String eventPlayerId = eventObject.getAttribute(HeosCommunicationAttribute.PLAYER_ID);
-        if (localGid == null || !(localGid.equals(eventGroupId) || localGid.equals(eventPlayerId))) {
+        if (gid == null || !(gid.equals(eventGroupId) || gid.equals(eventPlayerId))) {
             return;
         }
 

--- a/bundles/org.openhab.binding.heos/src/main/java/org/openhab/binding/heos/internal/handler/HeosPlayerHandler.java
+++ b/bundles/org.openhab.binding.heos/src/main/java/org/openhab/binding/heos/internal/handler/HeosPlayerHandler.java
@@ -26,6 +26,7 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.heos.internal.configuration.PlayerConfiguration;
 import org.openhab.binding.heos.internal.exception.HeosFunctionalException;
+import org.openhab.binding.heos.internal.exception.HeosNotFoundException;
 import org.openhab.binding.heos.internal.json.dto.HeosErrorCode;
 import org.openhab.binding.heos.internal.json.dto.HeosEventObject;
 import org.openhab.binding.heos.internal.json.dto.HeosResponseObject;
@@ -51,7 +52,7 @@ import org.slf4j.LoggerFactory;
 public class HeosPlayerHandler extends HeosThingBaseHandler {
     private final Logger logger = LoggerFactory.getLogger(HeosPlayerHandler.class);
 
-    private @NonNullByDefault({}) String pid;
+    private @Nullable String pid;
     private @Nullable Future<?> scheduledFuture;
 
     public HeosPlayerHandler(Thing thing, HeosDynamicStateDescriptionProvider heosDynamicStateDescriptionProvider) {
@@ -83,6 +84,11 @@ public class HeosPlayerHandler extends HeosThingBaseHandler {
     }
 
     private synchronized void delayedInitialize() {
+        String pid = this.pid;
+        if (pid == null) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, "Player ID is missing");
+            return;
+        }
         try {
             refreshPlayState(pid);
 
@@ -117,7 +123,11 @@ public class HeosPlayerHandler extends HeosThingBaseHandler {
     }
 
     @Override
-    public String getId() {
+    public String getId() throws HeosNotFoundException {
+        String pid = this.pid;
+        if (pid == null) {
+            throw new HeosNotFoundException();
+        }
         return pid;
     }
 
@@ -127,7 +137,8 @@ public class HeosPlayerHandler extends HeosThingBaseHandler {
 
     @Override
     public void playerStateChangeEvent(HeosEventObject eventObject) {
-        if (!pid.equals(eventObject.getAttribute(PLAYER_ID))) {
+        String pid = this.pid;
+        if (pid == null || !pid.equals(eventObject.getAttribute(PLAYER_ID))) {
             return;
         }
 
@@ -141,7 +152,8 @@ public class HeosPlayerHandler extends HeosThingBaseHandler {
 
     @Override
     public void playerStateChangeEvent(HeosResponseObject<?> responseObject) throws HeosFunctionalException {
-        if (!pid.equals(responseObject.getAttribute(PLAYER_ID))) {
+        String pid = this.pid;
+        if (pid == null || !pid.equals(responseObject.getAttribute(PLAYER_ID))) {
             return;
         }
 
@@ -149,8 +161,8 @@ public class HeosPlayerHandler extends HeosThingBaseHandler {
     }
 
     @Override
-    public void playerMediaChangeEvent(String eventPid, Media media) {
-        if (!pid.equals(eventPid)) {
+    public void playerMediaChangeEvent(String pid, Media media) {
+        if (!pid.equals(this.pid)) {
             return;
         }
 


### PR DESCRIPTION
Until 5.1 this caused a `NullPointerException` in core, and openHAB needed to be restarted to be able to retrieve Things again - see https://github.com/openhab/openhab-addons/issues/20041#issue-3801973451 and https://github.com/openhab/openhab-core/issues/5278#issue-3805116741

With 5.2, properties are now validated thanks to openhab/openhab-core#5416, so it now "only" causes `IllegalArgumentException` and the consequence is now isolated to the binding itself.

This first step prevents the issue and can be backported to 5.1.x where the consequence is most severe. The fix uses the same logic in `HeosPlayerHandler` as in `HeosGroupHandler`.

I think the initialization still has some issues and needs to be refactored. See my analysis here: https://github.com/openhab/openhab-addons/issues/20041#issuecomment-4185023294

Resolves #20041