### PR TITLE
Fix `-Dmarkdownlint.skip=true` breaks JS Scripting build

### DIFF
--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -787,14 +787,14 @@
           </execution>
         </executions>
       </plugin>
+
+      <!-- 4. Run markdownlint -->
       <plugin>
         <groupId>com.github.eirslett</groupId>
         <artifactId>frontend-maven-plugin</artifactId>
         <version>2.0.0</version>
 
         <configuration>
-          <skip>${markdownlint.skip}</skip>
-
           <!-- Central toolchain for markdownlint (Node 24) -->
           <installDirectory>${maven.multiModuleProjectDirectory}/target/.mvn/node-markdownlint</installDirectory>
           <nodeVersion>v24.12.0</nodeVersion>
@@ -810,6 +810,9 @@
               <goal>install-node-and-npm</goal>
             </goals>
             <phase>validate</phase>
+            <configuration>
+              <skip>${markdownlint.skip}</skip>
+            </configuration>
           </execution>
 
           <execution>
@@ -819,6 +822,7 @@
             </goals>
             <phase>validate</phase>
             <configuration>
+              <skip>${markdownlint.skip}</skip>
               <workingDirectory>${project.basedir}</workingDirectory>
               <arguments>exec --yes markdownlint-cli2 -- **/*.md !**/target/** !**/node_modules/** --config ${maven.multiModuleProjectDirectory}/.github/markdownlint.yaml</arguments>
             </configuration>


### PR DESCRIPTION
Regression from #19010.