### PR TITLE
[danfossairunit] Fix TCP read handling and improve value parsing precision

### DIFF
--- a/bundles/org.openhab.binding.danfossairunit/src/main/java/org/openhab/binding/danfossairunit/internal/CommunicationController.java
+++ b/bundles/org.openhab.binding.danfossairunit/src/main/java/org/openhab/binding/danfossairunit/internal/CommunicationController.java
@@ -23,10 +23,20 @@ import org.openhab.binding.danfossairunit.internal.protocol.Parameter;
  * @author Jacob Laursen - Initial contribution
  */
 @NonNullByDefault
-public interface CommunicationController {
-    void disconnect();
+public interface CommunicationController extends AutoCloseable {
+    /**
+     * Closes any open connection. Should be called when the controller is no longer needed.
+     */
+    @Override
+    void close();
 
+    /**
+     * Sends a request to the air unit. The implementation will establish a connection on demand.
+     */
     byte[] sendRobustRequest(Parameter parameter) throws IOException;
 
+    /**
+     * Sends a request to the air unit. The implementation will establish a connection on demand.
+     */
     byte[] sendRobustRequest(Parameter parameter, byte[] value) throws IOException;
 }

--- a/bundles/org.openhab.binding.danfossairunit/src/main/java/org/openhab/binding/danfossairunit/internal/CommunicationController.java
+++ b/bundles/org.openhab.binding.danfossairunit/src/main/java/org/openhab/binding/danfossairunit/internal/CommunicationController.java
@@ -24,8 +24,6 @@ import org.openhab.binding.danfossairunit.internal.protocol.Parameter;
  */
 @NonNullByDefault
 public interface CommunicationController {
-    void connect() throws IOException;
-
     void disconnect();
 
     byte[] sendRobustRequest(Parameter parameter) throws IOException;

--- a/bundles/org.openhab.binding.danfossairunit/src/main/java/org/openhab/binding/danfossairunit/internal/DanfossAirUnit.java
+++ b/bundles/org.openhab.binding.danfossairunit/src/main/java/org/openhab/binding/danfossairunit/internal/DanfossAirUnit.java
@@ -93,15 +93,6 @@ public class DanfossAirUnit {
         return ((result[0] & 0xff) << 24) | ((result[1] & 0xff) << 16) | ((result[2] & 0xff) << 8) | (result[3] & 0xff);
     }
 
-    private float getTemperature(Parameter parameter) throws IOException, UnexpectedResponseValueException {
-        short shortTemp = getShort(parameter);
-        float temp = ((float) shortTemp) / 100;
-        if (temp <= -274 || temp > 100) {
-            throw new UnexpectedResponseValueException("Invalid temperature: %s".formatted(temp));
-        }
-        return temp;
-    }
-
     private Instant getTimestamp(Parameter parameter) throws IOException, UnexpectedResponseValueException {
         byte[] result = communicationController.sendRobustRequest(parameter);
         return asInstant(result);
@@ -131,9 +122,9 @@ public class DanfossAirUnit {
         return b & 0xFF;
     }
 
-    private static float asPercentByte(byte b) {
-        float f = asUnsignedByte(b);
-        return f * 100 / 255;
+    private static BigDecimal asPercentByte(byte b) {
+        return BigDecimal.valueOf(asUnsignedByte(b)).multiply(BigDecimal.valueOf(100)).divide(BigDecimal.valueOf(255),
+                1, RoundingMode.HALF_UP);
     }
 
     public String getUnitName() throws IOException {
@@ -201,39 +192,47 @@ public class DanfossAirUnit {
     }
 
     public QuantityType<Dimensionless> getHumidity() throws IOException {
-        BigDecimal value = BigDecimal.valueOf(asPercentByte(getByte(Parameter.HUMIDITY)));
-        return new QuantityType<>(value.setScale(1, RoundingMode.HALF_UP), Units.PERCENT);
+        BigDecimal value = asPercentByte(getByte(Parameter.HUMIDITY));
+        return new QuantityType<>(value, Units.PERCENT);
     }
 
     public QuantityType<Temperature> getRoomTemperature() throws IOException, UnexpectedResponseValueException {
-        return getTemperatureAsDecimalType(Parameter.ROOM_TEMPERATURE);
+        return getTemperatureAsQuantityType(Parameter.ROOM_TEMPERATURE);
     }
 
     public QuantityType<Temperature> getRoomTemperatureCalculated()
             throws IOException, UnexpectedResponseValueException {
-        return getTemperatureAsDecimalType(Parameter.ROOM_TEMPERATURE_CALCULATED);
+        return getTemperatureAsQuantityType(Parameter.ROOM_TEMPERATURE_CALCULATED);
     }
 
     public QuantityType<Temperature> getOutdoorTemperature() throws IOException, UnexpectedResponseValueException {
-        return getTemperatureAsDecimalType(Parameter.OUTDOOR_TEMPERATURE);
+        return getTemperatureAsQuantityType(Parameter.OUTDOOR_TEMPERATURE);
     }
 
     public QuantityType<Temperature> getSupplyTemperature() throws IOException, UnexpectedResponseValueException {
-        return getTemperatureAsDecimalType(Parameter.SUPPLY_TEMPERATURE);
+        return getTemperatureAsQuantityType(Parameter.SUPPLY_TEMPERATURE);
     }
 
     public QuantityType<Temperature> getExtractTemperature() throws IOException, UnexpectedResponseValueException {
-        return getTemperatureAsDecimalType(Parameter.EXTRACT_TEMPERATURE);
+        return getTemperatureAsQuantityType(Parameter.EXTRACT_TEMPERATURE);
     }
 
     public QuantityType<Temperature> getExhaustTemperature() throws IOException, UnexpectedResponseValueException {
-        return getTemperatureAsDecimalType(Parameter.EXHAUST_TEMPERATURE);
+        return getTemperatureAsQuantityType(Parameter.EXHAUST_TEMPERATURE);
     }
 
-    private QuantityType<Temperature> getTemperatureAsDecimalType(Parameter parameter)
+    private QuantityType<Temperature> getTemperatureAsQuantityType(Parameter parameter)
             throws IOException, UnexpectedResponseValueException {
-        BigDecimal value = BigDecimal.valueOf(getTemperature(parameter));
-        return new QuantityType<>(value.setScale(1, RoundingMode.HALF_UP), SIUnits.CELSIUS);
+        short raw = getShort(parameter);
+
+        if (raw < -27315 || raw > 10000) {
+            BigDecimal invalid = BigDecimal.valueOf(raw).movePointLeft(2);
+            throw new UnexpectedResponseValueException("Invalid temperature: %s".formatted(invalid));
+        }
+
+        BigDecimal value = BigDecimal.valueOf(raw).movePointLeft(2).setScale(1, RoundingMode.HALF_UP);
+
+        return new QuantityType<>(value, SIUnits.CELSIUS);
     }
 
     public DecimalType getBatteryLife() throws IOException {
@@ -241,8 +240,8 @@ public class DanfossAirUnit {
     }
 
     public DecimalType getFilterLife() throws IOException {
-        BigDecimal value = BigDecimal.valueOf(asPercentByte(getByte(Parameter.FILTER_LIFE)));
-        return new DecimalType(value.setScale(1, RoundingMode.HALF_UP));
+        BigDecimal value = asPercentByte(getByte(Parameter.FILTER_LIFE));
+        return new DecimalType(value);
     }
 
     public DecimalType getFilterPeriod() throws IOException {

--- a/bundles/org.openhab.binding.danfossairunit/src/main/java/org/openhab/binding/danfossairunit/internal/DanfossAirUnitCommunicationController.java
+++ b/bundles/org.openhab.binding.danfossairunit/src/main/java/org/openhab/binding/danfossairunit/internal/DanfossAirUnitCommunicationController.java
@@ -79,7 +79,7 @@ public class DanfossAirUnitCommunicationController implements CommunicationContr
     }
 
     @Override
-    public synchronized void disconnect() {
+    public synchronized void close() {
         try {
             Socket socket = this.socket;
             if (socket != null && !socket.isClosed()) {
@@ -115,7 +115,7 @@ public class DanfossAirUnitCommunicationController implements CommunicationContr
         } catch (IOException suppressedException) {
             logger.debug("{} request failed, retrying once: {}", parameter, suppressedException.getMessage());
 
-            disconnect();
+            close();
 
             try {
                 connect();

--- a/bundles/org.openhab.binding.danfossairunit/src/main/java/org/openhab/binding/danfossairunit/internal/DanfossAirUnitCommunicationController.java
+++ b/bundles/org.openhab.binding.danfossairunit/src/main/java/org/openhab/binding/danfossairunit/internal/DanfossAirUnitCommunicationController.java
@@ -18,11 +18,11 @@ import java.io.OutputStream;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.Socket;
-import java.util.Arrays;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.danfossairunit.internal.protocol.Parameter;
+import org.openhab.core.util.HexUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -39,47 +39,51 @@ public class DanfossAirUnitCommunicationController implements CommunicationContr
     private static final int TCP_PORT = 30046;
     private static final int READ_TIMEOUT_MILLISECONDS = 5_000;
     private static final int DEFAULT_CONNECT_TIMEOUT_MILLISECONDS = 5_000;
+    private static final int RESPONSE_LENGTH = 63;
+    private static final byte[] EMPTY = new byte[0];
 
     private final Logger logger = LoggerFactory.getLogger(DanfossAirUnitCommunicationController.class);
-    private final InetAddress inetAddr;
+    private final InetAddress hostAddress;
     private final int connectTimeoutMilliseconds;
 
-    private boolean connected = false;
     private @Nullable Socket socket;
     private @Nullable OutputStream outputStream;
     private @Nullable InputStream inputStream;
 
-    public DanfossAirUnitCommunicationController(InetAddress inetAddr) {
-        this(inetAddr, DEFAULT_CONNECT_TIMEOUT_MILLISECONDS);
+    public DanfossAirUnitCommunicationController(InetAddress hostAddress) {
+        this(hostAddress, DEFAULT_CONNECT_TIMEOUT_MILLISECONDS);
     }
 
-    public DanfossAirUnitCommunicationController(InetAddress inetAddr, int connectTimeoutMilliseconds) {
-        this.inetAddr = inetAddr;
+    public DanfossAirUnitCommunicationController(InetAddress hostAddress, int connectTimeoutMilliseconds) {
+        this.hostAddress = hostAddress;
         this.connectTimeoutMilliseconds = connectTimeoutMilliseconds;
     }
 
-    @Override
-    public synchronized void connect() throws IOException {
-        if (connected) {
+    private synchronized void connect() throws IOException {
+        Socket socket = this.socket;
+        if (socket != null && !socket.isClosed()) {
+            // Already connected
             return;
         }
-        Socket socket = this.socket = new Socket();
-        socket.connect(new InetSocketAddress(inetAddr, TCP_PORT), connectTimeoutMilliseconds);
+
+        socket = new Socket();
+        socket.connect(new InetSocketAddress(hostAddress, TCP_PORT), connectTimeoutMilliseconds);
         socket.setSoTimeout(READ_TIMEOUT_MILLISECONDS);
-        outputStream = socket.getOutputStream();
-        inputStream = socket.getInputStream();
-        connected = true;
+
+        OutputStream outputStream = socket.getOutputStream();
+        InputStream inputStream = socket.getInputStream();
+
+        this.socket = socket;
+        this.outputStream = outputStream;
+        this.inputStream = inputStream;
     }
 
     @Override
     public synchronized void disconnect() {
-        if (!connected) {
-            return;
-        }
         try {
-            Socket localSocket = this.socket;
-            if (localSocket != null) {
-                localSocket.close();
+            Socket socket = this.socket;
+            if (socket != null && !socket.isClosed()) {
+                socket.close();
             }
         } catch (IOException ioe) {
             logger.debug("Connection to air unit could not be closed gracefully. {}", ioe.getMessage());
@@ -88,51 +92,78 @@ public class DanfossAirUnitCommunicationController implements CommunicationContr
             this.inputStream = null;
             this.outputStream = null;
         }
-        connected = false;
     }
 
     @Override
     public byte[] sendRobustRequest(Parameter parameter) throws IOException {
-        return sendRobustRequest(parameter, new byte[] {});
+        return sendRobustRequest(parameter, EMPTY);
     }
 
     @Override
     public synchronized byte[] sendRobustRequest(Parameter parameter, byte[] value) throws IOException {
-        connect();
         byte[] request = parameter.getRequest(value);
+
         try {
-            return sendRequestInternal(request);
-        } catch (IOException ioe) {
-            // retry once if there was connection problem
-            disconnect();
             connect();
-            return sendRequestInternal(request);
+
+            byte[] response = sendRequestInternal(request);
+            if (logger.isTraceEnabled()) {
+                logger.trace("{} response: {}", parameter, HexUtils.bytesToHex(response));
+            }
+
+            return response;
+        } catch (IOException suppressedException) {
+            logger.debug("{} request failed, retrying once: {}", parameter, suppressedException.getMessage());
+
+            disconnect();
+
+            try {
+                connect();
+
+                byte[] response = sendRequestInternal(request);
+                if (logger.isTraceEnabled()) {
+                    logger.trace("{} response: {}", parameter, HexUtils.bytesToHex(response));
+                }
+
+                return response;
+            } catch (IOException e) {
+                suppressedException.addSuppressed(e);
+                throw suppressedException;
+            }
         }
     }
 
-    private synchronized byte[] sendRequestInternal(byte[] request) throws IOException {
-        OutputStream localOutputStream = this.outputStream;
+    private byte[] sendRequestInternal(byte[] request) throws IOException {
+        OutputStream outputStream = this.outputStream;
+        InputStream inputStream = this.inputStream;
 
-        if (localOutputStream == null) {
-            throw new IOException(
-                    String.format("Output stream is null while sending request: %s", Arrays.toString(request)));
-        }
-        localOutputStream.write(request);
-        localOutputStream.flush();
-
-        byte[] result = new byte[63];
-        InputStream localInputStream = this.inputStream;
-        if (localInputStream == null) {
-            throw new IOException(
-                    String.format("Input stream is null while sending request: %s", Arrays.toString(request)));
+        if (outputStream == null || inputStream == null) {
+            throw new IOException("Input/output streams not initialized");
         }
 
-        int bytesRead = localInputStream.read(result, 0, 63);
-        if (bytesRead < 63) {
-            throw new IOException(String.format(
-                    "Error reading from stream, read returned %d as number of bytes read into the buffer", bytesRead));
+        outputStream.write(request);
+        outputStream.flush();
+
+        return readExact(inputStream, RESPONSE_LENGTH);
+    }
+
+    private byte[] readExact(InputStream inputStream, int length) throws IOException {
+        byte[] response = new byte[length];
+        int offset = 0;
+
+        while (offset < length) {
+            int bytesRead = inputStream.read(response, offset, length - offset);
+
+            if (bytesRead == -1) {
+                throw new IOException("Stream closed while reading response");
+            }
+            if (bytesRead == 0) {
+                throw new IOException("Read returned 0 bytes, possible stream stall");
+            }
+
+            offset += bytesRead;
         }
 
-        return result;
+        return response;
     }
 }

--- a/bundles/org.openhab.binding.danfossairunit/src/main/java/org/openhab/binding/danfossairunit/internal/discovery/DanfossAirUnitDiscoveryService.java
+++ b/bundles/org.openhab.binding.danfossairunit/src/main/java/org/openhab/binding/danfossairunit/internal/discovery/DanfossAirUnitDiscoveryService.java
@@ -166,14 +166,11 @@ public class DanfossAirUnitDiscoveryService extends AbstractDiscoveryService {
     }
 
     private @Nullable String getSerialNumber(InetAddress address) {
-        var controller = new DanfossAirUnitCommunicationController(address, SOCKET_TIMEOUT_MILLISECONDS);
-        var unit = new DanfossAirUnit(controller, FixedTimeZoneProvider.of(ZoneId.of("UTC")));
-        try {
+        try (var controller = new DanfossAirUnitCommunicationController(address, SOCKET_TIMEOUT_MILLISECONDS)) {
+            var unit = new DanfossAirUnit(controller, FixedTimeZoneProvider.of(ZoneId.of("UTC")));
             return unit.getUnitSerialNumber();
         } catch (IOException | UnexpectedResponseValueException e) {
             return null;
-        } finally {
-            controller.disconnect();
         }
     }
 }

--- a/bundles/org.openhab.binding.danfossairunit/src/main/java/org/openhab/binding/danfossairunit/internal/handler/DanfossAirUnitHandler.java
+++ b/bundles/org.openhab.binding.danfossairunit/src/main/java/org/openhab/binding/danfossairunit/internal/handler/DanfossAirUnitHandler.java
@@ -127,7 +127,7 @@ public class DanfossAirUnitHandler extends BaseThingHandler {
             return;
         }
 
-        logger.debug("Updating DanfossHRV data '{}'", getThing().getUID());
+        logger.trace("Updating DanfossHRV data '{}'", getThing().getUID());
 
         for (Channel channel : Channel.values()) {
             if (Thread.interrupted()) {

--- a/bundles/org.openhab.binding.danfossairunit/src/main/java/org/openhab/binding/danfossairunit/internal/handler/DanfossAirUnitHandler.java
+++ b/bundles/org.openhab.binding.danfossairunit/src/main/java/org/openhab/binding/danfossairunit/internal/handler/DanfossAirUnitHandler.java
@@ -219,7 +219,7 @@ public class DanfossAirUnitHandler extends BaseThingHandler {
 
         DanfossAirUnitCommunicationController communicationController = this.communicationController;
         if (communicationController != null) {
-            communicationController.disconnect();
+            communicationController.close();
         }
         this.communicationController = null;
     }


### PR DESCRIPTION
Fix partial TCP reads causing invalid response data:
- The communication layer previously relied on a single `InputStream.read` call to read a full response frame (63 bytes). Since `read` is not guaranteed to return the requested number of bytes, this could result in partial reads and misaligned frames.
- `sendRobustRequest` retried, but the new `read` could catch the tail of the previous frame, or a frame that was not fully written yet.
- In practice, this caused occasional invalid values (e.g. spikes to 100% filter life) due to corrupted response data.

Replace float-based parsing with `BigDecimal` for precision:
- Avoid floating point arithmetic (`float`).
- Use `BigDecimal` for exact scaling and rounding.

Resolves #20532