### PR TITLE
[systeminfo] Fix storage name reporting

### DIFF
--- a/bundles/org.openhab.binding.systeminfo/src/main/java/org/openhab/binding/systeminfo/internal/model/OSHISystemInfo.java
+++ b/bundles/org.openhab.binding.systeminfo/src/main/java/org/openhab/binding/systeminfo/internal/model/OSHISystemInfo.java
@@ -297,7 +297,7 @@ public class OSHISystemInfo implements SystemInfoInterface {
     @Override
     public StringType getStorageName(int index) throws DeviceNotFoundException {
         OSFileStore fileStore = getDevice(fileStores, index);
-        String name = fileStore.getName();
+        String name = fileStore.getMount();
         return new StringType(name);
     }
 

--- a/itests/org.openhab.binding.systeminfo.tests/src/main/java/org/openhab/binding/systeminfo/test/SystemInfoOSGiTest.java
+++ b/itests/org.openhab.binding.systeminfo.tests/src/main/java/org/openhab/binding/systeminfo/test/SystemInfoOSGiTest.java
@@ -631,7 +631,7 @@ public class SystemInfoOSGiTest extends JavaOSGiTest {
         String channnelID = SystemInfoBindingConstants.CHANNEL_STORAGE_NAME;
         String acceptedItemType = "String";
 
-        StringType mockedStorageName = new StringType("Mocked Storage Name");
+        StringType mockedStorageName = new StringType("/mocked/mount/point");
         when(mockedSystemInfo.getStorageName(DEFAULT_DEVICE_INDEX)).thenReturn(mockedStorageName);
 
         initializeThingWithChannel(channnelID, acceptedItemType);


### PR DESCRIPTION
# Description

Bugfix. The storage name channel was reporting the device name instead of the mount point. Fixes #20398.

The code was calling getName() which returns the device identifier, but users actually want the mount point like /mnt/storage. That's what shows up in file managers and system tools. Switched it to getMount().

Updated the test mock to match. No documentation needed.

# Testing

Small change, verified locally with the full test suite.