### PR TITLE
[systeminfo] Prevent noisy hostname-resolution logging

### DIFF
--- a/bundles/org.openhab.binding.systeminfo/src/main/java/org/openhab/binding/systeminfo/internal/discovery/SystemInfoDiscoveryService.java
+++ b/bundles/org.openhab.binding.systeminfo/src/main/java/org/openhab/binding/systeminfo/internal/discovery/SystemInfoDiscoveryService.java
@@ -66,7 +66,7 @@ public class SystemInfoDiscoveryService extends AbstractDiscoveryService {
             }
         } catch (UnknownHostException ex) {
             hostname = DEFAULT_THING_ID;
-            logger.info("Hostname can not be resolved. Computer name will be set to the default one: {}",
+            logger.debug("Hostname can not be resolved. Computer name will be set to the default one: {}",
                     DEFAULT_THING_ID);
         }
 

--- a/bundles/org.openhab.binding.systeminfo/src/main/java/org/openhab/binding/systeminfo/internal/discovery/SystemInfoDiscoveryService.java
+++ b/bundles/org.openhab.binding.systeminfo/src/main/java/org/openhab/binding/systeminfo/internal/discovery/SystemInfoDiscoveryService.java
@@ -66,7 +66,6 @@ public class SystemInfoDiscoveryService extends AbstractDiscoveryService {
             }
         } catch (UnknownHostException ex) {
             hostname = DEFAULT_THING_ID;
-            logger.debug("Hostname can not be resolved. Computer name will be set to the default one: {}",
                     DEFAULT_THING_ID);
         }
 


### PR DESCRIPTION
**Related issue:**
Fixes #20397

**Type of change:**
- [x] Bugfix

**Description:**
The discovery service was logging hostname resolution fallback messages at INFO level, which would show them regardless of the configured log level. Switched to DEBUG since this is only useful when troubleshooting.

**Testing:**
No new tests needed for a log level change. Verified the code follows existing logging patterns in the service.

**Checklist:**
- [x] Code follows style guidelines (Spotless)
- [x] Documentation updated (not applicable)
- [x] No new warnings introduced