### PR TITLE
Prevent duplicate event listeners

### DIFF
--- a/bundles/org.openhab.binding.monopriceaudio/src/main/java/org/openhab/binding/monopriceaudio/internal/handler/MonopriceAudioHandler.java
+++ b/bundles/org.openhab.binding.monopriceaudio/src/main/java/org/openhab/binding/monopriceaudio/internal/handler/MonopriceAudioHandler.java
@@ -462,9 +462,9 @@ public class MonopriceAudioHandler extends BaseThingHandler implements Monoprice
     private synchronized void closeConnection() {
         if (connector.isConnected()) {
             connector.close();
-            connector.removeEventListener(this);
             logger.debug("closeConnection(): disconnected");
         }
+        connector.removeEventListener(this);
     }
 
     @Override
@@ -698,10 +698,10 @@ public class MonopriceAudioHandler extends BaseThingHandler implements Monoprice
      * @param channelType the channel type to be updated
      */
     private void updateChannelState(String zoneId, String channelType) {
-        MonopriceAudioZoneDTO zoneData = zoneDataMap.get(zoneId);
+        final MonopriceAudioZoneDTO zoneData = zoneDataMap.get(zoneId);
 
         if (zoneData != null) {
-            String channel = amp.getZoneName(zoneId) + CHANNEL_DELIMIT + channelType;
+            final String channel = amp.getZoneName(zoneId) + CHANNEL_DELIMIT + channelType;
 
             if (!isLinked(channel)) {
                 return;

--- a/bundles/org.openhab.binding.nuvo/src/main/java/org/openhab/binding/nuvo/internal/handler/NuvoHandler.java
+++ b/bundles/org.openhab.binding.nuvo/src/main/java/org/openhab/binding/nuvo/internal/handler/NuvoHandler.java
@@ -680,10 +680,10 @@ public class NuvoHandler extends BaseThingHandler implements NuvoMessageEventLis
     private synchronized void closeConnection() {
         if (connector.isConnected()) {
             connector.close();
-            connector.removeEventListener(this);
             pollStatusNeeded = true;
             logger.debug("closeConnection(): disconnected");
         }
+        connector.removeEventListener(this);
     }
 
     /**

--- a/bundles/org.openhab.binding.oppo/src/main/java/org/openhab/binding/oppo/internal/handler/OppoHandler.java
+++ b/bundles/org.openhab.binding.oppo/src/main/java/org/openhab/binding/oppo/internal/handler/OppoHandler.java
@@ -379,9 +379,9 @@ public class OppoHandler extends BaseThingHandler implements OppoMessageEventLis
 
         if (connector.isConnected()) {
             connector.close();
-            connector.removeEventListener(this);
             logger.debug("closeConnection(): disconnected");
         }
+        connector.removeEventListener(this);
     }
 
     /**


### PR DESCRIPTION
Fix issue identified by copilot in #20485 for related bindings:

openConnection() adds this handler as an event listener on every reconnect attempt, but closeConnection() only removes the listener when connector.isConnected() is true. If open() fails (leaving isConnected() false), the listener is never removed and repeated reconnect attempts can accumulate duplicate listeners in KaleidescapeConnector (it stores listeners in an ArrayList), causing duplicate event processing once a connection is finally established. Consider removing the listener unconditionally (or otherwise ensuring it is added at most once).