### PR TITLE
[veSync] Auth V2 Support so users can use the binding again (#20236)

### DIFF
--- a/bundles/org.openhab.binding.vesync/src/main/java/org/openhab/binding/vesync/internal/api/LoginAuthV2Helper.java
+++ b/bundles/org.openhab.binding.vesync/src/main/java/org/openhab/binding/vesync/internal/api/LoginAuthV2Helper.java
@@ -1,0 +1,215 @@
+/**
+ * Copyright (c) 2010-2024 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.vesync.internal.api;
+
+import static org.openhab.binding.vesync.internal.VeSyncConstants.EMPTY_STRING;
+import static org.openhab.binding.vesync.internal.dto.requests.VeSyncProtocolConstants.*;
+
+import java.net.HttpURLConnection;
+import java.util.Locale;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.api.ContentResponse;
+import org.eclipse.jetty.client.api.Request;
+import org.eclipse.jetty.client.util.StringContentProvider;
+import org.eclipse.jetty.http.HttpHeader;
+import org.eclipse.jetty.http.HttpMethod;
+import org.openhab.binding.vesync.internal.VeSyncConstants;
+import org.openhab.binding.vesync.internal.dto.requests.VeSyncAuthLoginWithAuthorizeCodeVeSync;
+import org.openhab.binding.vesync.internal.dto.requests.VeSyncAuthLoginWithAuthorizeCodeVeSyncRegionChange;
+import org.openhab.binding.vesync.internal.dto.requests.VeSyncAuthTokenRequest;
+import org.openhab.binding.vesync.internal.dto.responses.VeSyncAuthLoginWithAuthorizeCodeVeSyncResponse;
+import org.openhab.binding.vesync.internal.dto.responses.VeSyncAuthTokenResponse;
+import org.openhab.binding.vesync.internal.dto.responses.VeSyncLoginResponse;
+import org.openhab.binding.vesync.internal.dto.responses.VeSyncUserSession;
+import org.openhab.binding.vesync.internal.exceptions.AuthenticationException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * @author David Goodyear - Initial contribution
+ */
+@NonNullByDefault
+class LoginAuthV2Helper {
+
+    private final Logger logger = LoggerFactory.getLogger(LoginAuthV2Helper.class);
+    private final HttpClient client;
+    private final VeSyncUserSession loginData = new VeSyncUserSession();
+
+    private static final String US_TOKEN_REQ_URL = US_SERVER + "/globalPlatform/api/accountAuth/v1/authByPWDOrOTM";
+    private static final String US_AUTH_BY_TOKEN = US_SERVER + "/user/api/accountManage/v1/loginByAuthorizeCode4Vesync";
+    private static final String AUTH_CONTENT_TYPE = "application/json";
+
+    private String authorizeCode;
+    private String bizToken;
+    private String userCurrentRegion;
+
+    protected LoginAuthV2Helper(HttpClient client) {
+        this.client = client;
+
+        // These parameters are utilised during the sequence
+        authorizeCode = EMPTY_STRING;
+        bizToken = EMPTY_STRING;
+        userCurrentRegion = "US";
+
+        // To reduce any potential issues preset this to the global instance
+        loginData.serverUrl = US_SERVER;
+    }
+
+    protected VeSyncLoginResponse getVeSyncLoginResponse() {
+        final VeSyncLoginResponse simResponse = new VeSyncLoginResponse();
+        simResponse.result = loginData;
+        return simResponse;
+    }
+
+    protected boolean requestAuthToken(final String username, final String password)
+            throws ExecutionException, InterruptedException, TimeoutException, AuthenticationException {
+        final Request request = client.newRequest(US_TOKEN_REQ_URL).method(HttpMethod.POST)
+                .timeout(VeSyncV2ApiHelper.RESPONSE_TIMEOUT_SEC, TimeUnit.SECONDS);
+
+        request.header(HttpHeader.CONTENT_TYPE, AUTH_CONTENT_TYPE);
+
+        request.content(new StringContentProvider(
+                VeSyncConstants.GSON.toJson(new VeSyncAuthTokenRequest(username, password, ""))));
+
+        final ContentResponse response = request.send();
+
+        // The 200 - OK confirms the server processed the request irrelevant of whether the credentials are any
+        // good.
+        if (response.getStatus() != HttpURLConnection.HTTP_OK) {
+            return false;
+        }
+
+        VeSyncAuthTokenResponse resp = VeSyncConstants.GSON.fromJson(response.getContentAsString(),
+                VeSyncAuthTokenResponse.class);
+
+        if (resp != null && resp.isMsgSuccess()) {
+            // Check for account lockout scenario
+            if (resp.result.accountLockTimeInSec != null && resp.result.accountLockTimeInSec > 0) {
+                logger.warn("Account locked out for {} seconds", resp.result.accountLockTimeInSec);
+                throw new AuthenticationException(
+                        "Account locked out for " + resp.result.accountLockTimeInSec + " seconds");
+            }
+
+            authorizeCode = resp.result.authorizeCode;
+            loginData.registerTime = resp.result.registerTime;
+        } else if (resp != null && resp.code != null && resp.msg != null) {
+            final String msg = resp.msg.toLowerCase(Locale.ENGLISH);
+            if ("-11202129".equals(resp.code) || msg.contains("the account does not exist")) {
+                throw new AuthenticationException("The account does not exist");
+            } else if ("-11201129".equals(resp.code) || msg.contains("account or password incorrect")) {
+                throw new AuthenticationException("Account or password incorrect");
+            } else {
+                return false;
+            }
+        } else {
+            return false;
+        }
+        return true;
+    }
+
+    protected boolean loginByAuthorizeCode()
+            throws ExecutionException, InterruptedException, TimeoutException, AuthenticationException {
+        final Request request = client.newRequest(US_AUTH_BY_TOKEN).method(HttpMethod.POST)
+                .timeout(VeSyncV2ApiHelper.RESPONSE_TIMEOUT_SEC, TimeUnit.SECONDS);
+
+        request.header(HttpHeader.CONTENT_TYPE, AUTH_CONTENT_TYPE);
+
+        request.content(new StringContentProvider(
+                VeSyncConstants.GSON.toJson(new VeSyncAuthLoginWithAuthorizeCodeVeSync(this.authorizeCode, ""))));
+
+        final ContentResponse response = request.send();
+        if (response.getStatus() != HttpURLConnection.HTTP_OK) {
+            return false;
+        }
+
+        final VeSyncAuthLoginWithAuthorizeCodeVeSyncResponse result = VeSyncConstants.GSON
+                .fromJson(response.getContentAsString(), VeSyncAuthLoginWithAuthorizeCodeVeSyncResponse.class);
+
+        if (result == null) {
+            return false;
+        }
+
+        if (result.result != null) {
+            userCurrentRegion = result.result.currentRegion;
+            loginData.countryCode = result.result.countryCode;
+            loginData.acceptLanguage = result.result.acceptLanguage;
+
+            if (result.isMsgSuccess()) {
+                loginData.token = result.result.token;
+                loginData.accountId = result.result.accountID;
+                return true;
+            }
+
+            // It is very likely now there is a redirect to an alternative data center suitable for the users region
+            if (result.msg != null && result.msg.toLowerCase(Locale.ENGLISH).contains("cross region error")) {
+                // We need to determine the correct URL that goes to the data center serving that region
+                switch (result.result.currentRegion) {
+                    case "EU":
+                        loginData.serverUrl = EU_SERVER;
+                        break;
+                    case "US":
+                    default:
+                        loginData.serverUrl = US_SERVER;
+                        break;
+                }
+
+                // We will need the biz token for the transfer to a new region
+                this.bizToken = result.result.bizToken;
+                return loginRegionalRedirectByAuthorizeCode();
+            }
+        }
+        return false;
+    }
+
+    private boolean loginRegionalRedirectByAuthorizeCode()
+            throws ExecutionException, InterruptedException, TimeoutException, AuthenticationException {
+        final String redirectedRegion = loginData.serverUrl + "/user/api/accountManage/v1/loginByAuthorizeCode4Vesync";
+
+        final Request request = client.newRequest(redirectedRegion).method(HttpMethod.POST)
+                .timeout(VeSyncV2ApiHelper.RESPONSE_TIMEOUT_SEC, TimeUnit.SECONDS);
+        request.header(HttpHeader.CONTENT_TYPE, AUTH_CONTENT_TYPE);
+
+        VeSyncAuthLoginWithAuthorizeCodeVeSyncRegionChange regionChange = new VeSyncAuthLoginWithAuthorizeCodeVeSyncRegionChange(
+                this.authorizeCode, loginData.countryCode, this.bizToken);
+
+        request.content(new StringContentProvider(VeSyncConstants.GSON.toJson(regionChange)));
+
+        final ContentResponse response = request.send();
+
+        if (response.getStatus() != HttpURLConnection.HTTP_OK) {
+            return false;
+        }
+
+        final VeSyncAuthLoginWithAuthorizeCodeVeSyncResponse result = VeSyncConstants.GSON
+                .fromJson(response.getContentAsString(), VeSyncAuthLoginWithAuthorizeCodeVeSyncResponse.class);
+
+        if (result == null) {
+            return false;
+        }
+
+        if (result.isMsgSuccess()) {
+            loginData.token = result.result.token;
+            loginData.accountId = result.result.accountID;
+            return true;
+        }
+        if (result.msg != null && result.msg.toLowerCase(Locale.ENGLISH).contains("cross region error")) {
+            throw new AuthenticationException("Code update required - region not supported - " + userCurrentRegion);
+        }
+        return false;
+    }
+}

--- a/bundles/org.openhab.binding.vesync/src/main/java/org/openhab/binding/vesync/internal/api/VeSyncV2ApiHelper.java
+++ b/bundles/org.openhab.binding.vesync/src/main/java/org/openhab/binding/vesync/internal/api/VeSyncV2ApiHelper.java
@@ -34,10 +34,8 @@ import org.eclipse.jetty.client.api.ContentResponse;
 import org.eclipse.jetty.client.api.Request;
 import org.eclipse.jetty.client.util.StringContentProvider;
 import org.eclipse.jetty.http.HttpHeader;
-import org.eclipse.jetty.http.HttpMethod;
 import org.openhab.binding.vesync.internal.VeSyncConstants;
 import org.openhab.binding.vesync.internal.dto.requests.VeSyncAuthenticatedRequest;
-import org.openhab.binding.vesync.internal.dto.requests.VeSyncLoginCredentials;
 import org.openhab.binding.vesync.internal.dto.requests.VeSyncRequestManagedDeviceBypassV2;
 import org.openhab.binding.vesync.internal.dto.requests.VeSyncRequestManagedDevicesPage;
 import org.openhab.binding.vesync.internal.dto.responses.VeSyncLoginResponse;
@@ -59,7 +57,7 @@ public class VeSyncV2ApiHelper {
 
     private final Logger logger = LoggerFactory.getLogger(VeSyncV2ApiHelper.class);
 
-    private static final int RESPONSE_TIMEOUT_SEC = 5;
+    protected static final int RESPONSE_TIMEOUT_SEC = 5;
 
     private volatile @Nullable VeSyncUserSession loggedInSession;
 
@@ -78,7 +76,7 @@ public class VeSyncV2ApiHelper {
 
     public void dispose() {
         loggedInSession = null;
-        macLookup.clear();
+        macLookup = new HashMap<>();
     }
 
     public static @NotNull String calculateMd5(final @Nullable String password) {
@@ -138,11 +136,20 @@ public class VeSyncV2ApiHelper {
         }
     }
 
-    public String reqV2Authorized(final String url, final String macId, final VeSyncAuthenticatedRequest requestData)
+    public String reqV2Authorized(String url, final String macId, final VeSyncAuthenticatedRequest requestData)
             throws AuthenticationException, DeviceUnknownException {
         if (loggedInSession == null) {
             throw new AuthenticationException("User is not logged in");
         }
+
+        @Nullable
+        VeSyncUserSession session = loggedInSession;
+        if (session != null && session.serverUrl != null) {
+            url = session.serverUrl + url;
+        } else {
+            url = US_SERVER + url; // Fallback
+        }
+
         // Apply current session authentication data
         requestData.applyAuthentication(loggedInSession);
 
@@ -165,13 +172,20 @@ public class VeSyncV2ApiHelper {
         return directReqV1Authorized(url, requestData);
     }
 
-    private String directReqV1Authorized(final String url, final VeSyncAuthenticatedRequest requestData)
+    private String directReqV1Authorized(String url, final VeSyncAuthenticatedRequest requestData)
             throws AuthenticationException {
         try {
             final HttpClient client = httpClient;
             if (client == null) {
                 throw new AuthenticationException("No HTTP Client");
             }
+
+            @Nullable
+            VeSyncUserSession session = loggedInSession;
+            if (session != null && session.serverUrl != null && !url.startsWith(session.serverUrl)) {
+                url = session.serverUrl + url;
+            }
+
             Request request = client.newRequest(url).method(requestData.httpMethod).timeout(RESPONSE_TIMEOUT_SEC,
                     TimeUnit.SECONDS);
 
@@ -213,7 +227,7 @@ public class VeSyncV2ApiHelper {
             return;
         }
         try {
-            loggedInSession = processLogin(username, password, timezone).getUserSession();
+            loggedInSession = processLoginAuthV2(username, password, timezone).getUserSession();
         } catch (final AuthenticationException ae) {
             loggedInSession = null;
             throw ae;
@@ -224,37 +238,26 @@ public class VeSyncV2ApiHelper {
         bridge.handleNewUserSession(loggedInSession);
     }
 
-    private VeSyncLoginResponse processLogin(String username, String password, String timezone)
+    private VeSyncLoginResponse processLoginAuthV2(String username, String password, String timezone)
             throws AuthenticationException {
         try {
             final HttpClient client = httpClient;
             if (client == null) {
                 throw new AuthenticationException("No HTTP Client");
             }
-            Request request = client.newRequest(V1_LOGIN_ENDPOINT).method(HttpMethod.POST).timeout(RESPONSE_TIMEOUT_SEC,
-                    TimeUnit.SECONDS);
 
-            // No headers for login
-            request.content(new StringContentProvider(
-                    VeSyncConstants.GSON.toJson(new VeSyncLoginCredentials(username, password))));
+            final LoginAuthV2Helper loginHelper = new LoginAuthV2Helper(client);
 
-            request.header(HttpHeader.CONTENT_TYPE, "application/json; utf-8");
-
-            ContentResponse response = request.send();
-            if (response.getStatus() == HttpURLConnection.HTTP_OK) {
-                VeSyncLoginResponse loginResponse = VeSyncConstants.GSON.fromJson(response.getContentAsString(),
-                        VeSyncLoginResponse.class);
-                if (loginResponse != null && loginResponse.isMsgSuccess()) {
-                    logger.debug("Login successful");
-                    return loginResponse;
-                } else {
-                    throw new AuthenticationException("Invalid / unexpected JSON response from login");
-                }
-            } else {
-                logger.warn("Login Failed - HTTP Response Code: {} - {}", response.getStatus(), response.getReason());
-                throw new AuthenticationException(
-                        "HTTP response " + response.getStatus() + " - " + response.getReason());
+            if (!loginHelper.requestAuthToken(username, password)) {
+                // We cant continue if we don't have the authorizeCode parameter
+                throw new AuthenticationException("Invalid username or password");
             }
+
+            if (!loginHelper.loginByAuthorizeCode()) {
+                throw new AuthenticationException("Invalid username or password");
+            }
+            return loginHelper.getVeSyncLoginResponse();
+
         } catch (InterruptedException | TimeoutException | ExecutionException e) {
             throw new AuthenticationException(e);
         }

--- a/bundles/org.openhab.binding.vesync/src/main/java/org/openhab/binding/vesync/internal/dto/requests/VeSyncAuthLoginWithAuthorizeCodeVeSync.java
+++ b/bundles/org.openhab.binding.vesync/src/main/java/org/openhab/binding/vesync/internal/dto/requests/VeSyncAuthLoginWithAuthorizeCodeVeSync.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) 2010-2024 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.vesync.internal.dto.requests;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * The {@link VeSyncAuthLoginWithAuthorizeCodeVeSync} is a Java class used as a DTO to hold the login token request
+ *
+ * @author David Goodyear - Initial contribution for new Auth Handling
+ */
+public class VeSyncAuthLoginWithAuthorizeCodeVeSync extends VeSyncBaseRequest {
+
+    @SerializedName("authorizeCode")
+    public String authorizeCode;
+
+    @SerializedName("accountID")
+    public String accountId = "";
+
+    @SerializedName("clientInfo")
+    public String clientInfo = "OpenHAB";
+
+    @SerializedName("clientType")
+    public String clientType = "vesyncApp";
+
+    @SerializedName("clientVersion")
+    public String clientVersion = "VeSync 5.6.60";
+
+    @SerializedName("debugMode")
+    public boolean debugMode = false;
+
+    @SerializedName("emailSubscriptions")
+    public boolean emailSubscriptions = false;
+
+    @SerializedName("osInfo")
+    public String osInfo = "Android";
+
+    @SerializedName("terminalId")
+    public String terminalId = "287f129ed1ca25cc0888348c0104744b9";
+
+    @SerializedName("timeZone")
+    public String timeZone = "America/New_York";
+
+    @SerializedName("token")
+    public String token = "";
+
+    @SerializedName("userCountryCode")
+    public String userCountryCode = "US";
+
+    public VeSyncAuthLoginWithAuthorizeCodeVeSync(final String authorizeCode, final String accountId) {
+        this.method = "loginByAuthorizeCode4Vesync";
+        traceId = String.valueOf(System.currentTimeMillis());
+        this.authorizeCode = authorizeCode;
+        this.accountId = accountId;
+    }
+}

--- a/bundles/org.openhab.binding.vesync/src/main/java/org/openhab/binding/vesync/internal/dto/requests/VeSyncAuthLoginWithAuthorizeCodeVeSyncRegionChange.java
+++ b/bundles/org.openhab.binding.vesync/src/main/java/org/openhab/binding/vesync/internal/dto/requests/VeSyncAuthLoginWithAuthorizeCodeVeSyncRegionChange.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) 2010-2024 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.vesync.internal.dto.requests;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * The {@link VeSyncAuthLoginWithAuthorizeCodeVeSync} is a Java class used as a DTO to hold the login token request
+ *
+ * @author David Goodyear - Initial contribution for new Auth Handling
+ */
+public class VeSyncAuthLoginWithAuthorizeCodeVeSyncRegionChange extends VeSyncAuthLoginWithAuthorizeCodeVeSync {
+
+    @SerializedName("regionChange")
+    public String regionChange = "lastRegion";
+
+    @SerializedName("bizToken")
+    public String bizToken = "";
+
+    public VeSyncAuthLoginWithAuthorizeCodeVeSyncRegionChange(final String authorizeCode, final String countryCode,
+            final String bizToken) {
+        super(authorizeCode, "");
+        this.bizToken = bizToken;
+        this.userCountryCode = countryCode;
+    }
+}

--- a/bundles/org.openhab.binding.vesync/src/main/java/org/openhab/binding/vesync/internal/dto/requests/VeSyncAuthTokenRequest.java
+++ b/bundles/org.openhab.binding.vesync/src/main/java/org/openhab/binding/vesync/internal/dto/requests/VeSyncAuthTokenRequest.java
@@ -1,0 +1,76 @@
+/**
+ * Copyright (c) 2010-2024 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.vesync.internal.dto.requests;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * The {@link VeSyncAuthTokenRequest} is a Java class used as a DTO to hold the login token request
+ *
+ * @author David Goodyear - Initial contribution for new Auth Handling
+ */
+public class VeSyncAuthTokenRequest extends VeSyncBaseRequest {
+
+    @SerializedName("email")
+    public String email = "";
+
+    @SerializedName("password")
+    public String password = "";
+
+    @SerializedName("accountID")
+    public String accountId = "";
+
+    @SerializedName("authProtocolType")
+    public String authProtocolType = "generic";
+
+    @SerializedName("clientInfo")
+    public String clientInfo = "OpenHAB";
+
+    @SerializedName("clientType")
+    public String clientType = "vesyncApp";
+
+    @SerializedName("clientVersion")
+    public String clientVersion = "VeSync 5.6.60";
+
+    @SerializedName("debugMode")
+    public boolean debugMode = false;
+
+    @SerializedName("osInfo")
+    public String osInfo = "Android";
+
+    @SerializedName("terminalId")
+    public String terminalId = "287f129ed1ca25cc0888348c0104744b9";
+
+    @SerializedName("timeZone")
+    public String timeZone = "America/New_York";
+
+    @SerializedName("token")
+    public String token = "";
+
+    @SerializedName("userCountryCode")
+    public String userCountryCode = "US";
+
+    @SerializedName("appID")
+    public String appId = "eldodkfj";
+
+    @SerializedName("sourceAppID")
+    public String sourceAppID = "eldodkfj";
+
+    public VeSyncAuthTokenRequest(final String email, final String password, final String accountId) {
+        this.method = "authByPWDOrOTM";
+        traceId = String.valueOf(System.currentTimeMillis());
+        this.email = email;
+        this.password = password;
+        this.accountId = accountId;
+    }
+}

--- a/bundles/org.openhab.binding.vesync/src/main/java/org/openhab/binding/vesync/internal/dto/requests/VeSyncBaseRequest.java
+++ b/bundles/org.openhab.binding.vesync/src/main/java/org/openhab/binding/vesync/internal/dto/requests/VeSyncBaseRequest.java
@@ -17,28 +17,24 @@ import org.eclipse.jetty.http.HttpMethod;
 import com.google.gson.annotations.SerializedName;
 
 /**
- * The {@link VeSyncRequest} is a Java class used as a DTO to hold the Vesync's API's common request data.
+ * The {@link VeSyncBaseRequest} is a Java class used as a DTO to hold the lowest common aspects of a VeSync Request
  *
  * @author David Goodyear - Initial contribution
  */
-public class VeSyncRequest extends VeSyncBaseRequest {
+public class VeSyncBaseRequest {
 
-    @SerializedName("timeZone")
-    public String timeZone = "America/New_York";
+    public transient HttpMethod httpMethod;
 
-    @SerializedName("appVersion")
-    public String appVersion = "2.5.1";
+    @SerializedName("acceptLanguage")
+    public String acceptLanguage = "en";
 
-    @SerializedName("phoneBrand")
-    public String phoneBrand = "SM N9005";
+    @SerializedName("traceId")
+    public String traceId = "";
 
-    @SerializedName("phoneOS")
-    public String phoneOS = "Android";
+    @SerializedName("method")
+    public String method = "";
 
-    @SerializedName("deviceId")
-    public String deviceId;
-
-    public VeSyncRequest() {
+    public VeSyncBaseRequest() {
         traceId = String.valueOf(System.currentTimeMillis());
         httpMethod = HttpMethod.POST;
     }

--- a/bundles/org.openhab.binding.vesync/src/main/java/org/openhab/binding/vesync/internal/dto/requests/VeSyncProtocolConstants.java
+++ b/bundles/org.openhab.binding.vesync/src/main/java/org/openhab/binding/vesync/internal/dto/requests/VeSyncProtocolConstants.java
@@ -57,12 +57,9 @@ public interface VeSyncProtocolConstants {
     /**
      * Base URL for AUTHENTICATION REQUESTS
      */
-    String PROTOCOL = "https";
-    String SERVER_ADDRESS = "smartapi.vesync.com";
-    String SERVER_ENDPOINT = PROTOCOL + "://" + SERVER_ADDRESS;
+    String US_SERVER = "https://smartapi.vesync.com";
+    String EU_SERVER = "https://smartapi.vesync.eu";
 
-    String HOST_ENDPOINT = SERVER_ENDPOINT + "/cloud";
-    String V1_LOGIN_ENDPOINT = HOST_ENDPOINT + "/v1/user/login";
-    String V1_MANAGED_DEVICES_ENDPOINT = HOST_ENDPOINT + "/v1/deviceManaged/devices";
-    String V2_BYPASS_ENDPOINT = HOST_ENDPOINT + "/v2/deviceManaged/bypassV2";
+    String V1_MANAGED_DEVICES_ENDPOINT = "/cloud/v1/deviceManaged/devices";
+    String V2_BYPASS_ENDPOINT = "/cloud/v2/deviceManaged/bypassV2";
 }

--- a/bundles/org.openhab.binding.vesync/src/main/java/org/openhab/binding/vesync/internal/dto/responses/VeSyncAuthLoginWithAuthorizeCodeVeSyncResponse.java
+++ b/bundles/org.openhab.binding.vesync/src/main/java/org/openhab/binding/vesync/internal/dto/responses/VeSyncAuthLoginWithAuthorizeCodeVeSyncResponse.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) 2010-2024 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.vesync.internal.dto.responses;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * The {@link VeSyncAuthLoginWithAuthorizeCodeVeSyncResponse} is a Java class used as a DTO to hold the Vesync's API's
+ * login response.
+ *
+ * @author David Goodyear - Initial contribution
+ */
+public class VeSyncAuthLoginWithAuthorizeCodeVeSyncResponse extends VeSyncResponse {
+
+    @SerializedName("result")
+    public VeSyncAuthLoginWithAuthorizeCodeVeSyncResponse.LoginTokenResponse result;
+
+    public static class LoginTokenResponse {
+
+        @SerializedName("currentRegion")
+        public String currentRegion = "";
+
+        @SerializedName("countryCode")
+        public String countryCode = "";
+
+        @SerializedName("accountID")
+        public String accountID;
+
+        @SerializedName("bizToken")
+        public String bizToken;
+
+        @SerializedName("token")
+        public String token;
+
+        @SerializedName("acceptLanguage")
+        public String acceptLanguage;
+
+        public String toString() {
+            return "currentRegion=" + currentRegion + ", countryCode=" + countryCode + ", accountID=" + accountID
+                    + ", bizToken=" + bizToken + ", acceptLanguage=" + acceptLanguage;
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "VeSyncAuthLoginTokenResponse [msg=" + getMsg() + ", result=" + result + "]";
+    }
+}

--- a/bundles/org.openhab.binding.vesync/src/main/java/org/openhab/binding/vesync/internal/dto/responses/VeSyncAuthTokenResponse.java
+++ b/bundles/org.openhab.binding.vesync/src/main/java/org/openhab/binding/vesync/internal/dto/responses/VeSyncAuthTokenResponse.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) 2010-2024 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.vesync.internal.dto.responses;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * The {@link VeSyncAuthTokenResponse} is a Java class used as a DTO to hold the Vesync's API's login response.
+ *
+ * @author David Goodyear - Initial contribution
+ */
+public class VeSyncAuthTokenResponse extends VeSyncResponse {
+
+    @SerializedName("result")
+    public VeSyncAuthTokenResponse.LoginTokenResponse result;
+
+    public static class LoginTokenResponse {
+        @SerializedName("accountID")
+        public String accountID;
+
+        @SerializedName("bizToken")
+        public String bizToken;
+
+        @SerializedName("authorizeCode")
+        public String authorizeCode;
+
+        @SerializedName("registerTime")
+        public String registerTime;
+
+        @SerializedName("accountLockTimeInSec")
+        public Integer accountLockTimeInSec = -1;
+
+        public String toString() {
+            return "accountLockTimeInSec=" + accountLockTimeInSec + ", accountId=" + accountID + ", bizToken="
+                    + bizToken + ", authorizeCode=" + authorizeCode;
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "VeSyncAuthLoginTokenResponse [msg=" + getMsg() + ", result=" + result + "]";
+    }
+}

--- a/bundles/org.openhab.binding.vesync/src/main/java/org/openhab/binding/vesync/internal/dto/responses/VeSyncManagedDevicesPage.java
+++ b/bundles/org.openhab.binding.vesync/src/main/java/org/openhab/binding/vesync/internal/dto/responses/VeSyncManagedDevicesPage.java
@@ -25,7 +25,7 @@ public class VeSyncManagedDevicesPage extends VeSyncResponse {
     @SerializedName("result")
     public Outcome outcome;
 
-    public class Outcome {
+    public static class Outcome {
         @SerializedName("pageNo")
         public String pageNo;
 

--- a/bundles/org.openhab.binding.vesync/src/main/java/org/openhab/binding/vesync/internal/dto/responses/VeSyncUserSession.java
+++ b/bundles/org.openhab.binding.vesync/src/main/java/org/openhab/binding/vesync/internal/dto/responses/VeSyncUserSession.java
@@ -26,6 +26,8 @@ public class VeSyncUserSession {
 
     public String token;
 
+    public String serverUrl;
+
     public String getToken() {
         return token;
     }
@@ -33,24 +35,20 @@ public class VeSyncUserSession {
     @SerializedName("registerTime")
     public String registerTime;
 
-    @SerializedName("accountID")
     public String accountId;
 
     public String getAccountId() {
         return accountId;
     }
 
-    @SerializedName("registerAppVersion")
-    public String registerAppVersion;
+    @SerializedName("acceptLanguage")
+    public String acceptLanguage;
 
     @SerializedName("countryCode")
     public String countryCode;
 
-    @SerializedName("acceptLanguage")
-    public String acceptLanguage;
-
     @Override
     public String toString() {
-        return "Data [user=AB" + ", token=" + token + "]";
+        return "Data [token=" + token + "]";
     }
 }

--- a/bundles/org.openhab.binding.vesync/src/main/java/org/openhab/binding/vesync/internal/dto/responses/VeSyncV2BypassHumidifierStatus.java
+++ b/bundles/org.openhab.binding.vesync/src/main/java/org/openhab/binding/vesync/internal/dto/responses/VeSyncV2BypassHumidifierStatus.java
@@ -25,12 +25,12 @@ public class VeSyncV2BypassHumidifierStatus extends VeSyncResponse {
     @SerializedName("result")
     public HumidifierrStatus result;
 
-    public class HumidifierrStatus extends VeSyncResponse {
+    public static class HumidifierrStatus extends VeSyncResponse {
 
         @SerializedName("result")
         public AirHumidifierStatus result;
 
-        public class AirHumidifierStatus {
+        public static class AirHumidifierStatus {
             @SerializedName("enabled")
             public boolean enabled;
 
@@ -73,7 +73,7 @@ public class VeSyncV2BypassHumidifierStatus extends VeSyncResponse {
             @SerializedName("warm_level")
             public int warmLevel;
 
-            public class HumidityPurifierConfig {
+            public static class HumidityPurifierConfig {
                 @SerializedName("auto_target_humidity")
                 public int autoTargetHumidity;
 

--- a/bundles/org.openhab.binding.vesync/src/main/java/org/openhab/binding/vesync/internal/dto/responses/VeSyncV2BypassPurifierStatus.java
+++ b/bundles/org.openhab.binding.vesync/src/main/java/org/openhab/binding/vesync/internal/dto/responses/VeSyncV2BypassPurifierStatus.java
@@ -25,12 +25,12 @@ public class VeSyncV2BypassPurifierStatus extends VeSyncResponse {
     @SerializedName("result")
     public PurifierStatus result;
 
-    public class PurifierStatus extends VeSyncResponse {
+    public static class PurifierStatus extends VeSyncResponse {
 
         @SerializedName("result")
         public AirPurifierStatus result;
 
-        public class AirPurifierStatus {
+        public static class AirPurifierStatus {
             @SerializedName("enabled")
             public boolean enabled;
 
@@ -61,7 +61,7 @@ public class VeSyncV2BypassPurifierStatus extends VeSyncResponse {
             @SerializedName("configuration")
             public AirPurifierConfig configuration;
 
-            public class AirPurifierConfig {
+            public static class AirPurifierConfig {
                 @SerializedName("display")
                 public boolean display;
 
@@ -71,7 +71,7 @@ public class VeSyncV2BypassPurifierStatus extends VeSyncResponse {
                 @SerializedName("auto_preference")
                 public AirPurifierConfigAutoPref autoPreference;
 
-                public class AirPurifierConfigAutoPref {
+                public static class AirPurifierConfigAutoPref {
                     @SerializedName("type")
                     public String autoType;
 
@@ -83,7 +83,7 @@ public class VeSyncV2BypassPurifierStatus extends VeSyncResponse {
             @SerializedName("extension")
             public AirPurifierExtension extension;
 
-            public class AirPurifierExtension {
+            public static class AirPurifierExtension {
                 @SerializedName("schedule_count")
                 public int scheduleCount;
 

--- a/bundles/org.openhab.binding.vesync/src/main/java/org/openhab/binding/vesync/internal/dto/responses/VeSyncV2Ver2BypassHumidifierStatus.java
+++ b/bundles/org.openhab.binding.vesync/src/main/java/org/openhab/binding/vesync/internal/dto/responses/VeSyncV2Ver2BypassHumidifierStatus.java
@@ -25,12 +25,12 @@ public class VeSyncV2Ver2BypassHumidifierStatus extends VeSyncResponse {
     @SerializedName("result")
     public VeSyncV2Ver2BypassHumidifierStatus.HumidifierStatus result;
 
-    public class HumidifierStatus extends VeSyncResponse {
+    public static class HumidifierStatus extends VeSyncResponse {
 
         @SerializedName("result")
         public VeSyncV2Ver2BypassHumidifierStatus.HumidifierStatus.AirHumidifierStatus result;
 
-        public class AirHumidifierStatus {
+        public static class AirHumidifierStatus {
 
             @SerializedName("powerSwitch")
             public int powerSwitch;

--- a/bundles/org.openhab.binding.vesync/src/main/java/org/openhab/binding/vesync/internal/dto/responses/VeSyncV2Ver2BypassPurifierStatus.java
+++ b/bundles/org.openhab.binding.vesync/src/main/java/org/openhab/binding/vesync/internal/dto/responses/VeSyncV2Ver2BypassPurifierStatus.java
@@ -25,12 +25,12 @@ public class VeSyncV2Ver2BypassPurifierStatus extends VeSyncResponse {
     @SerializedName("result")
     public PurifierStatus result;
 
-    public class PurifierStatus extends VeSyncResponse {
+    public static class PurifierStatus extends VeSyncResponse {
 
         @SerializedName("result")
         public AirPurifierStatus result;
 
-        public class AirPurifierStatus {
+        public static class AirPurifierStatus {
             @SerializedName("AQLevel")
             public int airQuality;
 
@@ -106,7 +106,7 @@ public class VeSyncV2Ver2BypassPurifierStatus extends VeSyncResponse {
             @SerializedName("autoPreference")
             public VeSyncV2Ver2BypassPurifierStatus.PurifierStatus.AirPurifierStatus.AirPurifierConfigAutoPref autoPreference;
 
-            public class AirPurifierConfigAutoPref {
+            public static class AirPurifierConfigAutoPref {
                 @SerializedName("autoPreferenceType")
                 public String autoType;
 
@@ -117,7 +117,7 @@ public class VeSyncV2Ver2BypassPurifierStatus extends VeSyncResponse {
             @SerializedName("sleepPreference")
             public VeSyncV2Ver2BypassPurifierStatus.PurifierStatus.AirPurifierStatus.AirPurifierSleepPref sleepPreference;
 
-            public class AirPurifierSleepPref {
+            public static class AirPurifierSleepPref {
                 @SerializedName("sleepPreferenceType")
                 public String sleepPreferenceType;
 

--- a/bundles/org.openhab.binding.vesync/src/main/java/org/openhab/binding/vesync/internal/handlers/VeSyncBaseDeviceHandler.java
+++ b/bundles/org.openhab.binding.vesync/src/main/java/org/openhab/binding/vesync/internal/handlers/VeSyncBaseDeviceHandler.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -33,7 +34,6 @@ import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.vesync.internal.VeSyncBridgeConfiguration;
 import org.openhab.binding.vesync.internal.VeSyncDeviceConfiguration;
 import org.openhab.binding.vesync.internal.dto.requests.VeSyncAuthenticatedRequest;
-import org.openhab.binding.vesync.internal.dto.requests.VeSyncProtocolConstants;
 import org.openhab.binding.vesync.internal.dto.requests.VeSyncRequestManagedDeviceBypassV2;
 import org.openhab.binding.vesync.internal.dto.responses.VeSyncManagedDeviceBase;
 import org.openhab.binding.vesync.internal.exceptions.AuthenticationException;
@@ -297,7 +297,7 @@ public abstract class VeSyncBaseDeviceHandler extends BaseThingHandler {
                 logger.debug("Searching for device mac id : {}", configMac);
                 @Nullable
                 VeSyncManagedDeviceBase metadata = vesyncBridgeHandler.api.getMacLookupMap()
-                        .get(configMac.toLowerCase());
+                        .get(configMac.toLowerCase(Locale.ENGLISH));
 
                 if (metadata != null && metadata.macId != null) {
                     return metadata.macId;
@@ -455,7 +455,7 @@ public abstract class VeSyncBaseDeviceHandler extends BaseThingHandler {
             }
             VeSyncClient client = getVeSyncClient();
             if (client != null) {
-                final String url = VeSyncProtocolConstants.SERVER_ENDPOINT + "/" + urlPath;
+                final String url = "/" + urlPath;
                 return client.reqV2Authorized(url, deviceLookupKey, request);
             } else {
                 throw new DeviceUnknownException("Missing client");

--- a/bundles/org.openhab.binding.vesync/src/main/java/org/openhab/binding/vesync/internal/handlers/VeSyncBridgeHandler.java
+++ b/bundles/org.openhab.binding.vesync/src/main/java/org/openhab/binding/vesync/internal/handlers/VeSyncBridgeHandler.java
@@ -16,6 +16,7 @@ import static org.openhab.binding.vesync.internal.VeSyncConstants.*;
 
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -28,11 +29,13 @@ import javax.validation.constraints.NotNull;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.vesync.internal.VeSyncBridgeConfiguration;
+import org.openhab.binding.vesync.internal.VeSyncConstants;
 import org.openhab.binding.vesync.internal.api.VeSyncV2ApiHelper;
 import org.openhab.binding.vesync.internal.discovery.DeviceMetaDataUpdatedHandler;
 import org.openhab.binding.vesync.internal.discovery.VeSyncDiscoveryService;
 import org.openhab.binding.vesync.internal.dto.requests.VeSyncAuthenticatedRequest;
 import org.openhab.binding.vesync.internal.dto.responses.VeSyncManagedDeviceBase;
+import org.openhab.binding.vesync.internal.dto.responses.VeSyncResponse;
 import org.openhab.binding.vesync.internal.dto.responses.VeSyncUserSession;
 import org.openhab.binding.vesync.internal.exceptions.AuthenticationException;
 import org.openhab.binding.vesync.internal.exceptions.DeviceUnknownException;
@@ -222,7 +225,7 @@ public class VeSyncBridgeHandler extends BaseBridgeHandler implements VeSyncClie
             final String passwordMd5 = VeSyncV2ApiHelper.calculateMd5(config.password);
 
             try {
-                api.login(config.username, passwordMd5, "Europe/London");
+                api.login(config.username, passwordMd5, "America/New_York");
                 api.updateBridgeData(this);
                 runDeviceScanSequence();
                 updateStatus(ThingStatus.ONLINE);
@@ -260,6 +263,25 @@ public class VeSyncBridgeHandler extends BaseBridgeHandler implements VeSyncClie
     @Override
     public String reqV2Authorized(final String url, final String macId, final VeSyncAuthenticatedRequest requestData)
             throws AuthenticationException, DeviceUnknownException {
-        return api.reqV2Authorized(url, macId, requestData);
+        // This is common to all call's check the response code for token expiry, if the token has expired
+        // then perform a new login before a final attempt. all errors such as invalid token or expired token all have
+        // token
+        // in the message.
+        String result = api.reqV2Authorized(url, macId, requestData);
+
+        VeSyncResponse responseFrame = VeSyncConstants.GSON.fromJson(result, VeSyncResponse.class);
+
+        if (responseFrame != null && responseFrame.code != null && responseFrame.msg != null) {
+            final String message = responseFrame.msg;
+            if (!"0".equals(responseFrame.code) && message.toLowerCase(Locale.ENGLISH).contains("token")) {
+                logger.trace("Refreshing API token due to error response regarding the token");
+                final VeSyncBridgeConfiguration config = getConfigAs(VeSyncBridgeConfiguration.class);
+                final String passwordMd5 = VeSyncV2ApiHelper.calculateMd5(config.password);
+                api.login(config.username, passwordMd5, "America/New_York");
+                return api.reqV2Authorized(url, macId, requestData);
+            }
+        }
+
+        return result;
     }
 }

--- a/bundles/org.openhab.binding.vesync/src/main/java/org/openhab/binding/vesync/internal/handlers/VeSyncDeviceAirHumidifierHandler.java
+++ b/bundles/org.openhab.binding.vesync/src/main/java/org/openhab/binding/vesync/internal/handlers/VeSyncDeviceAirHumidifierHandler.java
@@ -15,12 +15,13 @@ package org.openhab.binding.vesync.internal.handlers;
 import static org.openhab.binding.vesync.internal.VeSyncConstants.*;
 import static org.openhab.binding.vesync.internal.dto.requests.VeSyncProtocolConstants.*;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
@@ -59,7 +60,6 @@ import org.slf4j.LoggerFactory;
  * @author David Goodyear - Initial contribution
  */
 @NonNullByDefault
-@SuppressWarnings("serial")
 public class VeSyncDeviceAirHumidifierHandler extends VeSyncBaseDeviceHandler {
 
     public static final String DEV_TYPE_FAMILY_AIR_HUMIDIFIER = "LUH";
@@ -310,7 +310,7 @@ public class VeSyncDeviceAirHumidifierHandler extends VeSyncBaseDeviceHandler {
                         break;
                 }
             } else if (command instanceof StringType) {
-                final String targetMode = command.toString().toLowerCase();
+                final String targetMode = command.toString().toLowerCase(Locale.ENGLISH);
                 switch (channelUID.getId()) {
                     case DEVICE_CHANNEL_HUMIDIFIER_MODE:
                         if (!devContraints.fanModes.contains(targetMode)) {
@@ -479,8 +479,8 @@ public class VeSyncDeviceAirHumidifierHandler extends VeSyncBaseDeviceHandler {
         updateState(DEVICE_CHANNEL_ERROR_CODE, new DecimalType(humidifierStatus.result.result.errorCode));
         updateState(DEVICE_CHANNEL_AF_SCHEDULES_COUNT, new DecimalType(humidifierStatus.result.result.scheduleCount));
         if (humidifierStatus.result.result.timerRemain > 0) {
-            updateState(DEVICE_CHANNEL_AF_AUTO_OFF_CALC_TIME, new DateTimeType(LocalDateTime.now()
-                    .plus(humidifierStatus.result.result.timerRemain, ChronoUnit.MINUTES).toString()));
+            updateState(DEVICE_CHANNEL_AF_AUTO_OFF_CALC_TIME, new DateTimeType(
+                    Instant.now().plus(humidifierStatus.result.result.timerRemain, ChronoUnit.MINUTES)));
         } else {
             updateState(DEVICE_CHANNEL_AF_AUTO_OFF_CALC_TIME, new DateTimeItem("nullEnforcements").getState());
         }

--- a/bundles/org.openhab.binding.vesync/src/main/java/org/openhab/binding/vesync/internal/handlers/VeSyncDeviceAirPurifierHandler.java
+++ b/bundles/org.openhab.binding.vesync/src/main/java/org/openhab/binding/vesync/internal/handlers/VeSyncDeviceAirPurifierHandler.java
@@ -21,6 +21,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -67,7 +68,6 @@ import org.slf4j.LoggerFactory;
  * @author David Goodyear - Initial contribution
  */
 @NonNullByDefault
-@SuppressWarnings("serial")
 public class VeSyncDeviceAirPurifierHandler extends VeSyncBaseDeviceHandler {
 
     public static final String DEV_TYPE_FAMILY_AIR_PURIFIER = "LAP";
@@ -293,7 +293,7 @@ public class VeSyncDeviceAirPurifierHandler extends VeSyncBaseDeviceHandler {
             } else if (command instanceof StringType) {
                 switch (channelUID.getId()) {
                     case DEVICE_CHANNEL_FAN_MODE_ENABLED:
-                        final String targetFanMode = command.toString().toLowerCase();
+                        final String targetFanMode = command.toString().toLowerCase(Locale.ENGLISH);
 
                         if (!devContraints.isFanModeSupported(targetFanMode)) {
                             logger.warn("{}", getLocalizedText("warning.device.fan-mode-invalid", command,
@@ -317,7 +317,7 @@ public class VeSyncDeviceAirPurifierHandler extends VeSyncBaseDeviceHandler {
                         }
                         break;
                     case DEVICE_CHANNEL_AF_NIGHT_LIGHT:
-                        final String targetNightLightMode = command.toString().toLowerCase();
+                        final String targetNightLightMode = command.toString().toLowerCase(Locale.ENGLISH);
                         if (!devContraints.isNightLightModeSupported(targetNightLightMode)) {
                             logger.warn("{}", getLocalizedText("warning.device.night-light-invalid", command,
                                     devContraints.deviceFamilyName, String.join(",", devContraints.nightLightModes)));


### PR DESCRIPTION
[veSync] Auth V2 Support so users can use the binding again (#20236)

Backport of changes for 4.3.X for changes applied in commit`4895202d5e172854b74559dc9dc46dfe8d685b4b` on this commit to main: https://github.com/openhab/openhab-addons/commit/4895202d5e172854b74559dc9dc46dfe8d685b4b


