### PR TITLE
[teslascope] Improve handling of http 500/502 errors

### DIFF
--- a/bundles/org.openhab.binding.teslascope/src/main/java/org/openhab/binding/teslascope/internal/TeslascopeAccountHandler.java
+++ b/bundles/org.openhab.binding.teslascope/src/main/java/org/openhab/binding/teslascope/internal/TeslascopeAccountHandler.java
@@ -73,7 +73,7 @@ public class TeslascopeAccountHandler extends BaseBridgeHandler {
                 updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
                         "Authentication problem: " + e.getMessage());
             } catch (TeslascopeCommunicationException e) {
-                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
+                updateStatus(ThingStatus.UNKNOWN, ThingStatusDetail.COMMUNICATION_ERROR,
                         "Communication problem: " + e.getMessage());
             }
         }
@@ -89,7 +89,7 @@ public class TeslascopeAccountHandler extends BaseBridgeHandler {
                 updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
                         "Authentication problem: " + e.getMessage());
             } catch (TeslascopeCommunicationException e) {
-                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
+                updateStatus(ThingStatus.UNKNOWN, ThingStatusDetail.COMMUNICATION_ERROR,
                         "Communication problem: " + e.getMessage());
             }
         }
@@ -105,7 +105,7 @@ public class TeslascopeAccountHandler extends BaseBridgeHandler {
                 updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
                         "Authentication problem: " + e.getMessage());
             } catch (TeslascopeCommunicationException e) {
-                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
+                updateStatus(ThingStatus.UNKNOWN, ThingStatusDetail.COMMUNICATION_ERROR,
                         "Communication problem: " + e.getMessage());
             }
         }
@@ -120,7 +120,7 @@ public class TeslascopeAccountHandler extends BaseBridgeHandler {
                 updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
                         "Authentication problem: " + e.getMessage());
             } catch (TeslascopeCommunicationException e) {
-                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
+                updateStatus(ThingStatus.UNKNOWN, ThingStatusDetail.COMMUNICATION_ERROR,
                         "Communication problem: " + e.getMessage());
             }
         }

--- a/bundles/org.openhab.binding.teslascope/src/main/java/org/openhab/binding/teslascope/internal/TeslascopeAccountHandler.java
+++ b/bundles/org.openhab.binding.teslascope/src/main/java/org/openhab/binding/teslascope/internal/TeslascopeAccountHandler.java
@@ -73,7 +73,7 @@ public class TeslascopeAccountHandler extends BaseBridgeHandler {
                 updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
                         "Authentication problem: " + e.getMessage());
             } catch (TeslascopeCommunicationException e) {
-                updateStatus(ThingStatus.UNKNOWN, ThingStatusDetail.COMMUNICATION_ERROR,
+                updateStatus(ThingStatus.UNKNOWN, ThingStatusDetail.NONE,
                         "Communication problem: " + e.getMessage());
             }
         }
@@ -89,7 +89,7 @@ public class TeslascopeAccountHandler extends BaseBridgeHandler {
                 updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
                         "Authentication problem: " + e.getMessage());
             } catch (TeslascopeCommunicationException e) {
-                updateStatus(ThingStatus.UNKNOWN, ThingStatusDetail.COMMUNICATION_ERROR,
+                updateStatus(ThingStatus.UNKNOWN, ThingStatusDetail.NONE,
                         "Communication problem: " + e.getMessage());
             }
         }
@@ -105,7 +105,7 @@ public class TeslascopeAccountHandler extends BaseBridgeHandler {
                 updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
                         "Authentication problem: " + e.getMessage());
             } catch (TeslascopeCommunicationException e) {
-                updateStatus(ThingStatus.UNKNOWN, ThingStatusDetail.COMMUNICATION_ERROR,
+                updateStatus(ThingStatus.UNKNOWN, ThingStatusDetail.NONE,
                         "Communication problem: " + e.getMessage());
             }
         }
@@ -120,7 +120,7 @@ public class TeslascopeAccountHandler extends BaseBridgeHandler {
                 updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
                         "Authentication problem: " + e.getMessage());
             } catch (TeslascopeCommunicationException e) {
-                updateStatus(ThingStatus.UNKNOWN, ThingStatusDetail.COMMUNICATION_ERROR,
+                updateStatus(ThingStatus.UNKNOWN, ThingStatusDetail.NONE,
                         "Communication problem: " + e.getMessage());
             }
         }

--- a/bundles/org.openhab.binding.teslascope/src/main/java/org/openhab/binding/teslascope/internal/TeslascopeAccountHandler.java
+++ b/bundles/org.openhab.binding.teslascope/src/main/java/org/openhab/binding/teslascope/internal/TeslascopeAccountHandler.java
@@ -73,8 +73,7 @@ public class TeslascopeAccountHandler extends BaseBridgeHandler {
                 updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
                         "Authentication problem: " + e.getMessage());
             } catch (TeslascopeCommunicationException e) {
-                updateStatus(ThingStatus.UNKNOWN, ThingStatusDetail.NONE,
-                        "Communication problem: " + e.getMessage());
+                updateStatus(ThingStatus.UNKNOWN, ThingStatusDetail.NONE, "Communication problem: " + e.getMessage());
             }
         }
         return "";
@@ -89,8 +88,7 @@ public class TeslascopeAccountHandler extends BaseBridgeHandler {
                 updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
                         "Authentication problem: " + e.getMessage());
             } catch (TeslascopeCommunicationException e) {
-                updateStatus(ThingStatus.UNKNOWN, ThingStatusDetail.NONE,
-                        "Communication problem: " + e.getMessage());
+                updateStatus(ThingStatus.UNKNOWN, ThingStatusDetail.NONE, "Communication problem: " + e.getMessage());
             }
         }
         return "";
@@ -105,8 +103,7 @@ public class TeslascopeAccountHandler extends BaseBridgeHandler {
                 updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
                         "Authentication problem: " + e.getMessage());
             } catch (TeslascopeCommunicationException e) {
-                updateStatus(ThingStatus.UNKNOWN, ThingStatusDetail.NONE,
-                        "Communication problem: " + e.getMessage());
+                updateStatus(ThingStatus.UNKNOWN, ThingStatusDetail.NONE, "Communication problem: " + e.getMessage());
             }
         }
     }
@@ -120,8 +117,7 @@ public class TeslascopeAccountHandler extends BaseBridgeHandler {
                 updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
                         "Authentication problem: " + e.getMessage());
             } catch (TeslascopeCommunicationException e) {
-                updateStatus(ThingStatus.UNKNOWN, ThingStatusDetail.NONE,
-                        "Communication problem: " + e.getMessage());
+                updateStatus(ThingStatus.UNKNOWN, ThingStatusDetail.NONE, "Communication problem: " + e.getMessage());
             }
         }
     }

--- a/bundles/org.openhab.binding.teslascope/src/main/java/org/openhab/binding/teslascope/internal/TeslascopeAccountHandler.java
+++ b/bundles/org.openhab.binding.teslascope/src/main/java/org/openhab/binding/teslascope/internal/TeslascopeAccountHandler.java
@@ -73,7 +73,8 @@ public class TeslascopeAccountHandler extends BaseBridgeHandler {
                 updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
                         "Authentication problem: " + e.getMessage());
             } catch (TeslascopeCommunicationException e) {
-                updateStatus(ThingStatus.UNKNOWN, ThingStatusDetail.NONE, "Communication problem: " + e.getMessage());
+                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
+                        "Communication problem: " + e.getMessage());
             }
         }
         return "";
@@ -88,7 +89,8 @@ public class TeslascopeAccountHandler extends BaseBridgeHandler {
                 updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
                         "Authentication problem: " + e.getMessage());
             } catch (TeslascopeCommunicationException e) {
-                updateStatus(ThingStatus.UNKNOWN, ThingStatusDetail.NONE, "Communication problem: " + e.getMessage());
+                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
+                        "Communication problem: " + e.getMessage());
             }
         }
         return "";
@@ -103,7 +105,8 @@ public class TeslascopeAccountHandler extends BaseBridgeHandler {
                 updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
                         "Authentication problem: " + e.getMessage());
             } catch (TeslascopeCommunicationException e) {
-                updateStatus(ThingStatus.UNKNOWN, ThingStatusDetail.NONE, "Communication problem: " + e.getMessage());
+                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
+                        "Communication problem: " + e.getMessage());
             }
         }
     }
@@ -117,7 +120,8 @@ public class TeslascopeAccountHandler extends BaseBridgeHandler {
                 updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
                         "Authentication problem: " + e.getMessage());
             } catch (TeslascopeCommunicationException e) {
-                updateStatus(ThingStatus.UNKNOWN, ThingStatusDetail.NONE, "Communication problem: " + e.getMessage());
+                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
+                        "Communication problem: " + e.getMessage());
             }
         }
     }

--- a/bundles/org.openhab.binding.teslascope/src/main/java/org/openhab/binding/teslascope/internal/TeslascopeWebTargets.java
+++ b/bundles/org.openhab.binding.teslascope/src/main/java/org/openhab/binding/teslascope/internal/TeslascopeWebTargets.java
@@ -104,7 +104,6 @@ public class TeslascopeWebTargets {
                 if (HttpStatus.isSuccess(status)) {
                     jsonResponse = response.getContentAsString();
                     logger.trace("JSON response: '{}'", jsonResponse);
-                    return jsonResponse;
                 } else {
                     switch (status) {
                         case HttpStatus.UNAUTHORIZED_401:
@@ -112,17 +111,18 @@ public class TeslascopeWebTargets {
                         case HttpStatus.INTERNAL_SERVER_ERROR_500:
                         case HttpStatus.BAD_GATEWAY_502:
                             logger.debug("Teslascope returned {}, retrying", status);
+                            Thread.sleep(2000);
                         default:
                             throw new TeslascopeCommunicationException(
                                     String.format("Teslascope returned error <%d> while invoking %s", status, uri));
                     }
                 }
-                Thread.sleep(2000);
             } catch (InterruptedException ex) {
                 Thread.currentThread().interrupt();
                 throw new TeslascopeCommunicationException(ex.getLocalizedMessage(), ex);
             } catch (TimeoutException | ExecutionException ex) {
-                throw new TeslascopeCommunicationException(ex.getLocalizedMessage(), ex);            }
+                throw new TeslascopeCommunicationException(ex.getLocalizedMessage(), ex);
+            }
         }
         return jsonResponse;
     }

--- a/bundles/org.openhab.binding.teslascope/src/main/java/org/openhab/binding/teslascope/internal/TeslascopeWebTargets.java
+++ b/bundles/org.openhab.binding.teslascope/src/main/java/org/openhab/binding/teslascope/internal/TeslascopeWebTargets.java
@@ -105,10 +105,6 @@ public class TeslascopeWebTargets {
                 switch (status) {
                     case HttpStatus.UNAUTHORIZED_401:
                         throw new TeslascopeAuthenticationException("Unauthorized");
-                    case HttpStatus.INTERNAL_SERVER_ERROR_500:
-                    case HttpStatus.BAD_GATEWAY_502:
-                        logger.debug("Http error 500/502 received, continuing");
-                        break;
                     default:
                         throw new TeslascopeCommunicationException(
                                 String.format("Teslascope returned error <%d> while invoking %s", status, uri));

--- a/bundles/org.openhab.binding.teslascope/src/main/java/org/openhab/binding/teslascope/internal/TeslascopeWebTargets.java
+++ b/bundles/org.openhab.binding.teslascope/src/main/java/org/openhab/binding/teslascope/internal/TeslascopeWebTargets.java
@@ -97,20 +97,24 @@ public class TeslascopeWebTargets {
                 logger.trace("{} request for {}", HttpMethod.GET, uri);
             }
             ContentResponse response = request.send();
-            status = response.getStatus();
-            jsonResponse = response.getContentAsString();
-            logger.trace("JSON response: '{}'", jsonResponse);
-            if (status == HttpStatus.UNAUTHORIZED_401) {
-                throw new TeslascopeAuthenticationException("Unauthorized");
-            }
-            if (!HttpStatus.isSuccess(status)) {
-                throw new TeslascopeCommunicationException(
-                        String.format("Teslascope returned error <%d> while invoking %s", status, uri));
+            switch (response.getStatus()) {
+                case HttpStatus.OK_200:
+                    jsonResponse = response.getContentAsString();
+                    logger.trace("JSON response: '{}'", jsonResponse);
+                    break;
+                case HttpStatus.UNAUTHORIZED_401:
+                    throw new TeslascopeAuthenticationException("Unauthorized");
+                case HttpStatus.INTERNAL_SERVER_ERROR_500:
+                case HttpStatus.BAD_GATEWAY_502:
+                    logger.debug("Http error 500/502 received, continuing");
+                    break;
+                default:
+                    throw new TeslascopeCommunicationException(
+                            String.format("Teslascope returned error <%d> while invoking %s", status, uri));
             }
         } catch (TimeoutException | ExecutionException | InterruptedException ex) {
             throw new TeslascopeCommunicationException(ex.getLocalizedMessage(), ex);
         }
-
         return jsonResponse;
     }
 }

--- a/bundles/org.openhab.binding.teslascope/src/main/java/org/openhab/binding/teslascope/internal/TeslascopeWebTargets.java
+++ b/bundles/org.openhab.binding.teslascope/src/main/java/org/openhab/binding/teslascope/internal/TeslascopeWebTargets.java
@@ -87,31 +87,38 @@ public class TeslascopeWebTargets {
         logger.debug("Calling url: {}", uri);
         String jsonResponse = "";
         int status = 0;
-        try {
-            Request request = httpClient.newRequest(uri).method(HttpMethod.GET).timeout(TIMEOUT_MS,
-                    TimeUnit.MILLISECONDS);
-            if (!personalAccessToken.isBlank()) {
-                request.header(HttpHeader.AUTHORIZATION.asString(), "Bearer " + personalAccessToken);
-            }
-            if (logger.isTraceEnabled()) {
-                logger.trace("{} request for {}", HttpMethod.GET, uri);
-            }
-            ContentResponse response = request.send();
-            status = response.getStatus();
-            if (HttpStatus.isSuccess(status)) {
-                jsonResponse = response.getContentAsString();
-                logger.trace("JSON response: '{}'", jsonResponse);
-            } else {
-                switch (status) {
-                    case HttpStatus.UNAUTHORIZED_401:
-                        throw new TeslascopeAuthenticationException("Unauthorized");
-                    default:
-                        throw new TeslascopeCommunicationException(
-                                String.format("Teslascope returned error <%d> while invoking %s", status, uri));
+        int retry = 0;
+        for (int retryCounter = 1; retryCounter <= 3; retryCounter++) {
+            try {
+                Request request = httpClient.newRequest(uri).method(HttpMethod.GET).timeout(TIMEOUT_MS,
+                        TimeUnit.MILLISECONDS);
+                if (!personalAccessToken.isBlank()) {
+                    request.header(HttpHeader.AUTHORIZATION.asString(), "Bearer " + personalAccessToken);
                 }
+                if (logger.isTraceEnabled()) {
+                    logger.trace("{} request for {}", HttpMethod.GET, uri);
+                }
+                ContentResponse response = request.send();
+                status = response.getStatus();
+                if (HttpStatus.isSuccess(status)) {
+                    jsonResponse = response.getContentAsString();
+                    logger.trace("JSON response: '{}'", jsonResponse);
+                } else {
+                    switch (status) {
+                        case HttpStatus.UNAUTHORIZED_401:
+                            throw new TeslascopeAuthenticationException("Unauthorized");
+                        case HttpStatus.INTERNAL_SERVER_ERROR_500:
+                        case HttpStatus.BAD_GATEWAY_502:
+                            logger.debug("Teslascope returned {}, retrying", status);
+                        default:
+                            throw new TeslascopeCommunicationException(
+                                    String.format("Teslascope returned error <%d> while invoking %s", status, uri));
+                    }
+                }
+                Thread.sleep(2000);
+            } catch (TimeoutException | ExecutionException | InterruptedException ex) {
+                throw new TeslascopeCommunicationException(ex.getLocalizedMessage(), ex);
             }
-        } catch (TimeoutException | ExecutionException | InterruptedException ex) {
-            throw new TeslascopeCommunicationException(ex.getLocalizedMessage(), ex);
         }
         return jsonResponse;
     }

--- a/bundles/org.openhab.binding.teslascope/src/main/java/org/openhab/binding/teslascope/internal/TeslascopeWebTargets.java
+++ b/bundles/org.openhab.binding.teslascope/src/main/java/org/openhab/binding/teslascope/internal/TeslascopeWebTargets.java
@@ -97,20 +97,22 @@ public class TeslascopeWebTargets {
                 logger.trace("{} request for {}", HttpMethod.GET, uri);
             }
             ContentResponse response = request.send();
-            switch (response.getStatus()) {
-                case HttpStatus.OK_200:
-                    jsonResponse = response.getContentAsString();
-                    logger.trace("JSON response: '{}'", jsonResponse);
-                    break;
-                case HttpStatus.UNAUTHORIZED_401:
-                    throw new TeslascopeAuthenticationException("Unauthorized");
-                case HttpStatus.INTERNAL_SERVER_ERROR_500:
-                case HttpStatus.BAD_GATEWAY_502:
-                    logger.debug("Http error 500/502 received, continuing");
-                    break;
-                default:
-                    throw new TeslascopeCommunicationException(
-                            String.format("Teslascope returned error <%d> while invoking %s", status, uri));
+            status = response.getStatus();
+            if (HttpStatus.isSuccess(status)) {
+                jsonResponse = response.getContentAsString();
+                logger.trace("JSON response: '{}'", jsonResponse);
+            } else {
+                switch (status) {
+                    case HttpStatus.UNAUTHORIZED_401:
+                        throw new TeslascopeAuthenticationException("Unauthorized");
+                    case HttpStatus.INTERNAL_SERVER_ERROR_500:
+                    case HttpStatus.BAD_GATEWAY_502:
+                        logger.debug("Http error 500/502 received, continuing");
+                        break;
+                    default:
+                        throw new TeslascopeCommunicationException(
+                                String.format("Teslascope returned error <%d> while invoking %s", status, uri));
+                }
             }
         } catch (TimeoutException | ExecutionException | InterruptedException ex) {
             throw new TeslascopeCommunicationException(ex.getLocalizedMessage(), ex);

--- a/bundles/org.openhab.binding.teslascope/src/main/java/org/openhab/binding/teslascope/internal/TeslascopeWebTargets.java
+++ b/bundles/org.openhab.binding.teslascope/src/main/java/org/openhab/binding/teslascope/internal/TeslascopeWebTargets.java
@@ -35,6 +35,7 @@ import org.slf4j.LoggerFactory;
 @NonNullByDefault
 public class TeslascopeWebTargets {
     private static final int TIMEOUT_MS = 30000;
+    private static final int MAX_RETRIES = 3;
     private static final String BASE_URI = "https://teslascope.com/api/";
     private static final String BASE_VEHICLE_URI = BASE_URI + "vehicle/";
     private final Logger logger = LoggerFactory.getLogger(TeslascopeWebTargets.class);
@@ -87,8 +88,8 @@ public class TeslascopeWebTargets {
         logger.debug("Calling url: {}", uri);
         String jsonResponse = "";
         int status = 0;
-        int retry = 0;
-        for (int retryCounter = 1; retryCounter <= 3; retryCounter++) {
+
+        for (int retryCounter = 1; retryCounter <= MAX_RETRIES; retryCounter++) {
             try {
                 Request request = httpClient.newRequest(uri).method(HttpMethod.GET).timeout(TIMEOUT_MS,
                         TimeUnit.MILLISECONDS);
@@ -103,6 +104,7 @@ public class TeslascopeWebTargets {
                 if (HttpStatus.isSuccess(status)) {
                     jsonResponse = response.getContentAsString();
                     logger.trace("JSON response: '{}'", jsonResponse);
+                    return jsonResponse;
                 } else {
                     switch (status) {
                         case HttpStatus.UNAUTHORIZED_401:
@@ -116,9 +118,11 @@ public class TeslascopeWebTargets {
                     }
                 }
                 Thread.sleep(2000);
-            } catch (TimeoutException | ExecutionException | InterruptedException ex) {
+            } catch (InterruptedException ex) {
+                Thread.currentThread().interrupt();
                 throw new TeslascopeCommunicationException(ex.getLocalizedMessage(), ex);
-            }
+            } catch (TimeoutException | ExecutionException ex) {
+                throw new TeslascopeCommunicationException(ex.getLocalizedMessage(), ex);            }
         }
         return jsonResponse;
     }

--- a/bundles/org.openhab.binding.teslascope/src/main/java/org/openhab/binding/teslascope/internal/TeslascopeWebTargets.java
+++ b/bundles/org.openhab.binding.teslascope/src/main/java/org/openhab/binding/teslascope/internal/TeslascopeWebTargets.java
@@ -112,6 +112,7 @@ public class TeslascopeWebTargets {
                         case HttpStatus.BAD_GATEWAY_502:
                             logger.debug("Teslascope returned {}, retrying", status);
                             Thread.sleep(2000);
+                            break;
                         default:
                             throw new TeslascopeCommunicationException(
                                     String.format("Teslascope returned error <%d> while invoking %s", status, uri));


### PR DESCRIPTION
In the last few weeks, I've been getting some 500/502 errors from the Teslascope servers, which the current code was treating as an exception, and taking the bridge offline, causing other issues.

I'm now ignoring 500/502 errors and treating them as being transient errors. I've been running this for the last 15 hours or so, and thus far, seems to be a winner.

Also open to better approaches.