### PR TITLE
[ntfy] Initial contribution

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -284,6 +284,7 @@
 /bundles/org.openhab.binding.nikohomecontrol/ @mherwege
 /bundles/org.openhab.binding.nobohub/ @espenaf
 /bundles/org.openhab.binding.novafinedust/ @t2000
+/bundles/org.openhab.binding.ntfy/ @EvilPingu
 /bundles/org.openhab.binding.ntp/ @marcelrv
 /bundles/org.openhab.binding.nuki/ @janvyb
 /bundles/org.openhab.binding.nuvo/ @mlobstein

--- a/bom/openhab-addons/pom.xml
+++ b/bom/openhab-addons/pom.xml
@@ -1403,6 +1403,11 @@
     </dependency>
     <dependency>
       <groupId>org.openhab.addons.bundles</groupId>
+      <artifactId>org.openhab.binding.ntfy</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.openhab.addons.bundles</groupId>
       <artifactId>org.openhab.binding.ntp</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/bundles/org.openhab.binding.ntfy/NOTICE
+++ b/bundles/org.openhab.binding.ntfy/NOTICE
@@ -1,0 +1,13 @@
+This content is produced and maintained by the openHAB project.
+
+* Project home: https://www.openhab.org
+
+== Declared Project Licenses
+
+This program and the accompanying materials are made available under the terms
+of the Eclipse Public License 2.0 which is available at
+https://www.eclipse.org/legal/epl-2.0/.
+
+== Source Code
+
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.ntfy/README.md
+++ b/bundles/org.openhab.binding.ntfy/README.md
@@ -19,12 +19,12 @@ This binding provides the following Thing types. The Thing type IDs match the de
 
 ### `ntfyConnection` Bridge Configuration
 
-| Name              | Type    | Description                             | Default         | Required | Advanced |
-|-------------------|---------|-----------------------------------------|-----------------|----------|----------|
-| hostname          | text    | Hostname or base URL of the ntfy server | [https://ntfy.sh](https://ntfy.sh) | yes      | no       |
-| username          | text    | Optional username for basic auth        | N/A             | no       | no       |
-| password          | text    | Optional password for basic auth        | N/A             | no       | no       |
-| connectionTimeout | integer | WebSocket / HTTP connection timeout ms  | 60000           | no       | yes      |
+| Name              | Type    | Description                             | Default                            | Required | Advanced |
+|-------------------|---------|-----------------------------------------|------------------------------------|----------|----------|
+| hostname          | text    | Base URL of the ntfy server             | [https://ntfy.sh](https://ntfy.sh) | yes      | no       |
+| username          | text    | Optional username for basic auth        | N/A                                | no       | no       |
+| password          | text    | Optional password for basic auth        | N/A                                | no       | no       |
+| connectionTimeout | integer | WebSocket / HTTP connection timeout ms  | 60000                              | no       | yes      |
 
 Configure the `ntfyConnection` as a bridge to hold shared server and authentication settings. Topic Things reference the bridge to reuse these settings.
 
@@ -38,10 +38,11 @@ Configure the `ntfyConnection` as a bridge to hold shared server and authenticat
 
 ### `ntfyTopic` Channels
 
-| Channel     | Type     | Read/Write | Description                                 |
-|-------------|----------|------------|---------------------------------------------|
-| lastMessage | String   | R          | Last received message payload (read-only)   |
-| messageTime | DateTime | R          | Timestamp of the last message (read-only)   |
+| Channel         | Type     | Read/Write | Description                                 |
+|-----------------|----------|------------|---------------------------------------------|
+| lastMessage     | String   | R          | Last received message payload (read-only)   |
+| lastMessageTime | DateTime | R          | Timestamp of the last message (read-only)   |
+| lastMessageId   | String   | R          | ID of the last message (read-only)          |
 
 ## Full Example
 
@@ -92,22 +93,23 @@ Important: Always check that the returned actions object is not null (the Thing 
 
 Below is a quick reference of the builder-style methods provided by the binding actions. Use these to construct messages before calling `send()`.
 
-| Method | Parameters | Description | Ntfy docs |
-|--------|------------|-------------|----------|
-| withMessage | (String message) | Set the main message text. | [publish](https://docs.ntfy.sh/publish/#message-title) |
-| withPriority | (int priority) | Set message priority (0-5). | [priority](https://ntfy.sh/docs/publish/#priority) |
-| withTag | (String tag) | Add a tag to the message. | [tags](https://ntfy.sh/docs/publish/#tags) |
-| withIcon | (String url) | Set an icon URL for the notification. | [icons](https://ntfy.sh/docs/publish/#icons) |
-| withAttachment | (String url, String filename) | Attach a file or resource URL with optional filename. | [attachments](https://docs.ntfy.sh/publish/#attach-file-from-a-url) |
-| withViewAction | (String label, Boolean clearNotification, String url) | Add a view action (opens URL) with optional clear flag. | [actions](https://docs.ntfy.sh/publish/#open-websiteapp) |
-| withCopyAction | (String label, Boolean clearNotification, String value) | Add an action that copies text to clipboard on the client. | [actions](https://docs.ntfy.sh/publish/#copy-to-clipboard) |
-| withHttpAction | (String label, Boolean clearNotification, String url, String method, String headers, String body) | Add an HTTP action with optional method, headers and body. | [actions](https://docs.ntfy.sh/publish/#send-http-request) |
-| withBroadcastAction | (String label, Boolean clearNotification, String params) | Add a broadcast action to trigger local apps/handlers. | [actions](https://docs.ntfy.sh/publish/#send-android-broadcast) |
-| withDelay | (String delay) | Assign a delay. | [delay](https://docs.ntfy.sh/publish/#scheduled-delivery) |
-| withSequenceId | (String sequenceId) | Assign a sequence id for later reference (useful for delete/update). | [sequence id](https://docs.ntfy.sh/publish/#updating-deleting-notifications) |
-| send | () | Send the built message; returns a message ID string. | [publish](https://ntfy.sh/docs/publish/) |
-| send | (String file, String filename, String sequenceId) | Send a file; returns a message ID string. | [publish_local_file](https://docs.ntfy.sh/publish/#attach-local-file) |
-| delete | (String sequenceId) | Delete a message previously sent with the given sequence id. | [delete](https://ntfy.sh/docs/publish/#deleting-notifications) |
+| Method              | Parameters                                                                                        | Description                                                          | Ntfy docs                                                                    |
+|---------------------|---------------------------------------------------------------------------------------------------|----------------------------------------------------------------------|------------------------------------------------------------------------------|
+| withMessage         | (String message)                                                                                  | Set the main message text.                                           | [publish](https://docs.ntfy.sh/publish)                                      |
+| withPriority        | (int priority)                                                                                    | Set message priority (1-5).                                          | [priority](https://ntfy.sh/docs/publish/#priority)                           |
+| withTitle           | (String title)                                                                                    | Set title.                                                           | [title](https://docs.ntfy.sh/publish/#message-title)                         |
+| withTag             | (String tag)                                                                                      | Add a tag to the message.                                            | [tags](https://ntfy.sh/docs/publish/#tags)                                   |
+| withIcon            | (String url)                                                                                      | Set an icon URL for the notification.                                | [icons](https://ntfy.sh/docs/publish/#icons)                                 |
+| withAttachment      | (String url, String filename)                                                                     | Attach a file or resource URL with optional filename.                | [attachments](https://docs.ntfy.sh/publish/#attach-file-from-a-url)          |
+| withViewAction      | (String label, Boolean clearNotification, String url)                                             | Add a view action (opens URL) with optional clear flag.              | [actions](https://docs.ntfy.sh/publish/#open-websiteapp)                     |
+| withCopyAction      | (String label, Boolean clearNotification, String value)                                           | Add an action that copies text to clipboard on the client.           | [actions](https://docs.ntfy.sh/publish/#copy-to-clipboard)                   |
+| withHttpAction      | (String label, Boolean clearNotification, String url, String method, String headers, String body) | Add an HTTP action with optional method, headers and body.           | [actions](https://docs.ntfy.sh/publish/#send-http-request)                   |
+| withBroadcastAction | (String label, Boolean clearNotification, String params)                                          | Add a broadcast action to trigger local apps/handlers.               | [actions](https://docs.ntfy.sh/publish/#send-android-broadcast)              |
+| withDelay           | (String delay)                                                                                    | Assign a delay.                                                      | [delay](https://docs.ntfy.sh/publish/#scheduled-delivery)                    |
+| withSequenceId      | (String sequenceId)                                                                               | Assign a sequence id for later reference (useful for delete/update). | [sequence id](https://docs.ntfy.sh/publish/#updating-deleting-notifications) |
+| send                | ()                                                                                                | Send the built message; returns a message ID string.                 | [publish](https://ntfy.sh/docs/publish/)                                     |
+| send                | (String file, String filename, String sequenceId)                                                 | Send a file; returns a message ID string.                            | [publish_local_file](https://docs.ntfy.sh/publish/#attach-local-file)        |
+| delete              | (String sequenceId)                                                                               | Delete a message previously sent with the given sequence id.         | [delete](https://ntfy.sh/docs/publish/#deleting-notifications)               |
 
 For more information about ntfy features and the notification format, see the ntfy project documentation: [https://ntfy.sh/docs/](https://ntfy.sh/docs/)
 

--- a/bundles/org.openhab.binding.ntfy/README.md
+++ b/bundles/org.openhab.binding.ntfy/README.md
@@ -1,0 +1,158 @@
+# Ntfy Binding
+
+The Ntfy binding enables openHAB to publish notifications to Ntfy-compatible servers (for example [ntfy.sh](https://ntfy.sh) or a self-hosted ntfy-compatible endpoint).
+
+Ntfy is a simple HTTP-based notification service and message broker; see [ntfy.sh](https://ntfy.sh) for details and public servers.
+
+It is intended for integrations where openHAB should push alert or informational messages to mobile or desktop clients that support the Ntfy protocol. The binding supports basic text messages as well as common rich features supported by the protocol: message priority, tags, icon URLs, attachments, click actions and simple action buttons.
+
+Typical uses include doorbell alerts, security notifications, system health messages, or any automation that should notify users in real time via an Ntfy-compatible notification channel.
+
+## Supported Things
+
+This binding provides the following Thing types. The Thing type IDs match the definitions in `src/main/resources/OH-INF/thing/thing-types.xml`.
+
+- `ntfy:ntfyConnection` (bridge) — Represents a connection to an Ntfy server. Configure the bridge with the server hostname (for example `https://ntfy.sh`) and optional credentials (username/password). The bridge holds shared connection settings (hostname, username, password, connectionTimeout) which are used by topic Things.
+- `ntfy:ntfyTopic` (Thing) — Represents a topic/channel on a configured Ntfy server. Each topic Thing must be associated with an `ntfyConnection` bridge and requires the `topicname` configuration parameter.
+
+## Thing Configuration
+
+### `ntfyConnection` Bridge Configuration
+
+| Name              | Type    | Description                             | Default         | Required | Advanced |
+|-------------------|---------|-----------------------------------------|-----------------|----------|----------|
+| hostname          | text    | Hostname or base URL of the ntfy server | [https://ntfy.sh](https://ntfy.sh) | yes      | no       |
+| username          | text    | Optional username for basic auth        | N/A             | no       | no       |
+| password          | text    | Optional password for basic auth        | N/A             | no       | no       |
+| connectionTimeout | integer | WebSocket / HTTP connection timeout ms  | 60000           | no       | yes      |
+
+Configure the `ntfyConnection` as a bridge to hold shared server and authentication settings. Topic Things reference the bridge to reuse these settings.
+
+### `ntfyTopic` Thing Configuration
+
+| Name      | Type | Description               | Default | Required | Advanced |
+|-----------|------|---------------------------|---------|----------|----------|
+| topicname | text | Name of the topic/channel | N/A     | yes      | no       |
+
+## Channels
+
+### `ntfyTopic` Channels
+
+| Channel     | Type     | Read/Write | Description                                 |
+|-------------|----------|------------|---------------------------------------------|
+| lastMessage | String   | R          | Last received message payload (read-only)   |
+| messageTime | DateTime | R          | Timestamp of the last message (read-only)   |
+
+## Full Example
+
+Below are examples for textual configuration files showing a bridge (`ntfyConnection`), a topic Thing (`ntfyTopic`), Items bound to the Thing's channels, and a simple sitemap to display the last message and its timestamp.
+
+### Thing Configuration
+
+```things
+Bridge ntfy:ntfyConnection:myConn "Ntfy Server" [ hostname="https://ntfy.sh", connectionTimeout=60000 ]
+
+Thing ntfy:ntfyTopic:home "Front Door Notifications" (ntfy:ntfyConnection:myConn) [ topicname="home" ]
+```
+
+If your server requires authentication, supply `username` and `password` in the bridge configuration. The `topicname` must be provided for each `ntfyTopic` Thing.
+
+### Item Configuration (items file)
+
+Bind Items to the read-only channels exposed by the topic Thing to show the last received message and its timestamp:
+
+```items
+String FrontDoorLastMessage "Front Door Message" { channel="ntfy:ntfyTopic:home:lastMessage" }
+DateTime FrontDoorMessageTime "Last message received" { channel="ntfy:ntfyTopic:home:messageTime" }
+```
+
+Note: Sending notifications from openHAB to ntfy is done via the binding's Actions from rules (the binding exposes Actions to publish/delete messages). The channels above are read-only and show incoming or last-state values.
+
+### Sitemap Configuration (sitemap file)
+
+Simple sitemap demonstrating how to display the last message and its timestamp:
+
+```sitemap
+ sitemap notifications label="Notifications"
+{
+    <Frame label="Front Door">
+        Text item=FrontDoorLastMessage label="Last message [%s]"
+        Text item=FrontDoorMessageTime label="Received [%1$td.%1$tm.%1$tY %1$tR]"
+    </Frame>
+}
+```
+
+## Actions (Rules DSL and JavaScript)
+
+This binding exposes Rule Actions to send and manage messages on a configured topic. Actions are available for use from the Rules DSL and the ECMAScript/JavaScript automation scripts. The actions support a builder-style API to configure a message (message text, priority, tags, icon, attachments, actions, sequence id, ...) and then send it.
+
+Important: Always check that the returned actions object is not null (the Thing must exist and be handled by the binding) before invoking methods.
+
+### Available action methods
+
+Below is a quick reference of the builder-style methods provided by the binding actions. Use these to construct messages before calling `send()`.
+
+| Method | Parameters | Description | Ntfy docs |
+|--------|------------|-------------|----------|
+| withMessage | (String message) | Set the main message text. | [publish](https://docs.ntfy.sh/publish/#message-title) |
+| withPriority | (int priority) | Set message priority (0-5). | [priority](https://ntfy.sh/docs/publish/#priority) |
+| withTag | (String tag) | Add a tag to the message. | [tags](https://ntfy.sh/docs/publish/#tags) |
+| withIcon | (String url) | Set an icon URL for the notification. | [icons](https://ntfy.sh/docs/publish/#icons) |
+| withAttachment | (String url, String filename) | Attach a file or resource URL with optional filename. | [attachments](https://docs.ntfy.sh/publish/#attach-file-from-a-url) |
+| withViewAction | (String label, Boolean clearNotification, String url) | Add a view action (opens URL) with optional clear flag. | [actions](https://docs.ntfy.sh/publish/#open-websiteapp) |
+| withCopyAction | (String label, Boolean clearNotification, String value) | Add an action that copies text to clipboard on the client. | [actions](https://docs.ntfy.sh/publish/#copy-to-clipboard) |
+| withHttpAction | (String label, Boolean clearNotification, String url, String method, String headers, String body) | Add an HTTP action with optional method, headers and body. | [actions](https://docs.ntfy.sh/publish/#send-http-request) |
+| withBroadcastAction | (String label, Boolean clearNotification, String params) | Add a broadcast action to trigger local apps/handlers. | [actions](https://docs.ntfy.sh/publish/#send-android-broadcast) |
+| withDelay | (String delay) | Assign a delay. | [delay](https://docs.ntfy.sh/publish/#scheduled-delivery) |
+| withSequenceId | (String sequenceId) | Assign a sequence id for later reference (useful for delete/update). | [sequence id](https://docs.ntfy.sh/publish/#updating-deleting-notifications) |
+| send | () | Send the built message; returns a message ID string. | [publish](https://ntfy.sh/docs/publish/) |
+| send | (String file, String filename, String sequenceId) | Send a file; returns a message ID string. | [publish_local_file](https://docs.ntfy.sh/publish/#attach-local-file) |
+| delete | (String sequenceId) | Delete a message previously sent with the given sequence id. | [delete](https://ntfy.sh/docs/publish/#deleting-notifications) |
+
+For more information about ntfy features and the notification format, see the ntfy project documentation: [https://ntfy.sh/docs/](https://ntfy.sh/docs/)
+
+### Rules DSL example
+
+```rules
+// Obtain the Thing-specific actions and use the builder to send a message
+val bindingActions = getActions("ntfy", "ntfy:ntfyTopic:frontdoor")
+if (bindingActions !== null) {
+    // simple one-liner: send a message
+    val msgId = bindingActions.withMessage("Someone is at the door").withPriority(4).send()
+
+    // or build up a more complex message
+    bindingActions.withMessage("Doorbell pressed")
+                  .withSequenceId("doorbell-1")
+                  .withTag("door")
+                  .withIcon("https://example.org/icons/door.png")
+                  .withViewAction("Open UI", true, "https://example.org/ui")
+                  .send()
+
+    // delete a previously sent message by sequence id
+    bindingActions.delete("doorbell-1")
+}
+```
+
+The builder methods available include: withMessage(String), withPriority(int), withTag(String), withIcon(String), withAttachment(String, String), withViewAction(...), withCopyAction(...), withHttpAction(...), withBroadcastAction(...), withSequenceId(String), send(), and delete(String).
+
+### ECMAScript / JavaScript example
+
+In ECMAScript scripts you can obtain the Thing Actions and use the same builder API. The example below assumes the automation engine provides an `actions` helper (typical in openHAB JavaScript environment):
+
+```javascript
+// get the Thing actions for the topic Thing
+var bindingActions = actions.get("ntfy", "ntfy:ntfyTopic:frontdoor");
+if (bindingActions) {
+    // send a simple message
+    var id = bindingActions.withMessage("Garage opened").withPriority(3).send();
+
+    // build and send a message with extra features
+    bindingActions.withMessage("Motion detected in garage")
+                  .withSequenceId("garage-1")
+                  .withTag("motion")
+                  .withHttpAction("Open Camera", true, "https://camera/local/snap", "POST", null, null)
+                  .send();
+}
+```
+
+If your scripting environment exposes a different API to retrieve Thing Actions, adapt the call accordingly. The important part is to obtain the Thing-specific actions object for the binding and then use the builder methods shown above.

--- a/bundles/org.openhab.binding.ntfy/README.md
+++ b/bundles/org.openhab.binding.ntfy/README.md
@@ -4,20 +4,21 @@ The Ntfy binding enables openHAB to publish notifications to Ntfy-compatible ser
 
 Ntfy is a simple HTTP-based notification service and message broker; see [ntfy.sh](https://ntfy.sh) for details and public servers.
 
-It is intended for integrations where openHAB should push alert or informational messages to mobile or desktop clients that support the Ntfy protocol. The binding supports basic text messages as well as common rich features supported by the protocol: message priority, tags, icon URLs, attachments, click actions and simple action buttons.
+It is intended for integrations where openHAB should push alert or informational messages to mobile or desktop clients that support the Ntfy protocol.
+The binding supports basic text messages as well as common rich features supported by the protocol: message priority, tags, icon URLs, attachments, click actions and simple action buttons
 
 Typical uses include doorbell alerts, security notifications, system health messages, or any automation that should notify users in real time via an Ntfy-compatible notification channel.
 
 ## Supported Things
 
-This binding provides the following Thing types. The Thing type IDs match the definitions in `src/main/resources/OH-INF/thing/thing-types.xml`.
+This binding provides the following Thing types:
 
-- `ntfy:ntfyConnection` (bridge) — Represents a connection to an Ntfy server. Configure the bridge with the server hostname (for example `https://ntfy.sh`) and optional credentials (username/password). The bridge holds shared connection settings (hostname, username, password, connectionTimeout) which are used by topic Things.
-- `ntfy:ntfyTopic` (Thing) — Represents a topic/channel on a configured Ntfy server. Each topic Thing must be associated with an `ntfyConnection` bridge and requires the `topicname` configuration parameter.
+- `server` (bridge) — Represents a connection to an Ntfy server. The bridge holds shared connection settings (hostname, username, password, connectionTimeout) which are used by topic Things.
+- `ntfy-topic` (Thing) — Represents a topic/channel on a configured Ntfy server. Each topic Thing must be associated with a `server` bridge.
 
 ## Thing Configuration
 
-### `ntfyConnection` Bridge Configuration
+### `server` Bridge Configuration
 
 | Name              | Type    | Description                                                                              | Default                            | Required | Advanced |
 |-------------------|---------|------------------------------------------------------------------------------------------|------------------------------------|----------|----------|
@@ -26,45 +27,44 @@ This binding provides the following Thing types. The Thing type IDs match the de
 | password          | text    | Optional password - if username is provided basic auth is used else Bearer token is used | N/A                                | no       | no       |
 | connectionTimeout | integer | WebSocket / HTTP connection timeout ms                                                   | 60000                              | no       | yes      |
 
-Configure the `ntfyConnection` as a bridge to hold shared server and authentication settings. Topic Things reference the bridge to reuse these settings. For authentication with access token only set the password and leave the username empty.
+Configure the `server` as a bridge to hold shared server and authentication settings.
+For authentication with access token only set the password and leave the username empty.
 
-### `ntfyTopic` Thing Configuration
+### `ntfy-topic` Thing Configuration
 
 | Name      | Type | Description               | Default | Required | Advanced |
 |-----------|------|---------------------------|---------|----------|----------|
-| topicname | text | Name of the topic/channel | N/A     | yes      | no       |
+| topicName | text | Name of the topic/channel | N/A     | yes      | no       |
 
 ## Channels
 
-### `ntfyTopic` Channels
+### `ntfy-topic` Channels
 
-| Channel         | Type     | Read/Write | Description                                 |
-|-----------------|----------|------------|---------------------------------------------|
-| lastMessage     | String   | R          | Last received message payload (read-only)   |
-| lastMessageTime | DateTime | R          | Timestamp of the last message (read-only)   |
-| lastMessageId   | String   | R          | ID of the last message (read-only)          |
+| Channel           | Type     | Read/Write | Description                                 |
+|-------------------|----------|------------|---------------------------------------------|
+| last-message      | String   | R          | Last received message payload (read-only)   |
+| last-message-time | DateTime | R          | Timestamp of the last message (read-only)   |
+| last-message-id   | String   | R          | ID of the last message (read-only)          |
 
 ## Full Example
 
-Below are examples for textual configuration files showing a bridge (`ntfyConnection`), a topic Thing (`ntfyTopic`), Items bound to the Thing's channels, and a simple sitemap to display the last message and its timestamp.
+Below are examples for textual configuration files showing a bridge (`server`), a topic Thing (`ntfy-topic`), Items bound to the Thing's channels, and a simple sitemap to display the last message and its timestamp.
 
 ### Thing Configuration
 
-```things
-Bridge ntfy:ntfyConnection:myConn "Ntfy Server" [ hostname="https://ntfy.sh", connectionTimeout=60000 ]
+```java
+Bridge ntfy:server:myConn "Ntfy Server" [ hostname="https://ntfy.sh", connectionTimeout=60000, username="ntfyUser", password="MyPaSsWoRd"]
 
-Thing ntfy:ntfyTopic:home "Front Door Notifications" (ntfy:ntfyConnection:myConn) [ topicname="home" ]
+Thing ntfy:ntfy-topic:home "Front Door Notifications" (ntfy:server:myConn) [ topicName="home" ]
 ```
-
-If your server requires authentication, supply `username` and `password` in the bridge configuration. The `topicname` must be provided for each `ntfyTopic` Thing.
 
 ### Item Configuration (items file)
 
 Bind Items to the read-only channels exposed by the topic Thing to show the last received message and its timestamp:
 
-```items
-String FrontDoorLastMessage "Front Door Message" { channel="ntfy:ntfyTopic:home:lastMessage" }
-DateTime FrontDoorMessageTime "Last message received" { channel="ntfy:ntfyTopic:home:messageTime" }
+```java
+String FrontDoorLastMessage "Front Door Message" { channel="ntfy:ntfy-topic:home:last-message" }
+DateTime FrontDoorMessageTime "Last message received" { channel="ntfy:ntfy-topic:home:last-message-time" }
 ```
 
 Note: Sending notifications from openHAB to ntfy is done via the binding's Actions from rules (the binding exposes Actions to publish/delete messages). The channels above are read-only and show incoming or last-state values.
@@ -73,7 +73,7 @@ Note: Sending notifications from openHAB to ntfy is done via the binding's Actio
 
 Simple sitemap demonstrating how to display the last message and its timestamp:
 
-```sitemap
+```perl
  sitemap notifications label="Notifications"
 {
     <Frame label="Front Door">
@@ -85,9 +85,11 @@ Simple sitemap demonstrating how to display the last message and its timestamp:
 
 ## Actions (Rules DSL and JavaScript)
 
-This binding exposes Rule Actions to send and manage messages on a configured topic. Actions are available for use from the Rules DSL and the ECMAScript/JavaScript automation scripts. The actions support a builder-style API to configure a message (message text, priority, tags, icon, attachments, actions, sequence id, ...) and then send it.
+This binding exposes Rule Actions to send and manage messages on a configured topic.
+Actions are available for use from the Rules DSL and the ECMAScript/JavaScript automation scripts.
+The actions support a builder-style API to configure a message (message text, priority, tags, icon, attachments, actions, sequence id, ...) and then send it.
 
-Important: Always check that the returned actions object is not null (the Thing must exist and be handled by the binding) before invoking methods.
+Important: Always check that the Thing exist before invoking methods.
 
 ### Available action methods
 
@@ -118,7 +120,7 @@ For more information about ntfy features and the notification format, see the nt
 
 ```rules
 // Obtain the Thing-specific actions and use the builder to send a message
-val bindingActions = getActions("ntfy", "ntfy:ntfyTopic:frontdoor")
+val bindingActions = getActions("ntfy", "ntfy:ntfy-topic:frontdoor")
 if (bindingActions !== null) {
     // simple one-liner: send a message
     val msgId = bindingActions.withMessage("Someone is at the door").withPriority(4).send()
@@ -144,7 +146,7 @@ In ECMAScript scripts you can obtain the Thing Actions and use the same builder 
 
 ```javascript
 // get the Thing actions for the topic Thing
-var bindingActions = actions.get("ntfy", "ntfy:ntfyTopic:frontdoor");
+var bindingActions = actions.get("ntfy", "ntfy:ntfy-topic:frontdoor");
 if (bindingActions) {
     // send a simple message
     var id = bindingActions.withMessage("Garage opened").withPriority(3).send();

--- a/bundles/org.openhab.binding.ntfy/README.md
+++ b/bundles/org.openhab.binding.ntfy/README.md
@@ -19,14 +19,14 @@ This binding provides the following Thing types. The Thing type IDs match the de
 
 ### `ntfyConnection` Bridge Configuration
 
-| Name              | Type    | Description                             | Default                            | Required | Advanced |
-|-------------------|---------|-----------------------------------------|------------------------------------|----------|----------|
-| hostname          | text    | Base URL of the ntfy server             | [https://ntfy.sh](https://ntfy.sh) | yes      | no       |
-| username          | text    | Optional username for basic auth        | N/A                                | no       | no       |
-| password          | text    | Optional password for basic auth        | N/A                                | no       | no       |
-| connectionTimeout | integer | WebSocket / HTTP connection timeout ms  | 60000                              | no       | yes      |
+| Name              | Type    | Description                                                                              | Default                            | Required | Advanced |
+|-------------------|---------|------------------------------------------------------------------------------------------|------------------------------------|----------|----------|
+| hostname          | text    | Base URL of the ntfy server                                                              | [https://ntfy.sh](https://ntfy.sh) | yes      | no       |
+| username          | text    | Optional username for basic auth                                                         | N/A                                | no       | no       |
+| password          | text    | Optional password - if username is provided basic auth is used else Bearer token is used | N/A                                | no       | no       |
+| connectionTimeout | integer | WebSocket / HTTP connection timeout ms                                                   | 60000                              | no       | yes      |
 
-Configure the `ntfyConnection` as a bridge to hold shared server and authentication settings. Topic Things reference the bridge to reuse these settings.
+Configure the `ntfyConnection` as a bridge to hold shared server and authentication settings. Topic Things reference the bridge to reuse these settings. For authentication with access token only set the password and leave the username empty.
 
 ### `ntfyTopic` Thing Configuration
 
@@ -93,23 +93,24 @@ Important: Always check that the returned actions object is not null (the Thing 
 
 Below is a quick reference of the builder-style methods provided by the binding actions. Use these to construct messages before calling `send()`.
 
-| Method              | Parameters                                                                                        | Description                                                          | Ntfy docs                                                                    |
-|---------------------|---------------------------------------------------------------------------------------------------|----------------------------------------------------------------------|------------------------------------------------------------------------------|
-| withMessage         | (String message)                                                                                  | Set the main message text.                                           | [publish](https://docs.ntfy.sh/publish)                                      |
-| withPriority        | (int priority)                                                                                    | Set message priority (1-5).                                          | [priority](https://ntfy.sh/docs/publish/#priority)                           |
-| withTitle           | (String title)                                                                                    | Set title.                                                           | [title](https://docs.ntfy.sh/publish/#message-title)                         |
-| withTag             | (String tag)                                                                                      | Add a tag to the message.                                            | [tags](https://ntfy.sh/docs/publish/#tags)                                   |
-| withIcon            | (String url)                                                                                      | Set an icon URL for the notification.                                | [icons](https://ntfy.sh/docs/publish/#icons)                                 |
-| withAttachment      | (String url, String filename)                                                                     | Attach a file or resource URL with optional filename.                | [attachments](https://docs.ntfy.sh/publish/#attach-file-from-a-url)          |
-| withViewAction      | (String label, Boolean clearNotification, String url)                                             | Add a view action (opens URL) with optional clear flag.              | [actions](https://docs.ntfy.sh/publish/#open-websiteapp)                     |
-| withCopyAction      | (String label, Boolean clearNotification, String value)                                           | Add an action that copies text to clipboard on the client.           | [actions](https://docs.ntfy.sh/publish/#copy-to-clipboard)                   |
-| withHttpAction      | (String label, Boolean clearNotification, String url, String method, String headers, String body) | Add an HTTP action with optional method, headers and body.           | [actions](https://docs.ntfy.sh/publish/#send-http-request)                   |
-| withBroadcastAction | (String label, Boolean clearNotification, String params)                                          | Add a broadcast action to trigger local apps/handlers.               | [actions](https://docs.ntfy.sh/publish/#send-android-broadcast)              |
-| withDelay           | (String delay)                                                                                    | Assign a delay.                                                      | [delay](https://docs.ntfy.sh/publish/#scheduled-delivery)                    |
-| withSequenceId      | (String sequenceId)                                                                               | Assign a sequence id for later reference (useful for delete/update). | [sequence id](https://docs.ntfy.sh/publish/#updating-deleting-notifications) |
-| send                | ()                                                                                                | Send the built message; returns a message ID string.                 | [publish](https://ntfy.sh/docs/publish/)                                     |
-| send                | (String file, String filename, String sequenceId)                                                 | Send a file; returns a message ID string.                            | [publish_local_file](https://docs.ntfy.sh/publish/#attach-local-file)        |
-| delete              | (String sequenceId)                                                                               | Delete a message previously sent with the given sequence id.         | [delete](https://ntfy.sh/docs/publish/#deleting-notifications)               |
+| Method                  | Parameters                                                                                        | Description                                                          | Ntfy docs                                                                    |
+|-------------------------|---------------------------------------------------------------------------------------------------|----------------------------------------------------------------------|------------------------------------------------------------------------------|
+| withMessage             | (String message)                                                                                  | Set the main message text.                                           | [publish](https://docs.ntfy.sh/publish)                                      |
+| withPriority            | (int priority)                                                                                    | Set message priority (1-5).                                          | [priority](https://ntfy.sh/docs/publish/#priority)                           |
+| withTitle               | (String title)                                                                                    | Set title.                                                           | [title](https://docs.ntfy.sh/publish/#message-title)                         |
+| withTag                 | (String tag)                                                                                      | Add a tag to the message.                                            | [tags](https://ntfy.sh/docs/publish/#tags)                                   |
+| withIcon                | (String url)                                                                                      | Set an icon URL for the notification.                                | [icons](https://ntfy.sh/docs/publish/#icons)                                 |
+| withAttachment          | (String url, String filename)                                                                     | Attach a file or resource URL with optional filename.                | [attachments](https://docs.ntfy.sh/publish/#attach-file-from-a-url)          |
+| withViewAction          | (String label, Boolean clearNotification, String url)                                             | Add a view action (opens URL) with optional clear flag.              | [actions](https://docs.ntfy.sh/publish/#open-websiteapp)                     |
+| withCopyAction          | (String label, Boolean clearNotification, String value)                                           | Add an action that copies text to clipboard on the client.           | [actions](https://docs.ntfy.sh/publish/#copy-to-clipboard)                   |
+| withHttpAction          | (String label, Boolean clearNotification, String url, String method, String headers, String body) | Add an HTTP action with optional method, headers and body.           | [actions](https://docs.ntfy.sh/publish/#send-http-request)                   |
+| withBroadcastAction     | (String label, Boolean clearNotification, String params)                                          | Add a broadcast action to trigger local apps/handlers.               | [actions](https://docs.ntfy.sh/publish/#send-android-broadcast)              |
+| withDelay               | (String delay)                                                                                    | Assign a delay.                                                      | [delay](https://docs.ntfy.sh/publish/#scheduled-delivery)                    |
+| withSequenceId          | (String sequenceId)                                                                               | Assign a sequence id for later reference (useful for delete/update). | [sequence id](https://docs.ntfy.sh/publish/#updating-deleting-notifications) |
+| send                    | ()                                                                                                | Send the built message; returns a message ID string.                 | [publish](https://ntfy.sh/docs/publish/)                                     |
+| send                    | (String file, String filename, String sequenceId)                                                 | Send a file; returns a message ID string.                            | [publish_local_file](https://docs.ntfy.sh/publish/#attach-local-file)        |
+| delete                  | (String sequenceId)                                                                               | Delete a message previously sent with the given sequence id.         | [delete](https://ntfy.sh/docs/publish/#deleting-notifications)               |
+| clearNtfyMessageBuilder | ()                                                                                                | Reset the message build explicitly                                   |                                                                              |
 
 For more information about ntfy features and the notification format, see the ntfy project documentation: [https://ntfy.sh/docs/](https://ntfy.sh/docs/)
 

--- a/bundles/org.openhab.binding.ntfy/pom.xml
+++ b/bundles/org.openhab.binding.ntfy/pom.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.openhab.addons.bundles</groupId>
+    <artifactId>org.openhab.addons.reactor.bundles</artifactId>
+    <version>5.2.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>org.openhab.binding.ntfy</artifactId>
+
+  <name>openHAB Add-ons :: Bundles :: Ntfy Binding</name>
+
+</project>

--- a/bundles/org.openhab.binding.ntfy/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.ntfy/src/main/feature/feature.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<features name="org.openhab.binding.ntfy-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.6.0">
+	<repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
+
+	<feature name="openhab-binding-ntfy" description="Ntfy Binding" version="${project.version}">
+		<feature>openhab-runtime-base</feature>
+		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.ntfy/${project.version}</bundle>
+	</feature>
+</features>

--- a/bundles/org.openhab.binding.ntfy/src/main/java/org/openhab/binding/ntfy/internal/NtfyBindingConstants.java
+++ b/bundles/org.openhab.binding.ntfy/src/main/java/org/openhab/binding/ntfy/internal/NtfyBindingConstants.java
@@ -24,14 +24,14 @@ import org.openhab.core.thing.ThingTypeUID;
 @NonNullByDefault
 public class NtfyBindingConstants {
 
-    private static final String BINDING_ID = "ntfy";
+    public static final String BINDING_ID = "ntfy";
 
     // List of all Thing Type UIDs
-    public static final ThingTypeUID NTFY_CONNECTION_THING = new ThingTypeUID(BINDING_ID, "ntfyConnection");
-    public static final ThingTypeUID NTFY_TOPIC_THING = new ThingTypeUID(BINDING_ID, "ntfyTopic");
+    public static final ThingTypeUID NTFY_CONNECTION_THING = new ThingTypeUID(BINDING_ID, "server");
+    public static final ThingTypeUID NTFY_TOPIC_THING = new ThingTypeUID(BINDING_ID, "ntfy-topic");
 
     // List of all Channel ids
-    public static final String CHANNEL_NTFY_LASTMESSAGE = "lastMessage";
-    public static final String CHANNEL_NTFY_LASTMESSAGETIME = "lastMessageTime";
-    public static final String CHANNEL_NTFY_LASTMESSAGEID = "lastMessageMessageId";
+    public static final String CHANNEL_LASTMESSAGE = "last-message";
+    public static final String CHANNEL_LASTMESSAGETIME = "last-message-time";
+    public static final String CHANNEL_LASTMESSAGEID = "last-message-id";
 }

--- a/bundles/org.openhab.binding.ntfy/src/main/java/org/openhab/binding/ntfy/internal/NtfyBindingConstants.java
+++ b/bundles/org.openhab.binding.ntfy/src/main/java/org/openhab/binding/ntfy/internal/NtfyBindingConstants.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.ntfy.internal;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.core.thing.ThingTypeUID;
+
+/**
+ * The {@link NtfyBindingConstants} class defines common constants, which are
+ * used across the whole binding.
+ *
+ * @author Christian Kittel - Initial contribution
+ */
+@NonNullByDefault
+public class NtfyBindingConstants {
+
+    private static final String BINDING_ID = "ntfy";
+
+    // List of all Thing Type UIDs
+    public static final ThingTypeUID NTFY_CONNECTION_THING = new ThingTypeUID(BINDING_ID, "ntfyConnection");
+    public static final ThingTypeUID NTFY_TOPIC_THING = new ThingTypeUID(BINDING_ID, "ntfyTopic");
+
+    // List of all Channel ids
+    public static final String CHANNEL_NTFY_LASTMESSAGE = "lastMessage";
+    public static final String CHANNEL_NTFY_LASTMESSAGETIME = "lastMessageTime";
+    public static final String CHANNEL_NTFY_LASTMESSAGEID = "lastMessageMessageId";
+}

--- a/bundles/org.openhab.binding.ntfy/src/main/java/org/openhab/binding/ntfy/internal/NtfyConnectionConfiguration.java
+++ b/bundles/org.openhab.binding.ntfy/src/main/java/org/openhab/binding/ntfy/internal/NtfyConnectionConfiguration.java
@@ -27,7 +27,7 @@ import org.eclipse.jdt.annotation.Nullable;
 public class NtfyConnectionConfiguration {
 
     /**
-     * Hostname of the ntfy server, e.g. "ntfy.sh"
+     * Hostname of the ntfy server, e.g. "https://ntfy.sh"
      */
     public String hostname = "";
 
@@ -54,6 +54,8 @@ public class NtfyConnectionConfiguration {
      *         {@code false} otherwise
      */
     public boolean isAuthHeaderNeeded() {
+        final @Nullable String username = this.username;
+        final @Nullable String password = this.password;
         return username != null && !username.isBlank() && password != null && !password.isBlank();
     }
 

--- a/bundles/org.openhab.binding.ntfy/src/main/java/org/openhab/binding/ntfy/internal/NtfyConnectionConfiguration.java
+++ b/bundles/org.openhab.binding.ntfy/src/main/java/org/openhab/binding/ntfy/internal/NtfyConnectionConfiguration.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.ntfy.internal;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
+/**
+ * The {@link NtfyConnectionConfiguration} class contains fields mapping thing configuration parameters.
+ *
+ * @author Christian Kittel - Initial contribution
+ */
+@NonNullByDefault
+public class NtfyConnectionConfiguration {
+
+    /**
+     * Hostname of the ntfy server, e.g. "ntfy.sh"
+     */
+    public String hostname = "";
+
+    /**
+     * Username for basic authentication
+     */
+    public @Nullable String username;
+
+    /**
+     * Password for basic authentication
+     */
+    public @Nullable String password;
+
+    /**
+     * Connection timeout in milliseconds
+     */
+    public long connectionTimeout = 60000;
+
+    /**
+     * Checks whether a Basic Authorization header should be provided based on the configured
+     * username and password values.
+     *
+     * @return {@code true} when both username and password are non-null and non-blank,
+     *         {@code false} otherwise
+     */
+    public boolean isAuthHeaderNeeded() {
+        return username != null && !username.isBlank() && password != null && !password.isBlank();
+    }
+
+    /**
+     * Builds the HTTP Basic Authorization header value from the configured username and password.
+     *
+     * <p>
+     * The credentials are combined as "username:password" and Base64-encoded using UTF-8.
+     * The returned value is prefixed with "Basic ".
+     *
+     * @return the full value for the HTTP Authorization header
+     */
+    public String buildAuthHeader() {
+        String auth = username + ":" + password;
+        String encodedAuth = Base64.getEncoder().encodeToString(auth.getBytes(StandardCharsets.UTF_8));
+        String authHeader = "Basic " + encodedAuth;
+        return authHeader;
+    }
+}

--- a/bundles/org.openhab.binding.ntfy/src/main/java/org/openhab/binding/ntfy/internal/NtfyConnectionConfiguration.java
+++ b/bundles/org.openhab.binding.ntfy/src/main/java/org/openhab/binding/ntfy/internal/NtfyConnectionConfiguration.java
@@ -14,6 +14,7 @@ package org.openhab.binding.ntfy.internal;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
+import java.util.Objects;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
@@ -47,31 +48,29 @@ public class NtfyConnectionConfiguration {
     public long connectionTimeout = 60000;
 
     /**
-     * Checks whether a Basic Authorization header should be provided based on the configured
-     * username and password values.
+     * Checks whether a Basic Authorization header should be provided based on the configured password value.
      *
-     * @return {@code true} when both username and password are non-null and non-blank,
+     * @return {@code true} when password are non-null and non-blank,
      *         {@code false} otherwise
      */
     public boolean isAuthHeaderNeeded() {
-        final @Nullable String username = this.username;
         final @Nullable String password = this.password;
-        return username != null && !username.isBlank() && password != null && !password.isBlank();
+        return password != null && !password.isBlank();
     }
 
     /**
-     * Builds the HTTP Basic Authorization header value from the configured username and password.
-     *
-     * <p>
-     * The credentials are combined as "username:password" and Base64-encoded using UTF-8.
-     * The returned value is prefixed with "Basic ".
+     * If both username and password are provided, a Basic Authorization header is created. If only password is
+     * provided, a Bearer Authorization header is created
      *
      * @return the full value for the HTTP Authorization header
      */
     public String buildAuthHeader() {
-        String auth = username + ":" + password;
-        String encodedAuth = Base64.getEncoder().encodeToString(auth.getBytes(StandardCharsets.UTF_8));
-        String authHeader = "Basic " + encodedAuth;
-        return authHeader;
+        final @Nullable String username = this.username;
+        final String password = Objects.requireNonNull(this.password);
+        if (username == null || username.isBlank()) {
+            return "Bearer " + password;
+        }
+        return "Basic "
+                + Base64.getEncoder().encodeToString((username + ":" + password).getBytes(StandardCharsets.UTF_8));
     }
 }

--- a/bundles/org.openhab.binding.ntfy/src/main/java/org/openhab/binding/ntfy/internal/NtfyConnectionHandler.java
+++ b/bundles/org.openhab.binding.ntfy/src/main/java/org/openhab/binding/ntfy/internal/NtfyConnectionHandler.java
@@ -12,14 +12,20 @@
  */
 package org.openhab.binding.ntfy.internal;
 
+import java.io.IOException;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.jetty.websocket.client.ClientUpgradeRequest;
 import org.eclipse.jetty.websocket.client.WebSocketClient;
+import org.openhab.binding.ntfy.internal.network.NtfySender;
 import org.openhab.binding.ntfy.internal.network.NtfyWebSocket;
 import org.openhab.core.io.net.http.WebSocketFactory;
 import org.openhab.core.thing.Bridge;
@@ -48,6 +54,9 @@ public class NtfyConnectionHandler extends BaseBridgeHandler {
     private NtfyConnectionConfiguration config;
     private Map<ThingUID, WebSocketClient> webSocketConnections = new HashMap<>();
     private WebSocketFactory webSocketFactory;
+    private HttpClient httpClient;
+    private @Nullable ScheduledFuture<?> retryConnectionFuture;
+    private @Nullable String scheme;
 
     /**
      * Creates a new {@link NtfyConnectionHandler} for the given bridge (connection) thing.
@@ -55,9 +64,10 @@ public class NtfyConnectionHandler extends BaseBridgeHandler {
      * @param thing the bridge thing representing the ntfy connection
      * @param webSocketFactory factory used to create WebSocketClient instances
      */
-    public NtfyConnectionHandler(Bridge thing, WebSocketFactory webSocketFactory) {
+    public NtfyConnectionHandler(Bridge thing, WebSocketFactory webSocketFactory, HttpClient httpClient) {
         super(thing);
         this.webSocketFactory = webSocketFactory;
+        this.httpClient = httpClient;
         config = getConfigAs(NtfyConnectionConfiguration.class);
     }
 
@@ -65,13 +75,42 @@ public class NtfyConnectionHandler extends BaseBridgeHandler {
     public void handleCommand(ChannelUID channelUID, Command command) {
     }
 
+    public NtfySender CreateSender(String topicName) {
+        return new NtfySender(topicName, httpClient, this);
+    }
+
     @Override
     public void initialize() {
-        updateStatus(ThingStatus.UNKNOWN);
+        cancelRetryFuture();
 
         config = getConfigAs(NtfyConnectionConfiguration.class);
 
-        scheduler.execute(() -> updateStatus(ThingStatus.ONLINE));
+        updateStatus(ThingStatus.UNKNOWN);
+
+        String scheme;
+        try {
+            scheme = (new URI(config.hostname)).getScheme();
+        } catch (URISyntaxException e) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, e.getLocalizedMessage());
+            return;
+        }
+        if (!"http".equals(scheme) && !"https".equals(scheme)) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
+                    "URI scheme is missing in hostname or unsupported URI scheme (only http or https are supported): "
+                            + config.hostname);
+            return;
+        }
+
+        this.scheme = scheme;
+        updateStatus(ThingStatus.ONLINE);
+    }
+
+    private void cancelRetryFuture() {
+        final @Nullable ScheduledFuture<?> retryConnectionFuture = this.retryConnectionFuture;
+        this.retryConnectionFuture = null;
+        if (retryConnectionFuture != null) {
+            retryConnectionFuture.cancel(true);
+        }
     }
 
     /**
@@ -82,8 +121,8 @@ public class NtfyConnectionHandler extends BaseBridgeHandler {
      * @param thing the thing for which to create and register the WebSocket client
      */
     public synchronized void createAndRegisterWebSocketClient(Thing thing) {
-        WebSocketClient newClient = webSocketFactory
-                .createWebSocketClient(ThingWebClientUtil.buildWebClientConsumerName(thing.getUID(), "ntfy"));
+        WebSocketClient newClient = webSocketFactory.createWebSocketClient(
+                ThingWebClientUtil.buildWebClientConsumerName(thing.getUID(), NtfyBindingConstants.BINDING_ID));
 
         WebSocketClient client = webSocketConnections.get(thing.getUID());
 
@@ -91,8 +130,9 @@ public class NtfyConnectionHandler extends BaseBridgeHandler {
             try {
                 client.stop();
             } catch (Exception e) {
-                logger.error("Error stopping WebSocketConnection", e);
+                logger.warn("Error stopping WebSocketConnection", e);
             }
+            webSocketConnections.remove(thing.getUID());
         }
 
         webSocketConnections.put(thing.getUID(), newClient);
@@ -122,28 +162,49 @@ public class NtfyConnectionHandler extends BaseBridgeHandler {
         String topicName = getTopicNameFromThing(topicThing);
 
         if (client != null) {
-            try {
-                if (client.isStarted()) {
+            if (client.isStarted()) {
+                try {
                     client.stop();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    logger.error("WebSocket connection was interrupted", e);
+                    updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, e.getLocalizedMessage());
+                    return false;
+                } catch (Exception e) {
+                    logger.warn("Error stopping WebSocket connection - ignore it and continue", e);
                 }
+            }
+            try {
                 client.start();
-                client.setMaxIdleTimeout(config.connectionTimeout);
-
-                client.connect(ntfyWebSocket,
-                        new URI("wss:"
-                                + (new URI(config.hostname + "/" + topicName + "/ws")).getRawSchemeSpecificPart()),
-                        setupRequest());
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, e.getLocalizedMessage());
+                return false;
             } catch (Exception e) {
-                logger.error("Error creating WebSocketConnection", e);
-                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, e.getLocalizedMessage());
+                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, e.getLocalizedMessage());
                 return false;
             }
+
+            client.setMaxIdleTimeout(config.connectionTimeout);
+            String webSocketScheme = "http".equals(this.scheme) ? "ws" : "wss";
+
+            try {
+                client.connect(ntfyWebSocket,
+                        new URI(webSocketScheme + ":"
+                                + (new URI(config.hostname + "/" + topicName + "/ws")).getRawSchemeSpecificPart()),
+                        setupRequest());
+            } catch (IOException | URISyntaxException e) {
+                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, e.getLocalizedMessage());
+                return false;
+            }
+            updateStatus(ThingStatus.ONLINE);
+
         }
         return true;
     }
 
     private String getTopicNameFromThing(Thing topicThing) {
-        return topicThing.getConfiguration().as(NtfyTopicConfiguration.class).topicname;
+        return topicThing.getConfiguration().as(NtfyTopicConfiguration.class).topicName;
     }
 
     /**
@@ -154,6 +215,26 @@ public class NtfyConnectionHandler extends BaseBridgeHandler {
      */
     public void connectionError(Throwable cause) {
         updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, cause.getLocalizedMessage());
-        scheduler.schedule(() -> updateStatus(ThingStatus.ONLINE), 30, TimeUnit.SECONDS);
+        retryConnectionFuture = scheduler.schedule(() -> {
+            retryConnectionFuture = null;
+            updateStatus(ThingStatus.ONLINE);
+        }, 30, TimeUnit.SECONDS);
+    }
+
+    @Override
+    public void dispose() {
+        super.dispose();
+
+        cancelRetryFuture();
+
+        webSocketConnections.values().forEach(client -> {
+            try {
+                if (client.isRunning()) {
+                    client.stop();
+                }
+            } catch (Exception e) {
+                logger.warn("Error stopping WebSocketConnection", e);
+            }
+        });
     }
 }

--- a/bundles/org.openhab.binding.ntfy/src/main/java/org/openhab/binding/ntfy/internal/NtfyConnectionHandler.java
+++ b/bundles/org.openhab.binding.ntfy/src/main/java/org/openhab/binding/ntfy/internal/NtfyConnectionHandler.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.ntfy.internal;
+
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jetty.websocket.client.ClientUpgradeRequest;
+import org.eclipse.jetty.websocket.client.WebSocketClient;
+import org.openhab.binding.ntfy.internal.network.NtfyWebSocket;
+import org.openhab.core.io.net.http.WebSocketFactory;
+import org.openhab.core.thing.Bridge;
+import org.openhab.core.thing.ChannelUID;
+import org.openhab.core.thing.Thing;
+import org.openhab.core.thing.ThingStatus;
+import org.openhab.core.thing.ThingStatusDetail;
+import org.openhab.core.thing.ThingUID;
+import org.openhab.core.thing.binding.BaseBridgeHandler;
+import org.openhab.core.thing.util.ThingWebClientUtil;
+import org.openhab.core.types.Command;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link NtfyConnectionHandler} is responsible for handling commands, which are
+ * sent to one of the channels.
+ *
+ * @author Christian Kittel - Initial contribution
+ */
+@NonNullByDefault
+public class NtfyConnectionHandler extends BaseBridgeHandler {
+
+    private final Logger logger = LoggerFactory.getLogger(NtfyConnectionHandler.class);
+
+    private NtfyConnectionConfiguration config;
+    private Map<ThingUID, WebSocketClient> webSocketConnections = new HashMap<>();
+    private WebSocketFactory webSocketFactory;
+
+    /**
+     * Creates a new {@link NtfyConnectionHandler} for the given bridge (connection) thing.
+     *
+     * @param thing the bridge thing representing the ntfy connection
+     * @param webSocketFactory factory used to create WebSocketClient instances
+     */
+    public NtfyConnectionHandler(Bridge thing, WebSocketFactory webSocketFactory) {
+        super(thing);
+        this.webSocketFactory = webSocketFactory;
+        config = getConfigAs(NtfyConnectionConfiguration.class);
+    }
+
+    @Override
+    public void handleCommand(ChannelUID channelUID, Command command) {
+    }
+
+    @Override
+    public void initialize() {
+        updateStatus(ThingStatus.UNKNOWN);
+
+        config = getConfigAs(NtfyConnectionConfiguration.class);
+
+        scheduler.execute(() -> updateStatus(ThingStatus.ONLINE));
+    }
+
+    /**
+     * Creates a new Jetty {@link WebSocketClient} for the provided thing and registers
+     * it under the thing's UID. If an existing client is present and running it will be
+     * stopped before the new client is stored.
+     *
+     * @param thing the thing for which to create and register the WebSocket client
+     */
+    public synchronized void createAndRegisterWebSocketClient(Thing thing) {
+        WebSocketClient newClient = webSocketFactory
+                .createWebSocketClient(ThingWebClientUtil.buildWebClientConsumerName(thing.getUID(), "ntfy"));
+
+        WebSocketClient client = webSocketConnections.get(thing.getUID());
+
+        if (client != null && client.isRunning()) {
+            try {
+                client.stop();
+            } catch (Exception e) {
+                logger.error("Error stopping WebSocketConnection", e);
+            }
+        }
+
+        webSocketConnections.put(thing.getUID(), newClient);
+    }
+
+    private ClientUpgradeRequest setupRequest() {
+        ClientUpgradeRequest request = new ClientUpgradeRequest();
+        if (config.isAuthHeaderNeeded()) {
+            String authHeader = config.buildAuthHeader();
+            request.setHeader("Authorization", authHeader);
+        }
+        return request;
+    }
+
+    /**
+     * Starts a WebSocket connection for the provided topic thing using the given
+     * {@link NtfyWebSocket} listener.
+     *
+     * @param topicThing the thing representing the ntfy topic to connect to
+     * @param ntfyWebSocket the WebSocket listener that will handle incoming events
+     * @return {@code true} when the connection was successfully started or when there
+     *         was no client registered for the thing; {@code false} on failure
+     */
+    public synchronized boolean startWebSocketConnection(Thing topicThing, NtfyWebSocket ntfyWebSocket) {
+        WebSocketClient client = webSocketConnections.get(topicThing.getUID());
+
+        String topicName = getTopicNameFromThing(topicThing);
+
+        if (client != null) {
+            try {
+                if (client.isStarted()) {
+                    client.stop();
+                }
+                client.start();
+                client.setMaxIdleTimeout(config.connectionTimeout);
+
+                client.connect(ntfyWebSocket,
+                        new URI("wss:"
+                                + (new URI(config.hostname + "/" + topicName + "/ws")).getRawSchemeSpecificPart()),
+                        setupRequest());
+            } catch (Exception e) {
+                logger.error("Error creating WebSocketConnection", e);
+                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, e.getLocalizedMessage());
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private String getTopicNameFromThing(Thing topicThing) {
+        return topicThing.getConfiguration().as(NtfyTopicConfiguration.class).topicname;
+    }
+
+    /**
+     * Handles a connection error by setting the thing status to OFFLINE and scheduling
+     * a retry to set the status back to ONLINE after a fixed delay.
+     *
+     * @param cause the cause of the connection error
+     */
+    public void connectionError(Throwable cause) {
+        updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, cause.getLocalizedMessage());
+        scheduler.schedule(() -> updateStatus(ThingStatus.ONLINE), 30, TimeUnit.SECONDS);
+    }
+}

--- a/bundles/org.openhab.binding.ntfy/src/main/java/org/openhab/binding/ntfy/internal/NtfyConnectionHandler.java
+++ b/bundles/org.openhab.binding.ntfy/src/main/java/org/openhab/binding/ntfy/internal/NtfyConnectionHandler.java
@@ -75,7 +75,7 @@ public class NtfyConnectionHandler extends BaseBridgeHandler {
     public void handleCommand(ChannelUID channelUID, Command command) {
     }
 
-    public NtfySender CreateSender(String topicName) {
+    public NtfySender createSender(String topicName) {
         return new NtfySender(topicName, httpClient, this);
     }
 
@@ -84,8 +84,6 @@ public class NtfyConnectionHandler extends BaseBridgeHandler {
         cancelRetryFuture();
 
         config = getConfigAs(NtfyConnectionConfiguration.class);
-
-        updateStatus(ThingStatus.UNKNOWN);
 
         String scheme;
         try {
@@ -96,8 +94,7 @@ public class NtfyConnectionHandler extends BaseBridgeHandler {
         }
         if (!"http".equals(scheme) && !"https".equals(scheme)) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
-                    "URI scheme is missing in hostname or unsupported URI scheme (only http or https are supported): "
-                            + config.hostname);
+                    "@text/offline.communication-error.unsupported-schema");
             return;
         }
 
@@ -167,11 +164,10 @@ public class NtfyConnectionHandler extends BaseBridgeHandler {
                     client.stop();
                 } catch (InterruptedException e) {
                     Thread.currentThread().interrupt();
-                    logger.error("WebSocket connection was interrupted", e);
                     updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, e.getLocalizedMessage());
                     return false;
                 } catch (Exception e) {
-                    logger.warn("Error stopping WebSocket connection - ignore it and continue", e);
+                    logger.debug("Error stopping WebSocket connection - ignore it and continue", e);
                 }
             }
             try {
@@ -198,7 +194,6 @@ public class NtfyConnectionHandler extends BaseBridgeHandler {
                 return false;
             }
             updateStatus(ThingStatus.ONLINE);
-
         }
         return true;
     }
@@ -215,10 +210,8 @@ public class NtfyConnectionHandler extends BaseBridgeHandler {
      */
     public void connectionError(Throwable cause) {
         updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, cause.getLocalizedMessage());
-        retryConnectionFuture = scheduler.schedule(() -> {
-            retryConnectionFuture = null;
-            updateStatus(ThingStatus.ONLINE);
-        }, 30, TimeUnit.SECONDS);
+        cancelRetryFuture();
+        retryConnectionFuture = scheduler.schedule(this::initialize, 30, TimeUnit.SECONDS);
     }
 
     @Override

--- a/bundles/org.openhab.binding.ntfy/src/main/java/org/openhab/binding/ntfy/internal/NtfyHandlerFactory.java
+++ b/bundles/org.openhab.binding.ntfy/src/main/java/org/openhab/binding/ntfy/internal/NtfyHandlerFactory.java
@@ -18,7 +18,6 @@ import java.util.Set;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
-import org.eclipse.jetty.client.HttpClient;
 import org.openhab.core.io.net.http.HttpClientFactory;
 import org.openhab.core.io.net.http.WebSocketFactory;
 import org.openhab.core.thing.Bridge;
@@ -42,20 +41,20 @@ import org.osgi.service.component.annotations.Reference;
 public class NtfyHandlerFactory extends BaseThingHandlerFactory {
 
     private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Set.of(NTFY_CONNECTION_THING, NTFY_TOPIC_THING);
-    private HttpClient httpClient;
+    private HttpClientFactory httpClientFactory;
     private WebSocketFactory webSocketFactory;
 
     /**
      * OSGi activation constructor. Initializes the handler factory with the
      * shared HTTP client and a WebSocketFactory used to create WebSocket clients.
      *
-     * @param httpClientFactory factory providing a common {@link HttpClient}
+     * @param httpClientFactory factory providing a common
      * @param webSocketFactory factory used to create {@link org.eclipse.jetty.websocket.client.WebSocketClient}
      */
     @Activate
     public NtfyHandlerFactory(@Reference HttpClientFactory httpClientFactory,
             @Reference WebSocketFactory webSocketFactory) {
-        this.httpClient = httpClientFactory.getCommonHttpClient();
+        this.httpClientFactory = httpClientFactory;
         this.webSocketFactory = webSocketFactory;
     }
 
@@ -69,11 +68,11 @@ public class NtfyHandlerFactory extends BaseThingHandlerFactory {
         ThingTypeUID thingTypeUID = thing.getThingTypeUID();
 
         if (NTFY_CONNECTION_THING.equals(thingTypeUID)) {
-            return new NtfyConnectionHandler((Bridge) thing, webSocketFactory);
+            return new NtfyConnectionHandler((Bridge) thing, webSocketFactory, httpClientFactory.getCommonHttpClient());
         }
 
         if (NTFY_TOPIC_THING.equals(thingTypeUID)) {
-            return new NtfyTopicHandler(thing, httpClient);
+            return new NtfyTopicHandler(thing);
         }
 
         return null;

--- a/bundles/org.openhab.binding.ntfy/src/main/java/org/openhab/binding/ntfy/internal/NtfyHandlerFactory.java
+++ b/bundles/org.openhab.binding.ntfy/src/main/java/org/openhab/binding/ntfy/internal/NtfyHandlerFactory.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.ntfy.internal;
+
+import static org.openhab.binding.ntfy.internal.NtfyBindingConstants.*;
+
+import java.util.Set;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.jetty.client.HttpClient;
+import org.openhab.core.io.net.http.HttpClientFactory;
+import org.openhab.core.io.net.http.WebSocketFactory;
+import org.openhab.core.thing.Bridge;
+import org.openhab.core.thing.Thing;
+import org.openhab.core.thing.ThingTypeUID;
+import org.openhab.core.thing.binding.BaseThingHandlerFactory;
+import org.openhab.core.thing.binding.ThingHandler;
+import org.openhab.core.thing.binding.ThingHandlerFactory;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * The {@link NtfyHandlerFactory} is responsible for creating things and thing
+ * handlers.
+ *
+ * @author Christian Kittel - Initial contribution
+ */
+@NonNullByDefault
+@Component(configurationPid = "binding.ntfy", service = ThingHandlerFactory.class)
+public class NtfyHandlerFactory extends BaseThingHandlerFactory {
+
+    private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Set.of(NTFY_CONNECTION_THING, NTFY_TOPIC_THING);
+    private HttpClient httpClient;
+    private WebSocketFactory webSocketFactory;
+
+    /**
+     * OSGi activation constructor. Initializes the handler factory with the
+     * shared HTTP client and a WebSocketFactory used to create WebSocket clients.
+     *
+     * @param httpClientFactory factory providing a common {@link HttpClient}
+     * @param webSocketFactory factory used to create {@link org.eclipse.jetty.websocket.client.WebSocketClient}
+     */
+    @Activate
+    public NtfyHandlerFactory(@Reference HttpClientFactory httpClientFactory,
+            @Reference WebSocketFactory webSocketFactory) {
+        this.httpClient = httpClientFactory.getCommonHttpClient();
+        this.webSocketFactory = webSocketFactory;
+    }
+
+    @Override
+    public boolean supportsThingType(ThingTypeUID thingTypeUID) {
+        return SUPPORTED_THING_TYPES_UIDS.contains(thingTypeUID);
+    }
+
+    @Override
+    protected @Nullable ThingHandler createHandler(Thing thing) {
+        ThingTypeUID thingTypeUID = thing.getThingTypeUID();
+
+        if (NTFY_CONNECTION_THING.equals(thingTypeUID)) {
+            return new NtfyConnectionHandler((Bridge) thing, webSocketFactory);
+        }
+
+        if (NTFY_TOPIC_THING.equals(thingTypeUID)) {
+            return new NtfyTopicHandler(thing, httpClient);
+        }
+
+        return null;
+    }
+}

--- a/bundles/org.openhab.binding.ntfy/src/main/java/org/openhab/binding/ntfy/internal/NtfyHandlerFactory.java
+++ b/bundles/org.openhab.binding.ntfy/src/main/java/org/openhab/binding/ntfy/internal/NtfyHandlerFactory.java
@@ -48,7 +48,7 @@ public class NtfyHandlerFactory extends BaseThingHandlerFactory {
      * OSGi activation constructor. Initializes the handler factory with the
      * shared HTTP client and a WebSocketFactory used to create WebSocket clients.
      *
-     * @param httpClientFactory factory providing a common
+     * @param httpClientFactory factory providing a common HTTP client for the binding
      * @param webSocketFactory factory used to create {@link org.eclipse.jetty.websocket.client.WebSocketClient}
      */
     @Activate

--- a/bundles/org.openhab.binding.ntfy/src/main/java/org/openhab/binding/ntfy/internal/NtfyTopicConfiguration.java
+++ b/bundles/org.openhab.binding.ntfy/src/main/java/org/openhab/binding/ntfy/internal/NtfyTopicConfiguration.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.ntfy.internal;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * The {@link NtfyTopicConfiguration} class contains fields mapping thing configuration parameters.
+ *
+ * @author Christian Kittel - Initial contribution
+ */
+@NonNullByDefault
+public class NtfyTopicConfiguration {
+
+    /**
+     * Topic name to subscribe to
+     */
+    public String topicname = "";
+}

--- a/bundles/org.openhab.binding.ntfy/src/main/java/org/openhab/binding/ntfy/internal/NtfyTopicConfiguration.java
+++ b/bundles/org.openhab.binding.ntfy/src/main/java/org/openhab/binding/ntfy/internal/NtfyTopicConfiguration.java
@@ -25,5 +25,5 @@ public class NtfyTopicConfiguration {
     /**
      * Topic name to subscribe to
      */
-    public String topicname = "";
+    public String topicName = "";
 }

--- a/bundles/org.openhab.binding.ntfy/src/main/java/org/openhab/binding/ntfy/internal/NtfyTopicHandler.java
+++ b/bundles/org.openhab.binding.ntfy/src/main/java/org/openhab/binding/ntfy/internal/NtfyTopicHandler.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.ntfy.internal;
+
+import java.net.URISyntaxException;
+import java.util.Collection;
+import java.util.List;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.jetty.client.HttpClient;
+import org.openhab.binding.ntfy.internal.action.NtfyActions;
+import org.openhab.binding.ntfy.internal.models.BaseEvent;
+import org.openhab.binding.ntfy.internal.models.MessageEvent;
+import org.openhab.binding.ntfy.internal.network.NtfyMessage;
+import org.openhab.binding.ntfy.internal.network.NtfySender;
+import org.openhab.binding.ntfy.internal.network.NtfyWebSocket;
+import org.openhab.binding.ntfy.internal.network.WebSocketConnectionListener;
+import org.openhab.core.library.types.DateTimeType;
+import org.openhab.core.library.types.StringType;
+import org.openhab.core.thing.ChannelUID;
+import org.openhab.core.thing.Thing;
+import org.openhab.core.thing.ThingStatus;
+import org.openhab.core.thing.ThingStatusDetail;
+import org.openhab.core.thing.ThingStatusInfo;
+import org.openhab.core.thing.binding.BaseThingHandler;
+import org.openhab.core.thing.binding.ThingHandlerService;
+import org.openhab.core.types.Command;
+import org.openhab.core.types.RefreshType;
+
+/**
+ * The {@link NtfyTopicHandler} is responsible for handling commands, which are
+ * sent to one of the channels.
+ *
+ * @author Christian Kittel - Initial contribution
+ */
+@NonNullByDefault
+public class NtfyTopicHandler extends BaseThingHandler implements WebSocketConnectionListener {
+
+    private NtfyWebSocket ntfyWebSocket;
+    private NtfySender ntfySender;
+    private boolean isInitializing;
+    private @Nullable MessageEvent lastMessageEvent;
+
+    /**
+     * Creates a new {@link NtfyTopicHandler} for the provided topic thing.
+     *
+     * @param thing the topic thing this handler belongs to
+     * @param httpClient the HTTP client used by the sender to perform REST calls
+     */
+    public NtfyTopicHandler(Thing thing, HttpClient httpClient) {
+        super(thing);
+
+        this.ntfyWebSocket = new NtfyWebSocket(this);
+        this.ntfySender = new NtfySender(this.getConfigAs(NtfyTopicConfiguration.class).topicname, httpClient,
+                this::getBridgeHandler);
+    }
+
+    private NtfyConnectionHandler getBridgeHandler() {
+        return (NtfyConnectionHandler) (java.util.Objects
+                .requireNonNull(java.util.Objects.requireNonNull(getBridge()).getHandler()));
+    }
+
+    @Override
+    public Collection<Class<? extends ThingHandlerService>> getServices() {
+        return List.of(NtfyActions.class);
+    }
+
+    @Override
+    public void thingUpdated(Thing thing) {
+        super.thingUpdated(thing);
+
+        getBridgeHandler().createAndRegisterWebSocketClient(thing);
+    }
+
+    @Override
+    public void bridgeStatusChanged(ThingStatusInfo bridgeStatusInfo) {
+        if (bridgeStatusInfo.getStatus() == ThingStatus.ONLINE
+                && getThing().getStatusInfo().getStatusDetail() == ThingStatusDetail.BRIDGE_OFFLINE) {
+            updateStatus(ThingStatus.UNKNOWN);
+            initialize();
+        } else {
+            super.bridgeStatusChanged(bridgeStatusInfo);
+        }
+    }
+
+    @Override
+    public void handleCommand(ChannelUID channelUID, Command command) {
+        if (command instanceof RefreshType) {
+            updateChannels();
+        }
+    }
+
+    @Override
+    public void initialize() {
+        if (isInitializing) {
+            return;
+        }
+        this.isInitializing = true;
+
+        updateStatus(ThingStatus.UNKNOWN);
+
+        scheduler.execute(() -> {
+            try {
+                getBridgeHandler().createAndRegisterWebSocketClient(thing);
+                startConnection();
+            } finally {
+                this.isInitializing = false;
+            }
+        });
+    }
+
+    private void startConnection() {
+        if (getThing().getStatus() != ThingStatus.ONLINE) {
+            if (!getBridgeHandler().startWebSocketConnection(thing, ntfyWebSocket)) {
+                updateStatus(ThingStatus.OFFLINE);
+            }
+        }
+    }
+
+    @Override
+    public void connectionEstablished() {
+        updateStatus(ThingStatus.ONLINE);
+    }
+
+    @Override
+    public void connectionLost(String reason) {
+    }
+
+    @Override
+    public void connectionError(Throwable cause) {
+        getBridgeHandler().connectionError(cause);
+    }
+
+    @Override
+    public void messageRecieved(BaseEvent event) {
+        if (event instanceof MessageEvent message) {
+            this.lastMessageEvent = message;
+            updateChannels();
+        }
+    }
+
+    private void updateChannels() {
+        final MessageEvent lastMessageEvent = this.lastMessageEvent;
+        if (lastMessageEvent != null) {
+            updateState(NtfyBindingConstants.CHANNEL_NTFY_LASTMESSAGE,
+                    StringType.valueOf(lastMessageEvent.getMessage()));
+            updateState(NtfyBindingConstants.CHANNEL_NTFY_LASTMESSAGETIME,
+                    new DateTimeType(lastMessageEvent.getTime()));
+            updateState(NtfyBindingConstants.CHANNEL_NTFY_LASTMESSAGEID, StringType.valueOf(lastMessageEvent.getId()));
+        }
+    }
+
+    /**
+     * Sends a message using the configured {@link NtfySender}.
+     *
+     * @param ntfyMessage the message to send
+     * @return the id of the created message on success, or an empty string when sending failed
+     * @throws URISyntaxException
+     */
+    public String sendMessage(NtfyMessage ntfyMessage) throws URISyntaxException {
+        @Nullable
+        MessageEvent sendMessage = ntfySender.sendMessage(ntfyMessage);
+
+        if (sendMessage == null) {
+            return "";
+        }
+        return sendMessage.getId();
+    }
+
+    public String sendFile(String file, @Nullable String filename, @Nullable String sequenceId)
+            throws URISyntaxException {
+        @Nullable
+        MessageEvent sendMessage = ntfySender.sendFile(file, filename, sequenceId);
+
+        if (sendMessage == null) {
+            return "";
+        }
+        return sendMessage.getId();
+    }
+
+    /**
+     * Deletes a message identified by the given sequence id via the {@link NtfySender}.
+     *
+     * @param sequenceId the id of the message to delete
+     * @return {@code true} when deletion succeeded, {@code false} otherwise
+     * @throws URISyntaxException when the underlying request URI could not be constructed
+     */
+    public boolean deleteMessage(String sequenceId) throws URISyntaxException {
+        return ntfySender.deleteMessage(sequenceId);
+    }
+}

--- a/bundles/org.openhab.binding.ntfy/src/main/java/org/openhab/binding/ntfy/internal/NtfyTopicHandler.java
+++ b/bundles/org.openhab.binding.ntfy/src/main/java/org/openhab/binding/ntfy/internal/NtfyTopicHandler.java
@@ -12,13 +12,14 @@
  */
 package org.openhab.binding.ntfy.internal;
 
+import static org.openhab.binding.ntfy.internal.NtfyBindingConstants.*;
+
 import java.net.URISyntaxException;
 import java.util.Collection;
 import java.util.List;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
-import org.eclipse.jetty.client.HttpClient;
 import org.openhab.binding.ntfy.internal.action.NtfyActions;
 import org.openhab.binding.ntfy.internal.models.BaseEvent;
 import org.openhab.binding.ntfy.internal.models.MessageEvent;
@@ -28,6 +29,7 @@ import org.openhab.binding.ntfy.internal.network.NtfyWebSocket;
 import org.openhab.binding.ntfy.internal.network.WebSocketConnectionListener;
 import org.openhab.core.library.types.DateTimeType;
 import org.openhab.core.library.types.StringType;
+import org.openhab.core.thing.Bridge;
 import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.Thing;
 import org.openhab.core.thing.ThingStatus;
@@ -48,7 +50,7 @@ import org.openhab.core.types.RefreshType;
 public class NtfyTopicHandler extends BaseThingHandler implements WebSocketConnectionListener {
 
     private NtfyWebSocket ntfyWebSocket;
-    private NtfySender ntfySender;
+    private @Nullable NtfySender ntfySender;
     private boolean isInitializing;
     private @Nullable MessageEvent lastMessageEvent;
 
@@ -58,17 +60,21 @@ public class NtfyTopicHandler extends BaseThingHandler implements WebSocketConne
      * @param thing the topic thing this handler belongs to
      * @param httpClient the HTTP client used by the sender to perform REST calls
      */
-    public NtfyTopicHandler(Thing thing, HttpClient httpClient) {
+    public NtfyTopicHandler(Thing thing) {
         super(thing);
 
         this.ntfyWebSocket = new NtfyWebSocket(this);
-        this.ntfySender = new NtfySender(this.getConfigAs(NtfyTopicConfiguration.class).topicname, httpClient,
-                this::getBridgeHandler);
     }
 
-    private NtfyConnectionHandler getBridgeHandler() {
-        return (NtfyConnectionHandler) (java.util.Objects
-                .requireNonNull(java.util.Objects.requireNonNull(getBridge()).getHandler()));
+    private @Nullable NtfyConnectionHandler getBridgeHandler() {
+        Bridge bridge = getBridge();
+
+        if (bridge != null) {
+            if (bridge.getHandler() instanceof NtfyConnectionHandler bridgeHandler) {
+                return bridgeHandler;
+            }
+        }
+        return null;
     }
 
     @Override
@@ -80,18 +86,30 @@ public class NtfyTopicHandler extends BaseThingHandler implements WebSocketConne
     public void thingUpdated(Thing thing) {
         super.thingUpdated(thing);
 
-        getBridgeHandler().createAndRegisterWebSocketClient(thing);
+        start(thing);
+    }
+
+    private void start(Thing thing) {
+        NtfyConnectionHandler bridgeHandler = getBridgeHandler();
+
+        if (bridgeHandler == null) {
+            return;
+        }
+        ntfySender = bridgeHandler.CreateSender(this.getConfigAs(NtfyTopicConfiguration.class).topicName);
+        bridgeHandler.createAndRegisterWebSocketClient(thing);
+        startConnection();
     }
 
     @Override
     public void bridgeStatusChanged(ThingStatusInfo bridgeStatusInfo) {
-        if (bridgeStatusInfo.getStatus() == ThingStatus.ONLINE
-                && getThing().getStatusInfo().getStatusDetail() == ThingStatusDetail.BRIDGE_OFFLINE) {
-            updateStatus(ThingStatus.UNKNOWN);
+        if (bridgeStatusInfo.getStatus() == ThingStatus.ONLINE) {
             initialize();
         } else {
-            super.bridgeStatusChanged(bridgeStatusInfo);
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE);
+            ntfySender = null;
         }
+
+        super.bridgeStatusChanged(bridgeStatusInfo);
     }
 
     @Override
@@ -112,8 +130,7 @@ public class NtfyTopicHandler extends BaseThingHandler implements WebSocketConne
 
         scheduler.execute(() -> {
             try {
-                getBridgeHandler().createAndRegisterWebSocketClient(thing);
-                startConnection();
+                start(thing);
             } finally {
                 this.isInitializing = false;
             }
@@ -122,7 +139,11 @@ public class NtfyTopicHandler extends BaseThingHandler implements WebSocketConne
 
     private void startConnection() {
         if (getThing().getStatus() != ThingStatus.ONLINE) {
-            if (!getBridgeHandler().startWebSocketConnection(thing, ntfyWebSocket)) {
+            NtfyConnectionHandler bridgeHandler = getBridgeHandler();
+            if (bridgeHandler == null) {
+                return;
+            }
+            if (!bridgeHandler.startWebSocketConnection(thing, ntfyWebSocket)) {
                 updateStatus(ThingStatus.OFFLINE);
             }
         }
@@ -134,16 +155,23 @@ public class NtfyTopicHandler extends BaseThingHandler implements WebSocketConne
     }
 
     @Override
-    public void connectionLost(String reason) {
+    public void connectionLost(@Nullable String reason) {
+        updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
+                reason == null || reason.isBlank() ? "WebSocket connection lost" : reason);
     }
 
     @Override
     public void connectionError(Throwable cause) {
-        getBridgeHandler().connectionError(cause);
+        NtfyConnectionHandler bridgeHandler = getBridgeHandler();
+        if (bridgeHandler == null) {
+            return;
+        }
+        updateStatus(ThingStatus.OFFLINE);
+        bridgeHandler.connectionError(cause);
     }
 
     @Override
-    public void messageRecieved(BaseEvent event) {
+    public void messageReceived(BaseEvent event) {
         if (event instanceof MessageEvent message) {
             this.lastMessageEvent = message;
             updateChannels();
@@ -153,11 +181,9 @@ public class NtfyTopicHandler extends BaseThingHandler implements WebSocketConne
     private void updateChannels() {
         final MessageEvent lastMessageEvent = this.lastMessageEvent;
         if (lastMessageEvent != null) {
-            updateState(NtfyBindingConstants.CHANNEL_NTFY_LASTMESSAGE,
-                    StringType.valueOf(lastMessageEvent.getMessage()));
-            updateState(NtfyBindingConstants.CHANNEL_NTFY_LASTMESSAGETIME,
-                    new DateTimeType(lastMessageEvent.getTime()));
-            updateState(NtfyBindingConstants.CHANNEL_NTFY_LASTMESSAGEID, StringType.valueOf(lastMessageEvent.getId()));
+            updateState(CHANNEL_LASTMESSAGE, StringType.valueOf(lastMessageEvent.getMessage()));
+            updateState(CHANNEL_LASTMESSAGETIME, new DateTimeType(lastMessageEvent.getTime()));
+            updateState(CHANNEL_LASTMESSAGEID, StringType.valueOf(lastMessageEvent.getId()));
         }
     }
 
@@ -169,8 +195,12 @@ public class NtfyTopicHandler extends BaseThingHandler implements WebSocketConne
      * @throws URISyntaxException
      */
     public String sendMessage(NtfyMessage ntfyMessage) throws URISyntaxException {
-        @Nullable
-        MessageEvent sendMessage = ntfySender.sendMessage(ntfyMessage);
+        final @Nullable NtfySender sender = ntfySender;
+        if (sender == null) {
+            return "";
+        }
+
+        MessageEvent sendMessage = sender.sendMessage(ntfyMessage);
 
         if (sendMessage == null) {
             return "";
@@ -178,10 +208,26 @@ public class NtfyTopicHandler extends BaseThingHandler implements WebSocketConne
         return sendMessage.getId();
     }
 
+    /**
+     * Uploads a local file to the configured topic via the underlying
+     * {@link NtfySender#sendFile(String, String, String)} and returns the
+     * created message id on success.
+     *
+     * @param file the filesystem path to the file to upload
+     * @param filename optional filename to present to recipients (may be null)
+     * @param sequenceId optional sequence id to associate with the uploaded message
+     * @return the created message id on success, or an empty string on failure
+     * @throws URISyntaxException when the constructed request URI is invalid
+     */
     public String sendFile(String file, @Nullable String filename, @Nullable String sequenceId)
             throws URISyntaxException {
+        final @Nullable NtfySender sender = ntfySender;
+        if (sender == null) {
+            return "";
+        }
+
         @Nullable
-        MessageEvent sendMessage = ntfySender.sendFile(file, filename, sequenceId);
+        MessageEvent sendMessage = sender.sendFile(file, filename, sequenceId);
 
         if (sendMessage == null) {
             return "";
@@ -197,6 +243,10 @@ public class NtfyTopicHandler extends BaseThingHandler implements WebSocketConne
      * @throws URISyntaxException when the underlying request URI could not be constructed
      */
     public boolean deleteMessage(String sequenceId) throws URISyntaxException {
-        return ntfySender.deleteMessage(sequenceId);
+        final @Nullable NtfySender sender = ntfySender;
+        if (sender == null) {
+            return false;
+        }
+        return sender.deleteMessage(sequenceId);
     }
 }

--- a/bundles/org.openhab.binding.ntfy/src/main/java/org/openhab/binding/ntfy/internal/NtfyTopicHandler.java
+++ b/bundles/org.openhab.binding.ntfy/src/main/java/org/openhab/binding/ntfy/internal/NtfyTopicHandler.java
@@ -17,6 +17,7 @@ import static org.openhab.binding.ntfy.internal.NtfyBindingConstants.*;
 import java.net.URISyntaxException;
 import java.util.Collection;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
@@ -51,14 +52,13 @@ public class NtfyTopicHandler extends BaseThingHandler implements WebSocketConne
 
     private NtfyWebSocket ntfyWebSocket;
     private @Nullable NtfySender ntfySender;
-    private boolean isInitializing;
+    private AtomicBoolean isInitializing = new AtomicBoolean(false);
     private @Nullable MessageEvent lastMessageEvent;
 
     /**
      * Creates a new {@link NtfyTopicHandler} for the provided topic thing.
      *
      * @param thing the topic thing this handler belongs to
-     * @param httpClient the HTTP client used by the sender to perform REST calls
      */
     public NtfyTopicHandler(Thing thing) {
         super(thing);
@@ -95,7 +95,7 @@ public class NtfyTopicHandler extends BaseThingHandler implements WebSocketConne
         if (bridgeHandler == null) {
             return;
         }
-        ntfySender = bridgeHandler.CreateSender(this.getConfigAs(NtfyTopicConfiguration.class).topicName);
+        ntfySender = bridgeHandler.createSender(this.getConfigAs(NtfyTopicConfiguration.class).topicName);
         bridgeHandler.createAndRegisterWebSocketClient(thing);
         startConnection();
     }
@@ -121,10 +121,9 @@ public class NtfyTopicHandler extends BaseThingHandler implements WebSocketConne
 
     @Override
     public void initialize() {
-        if (isInitializing) {
+        if (!isInitializing.compareAndSet(false, true)) {
             return;
         }
-        this.isInitializing = true;
 
         updateStatus(ThingStatus.UNKNOWN);
 
@@ -132,7 +131,7 @@ public class NtfyTopicHandler extends BaseThingHandler implements WebSocketConne
             try {
                 start(thing);
             } finally {
-                this.isInitializing = false;
+                isInitializing.set(false);
             }
         });
     }
@@ -157,7 +156,8 @@ public class NtfyTopicHandler extends BaseThingHandler implements WebSocketConne
     @Override
     public void connectionLost(@Nullable String reason) {
         updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
-                reason == null || reason.isBlank() ? "WebSocket connection lost" : reason);
+                reason == null || reason.isBlank() ? "@text/offline.communication-error.websocket-connection-lost"
+                        : reason);
     }
 
     @Override

--- a/bundles/org.openhab.binding.ntfy/src/main/java/org/openhab/binding/ntfy/internal/action/NtfyActions.java
+++ b/bundles/org.openhab.binding.ntfy/src/main/java/org/openhab/binding/ntfy/internal/action/NtfyActions.java
@@ -39,11 +39,16 @@ import org.osgi.service.component.annotations.ServiceScope;
 public class NtfyActions implements ThingActions {
 
     private @Nullable NtfyTopicHandler handler;
-    private final NtfyMessage ntfyMessage = new NtfyMessage();
+    private NtfyMessage ntfyMessage = new NtfyMessage();
+
+    private void resetNtfyMessage() {
+        ntfyMessage = new NtfyMessage();
+    }
 
     @Override
     public void setThingHandler(ThingHandler handler) {
         this.handler = (NtfyTopicHandler) handler;
+        resetNtfyMessage();
     }
 
     @Override
@@ -267,13 +272,13 @@ public class NtfyActions implements ThingActions {
      * @param actions the ThingActions instance
      * @param label the action label
      * @param clearNotification whether to clear the notification
-     * @param url the value to copy
+     * @param value the value to copy
      * @return the modified ThingActions builder instance
      * @throws MalformedURLException never thrown by this wrapper but declared for API compatibility
      */
-    public static ThingActions withCopyAction(ThingActions actions, String label, Boolean clearNotification, String url)
-            throws MalformedURLException {
-        return ((NtfyActions) actions).withCopyAction(label, clearNotification, url);
+    public static ThingActions withCopyAction(ThingActions actions, String label, Boolean clearNotification,
+            String value) throws MalformedURLException {
+        return ((NtfyActions) actions).withCopyAction(label, clearNotification, value);
     }
 
     /**
@@ -329,7 +334,7 @@ public class NtfyActions implements ThingActions {
     public @ActionOutput(label = "Ntfy Actions", type = "org.openhab.core.thing.binding.ThingActions") ThingActions withBroadcastAction(
             @ActionInput(name = "label") String label,
             @ActionInput(name = "clearNotification") Boolean clearNotification,
-            @ActionInput(name = "params") String params) {
+            @ActionInput(name = "params") @Nullable String params) {
         ntfyMessage.addBroadcastAction(label, clearNotification, params);
         return this;
     }
@@ -345,7 +350,7 @@ public class NtfyActions implements ThingActions {
      * @throws MalformedURLException never thrown by this wrapper but declared for API compatibility
      */
     public static ThingActions withBroadcastAction(ThingActions actions, String label, Boolean clearNotification,
-            String params) throws MalformedURLException {
+            @Nullable String params) throws MalformedURLException {
         return ((NtfyActions) actions).withBroadcastAction(label, clearNotification, params);
     }
 
@@ -400,6 +405,30 @@ public class NtfyActions implements ThingActions {
     }
 
     /**
+     * Adds a title to the internal message builder.
+     *
+     * @param title the title
+     * @return this {@link ThingActions} builder instance
+     */
+    @RuleAction(label = "add a title to the message", description = "Add a title to the content for the builder.")
+    public @ActionOutput(label = "Ntfy Actions", type = "org.openhab.core.thing.binding.ThingActions") ThingActions withTitle(
+            @ActionInput(name = "title") String title) {
+        ntfyMessage.setTitle(title);
+        return this;
+    }
+
+    /**
+     * Static helper to call {@link #withTitle(String)} from rule code.
+     *
+     * @param actions the ThingActions instance
+     * @param title the title
+     * @return the modified ThingActions builder instance
+     */
+    public static ThingActions withTitle(ThingActions actions, String title) {
+        return ((NtfyActions) actions).withTitle(title);
+    }
+
+    /**
      * Sends the message constructed via the builder-style methods and returns the
      * created message id.
      *
@@ -412,6 +441,12 @@ public class NtfyActions implements ThingActions {
         if (handler == null) {
             return "";
         }
+
+        if (!ntfyMessage.hasMessage() || ntfyMessage.getMessage().isBlank()) {
+            throw new IllegalStateException(
+                    "Cannot send message without content. Please set a message via withMessage() before sending.");
+        }
+
         return handler.sendMessage(ntfyMessage);
     }
 
@@ -491,5 +526,22 @@ public class NtfyActions implements ThingActions {
      */
     public static boolean delete(ThingActions actions, String sequenceId) throws URISyntaxException {
         return ((NtfyActions) actions).delete(sequenceId);
+    }
+
+    /**
+     * Clears the current in-progress message builder state.
+     */
+    @RuleAction(label = "clear ntfy message builder", description = "Reset the current ntfy message builder state.")
+    public void clearNtfyMessageBuilder() {
+        resetNtfyMessage();
+    }
+
+    /**
+     * Static helper to call {@link #clearNtfyMessageBuilder()} from rule code.
+     *
+     * @param actions the ThingActions instance
+     */
+    public static void clearNtfyMessageBuilder(ThingActions actions) {
+        ((NtfyActions) actions).clearNtfyMessageBuilder();
     }
 }

--- a/bundles/org.openhab.binding.ntfy/src/main/java/org/openhab/binding/ntfy/internal/action/NtfyActions.java
+++ b/bundles/org.openhab.binding.ntfy/src/main/java/org/openhab/binding/ntfy/internal/action/NtfyActions.java
@@ -1,0 +1,495 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.ntfy.internal.action;
+
+import java.net.MalformedURLException;
+import java.net.URISyntaxException;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.ntfy.internal.NtfyTopicHandler;
+import org.openhab.binding.ntfy.internal.network.NtfyMessage;
+import org.openhab.core.automation.annotation.ActionInput;
+import org.openhab.core.automation.annotation.ActionOutput;
+import org.openhab.core.automation.annotation.RuleAction;
+import org.openhab.core.thing.binding.ThingActions;
+import org.openhab.core.thing.binding.ThingActionsScope;
+import org.openhab.core.thing.binding.ThingHandler;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ServiceScope;
+
+/**
+ * Provides the actions for the ntfy API.
+ *
+ * @author Christian Kittel - Initial contribution
+ */
+@Component(scope = ServiceScope.PROTOTYPE, service = NtfyActions.class)
+@ThingActionsScope(name = "ntfy")
+@NonNullByDefault
+public class NtfyActions implements ThingActions {
+
+    private @Nullable NtfyTopicHandler handler;
+    private final NtfyMessage ntfyMessage = new NtfyMessage();
+
+    @Override
+    public void setThingHandler(ThingHandler handler) {
+        this.handler = (NtfyTopicHandler) handler;
+    }
+
+    @Override
+    public @Nullable ThingHandler getThingHandler() {
+        return handler;
+    }
+
+    /**
+     * Sends a simple message directly to the topic.
+     *
+     * @param message the message content to send
+     * @return the id of the created message or an empty string on failure
+     * @throws URISyntaxException
+     */
+    @RuleAction(label = "send a simple message", description = "Send a message to the ntfy topic.")
+    public @ActionOutput(label = "Message ID", type = "java.lang.String") String sendNtfyMessage(
+            @ActionInput(name = "message") String message) throws URISyntaxException {
+        final NtfyTopicHandler handler = this.handler;
+        if (handler == null) {
+            return "";
+        }
+        final NtfyMessage ntfyMessage = new NtfyMessage();
+        ntfyMessage.setMessage(message);
+        return handler.sendMessage(ntfyMessage);
+    }
+
+    /**
+     * Static helper to call {@link #sendNtfyMessage(String)} from rule code.
+     *
+     * @param actions the ThingActions instance
+     * @param message the message content
+     * @return the id of the created message or an empty string on failure
+     * @throws URISyntaxException
+     */
+    public static String sendNtfyMessage(ThingActions actions, String message) throws URISyntaxException {
+        return ((NtfyActions) actions).sendNtfyMessage(message);
+    }
+
+    /**
+     * Sets the message content on the internal builder instance and returns this
+     * actions instance to allow fluent chaining in automation rules.
+     *
+     * @param message the message content to set
+     * @return this {@link ThingActions} builder instance
+     */
+    @RuleAction(label = "set the message", description = "Set the message content for the builder.")
+    public @ActionOutput(label = "Ntfy Actions", type = "org.openhab.core.thing.binding.ThingActions") ThingActions withMessage(
+            @ActionInput(name = "message") String message) {
+        ntfyMessage.setMessage(message);
+        return this;
+    }
+
+    /**
+     * Static helper to call {@link #withMessage(String)} from rule code.
+     *
+     * @param actions the ThingActions instance
+     * @param message the message content
+     * @return the modified ThingActions builder instance
+     */
+    public static ThingActions withMessage(ThingActions actions, String message) {
+        return ((NtfyActions) actions).withMessage(message);
+    }
+
+    /**
+     * Sets the numeric priority for the message builder (1..5).
+     *
+     * @param priority the priority value
+     * @return this {@link ThingActions} builder instance
+     */
+    @RuleAction(label = "set the priority of the message", description = "Set the priority of the content for the builder.")
+    public @ActionOutput(label = "Ntfy Actions", type = "org.openhab.core.thing.binding.ThingActions") ThingActions withPriority(
+            @ActionInput(name = "priority") int priority) {
+        ntfyMessage.setPriority(priority);
+        return this;
+    }
+
+    /**
+     * Static helper to call {@link #withPriority(int)} from rule code.
+     *
+     * @param actions the ThingActions instance
+     * @param priority the priority value
+     * @return the modified ThingActions builder instance
+     */
+    public static ThingActions withPriority(ThingActions actions, int priority) {
+        return ((NtfyActions) actions).withPriority(priority);
+    }
+
+    /**
+     * Adds a tag to the internal message builder.
+     *
+     * @param tag the tag to add
+     * @return this {@link ThingActions} builder instance
+     */
+    @RuleAction(label = "add a tag to the message", description = "Add a tag to the content for the builder.")
+    public @ActionOutput(label = "Ntfy Actions", type = "org.openhab.core.thing.binding.ThingActions") ThingActions withTag(
+            @ActionInput(name = "tag") String tag) {
+        ntfyMessage.addTag(tag);
+        return this;
+    }
+
+    /**
+     * Static helper to call {@link #withTag(String)} from rule code.
+     *
+     * @param actions the ThingActions instance
+     * @param tag the tag to add
+     * @return the modified ThingActions builder instance
+     */
+    public static ThingActions withTag(ThingActions actions, String tag) {
+        return ((NtfyActions) actions).withTag(tag);
+    }
+
+    /**
+     * Sets an icon URL on the internal message builder.
+     *
+     * @param url the icon URL
+     * @return this {@link ThingActions} builder instance
+     * @throws URISyntaxException when the provided URL cannot be parsed
+     */
+    @RuleAction(label = "add an icon to the message", description = "Add an icon to the content for the builder.")
+    public @ActionOutput(label = "Ntfy Actions", type = "org.openhab.core.thing.binding.ThingActions") ThingActions withIcon(
+            @ActionInput(name = "url") String url) throws URISyntaxException {
+        ntfyMessage.setIcon(url);
+        return this;
+    }
+
+    /**
+     * Static helper to call {@link #withIcon(String)} from rule code.
+     *
+     * @param actions the ThingActions instance
+     * @param url the icon URL
+     * @return the modified ThingActions builder instance
+     * @throws URISyntaxException when the provided URL cannot be parsed
+     */
+    public static ThingActions withIcon(ThingActions actions, String url) throws URISyntaxException {
+        return ((NtfyActions) actions).withIcon(url);
+    }
+
+    /**
+     * Sets an attachment URL and optional filename on the message builder.
+     *
+     * @param url the attachment URL
+     * @param filename optional filename to present to recipients
+     * @return this {@link ThingActions} builder instance
+     * @throws URISyntaxException when the provided URL cannot be parsed
+     */
+    @RuleAction(label = "add an attachment to the message", description = "Add an attachment to the content for the builder.")
+    public @ActionOutput(label = "Ntfy Actions", type = "org.openhab.core.thing.binding.ThingActions") ThingActions withAttachment(
+            @ActionInput(name = "url") String url, @ActionInput(name = "filename") @Nullable String filename)
+            throws URISyntaxException {
+        ntfyMessage.setAttachment(url, filename);
+        return this;
+    }
+
+    /**
+     * Static helper to call {@link #withAttachment(String, String)} from rule code.
+     *
+     * @param actions the ThingActions instance
+     * @param url the attachment URL
+     * @param filename optional filename
+     * @return the modified ThingActions builder instance
+     * @throws URISyntaxException when the provided URL cannot be parsed
+     */
+    public static ThingActions withAttachment(ThingActions actions, String url, @Nullable String filename)
+            throws URISyntaxException {
+        return ((NtfyActions) actions).withAttachment(url, filename);
+    }
+
+    /**
+     * Adds a view action to the internal message builder which opens the supplied URL.
+     *
+     * @param label the label for the action
+     * @param clearNotification whether the notification should be cleared when the action is executed
+     * @param url the URL to open
+     * @return this {@link ThingActions} builder instance
+     * @throws MalformedURLException when the provided URL is not valid
+     */
+    @RuleAction(label = "add a view action to the message", description = "Add a view action to the content for the builder.")
+    public @ActionOutput(label = "Ntfy Actions", type = "org.openhab.core.thing.binding.ThingActions") ThingActions withViewAction(
+            @ActionInput(name = "label") String label,
+            @ActionInput(name = "clearNotification") Boolean clearNotification, @ActionInput(name = "url") String url)
+            throws MalformedURLException {
+        ntfyMessage.addViewAction(label, clearNotification, url);
+        return this;
+    }
+
+    /**
+     * Static helper to call {@link #withViewAction(String, Boolean, String)} from rule code.
+     *
+     * @param actions the ThingActions instance
+     * @param label the action label
+     * @param clearNotification whether to clear notification
+     * @param url the URL to open
+     * @return the modified ThingActions builder instance
+     * @throws MalformedURLException when the provided URL is not valid
+     */
+    public static ThingActions withViewAction(ThingActions actions, String label, Boolean clearNotification, String url)
+            throws MalformedURLException {
+        return ((NtfyActions) actions).withViewAction(label, clearNotification, url);
+    }
+
+    /**
+     * Adds a copy action to the message builder which copies a value to the clipboard.
+     *
+     * @param label the label for the action
+     * @param clearNotification whether the notification should be cleared when the action is executed
+     * @param value the value to copy
+     * @return this {@link ThingActions} builder instance
+     */
+    @RuleAction(label = "add a copy action to the message", description = "Add a copy action to the content for the builder.")
+    public @ActionOutput(label = "Ntfy Actions", type = "org.openhab.core.thing.binding.ThingActions") ThingActions withCopyAction(
+            @ActionInput(name = "label") String label,
+            @ActionInput(name = "clearNotification") Boolean clearNotification,
+            @ActionInput(name = "value") String value) {
+        ntfyMessage.addCopyAction(label, clearNotification, value);
+        return this;
+    }
+
+    /**
+     * Static helper to call {@link #withCopyAction(String, Boolean, String)} from rule code.
+     *
+     * @param actions the ThingActions instance
+     * @param label the action label
+     * @param clearNotification whether to clear the notification
+     * @param url the value to copy
+     * @return the modified ThingActions builder instance
+     * @throws MalformedURLException never thrown by this wrapper but declared for API compatibility
+     */
+    public static ThingActions withCopyAction(ThingActions actions, String label, Boolean clearNotification, String url)
+            throws MalformedURLException {
+        return ((NtfyActions) actions).withCopyAction(label, clearNotification, url);
+    }
+
+    /**
+     * Adds an HTTP action to the message builder which will perform a HTTP call when executed.
+     *
+     * @param label the label for the action
+     * @param clearNotification whether the notification should be cleared when the action is executed
+     * @param url the URL to call
+     * @param method optional HTTP method
+     * @param headers optional headers
+     * @param body optional request body
+     * @return this {@link ThingActions} builder instance
+     * @throws MalformedURLException when the provided URL is not valid
+     */
+    @RuleAction(label = "add a HTTP action to the message", description = "Add a HTTP action to the content for the builder.")
+    public @ActionOutput(label = "Ntfy Actions", type = "org.openhab.core.thing.binding.ThingActions") ThingActions withHttpAction(
+            @ActionInput(name = "label") String label,
+            @ActionInput(name = "clearNotification") Boolean clearNotification, @ActionInput(name = "url") String url,
+            @ActionInput(name = "method") @Nullable String method,
+            @ActionInput(name = "headers") @Nullable String headers, @ActionInput(name = "body") @Nullable String body)
+            throws MalformedURLException {
+        ntfyMessage.addHttpAction(label, clearNotification, url, method, headers, body);
+        return this;
+    }
+
+    /**
+     * Static helper to call {@link #withHttpAction(String, Boolean, String, String, String, String)} from rule code.
+     *
+     * @param actions the ThingActions instance
+     * @param label the action label
+     * @param clearNotification whether to clear the notification
+     * @param url the URL to call
+     * @param method optional method
+     * @param headers optional headers
+     * @param body optional body
+     * @return the modified ThingActions builder instance
+     * @throws MalformedURLException when the provided URL is not valid
+     */
+    public static ThingActions withHttpAction(ThingActions actions, String label, Boolean clearNotification, String url,
+            @Nullable String method, @Nullable String headers, @Nullable String body) throws MalformedURLException {
+        return ((NtfyActions) actions).withHttpAction(label, clearNotification, url, method, headers, body);
+    }
+
+    /**
+     * Adds a broadcast action to the internal message builder.
+     *
+     * @param label the action label
+     * @param clearNotification whether the notification should be cleared when the action is executed
+     * @param params parameters passed to the broadcast action
+     * @return this {@link ThingActions} builder instance
+     */
+    @RuleAction(label = "add a broadcast action to the message", description = "Add a broadcast action to the content for the builder.")
+    public @ActionOutput(label = "Ntfy Actions", type = "org.openhab.core.thing.binding.ThingActions") ThingActions withBroadcastAction(
+            @ActionInput(name = "label") String label,
+            @ActionInput(name = "clearNotification") Boolean clearNotification,
+            @ActionInput(name = "params") String params) {
+        ntfyMessage.addBroadcastAction(label, clearNotification, params);
+        return this;
+    }
+
+    /**
+     * Static helper to call {@link #withBroadcastAction(String, Boolean, String)} from rule code.
+     *
+     * @param actions the ThingActions instance
+     * @param label the action label
+     * @param clearNotification whether to clear the notification
+     * @param params parameters for the broadcast
+     * @return the modified ThingActions builder instance
+     * @throws MalformedURLException never thrown by this wrapper but declared for API compatibility
+     */
+    public static ThingActions withBroadcastAction(ThingActions actions, String label, Boolean clearNotification,
+            String params) throws MalformedURLException {
+        return ((NtfyActions) actions).withBroadcastAction(label, clearNotification, params);
+    }
+
+    /**
+     * Sets an optional delivery delay on the internal message builder.
+     * message is published.
+     *
+     * @param delay the provider-specific delay string (may be null)
+     * @return this {@link ThingActions} builder instance
+     */
+    @RuleAction(label = "add a delay to the message", description = "Add a delay for the content for the builder.")
+    public @ActionOutput(label = "Ntfy Actions", type = "org.openhab.core.thing.binding.ThingActions") ThingActions withDelay(
+            @ActionInput(name = "delay") @Nullable String delay) {
+        ntfyMessage.setDelay(delay);
+        return this;
+    }
+
+    /**
+     * Static helper to call {@link #withDelay(String)} from rule code.
+     *
+     * @param actions the ThingActions instance
+     * @param delay the provider-specific delay string (may be null)
+     * @return the modified ThingActions builder instance
+     */
+    public static ThingActions withDelay(ThingActions actions, @Nullable String delay) {
+        return ((NtfyActions) actions).withDelay(delay);
+    }
+
+    /**
+     * Sets the sequence id on the builder which can be used to later identify or
+     * delete the message on the server.
+     *
+     * @param sequenceId the sequence id or {@code null}
+     * @return this {@link ThingActions} builder instance
+     */
+    @RuleAction(label = "add a sequence ID to the message", description = "Add a sequence ID to the content for the builder.")
+    public @ActionOutput(label = "Ntfy Actions", type = "org.openhab.core.thing.binding.ThingActions") ThingActions withSequenceId(
+            @ActionInput(name = "sequenceId") @Nullable String sequenceId) {
+        ntfyMessage.setSequenceId(sequenceId);
+        return this;
+    }
+
+    /**
+     * Static helper to call {@link #withSequenceId(String)} from rule code.
+     *
+     * @param actions the ThingActions instance
+     * @param sequenceId the sequence id
+     * @return the modified ThingActions builder instance
+     */
+    public static ThingActions withSequenceId(ThingActions actions, @Nullable String sequenceId) {
+        return ((NtfyActions) actions).withSequenceId(sequenceId);
+    }
+
+    /**
+     * Sends the message constructed via the builder-style methods and returns the
+     * created message id.
+     *
+     * @return the created message id or an empty string on failure
+     * @throws URISyntaxException
+     */
+    @RuleAction(label = "send built message", description = "Send the message configured via builder methods.")
+    public @ActionOutput(label = "Message ID", type = "java.lang.String") String send() throws URISyntaxException {
+        final NtfyTopicHandler handler = this.handler;
+        if (handler == null) {
+            return "";
+        }
+        return handler.sendMessage(ntfyMessage);
+    }
+
+    /**
+     * Static helper to call {@link #send()} from rule code.
+     *
+     * @param actions the ThingActions instance
+     * @return the created message id or an empty string on failure
+     * @throws URISyntaxException
+     */
+    public static String send(ThingActions actions) throws URISyntaxException {
+        return ((NtfyActions) actions).send();
+    }
+
+    /**
+     * Sends the content of a local file to the configured topic using the
+     * {@link NtfyTopicHandler#sendFile(String, String, String)} method.
+     *
+     * @param file the filesystem path to the file to send
+     * @param filename optional filename to present to recipients (may be null)
+     * @param sequenceId optional sequence id to associate with the message
+     * @return the id of the created message or an empty string on failure
+     * @throws URISyntaxException when the constructed request URI is invalid
+     */
+    @RuleAction(label = "send a file", description = "Send a file with the given sequence ID.")
+    public @ActionOutput(label = "Message ID", type = "java.lang.String") String send(
+            @ActionInput(name = "file") String file, @ActionInput(name = "filename") @Nullable String filename,
+            @ActionInput(name = "sequenceId") @Nullable String sequenceId) throws URISyntaxException {
+        final NtfyTopicHandler handler = this.handler;
+        if (handler == null) {
+            return "";
+        }
+
+        return handler.sendFile(file, filename, sequenceId);
+    }
+
+    /**
+     * Static helper to call {@link #send(String, String, String)} from rule code.
+     *
+     * @param actions the ThingActions instance
+     * @param file the filesystem path to the file to send
+     * @param filename optional filename to present to recipients (may be null)
+     * @param sequenceId optional sequence id to associate with the message
+     * @return the id of the created message or an empty string on failure
+     * @throws URISyntaxException when the constructed request URI is invalid
+     */
+    public static String send(ThingActions actions, String file, @Nullable String filename, @Nullable String sequenceId)
+            throws URISyntaxException {
+        return ((NtfyActions) actions).send(file, filename, sequenceId);
+    }
+
+    /**
+     * Deletes a message with the provided sequence id.
+     *
+     * @param sequenceId the sequence id of the message to delete
+     * @return {@code true} when deletion succeeded
+     * @throws URISyntaxException when the constructed request URI is invalid
+     */
+    @RuleAction(label = "delete a message", description = "Delete the message with the given sequence ID.")
+    public @ActionOutput(label = "Deletion of the message was successful", type = "java.lang.Boolean") boolean delete(
+            @ActionInput(name = "sequenceId") String sequenceId) throws URISyntaxException {
+        final NtfyTopicHandler handler = this.handler;
+        if (handler == null || sequenceId.isBlank()) {
+            return false;
+        }
+
+        return handler.deleteMessage(sequenceId);
+    }
+
+    /**
+     * Static helper to call {@link #delete(String)} from rule code.
+     *
+     * @param actions the ThingActions instance
+     * @param sequenceId the sequence id to delete
+     * @return {@code true} when deletion succeeded
+     * @throws URISyntaxException when the constructed request URI is invalid
+     */
+    public static boolean delete(ThingActions actions, String sequenceId) throws URISyntaxException {
+        return ((NtfyActions) actions).delete(sequenceId);
+    }
+}

--- a/bundles/org.openhab.binding.ntfy/src/main/java/org/openhab/binding/ntfy/internal/action/NtfyActions.java
+++ b/bundles/org.openhab.binding.ntfy/src/main/java/org/openhab/binding/ntfy/internal/action/NtfyActions.java
@@ -447,7 +447,9 @@ public class NtfyActions implements ThingActions {
                     "Cannot send message without content. Please set a message via withMessage() before sending.");
         }
 
-        return handler.sendMessage(ntfyMessage);
+        String messageId = handler.sendMessage(ntfyMessage);
+        resetNtfyMessage();
+        return messageId;
     }
 
     /**

--- a/bundles/org.openhab.binding.ntfy/src/main/java/org/openhab/binding/ntfy/internal/models/BaseEvent.java
+++ b/bundles/org.openhab.binding.ntfy/src/main/java/org/openhab/binding/ntfy/internal/models/BaseEvent.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.ntfy.internal.models;
+
+import java.time.Instant;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * Base class for events received from the ntfy service.
+ * <p>
+ * This class contains common properties that are present on all events
+ * such as the event id, timestamp, raw event string and the topic name.
+ *
+ * @author Christian Kittel - Initial contribution
+ */
+@NonNullByDefault
+public abstract class BaseEvent {
+    @SerializedName("id")
+    private String id = "";
+
+    @SerializedName("time")
+    private Instant time = Instant.MIN;
+
+    @SerializedName("event")
+    private String eventAsString = "";
+
+    @SerializedName("topic")
+    private String topic = "";
+
+    /**
+     * Returns the identifier of the event.
+     *
+     * @return the event id as a string (never null)
+     */
+    public String getId() {
+        return id;
+    }
+
+    /**
+     * Sets the identifier of the event.
+     *
+     * @param id the event id
+     */
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    /**
+     * Returns the timestamp when the event occurred.
+     *
+     * @return the event time as {@link Instant}
+     */
+    public Instant getTime() {
+        return time;
+    }
+
+    /**
+     * Sets the timestamp when the event occurred.
+     *
+     * @param time the event time
+     */
+    public void setTime(Instant time) {
+        this.time = time;
+    }
+
+    /**
+     * Returns the raw event type string as provided by the server (for example "message").
+     *
+     * @return the raw event type string
+     */
+    public String getEventAsString() {
+        return eventAsString;
+    }
+
+    /**
+     * Sets the raw event type string.
+     *
+     * @param eventAsString the raw event type
+     */
+    public void setEventAsString(String eventAsString) {
+        this.eventAsString = eventAsString;
+    }
+
+    /**
+     * Returns the parsed {@link EventType} for the underlying raw event string.
+     *
+     * @return the {@link EventType} representation of the event
+     */
+    public EventType getEvent() {
+        return EventType.fromString(this.eventAsString);
+    }
+
+    /**
+     * Returns the topic name this event belongs to.
+     *
+     * @return the topic name
+     */
+    public String getTopic() {
+        return topic;
+    }
+
+    /**
+     * Sets the topic name this event belongs to.
+     *
+     * @param topic the topic name
+     */
+    public void setTopic(String topic) {
+        this.topic = topic;
+    }
+}

--- a/bundles/org.openhab.binding.ntfy/src/main/java/org/openhab/binding/ntfy/internal/models/EventType.java
+++ b/bundles/org.openhab.binding.ntfy/src/main/java/org/openhab/binding/ntfy/internal/models/EventType.java
@@ -30,6 +30,9 @@ public enum EventType {
     /** An "open" event indicating the user opened the notification. */
     OPEN,
 
+    /** A "delete" event indicating the user deleted the notification. */
+    DELETE,
+
     /** Unknown or unsupported event type. */
     UNKNOWN;
 
@@ -49,6 +52,8 @@ public enum EventType {
                 return MESSAGE;
             case "open":
                 return OPEN;
+            case "message_delete":
+                return DELETE;
             default:
                 return UNKNOWN;
         }

--- a/bundles/org.openhab.binding.ntfy/src/main/java/org/openhab/binding/ntfy/internal/models/EventType.java
+++ b/bundles/org.openhab.binding.ntfy/src/main/java/org/openhab/binding/ntfy/internal/models/EventType.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.ntfy.internal.models;
+
+import java.util.Locale;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
+/**
+ * Enumeration of supported event types returned by the ntfy service.
+ *
+ * @author Christian Kittel - Initial contribution
+ */
+@NonNullByDefault
+public enum EventType {
+    /** A regular message event containing a notification message. */
+    MESSAGE,
+
+    /** An "open" event indicating the user opened the notification. */
+    OPEN,
+
+    /** Unknown or unsupported event type. */
+    UNKNOWN;
+
+    /**
+     * Converts a string representation of an event type to the corresponding enum value.
+     * The comparison is performed using the root locale to avoid locale dependent behavior.
+     *
+     * @param text the raw event text (may be null)
+     * @return the matching {@link EventType} or {@link #UNKNOWN} if not recognised
+     */
+    public static EventType fromString(@Nullable String text) {
+        if (text == null) {
+            return UNKNOWN;
+        }
+        switch (text.toLowerCase(Locale.ROOT)) {
+            case "message":
+                return MESSAGE;
+            case "open":
+                return OPEN;
+            default:
+                return UNKNOWN;
+        }
+    }
+}

--- a/bundles/org.openhab.binding.ntfy/src/main/java/org/openhab/binding/ntfy/internal/models/MessageDeleteEvent.java
+++ b/bundles/org.openhab.binding.ntfy/src/main/java/org/openhab/binding/ntfy/internal/models/MessageDeleteEvent.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.ntfy.internal.models;
+
+import java.time.Instant;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * Represents a deleted message event returned by the ntfy service.
+ * <p>
+ * Contains fields such as the sequence id and expiration time
+ *
+ * @author Christian Kittel - Initial contribution
+ */
+@NonNullByDefault
+public class MessageDeleteEvent extends BaseEvent {
+    @SerializedName("sequence_id")
+    private String sequenceId = "";
+
+    @SerializedName("expires")
+    private Instant expires = Instant.MIN;
+
+    /**
+     * Returns the sequence identifier for this message.
+     *
+     * @return the sequence id
+     */
+    public String getSequenceId() {
+        return sequenceId;
+    }
+
+    /**
+     * Sets the sequence identifier for this message.
+     *
+     * @param sequenceId the sequence id
+     */
+    public void setSequenceId(String sequenceId) {
+        this.sequenceId = sequenceId;
+    }
+
+    /**
+     * Returns the expiry timestamp for the message, if provided.
+     *
+     * @return expiry as {@link Instant}
+     */
+    public Instant getExpires() {
+        return expires;
+    }
+
+    /**
+     * Sets the expiry timestamp for the message.
+     *
+     * @param expires the expiry instant
+     */
+    public void setExpires(Instant expires) {
+        this.expires = expires;
+    }
+}

--- a/bundles/org.openhab.binding.ntfy/src/main/java/org/openhab/binding/ntfy/internal/models/MessageEvent.java
+++ b/bundles/org.openhab.binding.ntfy/src/main/java/org/openhab/binding/ntfy/internal/models/MessageEvent.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.ntfy.internal.models;
+
+import java.time.Instant;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * Represents a message event returned by the ntfy service.
+ * <p>
+ * Contains fields such as the sequence id, expiration time, message body and priority.
+ *
+ * @author Christian Kittel - Initial contribution
+ */
+@NonNullByDefault
+public class MessageEvent extends BaseEvent {
+    @SerializedName("sequence_id")
+    private String sequenceId = "";
+
+    @SerializedName("expires")
+    private Instant expires = Instant.MIN;
+
+    @SerializedName("message")
+    private String message = "";
+
+    @SerializedName("priority")
+    private int priority;
+
+    /**
+     * Returns the sequence identifier for this message.
+     *
+     * @return the sequence id
+     */
+    public String getSequenceId() {
+        return sequenceId;
+    }
+
+    /**
+     * Sets the sequence identifier for this message.
+     *
+     * @param sequenceId the sequence id
+     */
+    public void setSequenceId(String sequenceId) {
+        this.sequenceId = sequenceId;
+    }
+
+    /**
+     * Returns the expiry timestamp for the message, if provided.
+     *
+     * @return expiry as {@link Instant}
+     */
+    public Instant getExpires() {
+        return expires;
+    }
+
+    /**
+     * Sets the expiry timestamp for the message.
+     *
+     * @param expires the expiry instant
+     */
+    public void setExpires(Instant expires) {
+        this.expires = expires;
+    }
+
+    /**
+     * Returns the message body.
+     *
+     * @return the message text
+     */
+    public String getMessage() {
+        return message;
+    }
+
+    /**
+     * Sets the message body.
+     *
+     * @param message the message text
+     */
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    /**
+     * Returns the numeric priority of the message.
+     *
+     * @return priority as int
+     */
+    public int getPriority() {
+        return priority;
+    }
+
+    /**
+     * Sets the numeric priority of the message.
+     *
+     * @param priority the priority value
+     */
+    public void setPriority(int priority) {
+        this.priority = priority;
+    }
+}

--- a/bundles/org.openhab.binding.ntfy/src/main/java/org/openhab/binding/ntfy/internal/models/OpenEvent.java
+++ b/bundles/org.openhab.binding.ntfy/src/main/java/org/openhab/binding/ntfy/internal/models/OpenEvent.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.ntfy.internal.models;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * Represents an "open" event sent by the ntfy service when a notification
+ * has been opened by the user.
+ *
+ * @author Christian Kittel - Initial contribution
+ */
+@NonNullByDefault
+public class OpenEvent extends BaseEvent {
+
+}

--- a/bundles/org.openhab.binding.ntfy/src/main/java/org/openhab/binding/ntfy/internal/network/ActionButtonBase.java
+++ b/bundles/org.openhab.binding.ntfy/src/main/java/org/openhab/binding/ntfy/internal/network/ActionButtonBase.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.ntfy.internal.network;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * Base class for action buttons used in message headers.
+ * <p>
+ * Action buttons are used to describe user actions (view, copy, http, broadcast)
+ * that are attached to a notification message and are serialized into the
+ * X-Actions request header.
+ *
+ * @author Christian Kittel - Initial contribution
+ */
+@NonNullByDefault
+public abstract class ActionButtonBase {
+    protected String label;
+    protected Boolean clearNotification;
+
+    /**
+     * Creates a new action button descriptor.
+     *
+     * @param label the label shown for the action button
+     * @param clearNotification whether the action should clear the notification when executed
+     */
+    public ActionButtonBase(String label, Boolean clearNotification) {
+        this.label = label;
+        this.clearNotification = clearNotification;
+    }
+
+    /**
+     * Returns the serialized header representation of the action for inclusion
+     * in the X-Actions HTTP header.
+     *
+     * @return the header string representation of the action
+     */
+    public abstract String getHeader();
+}

--- a/bundles/org.openhab.binding.ntfy/src/main/java/org/openhab/binding/ntfy/internal/network/BroadcastActionButton.java
+++ b/bundles/org.openhab.binding.ntfy/src/main/java/org/openhab/binding/ntfy/internal/network/BroadcastActionButton.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.ntfy.internal.network;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
+/**
+ * Action button that represents a broadcast action attached to a notification.
+ *
+ * @author Christian Kittel - Initial contribution
+ */
+@NonNullByDefault
+public class BroadcastActionButton extends ActionButtonBase {
+
+    private @Nullable String params;
+
+    /**
+     * Creates a broadcast action button descriptor.
+     *
+     * @param label the label shown for the action
+     * @param clearNotification whether executing the action should clear the notification
+     * @param params additional parameters passed with the broadcast action (may be null)
+     */
+    public BroadcastActionButton(String label, Boolean clearNotification, @Nullable String params) {
+        super(label, clearNotification);
+        this.params = params;
+    }
+
+    @Override
+    public String getHeader() {
+        return "broadcast, " + label + (params != null ? ", " + params : "")
+                + (clearNotification ? ", clear=true" : "");
+    }
+}

--- a/bundles/org.openhab.binding.ntfy/src/main/java/org/openhab/binding/ntfy/internal/network/BroadcastActionButton.java
+++ b/bundles/org.openhab.binding.ntfy/src/main/java/org/openhab/binding/ntfy/internal/network/BroadcastActionButton.java
@@ -40,6 +40,6 @@ public class BroadcastActionButton extends ActionButtonBase {
     @Override
     public String getHeader() {
         return "broadcast, " + label + (params != null ? ", " + params : "")
-                + (clearNotification ? ", clear=true" : "");
+                + (Boolean.TRUE.equals(clearNotification) ? ", clear=true" : "");
     }
 }

--- a/bundles/org.openhab.binding.ntfy/src/main/java/org/openhab/binding/ntfy/internal/network/CopyActionButton.java
+++ b/bundles/org.openhab.binding.ntfy/src/main/java/org/openhab/binding/ntfy/internal/network/CopyActionButton.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.ntfy.internal.network;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * Action button that represents a copy action attached to a notification.
+ *
+ * @author Christian Kittel - Initial contribution
+ */
+@NonNullByDefault
+public class CopyActionButton extends ActionButtonBase {
+
+    private String value;
+
+    /**
+     * Creates a copy action button descriptor.
+     *
+     * @param label the label shown for the action
+     * @param clearNotification whether executing the action should clear the notification
+     * @param value the value that will be copied when the action is executed
+     */
+    public CopyActionButton(String label, Boolean clearNotification, String value) {
+        super(label, clearNotification);
+        this.value = value;
+    }
+
+    @Override
+    public String getHeader() {
+        return "copy, " + label + ", " + value + (clearNotification ? ", clear=true" : "");
+    }
+}

--- a/bundles/org.openhab.binding.ntfy/src/main/java/org/openhab/binding/ntfy/internal/network/CopyActionButton.java
+++ b/bundles/org.openhab.binding.ntfy/src/main/java/org/openhab/binding/ntfy/internal/network/CopyActionButton.java
@@ -38,6 +38,6 @@ public class CopyActionButton extends ActionButtonBase {
 
     @Override
     public String getHeader() {
-        return "copy, " + label + ", " + value + (clearNotification ? ", clear=true" : "");
+        return "copy, " + label + ", " + value + (Boolean.TRUE.equals(clearNotification) ? ", clear=true" : "");
     }
 }

--- a/bundles/org.openhab.binding.ntfy/src/main/java/org/openhab/binding/ntfy/internal/network/EventDeserializer.java
+++ b/bundles/org.openhab.binding.ntfy/src/main/java/org/openhab/binding/ntfy/internal/network/EventDeserializer.java
@@ -18,6 +18,7 @@ import java.util.Locale;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.ntfy.internal.models.BaseEvent;
+import org.openhab.binding.ntfy.internal.models.MessageDeleteEvent;
 import org.openhab.binding.ntfy.internal.models.MessageEvent;
 import org.openhab.binding.ntfy.internal.models.OpenEvent;
 
@@ -48,6 +49,8 @@ public class EventDeserializer implements JsonDeserializer<BaseEvent> {
                     return context.deserialize(jsonObject, MessageEvent.class);
                 case "open":
                     return context.deserialize(jsonObject, OpenEvent.class);
+                case "message_delete":
+                    return context.deserialize(jsonObject, MessageDeleteEvent.class);
             }
         }
 

--- a/bundles/org.openhab.binding.ntfy/src/main/java/org/openhab/binding/ntfy/internal/network/EventDeserializer.java
+++ b/bundles/org.openhab.binding.ntfy/src/main/java/org/openhab/binding/ntfy/internal/network/EventDeserializer.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.ntfy.internal.network;
+
+import java.lang.reflect.Type;
+import java.util.Locale;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.ntfy.internal.models.BaseEvent;
+import org.openhab.binding.ntfy.internal.models.MessageEvent;
+import org.openhab.binding.ntfy.internal.models.OpenEvent;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+
+/**
+ * Gson deserializer that converts incoming JSON into specific {@link BaseEvent}
+ * implementations depending on the event type field.
+ *
+ * @author Christian Kittel - Initial contribution
+ */
+@NonNullByDefault
+public class EventDeserializer implements JsonDeserializer<BaseEvent> {
+    @Override
+    public @Nullable BaseEvent deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
+            throws JsonParseException {
+        JsonObject jsonObject = json.getAsJsonObject();
+        JsonElement eventElement = jsonObject.get("event");
+
+        if (eventElement != null) {
+            String eventType = eventElement.getAsString();
+            switch (eventType.toLowerCase(Locale.ROOT)) {
+                case "message":
+                    return context.deserialize(jsonObject, MessageEvent.class);
+                case "open":
+                    return context.deserialize(jsonObject, OpenEvent.class);
+            }
+        }
+
+        throw new JsonParseException("unknown event type");
+    }
+}

--- a/bundles/org.openhab.binding.ntfy/src/main/java/org/openhab/binding/ntfy/internal/network/GsonDeserializer.java
+++ b/bundles/org.openhab.binding.ntfy/src/main/java/org/openhab/binding/ntfy/internal/network/GsonDeserializer.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.ntfy.internal.network;
+
+import java.time.Instant;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.ntfy.internal.models.BaseEvent;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+
+/**
+ * Helper wrapper around Gson used to deserialize incoming ntfy JSON messages
+ * into typed event objects.
+ *
+ * @author Christian Kittel - Initial contribution
+ */
+@NonNullByDefault
+public class GsonDeserializer {
+
+    private static final Gson GSON = new GsonBuilder().registerTypeAdapter(BaseEvent.class, new EventDeserializer())
+            .registerTypeAdapter(Instant.class, new InstantDeserializer()).create();
+
+    /**
+     * Deserializes the provided JSON message into a {@link BaseEvent} instance.
+     *
+     * @param message the raw JSON message
+     * @return the deserialized {@link BaseEvent} or {@code null} when parsing failed
+     */
+    public static @Nullable BaseEvent deserialize(String message) {
+        return GSON.fromJson(message, BaseEvent.class);
+    }
+
+    /**
+     * Deserializes the provided JSON message into an instance of the given target
+     * class.
+     *
+     * @param <T> the target type
+     * @param message the raw JSON message
+     * @param classOfT the target class to deserialize into
+     * @return the deserialized instance or {@code null} when parsing failed
+     */
+    public static @Nullable <T> T deserialize(String message, Class<T> classOfT) {
+        return GSON.fromJson(message, classOfT);
+    }
+}

--- a/bundles/org.openhab.binding.ntfy/src/main/java/org/openhab/binding/ntfy/internal/network/GsonDeserializer.java
+++ b/bundles/org.openhab.binding.ntfy/src/main/java/org/openhab/binding/ntfy/internal/network/GsonDeserializer.java
@@ -20,6 +20,7 @@ import org.openhab.binding.ntfy.internal.models.BaseEvent;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.JsonSyntaxException;
 
 /**
  * Helper wrapper around Gson used to deserialize incoming ntfy JSON messages
@@ -39,7 +40,7 @@ public class GsonDeserializer {
      * @param message the raw JSON message
      * @return the deserialized {@link BaseEvent} or {@code null} when parsing failed
      */
-    public static @Nullable BaseEvent deserialize(String message) {
+    public static @Nullable BaseEvent deserialize(String message) throws JsonSyntaxException {
         return GSON.fromJson(message, BaseEvent.class);
     }
 

--- a/bundles/org.openhab.binding.ntfy/src/main/java/org/openhab/binding/ntfy/internal/network/HttpActionButton.java
+++ b/bundles/org.openhab.binding.ntfy/src/main/java/org/openhab/binding/ntfy/internal/network/HttpActionButton.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.ntfy.internal.network;
+
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URL;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
+/**
+ * Action button that represents an HTTP action attached to a notification.
+ *
+ * @author Christian Kittel - Initial contribution
+ */
+@NonNullByDefault
+public class HttpActionButton extends ActionButtonBase {
+
+    private URL url;
+    private @Nullable String body;
+    private @Nullable String headers;
+    private @Nullable String method;
+
+    /**
+     * Creates an HTTP action button descriptor.
+     *
+     * @param label the label shown for the action
+     * @param clearNotification whether executing the action should clear the notification
+     * @param url the URL to invoke when the action is executed
+     * @param method optional HTTP method (may be null)
+     * @param headers optional headers to include (may be null)
+     * @param body optional request body (may be null)
+     * @throws MalformedURLException when the provided URL is not a valid URL
+     */
+    public HttpActionButton(String label, Boolean clearNotification, String url, @Nullable String method,
+            @Nullable String headers, @Nullable String body) throws MalformedURLException {
+        super(label, clearNotification);
+
+        this.url = URI.create(url).toURL();
+        this.method = method;
+        this.headers = headers;
+        this.body = body;
+    }
+
+    @Override
+    public String getHeader() {
+        return "http, " + label + ", " + url.toString()
+                + (method != null && !method.isBlank() ? ", method=" + method : "")
+                + (headers != null && !headers.isBlank() ? ", headers=" + headers : "")
+                + (body != null && !body.isBlank() ? ", body=" + body : "") + (clearNotification ? ", clear=true" : "");
+    }
+}

--- a/bundles/org.openhab.binding.ntfy/src/main/java/org/openhab/binding/ntfy/internal/network/HttpActionButton.java
+++ b/bundles/org.openhab.binding.ntfy/src/main/java/org/openhab/binding/ntfy/internal/network/HttpActionButton.java
@@ -42,9 +42,10 @@ public class HttpActionButton extends ActionButtonBase {
      * @param headers optional headers to include (may be null)
      * @param body optional request body (may be null)
      * @throws MalformedURLException when the provided URL is not a valid URL
+     * @throws IllegalArgumentException when the provided URL is not valid
      */
     public HttpActionButton(String label, Boolean clearNotification, String url, @Nullable String method,
-            @Nullable String headers, @Nullable String body) throws MalformedURLException {
+            @Nullable String headers, @Nullable String body) throws IllegalArgumentException, MalformedURLException {
         super(label, clearNotification);
 
         this.url = URI.create(url).toURL();
@@ -55,6 +56,9 @@ public class HttpActionButton extends ActionButtonBase {
 
     @Override
     public String getHeader() {
+        final String method = this.method;
+        final String headers = this.headers;
+        final String body = this.body;
         return "http, " + label + ", " + url.toString()
                 + (method != null && !method.isBlank() ? ", method=" + method : "")
                 + (headers != null && !headers.isBlank() ? ", headers=" + headers : "")

--- a/bundles/org.openhab.binding.ntfy/src/main/java/org/openhab/binding/ntfy/internal/network/HttpActionButton.java
+++ b/bundles/org.openhab.binding.ntfy/src/main/java/org/openhab/binding/ntfy/internal/network/HttpActionButton.java
@@ -62,6 +62,7 @@ public class HttpActionButton extends ActionButtonBase {
         return "http, " + label + ", " + url.toString()
                 + (method != null && !method.isBlank() ? ", method=" + method : "")
                 + (headers != null && !headers.isBlank() ? ", " + headers : "")
-                + (body != null && !body.isBlank() ? ", body=" + body : "") + (clearNotification ? ", clear=true" : "");
+                + (body != null && !body.isBlank() ? ", body=" + body : "")
+                + (Boolean.TRUE.equals(clearNotification) ? ", clear=true" : "");
     }
 }

--- a/bundles/org.openhab.binding.ntfy/src/main/java/org/openhab/binding/ntfy/internal/network/HttpActionButton.java
+++ b/bundles/org.openhab.binding.ntfy/src/main/java/org/openhab/binding/ntfy/internal/network/HttpActionButton.java
@@ -61,7 +61,7 @@ public class HttpActionButton extends ActionButtonBase {
         final String body = this.body;
         return "http, " + label + ", " + url.toString()
                 + (method != null && !method.isBlank() ? ", method=" + method : "")
-                + (headers != null && !headers.isBlank() ? ", headers=" + headers : "")
+                + (headers != null && !headers.isBlank() ? ", " + headers : "")
                 + (body != null && !body.isBlank() ? ", body=" + body : "") + (clearNotification ? ", clear=true" : "");
     }
 }

--- a/bundles/org.openhab.binding.ntfy/src/main/java/org/openhab/binding/ntfy/internal/network/InstantDeserializer.java
+++ b/bundles/org.openhab.binding.ntfy/src/main/java/org/openhab/binding/ntfy/internal/network/InstantDeserializer.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.ntfy.internal.network;
+
+import java.lang.reflect.Type;
+import java.time.Instant;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParseException;
+
+/**
+ * Gson deserializer for converting epoch-second JSON values into {@link Instant}.
+ *
+ * @author Christian Kittel - Initial contribution
+ */
+@NonNullByDefault
+public class InstantDeserializer implements JsonDeserializer<Instant> {
+    @Override
+    public @Nullable Instant deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
+            throws JsonParseException {
+        return Instant.ofEpochSecond(json.getAsLong());
+    }
+}

--- a/bundles/org.openhab.binding.ntfy/src/main/java/org/openhab/binding/ntfy/internal/network/NtfyMessage.java
+++ b/bundles/org.openhab.binding.ntfy/src/main/java/org/openhab/binding/ntfy/internal/network/NtfyMessage.java
@@ -1,0 +1,329 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.ntfy.internal.network;
+
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
+/**
+ * The {@link NtfyMessage} contains the message information
+ *
+ * @author Christian Kittel - Initial contribution
+ */
+@NonNullByDefault
+public class NtfyMessage {
+
+    private @Nullable String message;
+    private int priority = 3;
+    private HashSet<String> tags = new HashSet<>();
+    private HashSet<ActionButtonBase> actions = new HashSet<>();
+    private @Nullable URI clickAction;
+    private @Nullable URI icon;
+    private @Nullable URI attachment;
+    private @Nullable String attachmentFilename;
+    private @Nullable String sequenceId;
+    private @Nullable String delay;
+
+    /**
+     * Sets the message body to be sent.
+     *
+     * @param message the message text
+     */
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    /**
+     * Returns the message body.
+     *
+     * @return the message text (never null when called after checking {@link #hasMessage()})
+     */
+    public String getMessage() {
+        return java.util.Objects.requireNonNull(message);
+    }
+
+    /**
+     * Checks whether a message body has been set.
+     *
+     * @return {@code true} when a message is present, {@code false} otherwise
+     */
+    public boolean hasMessage() {
+        final String message = this.message;
+        return message != null;
+    }
+
+    /**
+     * Sets the message priority. Allowed range is 1..5.
+     *
+     * @param priority the priority value
+     * @throws IllegalArgumentException when the priority is out of range
+     */
+    public void setPriority(int priority) {
+        if (priority < 1 || priority > 5) {
+            throw new IllegalArgumentException();
+        }
+        this.priority = priority;
+    }
+
+    /**
+     * Returns the configured priority for the message.
+     *
+     * @return the priority value
+     */
+    public int getPriority() {
+        return this.priority;
+    }
+
+    /**
+     * Sets the click action URL for the message.
+     *
+     * @param url the URL to open when the notification is clicked
+     * @throws URISyntaxException when the provided URL cannot be parsed
+     */
+    public void setClickAction(String url) throws URISyntaxException {
+        this.clickAction = new URI(url);
+    }
+
+    /**
+     * Returns the click action URL.
+     *
+     * @return the click action URI
+     */
+    public URI getClickAction() {
+        return java.util.Objects.requireNonNull(clickAction);
+    }
+
+    /**
+     * Checks whether a click action is configured.
+     *
+     * @return {@code true} when a click action URI is present
+     */
+    public boolean hasClickAction() {
+        return clickAction != null;
+    }
+
+    /**
+     * Adds a tag to the message.
+     *
+     * @param tag the tag to add
+     */
+    public void addTag(String tag) {
+        tags.add(tag);
+    }
+
+    /**
+     * Returns the configured tags for the message.
+     *
+     * @return a set of tag strings
+     */
+    public Set<String> getTags() {
+        return tags;
+    }
+
+    /**
+     * Sets an icon URI for the message.
+     *
+     * @param url the icon URL
+     * @throws URISyntaxException when the provided URL cannot be parsed
+     */
+    public void setIcon(String url) throws URISyntaxException {
+        this.icon = new URI(url);
+    }
+
+    /**
+     * Returns the icon URI for the message.
+     *
+     * @return the icon URI
+     */
+    public URI getIcon() {
+        return java.util.Objects.requireNonNull(icon);
+    }
+
+    /**
+     * Checks whether an icon is configured for the message.
+     *
+     * @return {@code true} when an icon URI is present
+     */
+    public boolean hasIcon() {
+        return icon != null;
+    }
+
+    /**
+     * Sets an attachment URL and optional filename for the message.
+     *
+     * @param url the attachment URL
+     * @param filename optional filename to present to recipients
+     * @throws URISyntaxException when the provided URL cannot be parsed
+     */
+    public void setAttachment(String url, @Nullable String filename) throws URISyntaxException {
+        this.attachment = new URI(url);
+        setFilename(filename);
+    }
+
+    /**
+     * Sets an optional filename.
+     *
+     * @param filename optional filename to present to recipients
+     */
+    public void setFilename(@Nullable String filename) {
+        this.attachmentFilename = filename;
+    }
+
+    /**
+     * Returns the attachment URI.
+     *
+     * @return the attachment URI
+     */
+    public URI getAttachment() {
+        return java.util.Objects.requireNonNull(attachment);
+    }
+
+    /**
+     * Returns the optional attachment filename provided when setting the attachment.
+     *
+     * @return the attachment filename or {@code null}
+     */
+    public @Nullable String getAttachmentFilename() {
+        return attachmentFilename;
+    }
+
+    /**
+     * Checks whether an attachment is configured for the message.
+     *
+     * @return {@code true} when an attachment URI is present
+     */
+    public boolean hasAttachment() {
+        return attachment != null;
+    }
+
+    /**
+     * Adds a view action to the message. The view action will open the supplied URL.
+     *
+     * @param label the label for the action
+     * @param clearNotification whether the notification should be cleared when the action is executed
+     * @param url the URL to open
+     * @throws MalformedURLException when the provided URL is not valid
+     */
+    public void addViewAction(String label, Boolean clearNotification, String url) throws MalformedURLException {
+        actions.add(new ViewActionButton(label, clearNotification, url));
+    }
+
+    /**
+     * Adds a copy action to the message which copies the provided value to the clipboard.
+     *
+     * @param label the label for the action
+     * @param clearNotification whether the notification should be cleared when the action is executed
+     * @param value the value to copy
+     */
+    public void addCopyAction(String label, Boolean clearNotification, String value) {
+        actions.add(new CopyActionButton(label, clearNotification, value));
+    }
+
+    /**
+     * Adds an HTTP action to the message which performs a HTTP request when executed.
+     *
+     * @param label the label for the action
+     * @param clearNotification whether the notification should be cleared when the action is executed
+     * @param url the URL to call
+     * @param method optional HTTP method
+     * @param headers optional headers
+     * @param body optional body
+     * @throws MalformedURLException when the provided URL is not valid
+     */
+    public void addHttpAction(String label, Boolean clearNotification, String url, @Nullable String method,
+            @Nullable String headers, @Nullable String body) throws MalformedURLException {
+        actions.add(new HttpActionButton(label, clearNotification, url, method, headers, body));
+    }
+
+    /**
+     * Adds a broadcast action to the message.
+     *
+     * @param label the label for the action
+     * @param clearNotification whether the notification should be cleared when the action is executed
+     * @param params optional parameters for the broadcast action
+     */
+    public void addBroadcastAction(String label, Boolean clearNotification, @Nullable String params) {
+        actions.add(new BroadcastActionButton(label, clearNotification, params));
+    }
+
+    /**
+     * Returns the set of action buttons configured for this message.
+     *
+     * @return a set of {@link ActionButtonBase}
+     */
+    public Set<ActionButtonBase> getActions() {
+        return actions;
+    }
+
+    /**
+     * Sets an optional sequence id for the message. This can be used for later
+     * deletion of the message.
+     *
+     * @param id the sequence id or {@code null}
+     */
+    public void setSequenceId(@Nullable String id) {
+        this.sequenceId = id;
+    }
+
+    /**
+     * Returns the configured sequence id for the message.
+     *
+     * @return the sequence id
+     */
+    public String getSequenceId() {
+        return java.util.Objects.requireNonNull(sequenceId);
+    }
+
+    /**
+     * Checks whether a non-blank sequence id is configured for the message.
+     *
+     * @return {@code true} when a sequence id is present and not blank
+     */
+    public boolean hasSequenceId() {
+        return sequenceId != null && !sequenceId.isBlank();
+    }
+
+    /**
+     * Sets an optional delivery delay for the message. The delay value is a
+     * provider-specific string (for example a duration) and may be null.
+     *
+     * @param delay the delay string or {@code null}
+     */
+    public void setDelay(@Nullable String delay) {
+        this.delay = delay;
+    }
+
+    /**
+     * Returns the configured delay string.
+     *
+     * @return the delay string
+     */
+    public String getDelay() {
+        return java.util.Objects.requireNonNull(delay);
+    }
+
+    /**
+     * Checks whether a non-blank delay value has been set.
+     *
+     * @return {@code true} when a delay is present and not blank
+     */
+    public boolean hasDelay() {
+        return delay != null && !delay.isBlank();
+    }
+}

--- a/bundles/org.openhab.binding.ntfy/src/main/java/org/openhab/binding/ntfy/internal/network/NtfyMessage.java
+++ b/bundles/org.openhab.binding.ntfy/src/main/java/org/openhab/binding/ntfy/internal/network/NtfyMessage.java
@@ -15,7 +15,7 @@ package org.openhab.binding.ntfy.internal.network;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -31,14 +31,15 @@ public class NtfyMessage {
 
     private @Nullable String message;
     private int priority = 3;
-    private HashSet<String> tags = new HashSet<>();
-    private HashSet<ActionButtonBase> actions = new HashSet<>();
+    private LinkedHashSet<String> tags = new LinkedHashSet<>();
+    private LinkedHashSet<ActionButtonBase> actions = new LinkedHashSet<>();
     private @Nullable URI clickAction;
     private @Nullable URI icon;
     private @Nullable URI attachment;
     private @Nullable String attachmentFilename;
     private @Nullable String sequenceId;
     private @Nullable String delay;
+    private @Nullable String title;
 
     /**
      * Sets the message body to be sent.
@@ -69,6 +70,34 @@ public class NtfyMessage {
     }
 
     /**
+     * Sets the title for the message to be sent.
+     *
+     * @param message the message text
+     */
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    /**
+     * Returns the title of the message.
+     *
+     * @return the title (never null when called after checking {@link #hasTitle()})
+     */
+    public String getTitle() {
+        return java.util.Objects.requireNonNull(title);
+    }
+
+    /**
+     * Checks whether the message has a title.
+     *
+     * @return {@code true} when the message has a title, {@code false} otherwise
+     */
+    public boolean hasTitle() {
+        final String title = this.title;
+        return title != null;
+    }
+
+    /**
      * Sets the message priority. Allowed range is 1..5.
      *
      * @param priority the priority value
@@ -76,7 +105,7 @@ public class NtfyMessage {
      */
     public void setPriority(int priority) {
         if (priority < 1 || priority > 5) {
-            throw new IllegalArgumentException();
+            throw new IllegalArgumentException("Invalid priority " + priority + ". Allowed range is 1..5.");
         }
         this.priority = priority;
     }
@@ -296,6 +325,7 @@ public class NtfyMessage {
      * @return {@code true} when a sequence id is present and not blank
      */
     public boolean hasSequenceId() {
+        final String sequenceId = this.sequenceId;
         return sequenceId != null && !sequenceId.isBlank();
     }
 
@@ -324,6 +354,7 @@ public class NtfyMessage {
      * @return {@code true} when a delay is present and not blank
      */
     public boolean hasDelay() {
+        final String delay = this.delay;
         return delay != null && !delay.isBlank();
     }
 }

--- a/bundles/org.openhab.binding.ntfy/src/main/java/org/openhab/binding/ntfy/internal/network/NtfyMessage.java
+++ b/bundles/org.openhab.binding.ntfy/src/main/java/org/openhab/binding/ntfy/internal/network/NtfyMessage.java
@@ -72,7 +72,7 @@ public class NtfyMessage {
     /**
      * Sets the title for the message to be sent.
      *
-     * @param message the message text
+     * @param title the title of the message
      */
     public void setTitle(String title) {
         this.title = title;

--- a/bundles/org.openhab.binding.ntfy/src/main/java/org/openhab/binding/ntfy/internal/network/NtfyMessageHeaderBuilder.java
+++ b/bundles/org.openhab.binding.ntfy/src/main/java/org/openhab/binding/ntfy/internal/network/NtfyMessageHeaderBuilder.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.ntfy.internal.network;
+
+import java.util.stream.Collectors;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.jetty.client.api.Request;
+
+/**
+ * The {@link NtfyMessageHeaderBuilder} builds the headers of the request
+ *
+ * @author Christian Kittel - Initial contribution
+ */
+@NonNullByDefault
+public class NtfyMessageHeaderBuilder {
+
+    private static final String X_SEQUENCE_ID = "X-Sequence-ID";
+    private static final String X_ACTIONS = "X-Actions";
+    private static final String X_FILENAME = "X-Filename";
+    private static final String X_ATTACH = "X-Attach";
+    private static final String X_ICON = "X-Icon";
+    private static final String X_CLICK = "X-Click";
+    private static final String X_TAGS = "X-Tags";
+    private static final String X_PRIORITY = "X-Priority";
+    private static final String X_DELAY = "X-Delay";
+
+    private NtfyMessage ntfyMessage;
+    private Request request;
+
+    /**
+     * Creates a new header builder for the given message and request.
+     *
+     * @param ntfyMessage the message containing header information
+     * @param request the Jetty {@link Request} to which headers will be added
+     */
+    public NtfyMessageHeaderBuilder(NtfyMessage ntfyMessage, Request request) {
+        this.ntfyMessage = ntfyMessage;
+        this.request = request;
+    }
+
+    /**
+     * Builds and applies all relevant ntfy HTTP headers to the wrapped request
+     * (priority, click/action headers, attachment, icon, tags, delay and sequence id).
+     */
+    public void build() {
+        request.header(X_PRIORITY, Integer.toString(ntfyMessage.getPriority()));
+
+        if (ntfyMessage.hasClickAction()) {
+            request.header(X_CLICK, ntfyMessage.getClickAction().toString());
+        }
+
+        String tags = String.join(",", ntfyMessage.getTags());
+        if (!tags.isEmpty()) {
+            request.header(X_TAGS, tags);
+        }
+
+        if (ntfyMessage.hasIcon()) {
+            request.header(X_ICON, ntfyMessage.getIcon().toString());
+        }
+
+        if (ntfyMessage.hasAttachment()) {
+            request.header(X_ATTACH, ntfyMessage.getAttachment().toString());
+            final @Nullable String filename = ntfyMessage.getAttachmentFilename();
+            if (filename != null && !filename.isBlank()) {
+                request.header(X_FILENAME, filename);
+            }
+        }
+
+        if (ntfyMessage.hasDelay()) {
+            final String delay = ntfyMessage.getDelay();
+            if (!delay.isBlank()) {
+                request.header(X_DELAY, delay);
+            }
+        }
+
+        String actions = String.join(";",
+                ntfyMessage.getActions().stream().map(action -> action.getHeader()).collect(Collectors.toList()));
+        if (!actions.isBlank()) {
+            request.header(X_ACTIONS, actions);
+        }
+
+        if (ntfyMessage.hasSequenceId()) {
+            String sequenceId = ntfyMessage.getSequenceId();
+            if (!sequenceId.isBlank()) {
+                request.header(X_SEQUENCE_ID, sequenceId);
+            }
+        }
+    }
+}

--- a/bundles/org.openhab.binding.ntfy/src/main/java/org/openhab/binding/ntfy/internal/network/NtfyMessageHeaderBuilder.java
+++ b/bundles/org.openhab.binding.ntfy/src/main/java/org/openhab/binding/ntfy/internal/network/NtfyMessageHeaderBuilder.java
@@ -35,6 +35,7 @@ public class NtfyMessageHeaderBuilder {
     private static final String X_TAGS = "X-Tags";
     private static final String X_PRIORITY = "X-Priority";
     private static final String X_DELAY = "X-Delay";
+    private static final String X_TITLE = "X-Title";
 
     private NtfyMessage ntfyMessage;
     private Request request;
@@ -61,6 +62,10 @@ public class NtfyMessageHeaderBuilder {
             request.header(X_CLICK, ntfyMessage.getClickAction().toString());
         }
 
+        if (ntfyMessage.hasTitle()) {
+            request.header(X_TITLE, ntfyMessage.getTitle());
+        }
+
         String tags = String.join(",", ntfyMessage.getTags());
         if (!tags.isEmpty()) {
             request.header(X_TAGS, tags);
@@ -85,8 +90,8 @@ public class NtfyMessageHeaderBuilder {
             }
         }
 
-        String actions = String.join(";",
-                ntfyMessage.getActions().stream().map(action -> action.getHeader()).collect(Collectors.toList()));
+        String actions = ntfyMessage.getActions().stream().map(action -> action.getHeader())
+                .collect(Collectors.joining(";"));
         if (!actions.isBlank()) {
             request.header(X_ACTIONS, actions);
         }

--- a/bundles/org.openhab.binding.ntfy/src/main/java/org/openhab/binding/ntfy/internal/network/NtfySender.java
+++ b/bundles/org.openhab.binding.ntfy/src/main/java/org/openhab/binding/ntfy/internal/network/NtfySender.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.ntfy.internal.network;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Supplier;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.api.ContentResponse;
+import org.eclipse.jetty.client.api.Request;
+import org.eclipse.jetty.client.util.InputStreamContentProvider;
+import org.eclipse.jetty.client.util.StringContentProvider;
+import org.eclipse.jetty.http.HttpMethod;
+import org.eclipse.jetty.http.HttpStatus;
+import org.openhab.binding.ntfy.internal.NtfyConnectionConfiguration;
+import org.openhab.binding.ntfy.internal.NtfyConnectionHandler;
+import org.openhab.binding.ntfy.internal.models.MessageEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link NtfySender} builds and sends a message to a topic
+ *
+ * @author Christian Kittel - Initial contribution
+ */
+@NonNullByDefault
+public class NtfySender {
+
+    private @Nullable NtfyConnectionConfiguration configuration;
+    private Supplier<NtfyConnectionHandler> getBridgeHandler;
+    private HttpClient httpClient;
+    private String topicName;
+    private final Logger logger = LoggerFactory.getLogger(NtfySender.class);
+
+    /**
+     * Creates a new sender for the given topic.
+     *
+     * @param topicName the ntfy topic name to send messages to
+     * @param httpClient the Jetty {@link HttpClient} used to perform requests
+     * @param getBridgeHandler supplier returning the associated {@link NtfyConnectionHandler}
+     */
+    public NtfySender(String topicName, HttpClient httpClient, Supplier<NtfyConnectionHandler> getBridgeHandler) {
+        this.topicName = topicName;
+        this.getBridgeHandler = getBridgeHandler;
+        this.httpClient = httpClient;
+    }
+
+    /**
+     * Sends the given message to the configured topic and returns the created
+     * {@link MessageEvent} on success.
+     *
+     * @param ntfyMessage the message to send
+     * @return the created {@link MessageEvent} when successful, or {@code null} on failure
+     * @throws URISyntaxException
+     */
+    public @Nullable MessageEvent sendMessage(NtfyMessage ntfyMessage) throws URISyntaxException {
+        NtfyConnectionConfiguration connectionConfiguration = getConfigurarion();
+
+        Request request = httpClient.newRequest(new URI(connectionConfiguration.hostname + "/" + topicName))
+                .method(HttpMethod.POST).content(new StringContentProvider(ntfyMessage.getMessage()))
+                .timeout(1, TimeUnit.MINUTES);
+
+        if (connectionConfiguration.isAuthHeaderNeeded()) {
+            String authHeader = connectionConfiguration.buildAuthHeader();
+            request.header("Authorization", authHeader);
+        }
+
+        new NtfyMessageHeaderBuilder(ntfyMessage, request).build();
+
+        ContentResponse response;
+        try {
+            response = request.send();
+            if (HttpStatus.isSuccess(response.getStatus())) {
+                return GsonDeserializer.deserialize(response.getContentAsString(), MessageEvent.class);
+            }
+        } catch (InterruptedException | TimeoutException | ExecutionException e) {
+            logger.error("Failed to send message: {}", e.getMessage());
+            getBridge().connectionError(e);
+        }
+
+        return null;
+    }
+
+    /**
+     * Uploads the content of a local file to the topic.
+     *
+     * @param file the filesystem path to the file whose contents will be sent as the request body
+     * @param filename optional filename that may be presented to recipients (may be null)
+     * @param sequenceId optional sequence id to associate with the uploaded message
+     * @return the created {@link MessageEvent} when successful, or {@code null} on failure
+     * @throws URISyntaxException when the constructed request URI is invalid
+     */
+    public @Nullable MessageEvent sendFile(String file, @Nullable String filename, @Nullable String sequenceId)
+            throws URISyntaxException {
+        NtfyConnectionConfiguration connectionConfiguration = getConfigurarion();
+
+        Request request = httpClient.newRequest(new URI(connectionConfiguration.hostname + "/" + topicName))
+                .method(HttpMethod.PUT);
+
+        NtfyMessage ntfyMessage = new NtfyMessage();
+        ntfyMessage.setSequenceId(sequenceId);
+        ntfyMessage.setFilename(filename);
+        new NtfyMessageHeaderBuilder(ntfyMessage, request).build();
+
+        if (connectionConfiguration.isAuthHeaderNeeded()) {
+            String authHeader = connectionConfiguration.buildAuthHeader();
+            request.header("Authorization", authHeader);
+        }
+
+        try {
+            java.nio.file.Path path = java.nio.file.Path.of(file);
+            request.content(new InputStreamContentProvider(java.nio.file.Files.newInputStream(path)));
+        } catch (IOException e) {
+            logger.error("Failed to read file for upload: {}", e.getMessage());
+            return null;
+        }
+
+        ContentResponse response;
+        try {
+            response = request.send();
+            if (HttpStatus.isSuccess(response.getStatus())) {
+                return GsonDeserializer.deserialize(response.getContentAsString(), MessageEvent.class);
+            }
+        } catch (InterruptedException | TimeoutException | ExecutionException e) {
+            logger.error("Failed to send file: {}", e.getMessage());
+            getBridge().connectionError(e);
+        }
+        return null;
+    }
+
+    /**
+     * Deletes a message identified by the provided sequence id from the topic.
+     *
+     * @param sequenceId the sequence id of the message to delete
+     * @return {@code true} when deletion succeeded, {@code false} otherwise
+     * @throws URISyntaxException when the request URI could not be constructed
+     */
+    public boolean deleteMessage(String sequenceId) throws URISyntaxException {
+        NtfyConnectionConfiguration connectionConfiguration = getConfigurarion();
+
+        Request request = httpClient
+                .newRequest(new URI(connectionConfiguration.hostname + "/" + topicName + "/" + sequenceId))
+                .method(HttpMethod.DELETE);
+
+        if (connectionConfiguration.isAuthHeaderNeeded()) {
+            String authHeader = connectionConfiguration.buildAuthHeader();
+            request.header("Authorization", authHeader);
+        }
+
+        try {
+            return HttpStatus.isSuccess(request.send().getStatus());
+        } catch (InterruptedException | TimeoutException | ExecutionException e) {
+            logger.error("Failed to delete message: {}", e.getMessage());
+            getBridge().connectionError(e);
+        }
+        return false;
+    }
+
+    private NtfyConnectionConfiguration getConfigurarion() {
+        NtfyConnectionConfiguration configuration = this.configuration;
+        if (configuration != null) {
+            return configuration;
+        }
+
+        configuration = getBridge().getThing().getConfiguration().as(NtfyConnectionConfiguration.class);
+        return configuration;
+    }
+
+    private NtfyConnectionHandler getBridge() {
+        return getBridgeHandler.get();
+    }
+}

--- a/bundles/org.openhab.binding.ntfy/src/main/java/org/openhab/binding/ntfy/internal/network/NtfySender.java
+++ b/bundles/org.openhab.binding.ntfy/src/main/java/org/openhab/binding/ntfy/internal/network/NtfySender.java
@@ -18,7 +18,6 @@ import java.net.URISyntaxException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.util.function.Supplier;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
@@ -44,21 +43,21 @@ import org.slf4j.LoggerFactory;
 public class NtfySender {
 
     private @Nullable NtfyConnectionConfiguration configuration;
-    private Supplier<NtfyConnectionHandler> getBridgeHandler;
     private HttpClient httpClient;
     private String topicName;
     private final Logger logger = LoggerFactory.getLogger(NtfySender.class);
+    private NtfyConnectionHandler bridgeHandler;
 
     /**
      * Creates a new sender for the given topic.
      *
      * @param topicName the ntfy topic name to send messages to
      * @param httpClient the Jetty {@link HttpClient} used to perform requests
-     * @param getBridgeHandler supplier returning the associated {@link NtfyConnectionHandler}
+     * @param bridgeHandler the associated {@link NtfyConnectionHandler}
      */
-    public NtfySender(String topicName, HttpClient httpClient, Supplier<NtfyConnectionHandler> getBridgeHandler) {
+    public NtfySender(String topicName, HttpClient httpClient, NtfyConnectionHandler bridgeHandler) {
         this.topicName = topicName;
-        this.getBridgeHandler = getBridgeHandler;
+        this.bridgeHandler = bridgeHandler;
         this.httpClient = httpClient;
     }
 
@@ -71,11 +70,11 @@ public class NtfySender {
      * @throws URISyntaxException
      */
     public @Nullable MessageEvent sendMessage(NtfyMessage ntfyMessage) throws URISyntaxException {
-        NtfyConnectionConfiguration connectionConfiguration = getConfigurarion();
+        NtfyConnectionConfiguration connectionConfiguration = getConfiguration();
 
-        Request request = httpClient.newRequest(new URI(connectionConfiguration.hostname + "/" + topicName))
-                .method(HttpMethod.POST).content(new StringContentProvider(ntfyMessage.getMessage()))
-                .timeout(1, TimeUnit.MINUTES);
+        Request request = httpClient.newRequest(buildRequestURI(connectionConfiguration)).method(HttpMethod.POST)
+                .content(new StringContentProvider(ntfyMessage.getMessage()))
+                .timeout(connectionConfiguration.connectionTimeout, TimeUnit.MILLISECONDS);
 
         if (connectionConfiguration.isAuthHeaderNeeded()) {
             String authHeader = connectionConfiguration.buildAuthHeader();
@@ -90,9 +89,13 @@ public class NtfySender {
             if (HttpStatus.isSuccess(response.getStatus())) {
                 return GsonDeserializer.deserialize(response.getContentAsString(), MessageEvent.class);
             }
-        } catch (InterruptedException | TimeoutException | ExecutionException e) {
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
             logger.error("Failed to send message: {}", e.getMessage());
-            getBridge().connectionError(e);
+            bridgeHandler.connectionError(e);
+        } catch (TimeoutException | ExecutionException e) {
+            logger.error("Failed to send message: {}", e.getMessage());
+            bridgeHandler.connectionError(e);
         }
 
         return null;
@@ -109,10 +112,10 @@ public class NtfySender {
      */
     public @Nullable MessageEvent sendFile(String file, @Nullable String filename, @Nullable String sequenceId)
             throws URISyntaxException {
-        NtfyConnectionConfiguration connectionConfiguration = getConfigurarion();
+        NtfyConnectionConfiguration connectionConfiguration = getConfiguration();
 
-        Request request = httpClient.newRequest(new URI(connectionConfiguration.hostname + "/" + topicName))
-                .method(HttpMethod.PUT);
+        Request request = httpClient.newRequest(buildRequestURI(connectionConfiguration)).method(HttpMethod.PUT)
+                .timeout(connectionConfiguration.connectionTimeout, TimeUnit.MILLISECONDS);
 
         NtfyMessage ntfyMessage = new NtfyMessage();
         ntfyMessage.setSequenceId(sequenceId);
@@ -124,23 +127,24 @@ public class NtfySender {
             request.header("Authorization", authHeader);
         }
 
-        try {
-            java.nio.file.Path path = java.nio.file.Path.of(file);
-            request.content(new InputStreamContentProvider(java.nio.file.Files.newInputStream(path)));
-        } catch (IOException e) {
-            logger.error("Failed to read file for upload: {}", e.getMessage());
-            return null;
-        }
-
-        ContentResponse response;
-        try {
-            response = request.send();
+        java.nio.file.Path path = java.nio.file.Path.of(file);
+        try (InputStreamContentProvider contentProvider = new InputStreamContentProvider(
+                java.nio.file.Files.newInputStream(path))) {
+            request.content(contentProvider);
+            ContentResponse response = request.send();
             if (HttpStatus.isSuccess(response.getStatus())) {
                 return GsonDeserializer.deserialize(response.getContentAsString(), MessageEvent.class);
             }
-        } catch (InterruptedException | TimeoutException | ExecutionException e) {
+        } catch (IOException e) {
+            logger.error("Failed to read file for upload: {}", e.getMessage());
+            return null;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            logger.error("Failed to send message: {}", e.getMessage());
+            bridgeHandler.connectionError(e);
+        } catch (TimeoutException | ExecutionException e) {
             logger.error("Failed to send file: {}", e.getMessage());
-            getBridge().connectionError(e);
+            bridgeHandler.connectionError(e);
         }
         return null;
     }
@@ -153,11 +157,12 @@ public class NtfySender {
      * @throws URISyntaxException when the request URI could not be constructed
      */
     public boolean deleteMessage(String sequenceId) throws URISyntaxException {
-        NtfyConnectionConfiguration connectionConfiguration = getConfigurarion();
+        NtfyConnectionConfiguration connectionConfiguration = getConfiguration();
 
-        Request request = httpClient
-                .newRequest(new URI(connectionConfiguration.hostname + "/" + topicName + "/" + sequenceId))
-                .method(HttpMethod.DELETE);
+        URI requestURI = buildRequestURI(connectionConfiguration);
+
+        Request request = httpClient.newRequest(requestURI.resolve(requestURI.getPath() + "/" + sequenceId))
+                .method(HttpMethod.DELETE).timeout(connectionConfiguration.connectionTimeout, TimeUnit.MILLISECONDS);
 
         if (connectionConfiguration.isAuthHeaderNeeded()) {
             String authHeader = connectionConfiguration.buildAuthHeader();
@@ -166,24 +171,28 @@ public class NtfySender {
 
         try {
             return HttpStatus.isSuccess(request.send().getStatus());
-        } catch (InterruptedException | TimeoutException | ExecutionException e) {
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
             logger.error("Failed to delete message: {}", e.getMessage());
-            getBridge().connectionError(e);
+            bridgeHandler.connectionError(e);
+        } catch (TimeoutException | ExecutionException e) {
+            logger.error("Failed to delete message: {}", e.getMessage());
+            bridgeHandler.connectionError(e);
         }
         return false;
     }
 
-    private NtfyConnectionConfiguration getConfigurarion() {
+    private NtfyConnectionConfiguration getConfiguration() {
         NtfyConnectionConfiguration configuration = this.configuration;
         if (configuration != null) {
             return configuration;
         }
-
-        configuration = getBridge().getThing().getConfiguration().as(NtfyConnectionConfiguration.class);
+        configuration = this.configuration = bridgeHandler.getThing().getConfiguration()
+                .as(NtfyConnectionConfiguration.class);
         return configuration;
     }
 
-    private NtfyConnectionHandler getBridge() {
-        return getBridgeHandler.get();
+    private URI buildRequestURI(NtfyConnectionConfiguration connectionConfiguration) throws URISyntaxException {
+        return new URI(connectionConfiguration.hostname).resolve("./" + topicName);
     }
 }

--- a/bundles/org.openhab.binding.ntfy/src/main/java/org/openhab/binding/ntfy/internal/network/NtfySender.java
+++ b/bundles/org.openhab.binding.ntfy/src/main/java/org/openhab/binding/ntfy/internal/network/NtfySender.java
@@ -143,14 +143,14 @@ public class NtfySender {
                 return GsonDeserializer.deserialize(response.getContentAsString(), MessageEvent.class);
             }
         } catch (IOException e) {
-            logger.error("Failed to read file for upload: {}", e.getMessage());
+            logger.warn("Failed to read file for upload: {}", e.getMessage());
             return null;
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            logger.error("Failed to send message: {}", e.getMessage());
+            logger.debug("Failed to send message: {}", e.getMessage());
             bridgeHandler.connectionError(e);
         } catch (TimeoutException | ExecutionException e) {
-            logger.error("Failed to send file: {}", e.getMessage());
+            logger.warn("Failed to send file: {}", e.getMessage());
             bridgeHandler.connectionError(e);
         }
         return null;
@@ -167,9 +167,10 @@ public class NtfySender {
         NtfyConnectionConfiguration connectionConfiguration = getConfiguration();
 
         URI requestURI = buildRequestURI(connectionConfiguration);
-
-        Request request = httpClient.newRequest(requestURI.resolve(requestURI.getPath() + "/" + sequenceId))
-                .method(HttpMethod.DELETE).timeout(connectionConfiguration.connectionTimeout, TimeUnit.MILLISECONDS);
+        URI deleteURI = new URI(requestURI.getScheme(), requestURI.getAuthority(),
+                requestURI.getPath() + "/" + sequenceId, null, null);
+        Request request = httpClient.newRequest(deleteURI).method(HttpMethod.DELETE)
+                .timeout(connectionConfiguration.connectionTimeout, TimeUnit.MILLISECONDS);
 
         if (connectionConfiguration.isAuthHeaderNeeded()) {
             String authHeader = connectionConfiguration.buildAuthHeader();
@@ -180,10 +181,10 @@ public class NtfySender {
             return HttpStatus.isSuccess(request.send().getStatus());
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            logger.error("Failed to delete message: {}", e.getMessage());
+            logger.warn("Failed to delete message: {}", e.getMessage());
             bridgeHandler.connectionError(e);
         } catch (TimeoutException | ExecutionException e) {
-            logger.error("Failed to delete message: {}", e.getMessage());
+            logger.warn("Failed to delete message: {}", e.getMessage());
             bridgeHandler.connectionError(e);
         }
         return false;
@@ -200,6 +201,12 @@ public class NtfySender {
     }
 
     private URI buildRequestURI(NtfyConnectionConfiguration connectionConfiguration) throws URISyntaxException {
-        return new URI(connectionConfiguration.hostname).resolve("./" + topicName);
+        URI baseUri = new URI(connectionConfiguration.hostname);
+        String path = baseUri.getPath();
+        if (path != null && !path.isEmpty() && !path.endsWith("/")) {
+            baseUri = new URI(baseUri.getScheme(), baseUri.getUserInfo(), baseUri.getHost(), baseUri.getPort(),
+                    path + "/", baseUri.getQuery(), baseUri.getFragment());
+        }
+        return baseUri.resolve("./" + topicName);
     }
 }

--- a/bundles/org.openhab.binding.ntfy/src/main/java/org/openhab/binding/ntfy/internal/network/NtfySender.java
+++ b/bundles/org.openhab.binding.ntfy/src/main/java/org/openhab/binding/ntfy/internal/network/NtfySender.java
@@ -89,6 +89,13 @@ public class NtfySender {
             if (HttpStatus.isSuccess(response.getStatus())) {
                 return GsonDeserializer.deserialize(response.getContentAsString(), MessageEvent.class);
             }
+            if (response.getStatus() == HttpStatus.BAD_REQUEST_400) {
+                logger.warn(
+                        "Failed to send message due to bad request - check if message content and headers are valid - error from server: {}",
+                        response.getContentAsString());
+            } else {
+                logger.warn("Failed to send message - received HTTP status {}", response.getStatus());
+            }
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             logger.error("Failed to send message: {}", e.getMessage());

--- a/bundles/org.openhab.binding.ntfy/src/main/java/org/openhab/binding/ntfy/internal/network/NtfyWebSocket.java
+++ b/bundles/org.openhab.binding.ntfy/src/main/java/org/openhab/binding/ntfy/internal/network/NtfyWebSocket.java
@@ -68,9 +68,14 @@ public class NtfyWebSocket {
     public void onMessage(String message) {
         logger.debug("Message from Server: {}", message);
 
-        BaseEvent fromJson = GsonDeserializer.deserialize(message);
-        if (fromJson != null) {
-            listener.messageRecieved(fromJson);
+        try {
+            BaseEvent fromJson = GsonDeserializer.deserialize(message);
+            if (fromJson != null) {
+                listener.messageReceived(fromJson);
+            }
+        } catch (RuntimeException e) {
+            logger.warn("Failed to deserialize websocket message: {}", message, e);
+            listener.connectionError(e);
         }
     }
 

--- a/bundles/org.openhab.binding.ntfy/src/main/java/org/openhab/binding/ntfy/internal/network/NtfyWebSocket.java
+++ b/bundles/org.openhab.binding.ntfy/src/main/java/org/openhab/binding/ntfy/internal/network/NtfyWebSocket.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.ntfy.internal.network;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jetty.websocket.api.Session;
+import org.eclipse.jetty.websocket.api.annotations.OnWebSocketClose;
+import org.eclipse.jetty.websocket.api.annotations.OnWebSocketConnect;
+import org.eclipse.jetty.websocket.api.annotations.OnWebSocketError;
+import org.eclipse.jetty.websocket.api.annotations.OnWebSocketMessage;
+import org.eclipse.jetty.websocket.api.annotations.WebSocket;
+import org.openhab.binding.ntfy.internal.models.BaseEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * WebSocket client implementation used to receive events from the ntfy server.
+ * The class forwards lifecycle and message events to the configured
+ * {@link WebSocketConnectionListener}.
+ *
+ * @author Christian Kittel - Initial contribution
+ */
+@WebSocket
+@NonNullByDefault
+public class NtfyWebSocket {
+
+    private final Logger logger = LoggerFactory.getLogger(NtfyWebSocket.class);
+
+    private WebSocketConnectionListener listener;
+
+    /**
+     * Creates a new WebSocket wrapper forwarding events to the provided listener.
+     *
+     * @param listener the listener to notify about connection and message events
+     */
+    public NtfyWebSocket(WebSocketConnectionListener listener) {
+        this.listener = listener;
+    }
+
+    /**
+     * Jetty callback invoked when the websocket connection has been established.
+     *
+     * @param session the websocket session
+     */
+    @OnWebSocketConnect
+    public void onConnect(Session session) {
+        listener.connectionEstablished();
+        logger.debug("Connected to: {}", session.getRemoteAddress().getAddress());
+    }
+
+    /**
+     * Jetty callback invoked for incoming text messages. The JSON payload is
+     * deserialized and forwarded to the configured listener.
+     *
+     * @param message the JSON message payload
+     */
+    @OnWebSocketMessage
+    public void onMessage(String message) {
+        logger.debug("Message from Server: {}", message);
+
+        BaseEvent fromJson = GsonDeserializer.deserialize(message);
+        if (fromJson != null) {
+            listener.messageRecieved(fromJson);
+        }
+    }
+
+    /**
+     * Jetty callback invoked when an error occurs on the websocket connection.
+     *
+     * @param cause the underlying error
+     */
+    @OnWebSocketError
+    public void onError(Throwable cause) {
+        listener.connectionError(cause);
+        logger.debug("Connection failed: {}", cause.getMessage());
+    }
+
+    /**
+     * Jetty callback invoked when the websocket connection is closed.
+     *
+     * @param statusCode the close status code
+     * @param reason the reason message for the close
+     */
+    @OnWebSocketClose
+    public void onClose(int statusCode, String reason) {
+        listener.connectionLost(reason);
+        logger.debug("WebSocket Closed. Code: {}; Reason: {}", statusCode, reason);
+    }
+}

--- a/bundles/org.openhab.binding.ntfy/src/main/java/org/openhab/binding/ntfy/internal/network/ViewActionButton.java
+++ b/bundles/org.openhab.binding.ntfy/src/main/java/org/openhab/binding/ntfy/internal/network/ViewActionButton.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.ntfy.internal.network;
+
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URL;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * Action button that represents a view action attached to a notification.
+ *
+ * @author Christian Kittel - Initial contribution
+ */
+@NonNullByDefault
+public class ViewActionButton extends ActionButtonBase {
+
+    private URL url;
+
+    /**
+     * Creates a view action button descriptor.
+     *
+     * @param label the label shown for the action
+     * @param clearNotification whether executing the action should clear the notification
+     * @param url the URL to open when the action is executed
+     * @throws MalformedURLException when the provided URL is not valid
+     */
+    public ViewActionButton(String label, Boolean clearNotification, String url) throws MalformedURLException {
+        super(label, clearNotification);
+
+        this.url = URI.create(url).toURL();
+    }
+
+    @Override
+    public String getHeader() {
+        return "view, " + label + ", " + url.toString() + (clearNotification ? ", clear=true" : "");
+    }
+}

--- a/bundles/org.openhab.binding.ntfy/src/main/java/org/openhab/binding/ntfy/internal/network/ViewActionButton.java
+++ b/bundles/org.openhab.binding.ntfy/src/main/java/org/openhab/binding/ntfy/internal/network/ViewActionButton.java
@@ -35,8 +35,10 @@ public class ViewActionButton extends ActionButtonBase {
      * @param clearNotification whether executing the action should clear the notification
      * @param url the URL to open when the action is executed
      * @throws MalformedURLException when the provided URL is not valid
+     * @throws IllegalArgumentException when the provided URL is not valid
      */
-    public ViewActionButton(String label, Boolean clearNotification, String url) throws MalformedURLException {
+    public ViewActionButton(String label, Boolean clearNotification, String url)
+            throws IllegalArgumentException, MalformedURLException {
         super(label, clearNotification);
 
         this.url = URI.create(url).toURL();

--- a/bundles/org.openhab.binding.ntfy/src/main/java/org/openhab/binding/ntfy/internal/network/ViewActionButton.java
+++ b/bundles/org.openhab.binding.ntfy/src/main/java/org/openhab/binding/ntfy/internal/network/ViewActionButton.java
@@ -46,6 +46,7 @@ public class ViewActionButton extends ActionButtonBase {
 
     @Override
     public String getHeader() {
-        return "view, " + label + ", " + url.toString() + (clearNotification ? ", clear=true" : "");
+        return "view, " + label + ", " + url.toString()
+                + (Boolean.TRUE.equals(clearNotification) ? ", clear=true" : "");
     }
 }

--- a/bundles/org.openhab.binding.ntfy/src/main/java/org/openhab/binding/ntfy/internal/network/WebSocketConnectionListener.java
+++ b/bundles/org.openhab.binding.ntfy/src/main/java/org/openhab/binding/ntfy/internal/network/WebSocketConnectionListener.java
@@ -13,6 +13,7 @@
 package org.openhab.binding.ntfy.internal.network;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.ntfy.internal.models.BaseEvent;
 
 /**
@@ -35,7 +36,7 @@ public interface WebSocketConnectionListener {
      *
      * @param reason A reason for the disconnection
      */
-    void connectionLost(String reason);
+    void connectionLost(@Nullable String reason);
 
     /**
      * Connection error
@@ -49,5 +50,5 @@ public interface WebSocketConnectionListener {
      *
      * @param messageEvent the parsed {@link BaseEvent}
      */
-    void messageRecieved(BaseEvent messageEvent);
+    void messageReceived(BaseEvent messageEvent);
 }

--- a/bundles/org.openhab.binding.ntfy/src/main/java/org/openhab/binding/ntfy/internal/network/WebSocketConnectionListener.java
+++ b/bundles/org.openhab.binding.ntfy/src/main/java/org/openhab/binding/ntfy/internal/network/WebSocketConnectionListener.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.ntfy.internal.network;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.binding.ntfy.internal.models.BaseEvent;
+
+/**
+ * Listener interface for WebSocket connection lifecycle and incoming messages.
+ * Implementations receive events such as connection established, errors and
+ * incoming parsed {@link org.openhab.binding.ntfy.internal.models.BaseEvent} instances.
+ *
+ * @author Christian Kittel - Initial contribution
+ */
+@NonNullByDefault
+public interface WebSocketConnectionListener {
+
+    /**
+     * Connection successfully established.
+     */
+    void connectionEstablished();
+
+    /**
+     * Connection lost
+     *
+     * @param reason A reason for the disconnection
+     */
+    void connectionLost(String reason);
+
+    /**
+     * Connection error
+     *
+     * @param cause The exception
+     */
+    void connectionError(Throwable cause);
+
+    /**
+     * Called when a parsed event message was received from the websocket.
+     *
+     * @param messageEvent the parsed {@link BaseEvent}
+     */
+    void messageRecieved(BaseEvent messageEvent);
+}

--- a/bundles/org.openhab.binding.ntfy/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.binding.ntfy/src/main/resources/OH-INF/addon/addon.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<addon:addon id="ntfy" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:addon="https://openhab.org/schemas/addon/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/addon/v1.0.0 https://openhab.org/schemas/addon-1.0.0.xsd">
+
+	<type>binding</type>
+	<name>Ntfy Binding</name>
+	<description>This is the binding for Ntfy.</description>
+
+</addon:addon>

--- a/bundles/org.openhab.binding.ntfy/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.binding.ntfy/src/main/resources/OH-INF/addon/addon.xml
@@ -6,5 +6,6 @@
 	<type>binding</type>
 	<name>Ntfy Binding</name>
 	<description>This is the binding for Ntfy.</description>
+	<connection>hybrid</connection>
 
 </addon:addon>

--- a/bundles/org.openhab.binding.ntfy/src/main/resources/OH-INF/i18n/ntfy.properties
+++ b/bundles/org.openhab.binding.ntfy/src/main/resources/OH-INF/i18n/ntfy.properties
@@ -5,26 +5,26 @@ addon.ntfy.description = This is the binding for Ntfy.
 
 # thing types
 
-thing-type.ntfy.ntfyConnection.label = Ntfy Connection
-thing-type.ntfy.ntfyConnection.description = Connection to a ntfy server
-thing-type.ntfy.ntfyTopic.label = Ntfy Topic
-thing-type.ntfy.ntfyTopic.description = Topic of a ntfy server
+thing-type.ntfy.ntfy-topic.label = Ntfy Topic
+thing-type.ntfy.ntfy-topic.description = Topic of a ntfy server
+thing-type.ntfy.server.label = Ntfy Connection
+thing-type.ntfy.server.description = Connection to an ntfy server
 
 # thing types config
 
-thing-type.config.ntfy.ntfyConnection.connectionTimeout.label = Web-Socket timeout
-thing-type.config.ntfy.ntfyConnection.connectionTimeout.description = Connection-Timeout for WebSocket
-thing-type.config.ntfy.ntfyConnection.hostname.label = Hostname
-thing-type.config.ntfy.ntfyConnection.hostname.description = Hostname of the ntfy server
-thing-type.config.ntfy.ntfyConnection.password.label = Password
-thing-type.config.ntfy.ntfyConnection.password.description = Password to access the server
-thing-type.config.ntfy.ntfyConnection.username.label = username
-thing-type.config.ntfy.ntfyConnection.username.description = Username to access the server
-thing-type.config.ntfy.ntfyTopic.topicname.label = Topic name
-thing-type.config.ntfy.ntfyTopic.topicname.description = Name of the topic
+thing-type.config.ntfy.ntfy-topic.topicName.label = Topic name
+thing-type.config.ntfy.ntfy-topic.topicName.description = Name of the topic
+thing-type.config.ntfy.server.connectionTimeout.label = Connection timeout
+thing-type.config.ntfy.server.connectionTimeout.description = Connection timeout for web requests and web socket connections in milliseconds
+thing-type.config.ntfy.server.hostname.label = Hostname
+thing-type.config.ntfy.server.hostname.description = Hostname of the ntfy server
+thing-type.config.ntfy.server.password.label = Password
+thing-type.config.ntfy.server.password.description = Password to access the server
+thing-type.config.ntfy.server.username.label = Username
+thing-type.config.ntfy.server.username.description = Username to access the server
 
 # channel types
 
-channel-type.ntfy.lastMessage.label = Last Message
-channel-type.ntfy.lastMessageMessageId.label = Message Id of the last message
-channel-type.ntfy.lastMessageTime.label = Time of the last message
+channel-type.ntfy.last-message-id.label = Message Id of the last message
+channel-type.ntfy.last-message-time.label = Time of the last message
+channel-type.ntfy.last-message.label = Last Message

--- a/bundles/org.openhab.binding.ntfy/src/main/resources/OH-INF/i18n/ntfy.properties
+++ b/bundles/org.openhab.binding.ntfy/src/main/resources/OH-INF/i18n/ntfy.properties
@@ -1,0 +1,30 @@
+# add-on
+
+addon.ntfy.name = Ntfy Binding
+addon.ntfy.description = This is the binding for Ntfy.
+
+# thing types
+
+thing-type.ntfy.ntfyConnection.label = Ntfy Connection
+thing-type.ntfy.ntfyConnection.description = Connection to a ntfy server
+thing-type.ntfy.ntfyTopic.label = Ntfy Topic
+thing-type.ntfy.ntfyTopic.description = Topic of a ntfy server
+
+# thing types config
+
+thing-type.config.ntfy.ntfyConnection.connectionTimeout.label = Web-Socket timeout
+thing-type.config.ntfy.ntfyConnection.connectionTimeout.description = Connection-Timeout for WebSocket
+thing-type.config.ntfy.ntfyConnection.hostname.label = Hostname
+thing-type.config.ntfy.ntfyConnection.hostname.description = Hostname of the ntfy server
+thing-type.config.ntfy.ntfyConnection.password.label = Password
+thing-type.config.ntfy.ntfyConnection.password.description = Password to access the server
+thing-type.config.ntfy.ntfyConnection.username.label = username
+thing-type.config.ntfy.ntfyConnection.username.description = Username to access the server
+thing-type.config.ntfy.ntfyTopic.topicname.label = Topic name
+thing-type.config.ntfy.ntfyTopic.topicname.description = Name of the topic
+
+# channel types
+
+channel-type.ntfy.lastMessage.label = Last Message
+channel-type.ntfy.lastMessageMessageId.label = Message Id of the last message
+channel-type.ntfy.lastMessageTime.label = Time of the last message

--- a/bundles/org.openhab.binding.ntfy/src/main/resources/OH-INF/i18n/ntfy.properties
+++ b/bundles/org.openhab.binding.ntfy/src/main/resources/OH-INF/i18n/ntfy.properties
@@ -12,7 +12,7 @@ thing-type.ntfy.server.description = Connection to an ntfy server
 
 # thing types config
 
-thing-type.config.ntfy.ntfy-topic.topicName.label = Topic name
+thing-type.config.ntfy.ntfy-topic.topicName.label = Topic Name
 thing-type.config.ntfy.ntfy-topic.topicName.description = Name of the topic
 thing-type.config.ntfy.server.connectionTimeout.label = Connection timeout
 thing-type.config.ntfy.server.connectionTimeout.description = Connection timeout for web requests and web socket connections in milliseconds
@@ -28,3 +28,8 @@ thing-type.config.ntfy.server.username.description = Username to access the serv
 channel-type.ntfy.last-message-id.label = Message Id of the last message
 channel-type.ntfy.last-message-time.label = Time of the last message
 channel-type.ntfy.last-message.label = Last Message
+
+# thing status descriptions
+
+offline.communication-error.unsupported-schema = URI scheme is missing in hostname or unsupported URI scheme (only http or https are supported)
+offline.communication-error.websocket-connection-lost = WebSocket connection lost

--- a/bundles/org.openhab.binding.ntfy/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.ntfy/src/main/resources/OH-INF/thing/thing-types.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="ntfy"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
+
+	<bridge-type id="ntfyConnection">
+
+		<label>Ntfy Connection</label>
+		<description>Connection to a ntfy server</description>
+		<representation-property>hostname</representation-property>
+
+		<config-description>
+			<parameter name="hostname" type="text" required="true">
+				<context>network-address</context>
+				<label>Hostname</label>
+				<description>Hostname of the ntfy server</description>
+				<default>https://ntfy.sh</default>
+			</parameter>
+			<parameter name="username" type="text" required="false">
+				<context>username</context>
+				<label>username</label>
+				<description>Username to access the server</description>
+			</parameter>
+			<parameter name="password" type="text" required="false">
+				<context>password</context>
+				<label>Password</label>
+				<description>Password to access the server</description>
+			</parameter>
+			<parameter name="connectionTimeout" type="integer" required="true">
+				<context>time</context>
+				<label>Web-Socket timeout</label>
+				<description>Connection-Timeout for WebSocket</description>
+				<default>60000</default>
+				<advanced>true</advanced>
+			</parameter>
+		</config-description>
+	</bridge-type>
+
+	<thing-type id="ntfyTopic">
+		<supported-bridge-type-refs>
+			<bridge-type-ref id="ntfyConnection"/>
+		</supported-bridge-type-refs>
+		<label>Ntfy Topic</label>
+		<description>Topic of a ntfy server</description>
+
+		<channels>
+			<channel id="lastMessage" typeId="lastMessage"/>
+			<channel id="lastMessageTime" typeId="lastMessageTime"/>
+			<channel id="lastMessageSequenceId" typeId="lastMessageSequenceId"/>
+		</channels>
+
+		<representation-property>topicname</representation-property>
+
+		<config-description>
+			<parameter name="topicname" type="text" required="true">
+				<context>topicname</context>
+				<label>Topic name</label>
+				<description>Name of the topic</description>
+			</parameter>
+		</config-description>
+
+
+	</thing-type>
+
+	<channel-type id="lastMessage">
+		<item-type>String</item-type>
+		<label>Last Message</label>
+		<state readOnly="true"/>
+	</channel-type>
+
+	<channel-type id="lastMessageMessageId">
+		<item-type>String</item-type>
+		<label>Message Id of the last message</label>
+		<state readOnly="true"/>
+	</channel-type>
+
+	<channel-type id="lastMessageTime">
+		<item-type>DateTime</item-type>
+		<label>Time of the last message</label>
+		<state readOnly="true"/>
+	</channel-type>
+
+</thing:thing-descriptions>

--- a/bundles/org.openhab.binding.ntfy/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.ntfy/src/main/resources/OH-INF/thing/thing-types.xml
@@ -4,10 +4,10 @@
 	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
 	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
 
-	<bridge-type id="ntfyConnection">
+	<bridge-type id="server">
 
 		<label>Ntfy Connection</label>
-		<description>Connection to a ntfy server</description>
+		<description>Connection to an ntfy server</description>
 		<representation-property>hostname</representation-property>
 
 		<config-description>
@@ -19,7 +19,7 @@
 			</parameter>
 			<parameter name="username" type="text" required="false">
 				<context>username</context>
-				<label>username</label>
+				<label>Username</label>
 				<description>Username to access the server</description>
 			</parameter>
 			<parameter name="password" type="text" required="false">
@@ -27,55 +27,53 @@
 				<label>Password</label>
 				<description>Password to access the server</description>
 			</parameter>
-			<parameter name="connectionTimeout" type="integer" required="true">
+			<parameter name="connectionTimeout" type="integer" required="false">
 				<context>time</context>
-				<label>Web-Socket timeout</label>
-				<description>Connection-Timeout for WebSocket</description>
-				<default>60000</default>
+				<label>Connection timeout</label>
+				<description>Connection timeout for web requests and web socket connections in milliseconds</description>
 				<advanced>true</advanced>
 			</parameter>
 		</config-description>
 	</bridge-type>
 
-	<thing-type id="ntfyTopic">
+	<thing-type id="ntfy-topic">
 		<supported-bridge-type-refs>
-			<bridge-type-ref id="ntfyConnection"/>
+			<bridge-type-ref id="server"/>
 		</supported-bridge-type-refs>
 		<label>Ntfy Topic</label>
 		<description>Topic of a ntfy server</description>
 
 		<channels>
-			<channel id="lastMessage" typeId="lastMessage"/>
-			<channel id="lastMessageTime" typeId="lastMessageTime"/>
-			<channel id="lastMessageSequenceId" typeId="lastMessageSequenceId"/>
+			<channel id="last-message" typeId="last-message"/>
+			<channel id="last-message-time" typeId="last-message-time"/>
+			<channel id="last-message-id" typeId="last-message-id"/>
 		</channels>
 
-		<representation-property>topicname</representation-property>
+		<representation-property>topicName</representation-property>
 
 		<config-description>
-			<parameter name="topicname" type="text" required="true">
-				<context>topicname</context>
+			<parameter name="topicName" type="text" required="true">
+				<context>topicName</context>
 				<label>Topic name</label>
 				<description>Name of the topic</description>
 			</parameter>
 		</config-description>
 
-
 	</thing-type>
 
-	<channel-type id="lastMessage">
+	<channel-type id="last-message">
 		<item-type>String</item-type>
 		<label>Last Message</label>
 		<state readOnly="true"/>
 	</channel-type>
 
-	<channel-type id="lastMessageMessageId">
+	<channel-type id="last-message-id">
 		<item-type>String</item-type>
 		<label>Message Id of the last message</label>
 		<state readOnly="true"/>
 	</channel-type>
 
-	<channel-type id="lastMessageTime">
+	<channel-type id="last-message-time">
 		<item-type>DateTime</item-type>
 		<label>Time of the last message</label>
 		<state readOnly="true"/>

--- a/bundles/org.openhab.binding.ntfy/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.ntfy/src/main/resources/OH-INF/thing/thing-types.xml
@@ -8,6 +8,7 @@
 
 		<label>Ntfy Connection</label>
 		<description>Connection to an ntfy server</description>
+		<semantic-equipment-tag>WebService</semantic-equipment-tag>
 		<representation-property>hostname</representation-property>
 
 		<config-description>
@@ -27,11 +28,12 @@
 				<label>Password</label>
 				<description>Password to access the server</description>
 			</parameter>
-			<parameter name="connectionTimeout" type="integer" required="false">
+			<parameter name="connectionTimeout" type="integer" required="true">
 				<context>time</context>
 				<label>Connection timeout</label>
 				<description>Connection timeout for web requests and web socket connections in milliseconds</description>
 				<advanced>true</advanced>
+				<default>60000</default>
 			</parameter>
 		</config-description>
 	</bridge-type>
@@ -42,7 +44,7 @@
 		</supported-bridge-type-refs>
 		<label>Ntfy Topic</label>
 		<description>Topic of a ntfy server</description>
-
+		<semantic-equipment-tag>WebService</semantic-equipment-tag>
 		<channels>
 			<channel id="last-message" typeId="last-message"/>
 			<channel id="last-message-time" typeId="last-message-time"/>
@@ -54,7 +56,7 @@
 		<config-description>
 			<parameter name="topicName" type="text" required="true">
 				<context>topicName</context>
-				<label>Topic name</label>
+				<label>Topic Name</label>
 				<description>Name of the topic</description>
 			</parameter>
 		</config-description>
@@ -76,6 +78,9 @@
 	<channel-type id="last-message-time">
 		<item-type>DateTime</item-type>
 		<label>Time of the last message</label>
+		<tags>
+			<tag>Timestamp</tag>
+		</tags>
 		<state readOnly="true"/>
 	</channel-type>
 

--- a/bundles/org.openhab.binding.ntfy/src/test/java/org/openhab/binding/ntfy/internal/network/NtfyMessageHeaderBuilderTest.java
+++ b/bundles/org.openhab.binding.ntfy/src/test/java/org/openhab/binding/ntfy/internal/network/NtfyMessageHeaderBuilderTest.java
@@ -105,8 +105,6 @@ public class NtfyMessageHeaderBuilderTest {
 
         new NtfyMessageHeaderBuilder(message, request).build();
 
-        new NtfyMessageHeaderBuilder(message, request).build();
-
         assertEquals("5", headers.get("X-Priority"), () -> "X-Priority header was: " + headers.get("X-Priority"));
         assertEquals("https://example.org/click", headers.get("X-Click"),
                 () -> "X-Click header was: " + headers.get("X-Click"));

--- a/bundles/org.openhab.binding.ntfy/src/test/java/org/openhab/binding/ntfy/internal/network/NtfyMessageHeaderBuilderTest.java
+++ b/bundles/org.openhab.binding.ntfy/src/test/java/org/openhab/binding/ntfy/internal/network/NtfyMessageHeaderBuilderTest.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.ntfy.internal.network;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.net.URISyntaxException;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.jetty.client.api.Request;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link NtfyMessageHeaderBuilder}.
+ *
+ * @author Christian Kittel - Initial contribution
+ */
+@NonNullByDefault
+public class NtfyMessageHeaderBuilderTest {
+
+    private static Request createRequestProxy(Map<String, String> headers) {
+        InvocationHandler handler = new InvocationHandler() {
+            @Override
+            public @Nullable Object invoke(@Nullable Object proxy, @Nullable Method method,
+                    @Nullable Object @Nullable [] args) throws Throwable {
+                if (method == null) {
+                    return null;
+                }
+                if ("header".equals(method.getName()) && args != null && args.length == 2) {
+                    Object nameObj = args[0];
+                    Object valueObj = args[1];
+                    if (nameObj == null || valueObj == null) {
+                        return proxy;
+                    }
+                    String name = (String) nameObj;
+                    String value = (String) valueObj;
+                    headers.put(name, value);
+                    return proxy;
+                }
+                if (method.getReturnType().isPrimitive()) {
+                    if (method.getReturnType() == boolean.class) {
+                        return false;
+                    }
+                    if (method.getReturnType() == int.class) {
+                        return 0;
+                    }
+                }
+                return null;
+            }
+        };
+
+        return (Request) Proxy.newProxyInstance(Request.class.getClassLoader(), new Class[] { Request.class }, handler);
+    }
+
+    /**
+     * Verifies that the default priority is written to the X-Priority header.
+     */
+    @Test
+    public void buildSetsPriority() {
+        NtfyMessage message = new NtfyMessage();
+        Map<String, String> headers = new HashMap<>();
+        Request request = createRequestProxy(headers);
+
+        new NtfyMessageHeaderBuilder(message, request).build();
+
+        assertEquals("3", headers.get("X-Priority"), () -> "X-Priority header was: " + headers.get("X-Priority"));
+    }
+
+    /**
+     * Verifies that click action, tags, icon, attachment, actions and sequence id
+     * are correctly added to the request headers.
+     */
+    @Test
+    public void buildWithClickTagsIconAttachmentSequenceAndAction() throws Exception {
+        NtfyMessage message = new NtfyMessage();
+        message.setPriority(5);
+        message.setClickAction("https://example.org/click");
+        message.addTag("tag1");
+        message.addTag("tag2");
+        message.setIcon("https://example.org/icon.png");
+        message.setAttachment("https://example.org/file.bin", "file.bin");
+        message.addCopyAction("CopyLabel", Boolean.TRUE, "somevalue");
+        message.setSequenceId("seq-123");
+
+        Map<String, String> headers = new HashMap<>();
+        Request request = createRequestProxy(headers);
+
+        new NtfyMessageHeaderBuilder(message, request).build();
+
+        new NtfyMessageHeaderBuilder(message, request).build();
+
+        assertEquals("5", headers.get("X-Priority"), () -> "X-Priority header was: " + headers.get("X-Priority"));
+        assertEquals("https://example.org/click", headers.get("X-Click"),
+                () -> "X-Click header was: " + headers.get("X-Click"));
+        String tags = headers.get("X-Tags");
+        assertNotNull(tags, () -> "X-Tags header is missing");
+        // set order is not guaranteed
+        Set<String> tagSet = new HashSet<>();
+        for (String t : tags.split(",")) {
+            tagSet.add(t.trim());
+        }
+        assertTrue(tagSet.contains("tag1"), () -> "Expected tags to contain 'tag1', actual: " + tags);
+        assertTrue(tagSet.contains("tag2"), () -> "Expected tags to contain 'tag2', actual: " + tags);
+
+        assertEquals("https://example.org/icon.png", headers.get("X-Icon"),
+                () -> "X-Icon header was: " + headers.get("X-Icon"));
+        assertEquals("https://example.org/file.bin", headers.get("X-Attach"),
+                () -> "X-Attach header was: " + headers.get("X-Attach"));
+        assertEquals("file.bin", headers.get("X-Filename"),
+                () -> "X-Filename header was: " + headers.get("X-Filename"));
+
+        String actions = headers.get("X-Actions");
+        assertNotNull(actions, () -> "X-Actions header is missing");
+        assertTrue(actions.contains("copy"), () -> "X-Actions did not contain 'copy', actual: " + actions);
+        assertTrue(actions.contains("CopyLabel"), () -> "X-Actions did not contain 'CopyLabel', actual: " + actions);
+
+        assertEquals("seq-123", headers.get("X-Sequence-ID"),
+                () -> "X-Sequence-ID header was: " + headers.get("X-Sequence-ID"));
+    }
+
+    /**
+     * Verifies that when an attachment filename is blank the X-Filename header is not set.
+     */
+    @Test
+    public void buildWithBlankFilenameDoesNotSetFilename() throws URISyntaxException {
+        NtfyMessage message = new NtfyMessage();
+        message.setAttachment("https://example.org/file.bin", "   ");
+
+        Map<String, String> headers = new HashMap<>();
+        Request request = createRequestProxy(headers);
+
+        new NtfyMessageHeaderBuilder(message, request).build();
+
+        assertEquals("https://example.org/file.bin", headers.get("X-Attach"),
+                () -> "X-Attach header was: " + headers.get("X-Attach"));
+        assertNull(headers.get("X-Filename"),
+                () -> "Expected X-Filename to be absent or blank but was: " + headers.get("X-Filename"));
+    }
+}

--- a/bundles/org.openhab.binding.ntfy/src/test/java/org/openhab/binding/ntfy/internal/network/NtfySenderTest.java
+++ b/bundles/org.openhab.binding.ntfy/src/test/java/org/openhab/binding/ntfy/internal/network/NtfySenderTest.java
@@ -86,7 +86,7 @@ public class NtfySenderTest {
 
         final NtfyConnectionHandler handler = java.util.Objects.requireNonNull(this.handler);
 
-        NtfySender sender = new NtfySender("topic", httpClient, () -> handler);
+        NtfySender sender = new NtfySender("topic", httpClient, handler);
 
         NtfyConnectionConfiguration cfg = new NtfyConnectionConfiguration();
         cfg.hostname = "http://example.org";
@@ -116,11 +116,12 @@ public class NtfySenderTest {
 
         when(httpClient.newRequest(any(URI.class))).thenReturn(request);
         when(request.method(HttpMethod.DELETE)).thenReturn(request);
+        when(request.timeout(anyLong(), any(TimeUnit.class))).thenReturn(request);
         when(request.send()).thenReturn(response);
         when(response.getStatus()).thenReturn(200);
 
         final NtfyConnectionHandler handler = java.util.Objects.requireNonNull(this.handler);
-        NtfySender sender = new NtfySender("topic", httpClient, () -> handler);
+        NtfySender sender = new NtfySender("topic", httpClient, handler);
 
         NtfyConnectionConfiguration cfg = new NtfyConnectionConfiguration();
         cfg.hostname = "http://example.org";
@@ -145,7 +146,7 @@ public class NtfySenderTest {
         when(request.send()).thenThrow(new ExecutionException(new RuntimeException("boom")));
 
         final NtfyConnectionHandler handler = java.util.Objects.requireNonNull(this.handler);
-        NtfySender sender = new NtfySender("topic", httpClient, () -> handler);
+        NtfySender sender = new NtfySender("topic", httpClient, handler);
 
         NtfyConnectionConfiguration cfg = new NtfyConnectionConfiguration();
         cfg.hostname = "http://example.org";
@@ -179,10 +180,11 @@ public class NtfySenderTest {
         String json = "{\"sequence_id\":\"seq-file-1\",\"message\":\"uploaded\",\"priority\":4,\"event\":\"message\"}";
         when(response.getStatus()).thenReturn(200);
         when(response.getContentAsString()).thenReturn(json);
+        when(request.timeout(anyLong(), any(TimeUnit.class))).thenReturn(request);
 
         NtfyConnectionHandler handler = mock(NtfyConnectionHandler.class);
 
-        NtfySender sender = new NtfySender("topic", httpClient, () -> handler);
+        NtfySender sender = new NtfySender("topic", httpClient, handler);
 
         NtfyConnectionConfiguration cfg = new NtfyConnectionConfiguration();
         cfg.hostname = "http://example.org";

--- a/bundles/org.openhab.binding.ntfy/src/test/java/org/openhab/binding/ntfy/internal/network/NtfySenderTest.java
+++ b/bundles/org.openhab.binding.ntfy/src/test/java/org/openhab/binding/ntfy/internal/network/NtfySenderTest.java
@@ -1,0 +1,205 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.ntfy.internal.network;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.lang.reflect.Field;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.api.ContentResponse;
+import org.eclipse.jetty.client.api.Request;
+import org.eclipse.jetty.http.HttpMethod;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.openhab.binding.ntfy.internal.NtfyConnectionConfiguration;
+import org.openhab.binding.ntfy.internal.NtfyConnectionHandler;
+import org.openhab.binding.ntfy.internal.models.MessageEvent;
+
+/**
+ * Unit tests for {@link NtfySender}.
+ *
+ * @author Christian Kittel - Initial contribution
+ */
+@NonNullByDefault
+public class NtfySenderTest {
+
+    private @Mock @Nullable Request request;
+    private @Mock @Nullable HttpClient httpClient;
+    private @Mock @Nullable ContentResponse response;
+    private @Mock @Nullable NtfyConnectionHandler handler;
+
+    private static void setConfiguration(NtfySender sender, NtfyConnectionConfiguration cfg) throws Exception {
+        Field f = NtfySender.class.getDeclaredField("configuration");
+        f.setAccessible(true);
+        f.set(sender, cfg);
+    }
+
+    @BeforeEach
+    public void setupMocks() {
+        request = mock(Request.class);
+        httpClient = mock(HttpClient.class);
+        response = mock(ContentResponse.class);
+        handler = mock(NtfyConnectionHandler.class);
+    }
+
+    /**
+     * Verifies that a successful HTTP POST returns a deserialized MessageEvent
+     * with the expected fields.
+     */
+    @Test
+    public void sendMessageSuccessReturnsDeserializedMessageEvent() throws Exception {
+        final HttpClient httpClient = java.util.Objects.requireNonNull(this.httpClient);
+        final Request request = java.util.Objects.requireNonNull(this.request);
+        final ContentResponse response = java.util.Objects.requireNonNull(this.response);
+
+        when(httpClient.newRequest(any(URI.class))).thenReturn(request);
+        when(request.method(HttpMethod.POST)).thenReturn(request);
+        when(request.content(any())).thenReturn(request);
+        when(request.timeout(anyLong(), any(TimeUnit.class))).thenReturn(request);
+        when(request.send()).thenReturn(response);
+
+        String json = "{\"sequence_id\":\"seq-1\",\"message\":\"hello\",\"priority\":5,\"event\":\"message\"}";
+        when(response.getStatus()).thenReturn(200);
+        when(response.getContentAsString()).thenReturn(json);
+
+        final NtfyConnectionHandler handler = java.util.Objects.requireNonNull(this.handler);
+
+        NtfySender sender = new NtfySender("topic", httpClient, () -> handler);
+
+        NtfyConnectionConfiguration cfg = new NtfyConnectionConfiguration();
+        cfg.hostname = "http://example.org";
+        setConfiguration(sender, cfg);
+
+        NtfyMessage m = new NtfyMessage();
+        m.setMessage("hello");
+
+        @Nullable
+        MessageEvent result = sender.sendMessage(m);
+
+        assertNotNull(result, "Expected non-null MessageEvent on success");
+        assertEquals("seq-1", result.getSequenceId());
+        assertEquals("hello", result.getMessage());
+        assertEquals(5, result.getPriority());
+    }
+
+    /**
+     * Verifies that a successful HTTP DELETE request results in a true return
+     * value from deleteMessage.
+     */
+    @Test
+    public void deleteMessageSuccessReturnsTrue() throws Exception {
+        final HttpClient httpClient = java.util.Objects.requireNonNull(this.httpClient);
+        final Request request = java.util.Objects.requireNonNull(this.request);
+        final ContentResponse response = java.util.Objects.requireNonNull(this.response);
+
+        when(httpClient.newRequest(any(URI.class))).thenReturn(request);
+        when(request.method(HttpMethod.DELETE)).thenReturn(request);
+        when(request.send()).thenReturn(response);
+        when(response.getStatus()).thenReturn(200);
+
+        final NtfyConnectionHandler handler = java.util.Objects.requireNonNull(this.handler);
+        NtfySender sender = new NtfySender("topic", httpClient, () -> handler);
+
+        NtfyConnectionConfiguration cfg = new NtfyConnectionConfiguration();
+        cfg.hostname = "http://example.org";
+        setConfiguration(sender, cfg);
+
+        assertTrue(sender.deleteMessage("seq-123"), "Expected deleteMessage to return true for 2xx status");
+    }
+
+    /**
+     * Verifies that when the POST send() throws an exception, sendMessage
+     * returns null and the bridge handler's connectionError is invoked.
+     */
+    @Test
+    public void sendMessageSendThrowsCallsConnectionError() throws Exception {
+        final HttpClient httpClient = java.util.Objects.requireNonNull(this.httpClient);
+        final Request request = java.util.Objects.requireNonNull(this.request);
+
+        when(httpClient.newRequest(any(URI.class))).thenReturn(request);
+        when(request.method(HttpMethod.POST)).thenReturn(request);
+        when(request.content(any())).thenReturn(request);
+        when(request.timeout(anyLong(), any(TimeUnit.class))).thenReturn(request);
+        when(request.send()).thenThrow(new ExecutionException(new RuntimeException("boom")));
+
+        final NtfyConnectionHandler handler = java.util.Objects.requireNonNull(this.handler);
+        NtfySender sender = new NtfySender("topic", httpClient, () -> handler);
+
+        NtfyConnectionConfiguration cfg = new NtfyConnectionConfiguration();
+        cfg.hostname = "http://example.org";
+        setConfiguration(sender, cfg);
+
+        NtfyMessage m = new NtfyMessage();
+        m.setMessage("x");
+
+        @Nullable
+        MessageEvent result = sender.sendMessage(m);
+
+        assertNull(result, "Expected null result when send throws");
+        verify(handler).connectionError(any());
+    }
+
+    /**
+     * Verifies that uploading a local file via sendFile results in a deserialized
+     * MessageEvent when the server responds with a success status.
+     */
+    @Test
+    public void sendFileUploadsFileAndReturnsMessageEvent() throws Exception {
+        HttpClient httpClient = mock(HttpClient.class);
+        Request request = mock(Request.class);
+        ContentResponse response = mock(ContentResponse.class);
+
+        when(httpClient.newRequest(any(URI.class))).thenReturn(request);
+        when(request.method(HttpMethod.PUT)).thenReturn(request);
+        when(request.content(any())).thenReturn(request);
+        when(request.send()).thenReturn(response);
+
+        String json = "{\"sequence_id\":\"seq-file-1\",\"message\":\"uploaded\",\"priority\":4,\"event\":\"message\"}";
+        when(response.getStatus()).thenReturn(200);
+        when(response.getContentAsString()).thenReturn(json);
+
+        NtfyConnectionHandler handler = mock(NtfyConnectionHandler.class);
+
+        NtfySender sender = new NtfySender("topic", httpClient, () -> handler);
+
+        NtfyConnectionConfiguration cfg = new NtfyConnectionConfiguration();
+        cfg.hostname = "http://example.org";
+        setConfiguration(sender, cfg);
+
+        Path tmp = Files.createTempFile("ntfy-test-", ".bin");
+        try {
+            Files.writeString(tmp, "file-contents", StandardCharsets.UTF_8);
+
+            MessageEvent result = sender.sendFile(tmp.toString(), "file.bin", "seq-file-1");
+
+            assertNotNull(result, "Expected non-null MessageEvent on successful file upload");
+            assertEquals("seq-file-1", result.getSequenceId());
+            assertEquals("uploaded", result.getMessage());
+            assertEquals(4, result.getPriority());
+        } finally {
+            Files.deleteIfExists(tmp);
+        }
+    }
+}

--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -1,21 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
-
   <modelVersion>4.0.0</modelVersion>
-
   <parent>
     <groupId>org.openhab.addons</groupId>
     <artifactId>org.openhab.addons.reactor</artifactId>
     <version>5.2.0-SNAPSHOT</version>
   </parent>
-
   <groupId>org.openhab.addons.bundles</groupId>
   <artifactId>org.openhab.addons.reactor.bundles</artifactId>
   <packaging>pom</packaging>
-
   <name>openHAB Add-ons :: Bundles</name>
-
   <modules>
     <!-- automation -->
     <module>org.openhab.automation.groovyscripting</module>
@@ -319,6 +314,7 @@
     <module>org.openhab.binding.nikohomecontrol</module>
     <module>org.openhab.binding.nobohub</module>
     <module>org.openhab.binding.novafinedust</module>
+    <module>org.openhab.binding.ntfy</module>
     <module>org.openhab.binding.ntp</module>
     <module>org.openhab.binding.nuki</module>
     <module>org.openhab.binding.nuvo</module>
@@ -527,13 +523,11 @@
     <module>org.openhab.voice.watsonstt</module>
     <module>org.openhab.voice.whisperstt</module>
   </modules>
-
   <properties>
     <m2e.jdt.annotationpath>target/dependency</m2e.jdt.annotationpath>
     <dep.noembedding/>
     <markdownlint.skip>false</markdownlint.skip>
   </properties>
-
   <dependencies>
     <dependency>
       <groupId>org.lastnpe.eea</groupId>
@@ -589,7 +583,6 @@
       <scope>provided</scope>
     </dependency>
   </dependencies>
-
   <build>
     <pluginManagement>
       <plugins>
@@ -659,7 +652,6 @@
         </plugin>
       </plugins>
     </pluginManagement>
-
     <plugins>
       <plugin>
         <groupId>biz.aQute.bnd</groupId>
@@ -744,7 +736,6 @@
               </target>
             </configuration>
           </execution>
-
           <!-- 2. Generate catalog dynamically -->
           <execution>
             <id>generate-catalog</id>
@@ -755,17 +746,16 @@
             <configuration>
               <target>
                 <mkdir dir="${maven.multiModuleProjectDirectory}/target/schemas"/>
-                <echo file="${maven.multiModuleProjectDirectory}/target/schemas/thing-type-xml-validation-catalog.xml"><![CDATA[<?xml version="1.0" encoding="UTF-8"?>
-<catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
-    <uri name="https://openhab.org/schemas/thing-description-1.0.0.xsd"
-         uri="file:///${maven.multiModuleProjectDirectory}/target/schemas/thing-description-1.0.0.xsd"/>
-</catalog>]]></echo>
+                <echo file="${maven.multiModuleProjectDirectory}/target/schemas/thing-type-xml-validation-catalog.xml">&lt;?xml version="1.0" encoding="UTF-8"?&gt;
+&lt;catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog"&gt;
+    &lt;uri name="https://openhab.org/schemas/thing-description-1.0.0.xsd"
+         uri="file:///${maven.multiModuleProjectDirectory}/target/schemas/thing-description-1.0.0.xsd"/&gt;
+&lt;/catalog&gt;</echo>
               </target>
             </configuration>
           </execution>
         </executions>
       </plugin>
-
       <!-- 3. XML validation plugin -->
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
@@ -834,7 +824,6 @@
       </plugin>
     </plugins>
   </build>
-
   <profiles>
     <profile>
       <id>skipXmlValidation</id>
@@ -879,5 +868,4 @@
       </build>
     </profile>
   </profiles>
-
 </project>

--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -1,16 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
   <modelVersion>4.0.0</modelVersion>
+
   <parent>
     <groupId>org.openhab.addons</groupId>
     <artifactId>org.openhab.addons.reactor</artifactId>
     <version>5.2.0-SNAPSHOT</version>
   </parent>
+
   <groupId>org.openhab.addons.bundles</groupId>
   <artifactId>org.openhab.addons.reactor.bundles</artifactId>
   <packaging>pom</packaging>
+
   <name>openHAB Add-ons :: Bundles</name>
+
   <modules>
     <!-- automation -->
     <module>org.openhab.automation.groovyscripting</module>
@@ -523,11 +528,13 @@
     <module>org.openhab.voice.watsonstt</module>
     <module>org.openhab.voice.whisperstt</module>
   </modules>
+
   <properties>
     <m2e.jdt.annotationpath>target/dependency</m2e.jdt.annotationpath>
     <dep.noembedding/>
     <markdownlint.skip>false</markdownlint.skip>
   </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.lastnpe.eea</groupId>
@@ -583,6 +590,7 @@
       <scope>provided</scope>
     </dependency>
   </dependencies>
+
   <build>
     <pluginManagement>
       <plugins>
@@ -652,6 +660,7 @@
         </plugin>
       </plugins>
     </pluginManagement>
+
     <plugins>
       <plugin>
         <groupId>biz.aQute.bnd</groupId>
@@ -736,6 +745,7 @@
               </target>
             </configuration>
           </execution>
+
           <!-- 2. Generate catalog dynamically -->
           <execution>
             <id>generate-catalog</id>
@@ -746,16 +756,17 @@
             <configuration>
               <target>
                 <mkdir dir="${maven.multiModuleProjectDirectory}/target/schemas"/>
-                <echo file="${maven.multiModuleProjectDirectory}/target/schemas/thing-type-xml-validation-catalog.xml">&lt;?xml version="1.0" encoding="UTF-8"?&gt;
-&lt;catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog"&gt;
-    &lt;uri name="https://openhab.org/schemas/thing-description-1.0.0.xsd"
-         uri="file:///${maven.multiModuleProjectDirectory}/target/schemas/thing-description-1.0.0.xsd"/&gt;
-&lt;/catalog&gt;</echo>
+                <echo file="${maven.multiModuleProjectDirectory}/target/schemas/thing-type-xml-validation-catalog.xml"><![CDATA[<?xml version="1.0" encoding="UTF-8"?>
+<catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
+    <uri name="https://openhab.org/schemas/thing-description-1.0.0.xsd"
+         uri="file:///${maven.multiModuleProjectDirectory}/target/schemas/thing-description-1.0.0.xsd"/>
+</catalog>]]></echo>
               </target>
             </configuration>
           </execution>
         </executions>
       </plugin>
+
       <!-- 3. XML validation plugin -->
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
@@ -824,6 +835,7 @@
       </plugin>
     </plugins>
   </build>
+
   <profiles>
     <profile>
       <id>skipXmlValidation</id>
@@ -868,4 +880,5 @@
       </build>
     </profile>
   </profiles>
+
 </project>


### PR DESCRIPTION
# Description

This pull request introduces a new binding for ntfy (https://ntfy.sh/), a simple HTTP-based pub-sub notification service.

# Motivation and Goal

The goal of this binding is to provide a seamless way for openHAB users to send push notifications to their devices without relying on proprietary services or complex setups. Since ntfy is open-source and can be self-hosted, it perfectly aligns with openHAB's privacy-focused philosophy.

# Features for the End User

- Action Support: Provides a dedicated Rule Action to send notifications (including priority, tags, and titles) directly from DSL, JavaScript, or Blocky rules.
- Flexible Configuration: Supports both the public ntfy.sh server and self-hosted instances.
- Authentication: Supports username/password.
- Dynamic Content: Allows sending notifications with custom icons (tags) and click-URLs.

# Noteworthy Changes & Documentation

- The binding includes a comprehensive README.md with configuration examples and a detailed description of the available Rule Actions.
- It follows the standard openHAB coding guidelines and has been checked against static code analysis (Checkstyle/SpotBugs).
- [community thread for feedback has been initialized](https://community.openhab.org/t/ntfy-new-binding-for-ntfy/169028)

# Testing

I have tested this binding on a local openHAB 5.x instance with the following scenarios:

- Sending messages to a self-hosted ntfy instance via Docker.
- Verified Rule Action execution via DSL scripts and MainUI rules.
- Tested different priority levels and tag combinations.