### PR TITLE
[roku] Improve polling for TV status

### DIFF
--- a/bundles/org.openhab.binding.roku/src/main/java/org/openhab/binding/roku/internal/RokuBindingConstants.java
+++ b/bundles/org.openhab.binding.roku/src/main/java/org/openhab/binding/roku/internal/RokuBindingConstants.java
@@ -87,4 +87,5 @@ public class RokuBindingConstants {
     public static final String TV_INPUT = "tvinput";
     public static final String POWER_ON = "POWERON";
     public static final String OFFLINE = "Offline";
+    public static final String HOST_RESOLVE_ERROR_MSG = "Unable to resolve host name";
 }

--- a/bundles/org.openhab.binding.roku/src/main/java/org/openhab/binding/roku/internal/handler/RokuHandler.java
+++ b/bundles/org.openhab.binding.roku/src/main/java/org/openhab/binding/roku/internal/handler/RokuHandler.java
@@ -157,8 +157,8 @@ public class RokuHandler extends BaseThingHandler {
                             updateState(POWER_STATE, new StringType(powerMode));
                             updateState(POWER, OnOffType.from(POWER_ON.equalsIgnoreCase(powerMode)));
 
-                            // If power off and limited mode check was done, stop here
-                            // Otherwise continue so the the thing can go online and have the limited mode checked
+                            // If power is off and the device was previously confirmed not to be in limited mode,
+                            // stop here. Otherwise continue so the thing can go online and have limited mode checked.
                             if (!POWER_ON.equalsIgnoreCase(powerMode) && limitedMode == 0) {
                                 return;
                             }

--- a/bundles/org.openhab.binding.roku/src/main/java/org/openhab/binding/roku/internal/handler/RokuHandler.java
+++ b/bundles/org.openhab.binding.roku/src/main/java/org/openhab/binding/roku/internal/handler/RokuHandler.java
@@ -157,7 +157,9 @@ public class RokuHandler extends BaseThingHandler {
                             updateState(POWER_STATE, new StringType(powerMode));
                             updateState(POWER, OnOffType.from(POWER_ON.equalsIgnoreCase(powerMode)));
 
-                            if (!POWER_ON.equalsIgnoreCase(powerMode)) {
+                            // If power off and limited mode check was done, stop here
+                            // Otherwise continue so the the thing can go online and have the limited mode checked
+                            if (!POWER_ON.equalsIgnoreCase(powerMode) && limitedMode == 0) {
                                 return;
                             }
                         }
@@ -463,6 +465,7 @@ public class RokuHandler extends BaseThingHandler {
      * Updates the ThingStatus and powerState channel to indicate that the Thing is offline
      */
     private void setStatusOffline() {
+        limitedMode = -1;
         updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR);
         if (thingTypeUID.equals(THING_TYPE_ROKU_TV)) {
             updateState(POWER_STATE, new StringType(OFFLINE));

--- a/bundles/org.openhab.binding.roku/src/main/java/org/openhab/binding/roku/internal/handler/RokuHandler.java
+++ b/bundles/org.openhab.binding.roku/src/main/java/org/openhab/binding/roku/internal/handler/RokuHandler.java
@@ -19,6 +19,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -140,12 +141,6 @@ public class RokuHandler extends BaseThingHandler {
                     try {
                         deviceInfo = communicator.getDeviceInfo();
 
-                        if (thingTypeUID.equals(THING_TYPE_ROKU_TV)) {
-                            final String powerMode = deviceInfo.getPowerMode();
-                            updateState(POWER_STATE, new StringType(powerMode));
-                            updateState(POWER, OnOffType.from(POWER_ON.equalsIgnoreCase(powerMode)));
-                        }
-
                         if (!deviceInfoLoaded) {
                             thing.setProperty(PROPERTY_MODEL_NAME, deviceInfo.getModelName());
                             thing.setProperty(PROPERTY_MODEL_NUMBER, deviceInfo.getModelNumber());
@@ -153,11 +148,27 @@ public class RokuHandler extends BaseThingHandler {
                             thing.setProperty(PROPERTY_SERIAL_NUMBER, deviceInfo.getSerialNumber());
                             thing.setProperty(PROPERTY_DEVICE_ID, deviceInfo.getDeviceId());
                             thing.setProperty(PROPERTY_SOFTWARE_VERSION, deviceInfo.getSoftwareVersion());
-                            thing.setProperty(PROPERTY_UUID, deviceInfo.getSerialNumber().toLowerCase());
+                            thing.setProperty(PROPERTY_UUID, deviceInfo.getSerialNumber().toLowerCase(Locale.ENGLISH));
                             deviceInfoLoaded = true;
+                        }
+
+                        if (thingTypeUID.equals(THING_TYPE_ROKU_TV)) {
+                            final String powerMode = deviceInfo.getPowerMode();
+                            updateState(POWER_STATE, new StringType(powerMode));
+                            updateState(POWER, OnOffType.from(POWER_ON.equalsIgnoreCase(powerMode)));
+
+                            if (!POWER_ON.equalsIgnoreCase(powerMode)) {
+                                return;
+                            }
                         }
                     } catch (RokuHttpException e) {
                         logger.debug("Unable to retrieve Roku device-info.", e);
+
+                        // Do not continue if unable to determine TV power state; non-TV will continue.
+                        if (thingTypeUID.equals(THING_TYPE_ROKU_TV)) {
+                            setStatusOffline();
+                            return;
+                        }
                     }
                 }
 
@@ -169,7 +180,7 @@ public class RokuHandler extends BaseThingHandler {
                 }
 
                 updateState(ACTIVE_APP, new StringType(activeAppId));
-                updateState(ACTIVE_APPNAME, new StringType(appMap.get(activeAppId)));
+                updateState(ACTIVE_APPNAME, new StringType(appMap.getOrDefault(activeAppId, EMPTY)));
 
                 if (TV_APP.equals(activeAppId)) {
                     tvActive = true;
@@ -338,7 +349,6 @@ public class RokuHandler extends BaseThingHandler {
 
                         stateDescriptionProvider.setStateOptions(new ChannelUID(getThing().getUID(), ACTIVE_CHANNEL),
                                 channelListOptions);
-
                     } catch (RokuHttpException e) {
                         logger.debug("Unable to retrieve Roku tv-channels. Exception: {}", e.getMessage(), e);
                         isSuccess = false;

--- a/bundles/org.openhab.binding.roku/src/main/java/org/openhab/binding/roku/internal/handler/RokuHandler.java
+++ b/bundles/org.openhab.binding.roku/src/main/java/org/openhab/binding/roku/internal/handler/RokuHandler.java
@@ -163,6 +163,11 @@ public class RokuHandler extends BaseThingHandler {
                                 return;
                             }
                         }
+                    } catch (RokuUnknownHostException e) {
+                        logger.debug("{}: {}", HOST_RESOLVE_ERROR_MSG, e.getMessage(), e);
+                        updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
+                                HOST_RESOLVE_ERROR_MSG);
+                        return;
                     } catch (RokuHttpException e) {
                         logger.debug("Unable to retrieve Roku device-info.", e);
 
@@ -198,8 +203,8 @@ public class RokuHandler extends BaseThingHandler {
                     tvActive = false;
                 }
             } catch (RokuUnknownHostException e) {
-                logger.debug("Unable to resolve host name: {}", e.getMessage(), e);
-                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, "Unable to resolve host name");
+                logger.debug("{}: {}", HOST_RESOLVE_ERROR_MSG, e.getMessage(), e);
+                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, HOST_RESOLVE_ERROR_MSG);
                 return;
             } catch (RokuHttpException e) {
                 logger.debug("Unable to retrieve Roku active-app info. Exception: {}", e.getMessage(), e);


### PR DESCRIPTION
Improve TV polling to only check device-info when the TV is off or unreachable. Also prevent a potential exception when retrieving a non-existent entry from appMap and fix a few checkstyle errors.

May also fix #20535