### PR TITLE
[amazonechocontrol] Fix SecurityPanelController crash

### DIFF
--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/smarthome/HandlerSecurityPanelController.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/smarthome/HandlerSecurityPanelController.java
@@ -91,7 +91,7 @@ public class HandlerSecurityPanelController extends AbstractInterfaceHandler {
             String propertyName = state.get("name").getAsString();
             if (ARM_STATE.propertyName.equals(propertyName)) {
                 if (armStateValue == null) {
-                    armStateValue = state.get("value").getAsString();
+                    armStateValue = propertyValue;
                 }
             } else if (BURGLARY_ALARM.propertyName.equals(propertyName)) {
                 if (burglaryAlarmValue == null) {

--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/smarthome/HandlerSecurityPanelController.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/smarthome/HandlerSecurityPanelController.java
@@ -28,6 +28,7 @@ import org.openhab.core.library.types.StringType;
 import org.openhab.core.types.Command;
 import org.openhab.core.types.UnDefType;
 
+import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 
 /**
@@ -84,7 +85,9 @@ public class HandlerSecurityPanelController extends AbstractInterfaceHandler {
         Boolean fireAlarmValue = null;
         Boolean waterAlarmValue = null;
         for (JsonObject state : stateList) {
-            String propertyValue = state.get("value").getAsJsonObject().get("value").getAsString();
+            JsonElement valueElement = state.get("value");
+            String propertyValue = valueElement.isJsonPrimitive() ? valueElement.getAsString()
+                    : valueElement.getAsJsonObject().get("value").getAsString();
             String propertyName = state.get("name").getAsString();
             if (ARM_STATE.propertyName.equals(propertyName)) {
                 if (armStateValue == null) {

--- a/bundles/org.openhab.binding.amazonechocontrol/src/test/java/org/openhab/binding/amazonechocontrol/internal/smarthome/HandlerSecurityPanelControllerTest.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/test/java/org/openhab/binding/amazonechocontrol/internal/smarthome/HandlerSecurityPanelControllerTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.amazonechocontrol.internal.smarthome;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+
+import java.util.List;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.openhab.binding.amazonechocontrol.internal.handler.SmartHomeDeviceHandler;
+import org.openhab.binding.amazonechocontrol.internal.smarthome.InterfaceHandler.UpdateChannelResult;
+import org.openhab.core.library.types.OpenClosedType;
+import org.openhab.core.library.types.StringType;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+/**
+ * The {@link HandlerSecurityPanelControllerTest} tests {@link HandlerSecurityPanelController}
+ *
+ * @author openHAB contributors - Initial contribution
+ */
+@NonNullByDefault
+@ExtendWith(MockitoExtension.class)
+public class HandlerSecurityPanelControllerTest {
+
+    @Mock
+    @NonNullByDefault({})
+    private SmartHomeDeviceHandler handler;
+
+    private JsonObject stateObject(String name, String valueJson) {
+        JsonObject obj = new JsonObject();
+        obj.addProperty("name", name);
+        obj.add("value", JsonParser.parseString(valueJson));
+        return obj;
+    }
+
+    @Test
+    public void testArmStatePrimitive() {
+        HandlerSecurityPanelController sut = new HandlerSecurityPanelController(handler);
+        List<JsonObject> states = List.of(stateObject("armState", "\"DISARMED\""),
+                stateObject("fireAlarm", "{\"value\":\"OK\"}"), stateObject("burglaryAlarm", "{\"value\":\"OK\"}"),
+                stateObject("carbonMonoxideAlarm", "{\"value\":\"OK\"}"));
+
+        sut.updateChannels(HandlerSecurityPanelController.INTERFACE, states, new UpdateChannelResult());
+
+        verify(handler).updateState(eq("armState"), eq(new StringType("DISARMED")));
+        verify(handler).updateState(eq("fireAlarm"), eq(OpenClosedType.OPEN));
+        verify(handler).updateState(eq("burglaryAlarm"), eq(OpenClosedType.OPEN));
+        verify(handler).updateState(eq("carbonMonoxideAlarm"), eq(OpenClosedType.OPEN));
+    }
+
+    @Test
+    public void testArmStateAlarm() {
+        HandlerSecurityPanelController sut = new HandlerSecurityPanelController(handler);
+        List<JsonObject> states = List.of(stateObject("armState", "\"ARMED_AWAY\""),
+                stateObject("burglaryAlarm", "{\"value\":\"ALARM\"}"));
+
+        sut.updateChannels(HandlerSecurityPanelController.INTERFACE, states, new UpdateChannelResult());
+
+        verify(handler).updateState(eq("armState"), eq(new StringType("ARMED_AWAY")));
+        verify(handler).updateState(eq("burglaryAlarm"), eq(OpenClosedType.CLOSED));
+    }
+}

--- a/bundles/org.openhab.binding.amazonechocontrol/src/test/java/org/openhab/binding/amazonechocontrol/internal/smarthome/HandlerSecurityPanelControllerTest.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/test/java/org/openhab/binding/amazonechocontrol/internal/smarthome/HandlerSecurityPanelControllerTest.java
@@ -76,4 +76,16 @@ public class HandlerSecurityPanelControllerTest {
         verify(handler).updateState(eq("armState"), eq(new StringType("ARMED_AWAY")));
         verify(handler).updateState(eq("burglaryAlarm"), eq(OpenClosedType.CLOSED));
     }
+
+    @Test
+    public void testArmStateLegacyFormat() {
+        HandlerSecurityPanelController sut = new HandlerSecurityPanelController(handler);
+        List<JsonObject> states = List.of(stateObject("armState", "{\"value\":\"DISARMED\"}"),
+                stateObject("fireAlarm", "{\"value\":\"OK\"}"));
+
+        sut.updateChannels(HandlerSecurityPanelController.INTERFACE, states, new UpdateChannelResult());
+
+        verify(handler).updateState(eq("armState"), eq(new StringType("DISARMED")));
+        verify(handler).updateState(eq("fireAlarm"), eq(OpenClosedType.OPEN));
+    }
 }


### PR DESCRIPTION
## Description

Classification: Bugfix

Amazon recently changed their security panel API so that the armState value now comes back as a primitive string instead of a nested object. The existing code assumed it was always an object and tried to call getAsJsonObject() on it, which caused a crash.

The fix handles both formats by checking if the value is a primitive string first. If it is, we use it directly. If not, we handle the old behavior of extracting the nested value property. Added unit tests that verify both code paths work correctly.

Since this is an internal binding fix with no user-facing changes, documentation updates aren't needed. Coding guidelines have been verified and static code analysis is clean. DCO sign-off is included.

Fixes #20091