### PR TITLE
[dahuadoor] Intercom: Add WebRTC sidecar foundation and wiring

### DIFF
--- a/bundles/org.openhab.binding.dahuadoor/README.md
+++ b/bundles/org.openhab.binding.dahuadoor/README.md
@@ -31,6 +31,13 @@ Single-button outdoor station.
 | password     | text    | Yes      |         | Password to access the device                                                                                                                                            |
 | snapshotPath | text    | Yes      |         | Linux path where image files are stored (e.g., /var/lib/openhab/door-images)                                                                                             |
 | useHttps     | boolean | No       | false   | Use HTTPS (port 443) for snapshot and door-open requests. Enable if the device has HTTPS turned on in its network settings. When disabled, plain HTTP (port 80) is used. |
+| enableWebRTC | boolean | No       | false   | Enables local go2rtc sidecar management and publishes a `webrtc-url` channel.                                                                                             |
+| go2rtcPath   | text    | No       |         | Absolute path to the go2rtc binary (required when `enableWebRTC=true`).                                                                                                   |
+| go2rtcApiPort | integer | No      | 1984    | HTTP API port used by go2rtc for SDP exchange.                                                                                                                             |
+| webRtcPort   | integer | No       | 8555    | Port used by go2rtc for WebRTC media transport.                                                                                                                            |
+| stunServer   | text    | No       | stun.l.google.com:19302 | STUN server in `host:port` format used by go2rtc.                                                                                                    |
+| rtspChannel  | integer | No       | 1       | RTSP channel index on the Dahua device.                                                                                                                                    |
+| rtspSubtype  | integer | No       | 0       | RTSP stream subtype (`0` main stream, `1` sub stream).                                                                                                                     |
 
 **Note:** Windows paths are not currently supported.
 
@@ -54,6 +61,7 @@ keytool -importcert -alias dahua-door -file ca.crt \
 | door-image  | Image   | Read       | Camera snapshot taken when doorbell is pressed            |
 | open-door-1 | Switch  | Write      | Command to open door relay 1                              |
 | open-door-2 | Switch  | Write      | Command to open door relay 2                              |
+| webrtc-url  | String  | Read       | Proxy path for browser SDP offer/answer exchange via openHAB |
 
 ### VTO3211 Channels (Dual Button)
 
@@ -65,6 +73,21 @@ keytool -importcert -alias dahua-door -file ca.crt \
 | door-image-2  | Image   | Read       | Camera snapshot when button 2 is pressed           |
 | open-door-1   | Switch  | Write      | Command to open door relay 1                       |
 | open-door-2   | Switch  | Write      | Command to open door relay 2                       |
+| webrtc-url    | String  | Read       | Proxy path for browser SDP offer/answer exchange via openHAB |
+
+## WebRTC (go2rtc)
+
+When `enableWebRTC=true`, the binding starts a per-thing go2rtc process and writes the channel `webrtc-url` with a path like `/dahuadoor/webrtc/dahua_<thing_uid>`.
+
+MainUI widgets can use this channel directly as SDP endpoint. Example snippet:
+
+```yaml
+- component: oh-video-card
+    config:
+        title: Front Door
+        sourceType: webrtc
+        url: =items[props.webrtcUrlItem].state
+```
 
 ## Full Example
 

--- a/bundles/org.openhab.binding.dahuadoor/README.md
+++ b/bundles/org.openhab.binding.dahuadoor/README.md
@@ -22,22 +22,22 @@ Devices in a different subnet or VLAN will not be found automatically and must b
 
 ### VTO2202/VTO3211 Device
 
-Single-button outdoor station.
+Outdoor station device configuration.
 
-| Parameter    | Type    | Required | Default | Description                                                                                                                                                              |
-| ------------ | ------- | -------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| hostname     | text    | Yes      |         | Hostname or IP address of the device (e.g., 192.168.1.100)                                                                                                               |
-| username     | text    | Yes      |         | Username to access the device                                                                                                                                            |
-| password     | text    | Yes      |         | Password to access the device                                                                                                                                            |
-| snapshotPath | text    | Yes      |         | Linux path where image files are stored (e.g., /var/lib/openhab/door-images)                                                                                             |
-| useHttps     | boolean | No       | false   | Use HTTPS (port 443) for snapshot and door-open requests. Enable if the device has HTTPS turned on in its network settings. When disabled, plain HTTP (port 80) is used. |
-| enableWebRTC | boolean | No       | false   | Enables local go2rtc sidecar management and publishes a `webrtc-url` channel.                                                                                             |
-| go2rtcPath   | text    | No       |         | Absolute path to the go2rtc binary (required when `enableWebRTC=true`).                                                                                                   |
-| go2rtcApiPort | integer | No      | 1984    | HTTP API port used by go2rtc for SDP exchange.                                                                                                                             |
-| webRtcPort   | integer | No       | 8555    | Port used by go2rtc for WebRTC media transport.                                                                                                                            |
-| stunServer   | text    | No       | stun.l.google.com:19302 | STUN server in `host:port` format used by go2rtc.                                                                                                    |
-| rtspChannel  | integer | No       | 1       | RTSP channel index on the Dahua device.                                                                                                                                    |
-| rtspSubtype  | integer | No       | 0       | RTSP stream subtype (`0` main stream, `1` sub stream).                                                                                                                     |
+| Parameter     | Type    | Required | Default                 | Description                                                                                                                                                              |
+| ------------- | ------- | -------- | ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| hostname      | text    | Yes      |                         | Hostname or IP address of the device (e.g., 192.168.1.100)                                                                                                               |
+| username      | text    | Yes      |                         | Username to access the device                                                                                                                                            |
+| password      | text    | Yes      |                         | Password to access the device                                                                                                                                            |
+| snapshotPath  | text    | Yes      |                         | Linux path where image files are stored (e.g., /var/lib/openhab/door-images)                                                                                             |
+| useHttps      | boolean | No       | false                   | Use HTTPS (port 443) for snapshot and door-open requests. Enable if the device has HTTPS turned on in its network settings. When disabled, plain HTTP (port 80) is used. |
+| enableWebRTC  | boolean | No       | false                   | Enables local go2rtc sidecar management and publishes a `webrtc-url` channel.                                                                                            |
+| go2rtcPath    | text    | No       |                         | Absolute path to the go2rtc binary (required when `enableWebRTC=true`).                                                                                                  |
+| go2rtcApiPort | integer | No       | 1984                    | HTTP API port used by go2rtc for SDP exchange.                                                                                                                           |
+| webRtcPort    | integer | No       | 8555                    | Port used by go2rtc for WebRTC media transport.                                                                                                                          |
+| stunServer    | text    | No       | stun.l.google.com:19302 | STUN server in `host:port` format used by go2rtc.                                                                                                                        |
+| rtspChannel   | integer | No       | 1                       | RTSP channel index on the Dahua device.                                                                                                                                  |
+| rtspSubtype   | integer | No       | 0                       | RTSP stream subtype (`0` main stream, `1` sub stream).                                                                                                                   |
 
 **Note:** Windows paths are not currently supported.
 
@@ -61,7 +61,7 @@ keytool -importcert -alias dahua-door -file ca.crt \
 | door-image  | Image   | Read       | Camera snapshot taken when doorbell is pressed            |
 | open-door-1 | Switch  | Write      | Command to open door relay 1                              |
 | open-door-2 | Switch  | Write      | Command to open door relay 2                              |
-| webrtc-url  | String  | Read       | Proxy path for browser SDP offer/answer exchange via openHAB |
+| webrtc-url  | String  | Read       | Proxy path for WebRTC SDP offer/answer exchange           |
 
 ### VTO3211 Channels (Dual Button)
 
@@ -73,23 +73,41 @@ keytool -importcert -alias dahua-door -file ca.crt \
 | door-image-2  | Image   | Read       | Camera snapshot when button 2 is pressed           |
 | open-door-1   | Switch  | Write      | Command to open door relay 1                       |
 | open-door-2   | Switch  | Write      | Command to open door relay 2                       |
-| webrtc-url    | String  | Read       | Proxy path for browser SDP offer/answer exchange via openHAB |
+| webrtc-url    | String  | Read       | Proxy path for WebRTC SDP offer/answer exchange    |
 
-## WebRTC (go2rtc)
+## Intercom Operation
 
-When `enableWebRTC=true`, the binding starts a per-thing go2rtc process and writes the channel `webrtc-url` with a path like `/dahuadoor/webrtc/dahua_<thing_uid>`.
+Intercom operation is implemented with WebRTC via the `go2rtc` binary.
+It converts the Dahua RTP audio/video stream into browser-compatible WebRTC. The audio stream is transcoded using `ffmpeg`. Hence both tools are needed.
+When `enableWebRTC=true`, the binding starts a local `go2rtc` sidecar and exposes the `webrtc-url` channel.
 
-MainUI widgets can use this channel directly as SDP endpoint. Example snippet:
+Known working version used during development: `go2rtc 1.9.9`.
 
-```yaml
-- component: oh-video-card
-    config:
-        title: Front Door
-        sourceType: webrtc
-        url: =items[props.webrtcUrlItem].state
+### Tool installation
+
+Download and install the matching `go2rtc` binary for your operating system:
+
+- <https://github.com/AlexxIT/go2rtc>
+- <https://github.com/AlexxIT/go2rtc/releases>
+
+Common binaries in releases are typically named like:
+
+- Linux x86_64: `go2rtc_linux_amd64`
+- Linux ARM64: `go2rtc_linux_arm64` (e.g. openHABian distro)
+- Windows x86_64: `go2rtc_windows_amd64.exe`
+- macOS Apple Silicon: `go2rtc_darwin_arm64`
+
+`ffmpeg` can be installed manually or via your openHABian setup tooling, depending on your setup.
+For Debian/openHABian you can use `sudo apt install ffmpeg`.
+
+Quick prerequisites check:
+
+```bash
+go2rtc -version
+ffmpeg -version
 ```
 
-## Full Example
+## Examples
 
 ### VTO2202 Example (Single Button)
 

--- a/bundles/org.openhab.binding.dahuadoor/src/main/java/org/openhab/binding/dahuadoor/internal/DahuaDoorBaseHandler.java
+++ b/bundles/org.openhab.binding.dahuadoor/src/main/java/org/openhab/binding/dahuadoor/internal/DahuaDoorBaseHandler.java
@@ -25,8 +25,11 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.dahuadoor.internal.dahuaeventhandler.DHIPEventListener;
 import org.openhab.binding.dahuadoor.internal.dahuaeventhandler.DahuaEventClient;
+import org.openhab.binding.dahuadoor.internal.media.Go2RtcManager;
+import org.openhab.binding.dahuadoor.internal.media.PlayStreamServlet;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.library.types.RawType;
+import org.openhab.core.library.types.StringType;
 import org.openhab.core.thing.Channel;
 import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.Thing;
@@ -58,9 +61,12 @@ public abstract class DahuaDoorBaseHandler extends BaseThingHandler implements D
     protected Gson gson = new Gson();
 
     protected @Nullable DahuaEventClient client = null;
+    private final PlayStreamServlet playStreamServlet;
+    private @Nullable Go2RtcManager go2rtcManager;
 
-    public DahuaDoorBaseHandler(Thing thing) {
+    public DahuaDoorBaseHandler(Thing thing, PlayStreamServlet playStreamServlet) {
         super(thing);
+        this.playStreamServlet = playStreamServlet;
     }
 
     @Override
@@ -113,8 +119,18 @@ public abstract class DahuaDoorBaseHandler extends BaseThingHandler implements D
             return;
         }
 
+        if (localConfig.enableWebRTC && localConfig.go2rtcPath.isBlank()) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
+                    "@text/offline.conf-error-missing-go2rtc-path");
+            return;
+        }
+
         client = new DahuaEventClient(localConfig.hostname, localConfig.username, localConfig.password,
                 localConfig.useHttps, this, this::errorInformer);
+
+        if (localConfig.enableWebRTC) {
+            startWebRtc(localConfig);
+        }
 
         // Set status to UNKNOWN - will be set to ONLINE when first DHIP event is received
         updateStatus(ThingStatus.UNKNOWN);
@@ -122,10 +138,45 @@ public abstract class DahuaDoorBaseHandler extends BaseThingHandler implements D
 
     @Override
     public void dispose() {
+        stopWebRtc();
+
         DahuaEventClient localClient = client;
         if (localClient != null) {
             localClient.dispose();
             client = null;
+        }
+    }
+
+    private void startWebRtc(DahuaDoorConfiguration cfg) {
+        String thingUidSafe = getThing().getUID().toString().replace(':', '_').replace('-', '_').replace('.', '_');
+        String streamName = GO2RTC_STREAM_PREFIX + thingUidSafe;
+
+        Go2RtcManager manager = new Go2RtcManager(cfg.go2rtcPath, cfg.go2rtcApiPort, cfg.webRtcPort, cfg.stunServer,
+                streamName, cfg.hostname, cfg.username, cfg.password, cfg.rtspChannel, cfg.rtspSubtype);
+        go2rtcManager = manager;
+
+        String proxyPath = WEBRTC_SERVLET_PATH + "/" + streamName;
+        updateState(CHANNEL_WEBRTC_URL, new StringType(proxyPath));
+
+        scheduler.submit(() -> {
+            try {
+                manager.start();
+                playStreamServlet.registerStream(streamName, cfg.go2rtcApiPort);
+                logger.info("WebRTC streaming active for {} at {}", streamName, proxyPath);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            } catch (IOException e) {
+                logger.warn("Failed to start WebRTC streaming for {}: {}", streamName, e.getMessage(), e);
+            }
+        });
+    }
+
+    private void stopWebRtc() {
+        Go2RtcManager localManager = go2rtcManager;
+        go2rtcManager = null;
+        if (localManager != null) {
+            playStreamServlet.unregisterStream(localManager.getStreamName());
+            localManager.stop();
         }
     }
 

--- a/bundles/org.openhab.binding.dahuadoor/src/main/java/org/openhab/binding/dahuadoor/internal/DahuaDoorBindingConstants.java
+++ b/bundles/org.openhab.binding.dahuadoor/src/main/java/org/openhab/binding/dahuadoor/internal/DahuaDoorBindingConstants.java
@@ -39,4 +39,11 @@ public class DahuaDoorBindingConstants {
     public static final String CHANNEL_DOOR_IMAGE_2 = "door-image-2";
     public static final String CHANNEL_OPEN_DOOR_1 = "open-door-1";
     public static final String CHANNEL_OPEN_DOOR_2 = "open-door-2";
+    public static final String CHANNEL_WEBRTC_URL = "webrtc-url";
+
+    // go2rtc stream name prefix (stream name = prefix + URL-safe thing UID)
+    public static final String GO2RTC_STREAM_PREFIX = "dahua_";
+
+    // Path under which the WebRTC SDP proxy servlet is registered
+    public static final String WEBRTC_SERVLET_PATH = "/dahuadoor/webrtc";
 }

--- a/bundles/org.openhab.binding.dahuadoor/src/main/java/org/openhab/binding/dahuadoor/internal/DahuaDoorConfiguration.java
+++ b/bundles/org.openhab.binding.dahuadoor/src/main/java/org/openhab/binding/dahuadoor/internal/DahuaDoorConfiguration.java
@@ -31,4 +31,13 @@ public class DahuaDoorConfiguration {
     public String password = "";
     public String snapshotPath = "";
     public boolean useHttps = false;
+
+    // WebRTC / go2rtc settings
+    public boolean enableWebRTC = false;
+    public String go2rtcPath = "";
+    public int go2rtcApiPort = 1984;
+    public int webRtcPort = 8555;
+    public String stunServer = "stun.l.google.com:19302";
+    public int rtspChannel = 1;
+    public int rtspSubtype = 0;
 }

--- a/bundles/org.openhab.binding.dahuadoor/src/main/java/org/openhab/binding/dahuadoor/internal/DahuaDoorHandlerFactory.java
+++ b/bundles/org.openhab.binding.dahuadoor/src/main/java/org/openhab/binding/dahuadoor/internal/DahuaDoorHandlerFactory.java
@@ -18,12 +18,16 @@ import java.util.Set;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.dahuadoor.internal.media.PlayStreamServlet;
 import org.openhab.core.thing.Thing;
 import org.openhab.core.thing.ThingTypeUID;
 import org.openhab.core.thing.binding.BaseThingHandlerFactory;
 import org.openhab.core.thing.binding.ThingHandler;
 import org.openhab.core.thing.binding.ThingHandlerFactory;
+import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.http.HttpService;
 
 /**
  * The {@link DahuaDoorHandlerFactory} is responsible for creating things and thing
@@ -36,6 +40,12 @@ import org.osgi.service.component.annotations.Component;
 public class DahuaDoorHandlerFactory extends BaseThingHandlerFactory {
 
     private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Set.of(THING_TYPE_VTO2202, THING_TYPE_VTO3211);
+    private final PlayStreamServlet playStreamServlet;
+
+    @Activate
+    public DahuaDoorHandlerFactory(@Reference HttpService httpService) {
+        this.playStreamServlet = new PlayStreamServlet(httpService);
+    }
 
     @Override
     public boolean supportsThingType(ThingTypeUID thingTypeUID) {
@@ -47,9 +57,9 @@ public class DahuaDoorHandlerFactory extends BaseThingHandlerFactory {
         ThingTypeUID thingTypeUID = thing.getThingTypeUID();
 
         if (THING_TYPE_VTO2202.equals(thingTypeUID)) {
-            return new DahuaVto2202Handler(thing);
+            return new DahuaVto2202Handler(thing, playStreamServlet);
         } else if (THING_TYPE_VTO3211.equals(thingTypeUID)) {
-            return new DahuaVto3211Handler(thing);
+            return new DahuaVto3211Handler(thing, playStreamServlet);
         }
 
         return null;

--- a/bundles/org.openhab.binding.dahuadoor/src/main/java/org/openhab/binding/dahuadoor/internal/DahuaVto2202Handler.java
+++ b/bundles/org.openhab.binding.dahuadoor/src/main/java/org/openhab/binding/dahuadoor/internal/DahuaVto2202Handler.java
@@ -14,6 +14,7 @@ package org.openhab.binding.dahuadoor.internal;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.binding.dahuadoor.internal.dahuaeventhandler.DahuaEventClient;
+import org.openhab.binding.dahuadoor.internal.media.PlayStreamServlet;
 import org.openhab.core.library.types.RawType;
 import org.openhab.core.thing.Channel;
 import org.openhab.core.thing.Thing;
@@ -28,8 +29,8 @@ import com.google.gson.JsonObject;
 @NonNullByDefault
 public class DahuaVto2202Handler extends DahuaDoorBaseHandler {
 
-    public DahuaVto2202Handler(Thing thing) {
-        super(thing);
+    public DahuaVto2202Handler(Thing thing, PlayStreamServlet playStreamServlet) {
+        super(thing, playStreamServlet);
     }
 
     @Override

--- a/bundles/org.openhab.binding.dahuadoor/src/main/java/org/openhab/binding/dahuadoor/internal/DahuaVto3211Handler.java
+++ b/bundles/org.openhab.binding.dahuadoor/src/main/java/org/openhab/binding/dahuadoor/internal/DahuaVto3211Handler.java
@@ -14,6 +14,7 @@ package org.openhab.binding.dahuadoor.internal;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.binding.dahuadoor.internal.dahuaeventhandler.DahuaEventClient;
+import org.openhab.binding.dahuadoor.internal.media.PlayStreamServlet;
 import org.openhab.core.library.types.RawType;
 import org.openhab.core.thing.Channel;
 import org.openhab.core.thing.Thing;
@@ -29,8 +30,8 @@ import com.google.gson.JsonObject;
 @NonNullByDefault
 public class DahuaVto3211Handler extends DahuaDoorBaseHandler {
 
-    public DahuaVto3211Handler(Thing thing) {
-        super(thing);
+    public DahuaVto3211Handler(Thing thing, PlayStreamServlet playStreamServlet) {
+        super(thing, playStreamServlet);
     }
 
     @Override

--- a/bundles/org.openhab.binding.dahuadoor/src/main/java/org/openhab/binding/dahuadoor/internal/media/Go2RtcManager.java
+++ b/bundles/org.openhab.binding.dahuadoor/src/main/java/org/openhab/binding/dahuadoor/internal/media/Go2RtcManager.java
@@ -1,0 +1,309 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.dahuadoor.internal.media;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.attribute.PosixFilePermissions;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link Go2RtcManager} manages the lifecycle of a go2rtc sidecar process for a single
+ * Dahua door station. It writes a per-thing YAML configuration, starts the go2rtc binary, and
+ * terminates it on disposal.
+ *
+ * <p>
+ * go2rtc v1.9.x is required. The binary must be provided by the user via the {@code go2rtcPath}
+ * configuration parameter.
+ * </p>
+ *
+ * @author Sven Schad - Initial contribution
+ */
+@NonNullByDefault
+public class Go2RtcManager {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(Go2RtcManager.class);
+
+    /** Health-check timeout in milliseconds. */
+    private static final int HEALTH_CHECK_TIMEOUT_MS = 2000;
+    /** Maximum number of health-check polls after process start. */
+    private static final int HEALTH_CHECK_MAX_POLLS = 10;
+    /** Delay between health-check polls in milliseconds. */
+    private static final long HEALTH_CHECK_POLL_DELAY_MS = 500;
+
+    private final String go2rtcBinary;
+    private final int apiPort;
+    private final int webRtcPort;
+    private final String stunServer;
+    private final String hostname;
+    private final String username;
+    private final String password;
+    private final int rtspChannel;
+    private final int rtspSubtype;
+    private final String streamName;
+
+    private @Nullable Process process;
+    private @Nullable File configFile;
+    private @Nullable Thread logThread;
+
+    /**
+     * Creates a new Go2RtcManager.
+     *
+     * @param go2rtcBinary absolute path to the go2rtc binary
+     * @param apiPort HTTP API port for go2rtc (typically 1984)
+     * @param webRtcPort WebRTC data port for go2rtc (typically 8555)
+     * @param stunServer STUN server in host:port format (e.g. stun.l.google.com:19302)
+     * @param streamName go2rtc stream name for this device (e.g. dahua_vto2202_living)
+     * @param hostname device hostname or IP
+     * @param username device username
+     * @param password device password
+     * @param rtspChannel RTSP channel index (typically 1)
+     * @param rtspSubtype RTSP sub-type index (0 = main, 1 = sub)
+     */
+    public Go2RtcManager(String go2rtcBinary, int apiPort, int webRtcPort, String stunServer, String streamName,
+            String hostname, String username, String password, int rtspChannel, int rtspSubtype) {
+        this.go2rtcBinary = go2rtcBinary;
+        this.apiPort = apiPort;
+        this.webRtcPort = webRtcPort;
+        this.stunServer = stunServer;
+        this.streamName = streamName;
+        this.hostname = hostname;
+        this.username = username;
+        this.password = password;
+        this.rtspChannel = rtspChannel;
+        this.rtspSubtype = rtspSubtype;
+    }
+
+    /**
+     * Returns the go2rtc stream name for this device.
+     *
+     * @return stream name string
+     */
+    public String getStreamName() {
+        return streamName;
+    }
+
+    /**
+     * Returns the go2rtc HTTP API port.
+     *
+     * @return API port
+     */
+    public int getApiPort() {
+        return apiPort;
+    }
+
+    /**
+     * Starts the go2rtc sidecar process.
+     * Writes a YAML config file, spawns the process, and waits until the HTTP API is healthy.
+     *
+     * @throws IOException if the binary does not exist, is not executable, config cannot be written,
+     *             or the process fails to start
+     * @throws InterruptedException if the thread is interrupted while waiting for startup
+     */
+    public void start() throws IOException, InterruptedException {
+        File binary = new File(go2rtcBinary);
+        if (!binary.exists() || !binary.isFile()) {
+            throw new IOException(
+                    "go2rtc binary not found: " + go2rtcBinary + " — set go2rtcPath in thing configuration");
+        }
+        if (!binary.canExecute()) {
+            try {
+                Files.setPosixFilePermissions(binary.toPath(), PosixFilePermissions.fromString("rwxr-xr-x"));
+            } catch (UnsupportedOperationException | IOException e) {
+                throw new IOException("go2rtc binary is not executable and could not chmod: " + go2rtcBinary, e);
+            }
+        }
+
+        File localConfigFile = writeConfig();
+        configFile = localConfigFile;
+
+        ProcessBuilder pb = new ProcessBuilder(go2rtcBinary, "-config", localConfigFile.getAbsolutePath());
+        pb.redirectErrorStream(true);
+        Process startedProcess = pb.start();
+        process = startedProcess;
+        LOGGER.info("go2rtc started (stream={}, apiPort={}, PID={})", streamName, apiPort, startedProcess.pid());
+
+        // Pipe go2rtc stdout+stderr into the openHAB log at DEBUG level so problems are visible.
+        Thread logTh = new Thread(() -> {
+            try (BufferedReader reader = new BufferedReader(
+                    new InputStreamReader(startedProcess.getInputStream(), StandardCharsets.UTF_8))) {
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    LOGGER.debug("go2rtc [{}]: {}", streamName, line);
+                }
+            } catch (IOException e) {
+                LOGGER.trace("go2rtc [{}] output reader closed: {}", streamName, e.getMessage());
+            }
+        }, "go2rtc-log-" + streamName);
+        logTh.setDaemon(true);
+        logTh.start();
+        logThread = logTh;
+
+        waitForHealthy();
+    }
+
+    /**
+     * Stops the go2rtc process and removes the temporary config file.
+     */
+    public void stop() {
+        Process localProcess = process;
+        if (localProcess != null) {
+            LOGGER.info("Stopping go2rtc (stream={}, PID={})", streamName, localProcess.pid());
+            localProcess.destroy();
+            try {
+                localProcess.waitFor();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            process = null;
+        }
+        Thread localLogThread = logThread;
+        if (localLogThread != null) {
+            localLogThread.interrupt();
+            logThread = null;
+        }
+        File localConfig = configFile;
+        if (localConfig != null && localConfig.exists()) {
+            if (!localConfig.delete()) {
+                LOGGER.debug("Could not delete go2rtc config file {}", localConfig.getAbsolutePath());
+            }
+            configFile = null;
+        }
+    }
+
+    /**
+     * Returns {@code true} if the go2rtc process is currently running.
+     *
+     * @return process alive status
+     */
+    public boolean isRunning() {
+        Process localProcess = process;
+        return localProcess != null && localProcess.isAlive();
+    }
+
+    // -------------------------------------------------------------------------
+    // Private helpers
+    // -------------------------------------------------------------------------
+
+    /**
+     * Builds the YAML configuration string for go2rtc, using the device RTSP URL constructed
+     * from this instance's parameters (explicit port 554, no {@code proto=Onvif}).
+     * <p>
+     * An explicit ICE host candidate for the local IPv4 address is auto-detected by opening a
+     * temporary socket towards the Dahua device. This ensures that browsers on the same LAN
+     * receive a reachable candidate even when go2rtc does not enumerate the IPv4 interface
+     * as a host candidate on its own.
+     */
+    private String buildYaml() {
+        // URL-encode password chars that are special in URLs (%, @, :, /) for safety,
+        // but Dahua passwords are typically alphanumeric so this stays simple.
+        String rtspUrl = "rtsp://" + username + ":" + password + "@" + hostname + ":554/cam/realmonitor?channel="
+                + rtspChannel + "&subtype=" + rtspSubtype;
+        String backchannelExec = "exec:ffmpeg -use_wallclock_as_timestamps 1 -re -fflags nobuffer -f alaw -ar 8000 "
+                + "-ac 1 -i - -vn -acodec pcm_alaw -ar 8000 -ac 1 -payload_type 8 -f rtp "
+                + "rtp://127.0.0.1:21984#backchannel=1#audio=alaw/8000";
+
+        StringBuilder candidates = new StringBuilder();
+        String localIp = detectLocalIp();
+        if (localIp != null) {
+            candidates.append("    - ").append(localIp).append(":").append(webRtcPort).append("\n");
+            LOGGER.debug("go2rtc config: adding local IPv4 ICE candidate {}:{}", localIp, webRtcPort);
+        }
+        candidates.append("    - stun:").append(stunServer).append("\n");
+
+        return "log:\n" + "  level: debug\n" + "streams:\n" + "  " + streamName + ":\n" + "    - '" + rtspUrl + "'\n"
+                + "    - '" + backchannelExec + "'\n" + "api:\n" + "  origin: \"*\"\n" + "  listen: \":" + apiPort
+                + "\"\n" + "webrtc:\n" + "  listen: \":" + webRtcPort + "\"\n" + "  candidates:\n" + candidates;
+    }
+
+    /**
+     * Detects the local IPv4 address used to reach the Dahua device by opening a temporary
+     * TCP socket towards {@code hostname:554}.
+     *
+     * @return local IPv4 address string (e.g. {@code "172.18.0.2"}), or {@code null} if detection fails
+     */
+    private @Nullable String detectLocalIp() {
+        try (Socket socket = new Socket()) {
+            socket.connect(new InetSocketAddress(hostname, 554), 2000);
+            String addr = socket.getLocalAddress().getHostAddress();
+            // Ignore loopback and IPv6 addresses — only use routable IPv4
+            if (!addr.startsWith("127.") && !addr.contains(":")) {
+                return addr;
+            }
+        } catch (IOException e) {
+            LOGGER.debug("Could not detect local IP by connecting to {}:554 — skipping explicit ICE candidate: {}",
+                    hostname, e.getMessage());
+        }
+        return null;
+    }
+
+    /**
+     * Writes the YAML config to a temporary file and returns that file.
+     */
+    private File writeConfig() throws IOException {
+        File cfg = File.createTempFile("go2rtc_" + streamName + "_", ".yaml");
+        cfg.deleteOnExit();
+        try (FileWriter fw = new FileWriter(cfg, StandardCharsets.UTF_8)) {
+            fw.write(buildYaml());
+        }
+        LOGGER.debug("go2rtc config written to {}", cfg.getAbsolutePath());
+        return cfg;
+    }
+
+    /**
+     * Polls the go2rtc {@code /api/config} endpoint until it returns HTTP 200 or the maximum
+     * number of polls is reached.
+     *
+     * @throws InterruptedException if interrupted while polling
+     * @throws IOException if go2rtc does not become healthy in time
+     */
+    private void waitForHealthy() throws InterruptedException, IOException {
+        String healthUrl = "http://127.0.0.1:" + apiPort + "/api/config";
+        for (int i = 0; i < HEALTH_CHECK_MAX_POLLS; i++) {
+            if (!isRunning()) {
+                throw new IOException("go2rtc process exited unexpectedly during startup");
+            }
+            try {
+                HttpURLConnection conn = (HttpURLConnection) URI.create(healthUrl).toURL().openConnection();
+                conn.setConnectTimeout(HEALTH_CHECK_TIMEOUT_MS);
+                conn.setReadTimeout(HEALTH_CHECK_TIMEOUT_MS);
+                conn.setRequestMethod("GET");
+                int status = conn.getResponseCode();
+                conn.disconnect();
+                if (status == HttpURLConnection.HTTP_OK) {
+                    LOGGER.debug("go2rtc API healthy after {} poll(s)", i + 1);
+                    return;
+                }
+            } catch (IOException e) {
+                LOGGER.trace("go2rtc health check attempt {}/{} failed: {}", i + 1, HEALTH_CHECK_MAX_POLLS,
+                        e.getMessage());
+            }
+            Thread.sleep(HEALTH_CHECK_POLL_DELAY_MS);
+        }
+        throw new IOException(
+                "go2rtc did not become healthy after " + HEALTH_CHECK_MAX_POLLS + " polls on port " + apiPort);
+    }
+}

--- a/bundles/org.openhab.binding.dahuadoor/src/main/java/org/openhab/binding/dahuadoor/internal/media/Go2RtcManager.java
+++ b/bundles/org.openhab.binding.dahuadoor/src/main/java/org/openhab/binding/dahuadoor/internal/media/Go2RtcManager.java
@@ -248,9 +248,8 @@ public class Go2RtcManager {
         candidates.append("    - stun:").append(stunServer).append("\n");
 
         return "log:\n" + "  level: debug\n" + "streams:\n" + "  " + streamName + ":\n" + "    - '" + safeRtspUrl
-                + "'\n" + "    - '" + safeBackchannelExec + "'\n" + "api:\n" + "  origin: \"*\"\n" + "  listen: \":"
-                + apiPort + "\"\n" + "webrtc:\n" + "  listen: \":" + webRtcPort + "\"\n" + "  candidates:\n"
-                + candidates;
+                + "'\n" + "    - '" + safeBackchannelExec + "'\n" + "api:\n" + "  listen: \"127.0.0.1:" + apiPort
+                + "\"\n" + "webrtc:\n" + "  listen: \":" + webRtcPort + "\"\n" + "  candidates:\n" + candidates;
     }
 
     /**

--- a/bundles/org.openhab.binding.dahuadoor/src/main/java/org/openhab/binding/dahuadoor/internal/media/Go2RtcManager.java
+++ b/bundles/org.openhab.binding.dahuadoor/src/main/java/org/openhab/binding/dahuadoor/internal/media/Go2RtcManager.java
@@ -21,9 +21,11 @@ import java.net.HttpURLConnection;
 import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.net.URI;
+import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.attribute.PosixFilePermissions;
+import java.util.concurrent.TimeUnit;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
@@ -53,6 +55,8 @@ public class Go2RtcManager {
     private static final int HEALTH_CHECK_MAX_POLLS = 10;
     /** Delay between health-check polls in milliseconds. */
     private static final long HEALTH_CHECK_POLL_DELAY_MS = 500;
+    /** Maximum wait for go2rtc to exit after SIGTERM. */
+    private static final long STOP_TIMEOUT_SECONDS = 5;
 
     private final String go2rtcBinary;
     private final int apiPort;
@@ -63,6 +67,7 @@ public class Go2RtcManager {
     private final String password;
     private final int rtspChannel;
     private final int rtspSubtype;
+    private final int backchannelRtpPort;
     private final String streamName;
 
     private @Nullable Process process;
@@ -95,6 +100,7 @@ public class Go2RtcManager {
         this.password = password;
         this.rtspChannel = rtspChannel;
         this.rtspSubtype = rtspSubtype;
+        this.backchannelRtpPort = apiPort + 20000;
     }
 
     /**
@@ -174,7 +180,11 @@ public class Go2RtcManager {
             LOGGER.info("Stopping go2rtc (stream={}, PID={})", streamName, localProcess.pid());
             localProcess.destroy();
             try {
-                localProcess.waitFor();
+                if (!localProcess.waitFor(STOP_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+                    LOGGER.warn("go2rtc did not terminate in {}s, forcing shutdown (stream={})", STOP_TIMEOUT_SECONDS,
+                            streamName);
+                    localProcess.destroyForcibly();
+                }
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
             }
@@ -218,13 +228,16 @@ public class Go2RtcManager {
      * as a host candidate on its own.
      */
     private String buildYaml() {
-        // URL-encode password chars that are special in URLs (%, @, :, /) for safety,
-        // but Dahua passwords are typically alphanumeric so this stays simple.
-        String rtspUrl = "rtsp://" + username + ":" + password + "@" + hostname + ":554/cam/realmonitor?channel="
-                + rtspChannel + "&subtype=" + rtspSubtype;
+        String userInfo = URLEncoder.encode(username, StandardCharsets.UTF_8) + ":"
+                + URLEncoder.encode(password, StandardCharsets.UTF_8);
+        String rtspUrl = "rtsp://" + userInfo + "@" + hostname + ":554/cam/realmonitor?channel=" + rtspChannel
+                + "&subtype=" + rtspSubtype;
         String backchannelExec = "exec:ffmpeg -use_wallclock_as_timestamps 1 -re -fflags nobuffer -f alaw -ar 8000 "
-                + "-ac 1 -i - -vn -acodec pcm_alaw -ar 8000 -ac 1 -payload_type 8 -f rtp "
-                + "rtp://127.0.0.1:21984#backchannel=1#audio=alaw/8000";
+                + "-ac 1 -i - -vn -acodec pcm_alaw -ar 8000 -ac 1 -payload_type 8 -f rtp " + "rtp://127.0.0.1:"
+                + backchannelRtpPort + "#backchannel=1#audio=alaw/8000";
+
+        String safeRtspUrl = rtspUrl.replace("'", "''");
+        String safeBackchannelExec = backchannelExec.replace("'", "''");
 
         StringBuilder candidates = new StringBuilder();
         String localIp = detectLocalIp();
@@ -234,9 +247,10 @@ public class Go2RtcManager {
         }
         candidates.append("    - stun:").append(stunServer).append("\n");
 
-        return "log:\n" + "  level: debug\n" + "streams:\n" + "  " + streamName + ":\n" + "    - '" + rtspUrl + "'\n"
-                + "    - '" + backchannelExec + "'\n" + "api:\n" + "  origin: \"*\"\n" + "  listen: \":" + apiPort
-                + "\"\n" + "webrtc:\n" + "  listen: \":" + webRtcPort + "\"\n" + "  candidates:\n" + candidates;
+        return "log:\n" + "  level: debug\n" + "streams:\n" + "  " + streamName + ":\n" + "    - '" + safeRtspUrl
+                + "'\n" + "    - '" + safeBackchannelExec + "'\n" + "api:\n" + "  origin: \"*\"\n" + "  listen: \":"
+                + apiPort + "\"\n" + "webrtc:\n" + "  listen: \":" + webRtcPort + "\"\n" + "  candidates:\n"
+                + candidates;
     }
 
     /**

--- a/bundles/org.openhab.binding.dahuadoor/src/main/java/org/openhab/binding/dahuadoor/internal/media/PlayStreamServlet.java
+++ b/bundles/org.openhab.binding.dahuadoor/src/main/java/org/openhab/binding/dahuadoor/internal/media/PlayStreamServlet.java
@@ -1,0 +1,292 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.dahuadoor.internal.media;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Dictionary;
+import java.util.Hashtable;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.binding.dahuadoor.internal.DahuaDoorBindingConstants;
+import org.osgi.service.http.HttpService;
+import org.osgi.service.http.NamespaceException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link PlayStreamServlet} is an HTTP servlet registered with the OSGi {@link HttpService}
+ * at {@value DahuaDoorBindingConstants#WEBRTC_SERVLET_PATH}.
+ *
+ * <p>
+ * It proxies WebRTC SDP offer/answer exchange between the browser and the local go2rtc instance,
+ * making go2rtc's localhost-only API accessible to browser clients via openHAB's HTTP port.
+ * </p>
+ *
+ * <h3>Usage</h3>
+ * 
+ * <pre>
+ *   POST /dahuadoor/webrtc/{streamName}
+ *   Content-Type: application/x-www-form-urlencoded
+ *   Body: data=&lt;base64(SDP offer)&gt;
+ *
+ *   Response 200:
+ *   Content-Type: text/plain
+ *   Body: base64(SDP answer)
+ * </pre>
+ *
+ * @author Sven Schad - Initial contribution
+ */
+@NonNullByDefault
+public class PlayStreamServlet extends HttpServlet {
+
+    private static final long serialVersionUID = 1L;
+    private static final Logger LOGGER = LoggerFactory.getLogger(PlayStreamServlet.class);
+
+    /** Timeout for the HTTP call to the go2rtc API. */
+    private static final int GO2RTC_API_TIMEOUT_MS = 10_000;
+
+    private final HttpService httpService;
+
+    /**
+     * Map from go2rtc stream name (e.g. {@code dahua_vto2202_living}) to API port.
+     * Modified from multiple threads → ConcurrentHashMap.
+     */
+    private final Map<String, Integer> streamApiPorts = new ConcurrentHashMap<>();
+
+    /** Number of currently registered streams; used to decide when to unregister the servlet. */
+    private volatile int registrationCount = 0;
+
+    public PlayStreamServlet(HttpService httpService) {
+        this.httpService = httpService;
+    }
+
+    // -------------------------------------------------------------------------
+    // Stream registration / de-registration
+    // -------------------------------------------------------------------------
+
+    /**
+     * Registers a stream and – on the first registration – activates the servlet.
+     *
+     * @param streamName go2rtc stream name
+     * @param apiPort go2rtc API port for that stream
+     */
+    public synchronized void registerStream(String streamName, int apiPort) {
+        streamApiPorts.put(streamName, apiPort);
+        if (registrationCount == 0) {
+            activate();
+        }
+        registrationCount++;
+        LOGGER.debug("Registered WebRTC stream '{}' on port {}", streamName, apiPort);
+    }
+
+    /**
+     * De-registers a stream and – on the last de-registration – deactivates the servlet.
+     *
+     * @param streamName go2rtc stream name
+     */
+    public synchronized void unregisterStream(String streamName) {
+        streamApiPorts.remove(streamName);
+        registrationCount = Math.max(0, registrationCount - 1);
+        if (registrationCount == 0) {
+            deactivate();
+        }
+        LOGGER.debug("Unregistered WebRTC stream '{}'", streamName);
+    }
+
+    // -------------------------------------------------------------------------
+    // Servlet implementation
+    // -------------------------------------------------------------------------
+
+    @Override
+    protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        addCorsHeaders(resp);
+
+        // Path info is /{streamName}
+        String pathInfo = req.getPathInfo();
+        if (pathInfo == null || pathInfo.length() <= 1) {
+            sendBase64Message(resp, HttpServletResponse.SC_BAD_REQUEST, "Stream name missing in URL path");
+            LOGGER.warn("Rejected request: missing stream name in URL path");
+            return;
+        }
+        String streamName = pathInfo.substring(1); // strip leading /
+
+        Integer apiPort = streamApiPorts.get(streamName);
+        if (apiPort == null) {
+            sendBase64Message(resp, HttpServletResponse.SC_NOT_FOUND,
+                    "Unknown stream: " + streamName + ". Is the thing online with WebRTC enabled?");
+            LOGGER.warn("Rejected request: unknown stream '{}'", streamName);
+            return;
+        }
+
+        String requestBody;
+        try (InputStream in = req.getInputStream()) {
+            requestBody = new String(in.readAllBytes(), StandardCharsets.UTF_8);
+        }
+        if (requestBody.isBlank()) {
+            sendBase64Message(resp, HttpServletResponse.SC_BAD_REQUEST, "Empty request body");
+            LOGGER.warn("Rejected request for stream '{}': empty body", streamName);
+            return;
+        }
+
+        if (!requestBody.startsWith("data=")) {
+            sendBase64Message(resp, HttpServletResponse.SC_BAD_REQUEST,
+                    "Unsupported request format. Expected form body: data=<base64(sdp)>.");
+            LOGGER.warn("Rejected request for stream '{}': unsupported input mode", streamName);
+            return;
+        }
+        if (requestBody.indexOf('&') >= 0) {
+            sendBase64Message(resp, HttpServletResponse.SC_BAD_REQUEST,
+                    "Unsupported request format. Only one form field is allowed: data=<base64(sdp)>.");
+            LOGGER.warn("Rejected request for stream '{}': additional form fields present", streamName);
+            return;
+        }
+
+        String decodedFormValue = URLDecoder.decode(requestBody.substring(5), StandardCharsets.UTF_8);
+        if (decodedFormValue.isBlank()) {
+            sendBase64Message(resp, HttpServletResponse.SC_BAD_REQUEST, "Missing SDP payload in form field 'data'.");
+            LOGGER.warn("Rejected request for stream '{}': empty data field", streamName);
+            return;
+        }
+
+        String sdpOffer;
+        try {
+            sdpOffer = new String(Base64.getDecoder().decode(decodedFormValue), StandardCharsets.UTF_8);
+        } catch (IllegalArgumentException e) {
+            sendBase64Message(resp, HttpServletResponse.SC_BAD_REQUEST, "Invalid Base64 payload in form field 'data'.");
+            LOGGER.warn("Rejected request for stream '{}': invalid base64 payload", streamName);
+            return;
+        }
+        if (sdpOffer.isBlank()) {
+            sendBase64Message(resp, HttpServletResponse.SC_BAD_REQUEST, "Decoded SDP offer is empty.");
+            LOGGER.warn("Rejected request for stream '{}': decoded SDP is empty", streamName);
+            return;
+        }
+
+        // Forward to go2rtc API
+        String go2rtcUrl = "http://127.0.0.1:" + apiPort + "/api/webrtc?src=" + streamName;
+
+        HttpURLConnection conn = (HttpURLConnection) URI.create(go2rtcUrl).toURL().openConnection();
+        try {
+            conn.setConnectTimeout(GO2RTC_API_TIMEOUT_MS);
+            conn.setReadTimeout(GO2RTC_API_TIMEOUT_MS);
+            conn.setRequestMethod("POST");
+            conn.setDoOutput(true);
+            conn.setRequestProperty("Content-Type", "application/sdp");
+            byte[] offerBytes = sdpOffer.getBytes(StandardCharsets.UTF_8);
+            conn.setRequestProperty("Content-Length", String.valueOf(offerBytes.length));
+            try (OutputStream out = conn.getOutputStream()) {
+                out.write(offerBytes);
+            }
+
+            int status = conn.getResponseCode();
+            if (status >= 300) {
+                byte[] errorBodyBytes;
+                InputStream errorStream = conn.getErrorStream();
+                if (errorStream != null) {
+                    try (InputStream in = errorStream) {
+                        errorBodyBytes = in.readAllBytes();
+                    }
+                } else {
+                    errorBodyBytes = new byte[0];
+                }
+                String errorBody = new String(errorBodyBytes, StandardCharsets.UTF_8).trim();
+                if (errorBody.length() > 300) {
+                    errorBody = errorBody.substring(0, 300);
+                }
+                String message = errorBody.isEmpty() ? "go2rtc API returned HTTP " + status
+                        : "go2rtc API returned HTTP " + status + ": " + errorBody;
+                sendBase64Message(resp, HttpServletResponse.SC_BAD_GATEWAY, message);
+                LOGGER.warn("Upstream error for stream '{}': mapped to 502 (status={}, bodyBytes={})", streamName,
+                        status, errorBodyBytes.length);
+                return;
+            }
+
+            byte[] sdpAnswer = conn.getInputStream().readAllBytes();
+
+            byte[] encoded = Base64.getEncoder().encode(sdpAnswer);
+
+            resp.setStatus(HttpServletResponse.SC_OK);
+            resp.setContentType("text/plain");
+            resp.setCharacterEncoding(StandardCharsets.UTF_8.name());
+            resp.getOutputStream().write(encoded);
+        } catch (IOException e) {
+            sendBase64Message(resp, HttpServletResponse.SC_BAD_GATEWAY,
+                    "Failed to reach go2rtc API: " + e.getMessage());
+            LOGGER.warn("Upstream communication failure for stream '{}': {}", streamName, e.getMessage());
+        } finally {
+            conn.disconnect();
+        }
+    }
+
+    @Override
+    protected void doOptions(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        addCorsHeaders(resp);
+        resp.setStatus(HttpServletResponse.SC_OK);
+    }
+
+    // -------------------------------------------------------------------------
+    // Lifecycle
+    // -------------------------------------------------------------------------
+
+    private void activate() {
+        Dictionary<String, String> params = new Hashtable<>();
+        try {
+            httpService.registerServlet(DahuaDoorBindingConstants.WEBRTC_SERVLET_PATH, this, params,
+                    httpService.createDefaultHttpContext());
+            LOGGER.debug("PlayStreamServlet registered at {}", DahuaDoorBindingConstants.WEBRTC_SERVLET_PATH);
+        } catch (ServletException | NamespaceException e) {
+            LOGGER.error("Failed to register PlayStreamServlet: {}", e.getMessage(), e);
+        }
+    }
+
+    private void deactivate() {
+        try {
+            httpService.unregister(DahuaDoorBindingConstants.WEBRTC_SERVLET_PATH);
+            LOGGER.debug("PlayStreamServlet unregistered");
+        } catch (IllegalArgumentException e) {
+            LOGGER.trace("PlayStreamServlet was not registered: {}", e.getMessage());
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Helper
+    // -------------------------------------------------------------------------
+
+    private static void addCorsHeaders(HttpServletResponse resp) {
+        resp.setHeader("Access-Control-Allow-Origin", "*");
+        resp.setHeader("Access-Control-Allow-Methods", "POST, OPTIONS");
+        resp.setHeader("Access-Control-Allow-Headers", "Content-Type");
+    }
+
+    private static void sendBase64Message(HttpServletResponse resp, int statusCode, String message) throws IOException {
+        byte[] encoded = Base64.getEncoder().encode(message.getBytes(StandardCharsets.UTF_8));
+        resp.setStatus(statusCode);
+        resp.setContentType("text/plain");
+        resp.setCharacterEncoding(StandardCharsets.UTF_8.name());
+        resp.getOutputStream().write(encoded);
+    }
+}

--- a/bundles/org.openhab.binding.dahuadoor/src/main/java/org/openhab/binding/dahuadoor/internal/media/PlayStreamServlet.java
+++ b/bundles/org.openhab.binding.dahuadoor/src/main/java/org/openhab/binding/dahuadoor/internal/media/PlayStreamServlet.java
@@ -12,12 +12,14 @@
  */
 package org.openhab.binding.dahuadoor.internal.media;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.URI;
 import java.net.URLDecoder;
+import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.Dictionary;
@@ -68,6 +70,8 @@ public class PlayStreamServlet extends HttpServlet {
 
     /** Timeout for the HTTP call to the go2rtc API. */
     private static final int GO2RTC_API_TIMEOUT_MS = 10_000;
+    /** Maximum accepted size for incoming request body. */
+    private static final int MAX_REQUEST_BODY_BYTES = 64 * 1024;
 
     private final HttpService httpService;
 
@@ -95,11 +99,17 @@ public class PlayStreamServlet extends HttpServlet {
      * @param apiPort go2rtc API port for that stream
      */
     public synchronized void registerStream(String streamName, int apiPort) {
-        streamApiPorts.put(streamName, apiPort);
-        if (registrationCount == 0) {
-            activate();
+        Integer previous = streamApiPorts.put(streamName, apiPort);
+        if (previous == null && registrationCount == 0) {
+            if (!activate()) {
+                streamApiPorts.remove(streamName);
+                LOGGER.warn("Could not register stream '{}' because servlet activation failed", streamName);
+                return;
+            }
         }
-        registrationCount++;
+        if (previous == null) {
+            registrationCount++;
+        }
         LOGGER.debug("Registered WebRTC stream '{}' on port {}", streamName, apiPort);
     }
 
@@ -109,12 +119,20 @@ public class PlayStreamServlet extends HttpServlet {
      * @param streamName go2rtc stream name
      */
     public synchronized void unregisterStream(String streamName) {
-        streamApiPorts.remove(streamName);
-        registrationCount = Math.max(0, registrationCount - 1);
-        if (registrationCount == 0) {
-            deactivate();
+        Integer removed = streamApiPorts.remove(streamName);
+        if (removed != null) {
+            registrationCount = Math.max(0, registrationCount - 1);
+            if (registrationCount == 0) {
+                deactivate();
+            }
         }
         LOGGER.debug("Unregistered WebRTC stream '{}'", streamName);
+    }
+
+    public synchronized void deactivateAll() {
+        streamApiPorts.clear();
+        registrationCount = 0;
+        deactivate();
     }
 
     // -------------------------------------------------------------------------
@@ -144,7 +162,13 @@ public class PlayStreamServlet extends HttpServlet {
 
         String requestBody;
         try (InputStream in = req.getInputStream()) {
-            requestBody = new String(in.readAllBytes(), StandardCharsets.UTF_8);
+            requestBody = new String(readLimitedBytes(in, MAX_REQUEST_BODY_BYTES), StandardCharsets.UTF_8);
+        } catch (RequestTooLargeException e) {
+            sendBase64Message(resp, HttpServletResponse.SC_REQUEST_ENTITY_TOO_LARGE,
+                    "Request body too large. Maximum supported size is " + MAX_REQUEST_BODY_BYTES + " bytes.");
+            LOGGER.warn("Rejected request for stream '{}': request body exceeded {} bytes", streamName,
+                    MAX_REQUEST_BODY_BYTES);
+            return;
         }
         if (requestBody.isBlank()) {
             sendBase64Message(resp, HttpServletResponse.SC_BAD_REQUEST, "Empty request body");
@@ -187,7 +211,8 @@ public class PlayStreamServlet extends HttpServlet {
         }
 
         // Forward to go2rtc API
-        String go2rtcUrl = "http://127.0.0.1:" + apiPort + "/api/webrtc?src=" + streamName;
+        String go2rtcUrl = "http://127.0.0.1:" + apiPort + "/api/webrtc?src="
+                + URLEncoder.encode(streamName, StandardCharsets.UTF_8);
 
         HttpURLConnection conn = (HttpURLConnection) URI.create(go2rtcUrl).toURL().openConnection();
         try {
@@ -225,7 +250,10 @@ public class PlayStreamServlet extends HttpServlet {
                 return;
             }
 
-            byte[] sdpAnswer = conn.getInputStream().readAllBytes();
+            byte[] sdpAnswer;
+            try (InputStream in = conn.getInputStream()) {
+                sdpAnswer = in.readAllBytes();
+            }
 
             byte[] encoded = Base64.getEncoder().encode(sdpAnswer);
 
@@ -252,14 +280,16 @@ public class PlayStreamServlet extends HttpServlet {
     // Lifecycle
     // -------------------------------------------------------------------------
 
-    private void activate() {
+    private boolean activate() {
         Dictionary<String, String> params = new Hashtable<>();
         try {
             httpService.registerServlet(DahuaDoorBindingConstants.WEBRTC_SERVLET_PATH, this, params,
                     httpService.createDefaultHttpContext());
             LOGGER.debug("PlayStreamServlet registered at {}", DahuaDoorBindingConstants.WEBRTC_SERVLET_PATH);
+            return true;
         } catch (ServletException | NamespaceException e) {
             LOGGER.error("Failed to register PlayStreamServlet: {}", e.getMessage(), e);
+            return false;
         }
     }
 
@@ -277,7 +307,6 @@ public class PlayStreamServlet extends HttpServlet {
     // -------------------------------------------------------------------------
 
     private static void addCorsHeaders(HttpServletResponse resp) {
-        resp.setHeader("Access-Control-Allow-Origin", "*");
         resp.setHeader("Access-Control-Allow-Methods", "POST, OPTIONS");
         resp.setHeader("Access-Control-Allow-Headers", "Content-Type");
     }
@@ -288,5 +317,24 @@ public class PlayStreamServlet extends HttpServlet {
         resp.setContentType("text/plain");
         resp.setCharacterEncoding(StandardCharsets.UTF_8.name());
         resp.getOutputStream().write(encoded);
+    }
+
+    private static byte[] readLimitedBytes(InputStream in, int maxBytes) throws IOException, RequestTooLargeException {
+        byte[] buffer = new byte[4096];
+        int total = 0;
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        int read;
+        while ((read = in.read(buffer)) != -1) {
+            total += read;
+            if (total > maxBytes) {
+                throw new RequestTooLargeException();
+            }
+            out.write(buffer, 0, read);
+        }
+        return out.toByteArray();
+    }
+
+    private static final class RequestTooLargeException extends Exception {
+        private static final long serialVersionUID = 1L;
     }
 }

--- a/bundles/org.openhab.binding.dahuadoor/src/main/resources/OH-INF/i18n/dahuadoor.properties
+++ b/bundles/org.openhab.binding.dahuadoor/src/main/resources/OH-INF/i18n/dahuadoor.properties
@@ -86,7 +86,7 @@ channel-type.dahuadoor.door-image.description = Snapshot image taken when doorbe
 channel-type.dahuadoor.open-door.label = Open Door
 channel-type.dahuadoor.open-door.description = Controls the door lock relay.
 channel-type.dahuadoor.webrtc-url.label = WebRTC URL
-channel-type.dahuadoor.webrtc-url.description = Proxy path for WebRTC SDP offer/answer exchange (POST form body data=<base64(SDP offer)> to this path on the openHAB HTTP port and receive base64(SDP answer) from go2rtc).
+channel-type.dahuadoor.webrtc-url.description = Base URL used by MainUI widgets to communicate with the binding.
 
 # thing status descriptions
 

--- a/bundles/org.openhab.binding.dahuadoor/src/main/resources/OH-INF/i18n/dahuadoor.properties
+++ b/bundles/org.openhab.binding.dahuadoor/src/main/resources/OH-INF/i18n/dahuadoor.properties
@@ -28,26 +28,54 @@ thing-type.dahuadoor.vto3211.channel.open-door-2.description = Relay control to 
 
 # thing types config
 
+thing-type.config.dahuadoor.vto2202.enableWebRTC.label = Enable WebRTC
+thing-type.config.dahuadoor.vto2202.enableWebRTC.description = Start a local go2rtc instance to bridge the RTSP stream to WebRTC. Requires go2rtcPath to be set.
+thing-type.config.dahuadoor.vto2202.go2rtcApiPort.label = go2rtc API Port
+thing-type.config.dahuadoor.vto2202.go2rtcApiPort.description = HTTP API port for the go2rtc instance (default 1984). Must be unique per thing if multiple things run WebRTC.
+thing-type.config.dahuadoor.vto2202.go2rtcPath.label = go2rtc Binary Path
+thing-type.config.dahuadoor.vto2202.go2rtcPath.description = Absolute path to the go2rtc binary (e.g. /opt/go2rtc). Required when Enable WebRTC is on.
 thing-type.config.dahuadoor.vto2202.hostname.label = Hostname
 thing-type.config.dahuadoor.vto2202.hostname.description = Hostname or IP address of the device
 thing-type.config.dahuadoor.vto2202.password.label = Password
 thing-type.config.dahuadoor.vto2202.password.description = Password to access the device
+thing-type.config.dahuadoor.vto2202.rtspChannel.label = RTSP Channel
+thing-type.config.dahuadoor.vto2202.rtspChannel.description = RTSP channel index on the device (default 1).
+thing-type.config.dahuadoor.vto2202.rtspSubtype.label = RTSP Sub-type
+thing-type.config.dahuadoor.vto2202.rtspSubtype.description = RTSP sub-type index: 0 = main stream, 1 = sub stream (default 0).
 thing-type.config.dahuadoor.vto2202.snapshotPath.label = Snapshot Path
 thing-type.config.dahuadoor.vto2202.snapshotPath.description = Path where snapshots will be saved (e.g., /var/lib/openhab/door-images)
+thing-type.config.dahuadoor.vto2202.stunServer.label = STUN Server
+thing-type.config.dahuadoor.vto2202.stunServer.description = STUN server for WebRTC NAT traversal in host:port format (default stun.l.google.com:19302).
 thing-type.config.dahuadoor.vto2202.useHttps.label = Use HTTPS
 thing-type.config.dahuadoor.vto2202.useHttps.description = Use HTTPS (port 443) for snapshot and door-open requests. Enable if the device has HTTPS turned on. Disable for plain HTTP (port 80).
 thing-type.config.dahuadoor.vto2202.username.label = Username
 thing-type.config.dahuadoor.vto2202.username.description = Username to access the device
+thing-type.config.dahuadoor.vto2202.webRtcPort.label = WebRTC Port
+thing-type.config.dahuadoor.vto2202.webRtcPort.description = UDP/TCP port for WebRTC data (default 8555). Must be unique per thing if multiple things run WebRTC.
+thing-type.config.dahuadoor.vto3211.enableWebRTC.label = Enable WebRTC
+thing-type.config.dahuadoor.vto3211.enableWebRTC.description = Start a local go2rtc instance to bridge the RTSP stream to WebRTC. Requires go2rtcPath to be set.
+thing-type.config.dahuadoor.vto3211.go2rtcApiPort.label = go2rtc API Port
+thing-type.config.dahuadoor.vto3211.go2rtcApiPort.description = HTTP API port for the go2rtc instance (default 1984). Must be unique per thing if multiple things run WebRTC.
+thing-type.config.dahuadoor.vto3211.go2rtcPath.label = go2rtc Binary Path
+thing-type.config.dahuadoor.vto3211.go2rtcPath.description = Absolute path to the go2rtc binary (e.g. /opt/go2rtc). Required when Enable WebRTC is on.
 thing-type.config.dahuadoor.vto3211.hostname.label = Hostname
 thing-type.config.dahuadoor.vto3211.hostname.description = Hostname or IP address of the device
 thing-type.config.dahuadoor.vto3211.password.label = Password
 thing-type.config.dahuadoor.vto3211.password.description = Password to access the device
+thing-type.config.dahuadoor.vto3211.rtspChannel.label = RTSP Channel
+thing-type.config.dahuadoor.vto3211.rtspChannel.description = RTSP channel index on the device (default 1).
+thing-type.config.dahuadoor.vto3211.rtspSubtype.label = RTSP Sub-type
+thing-type.config.dahuadoor.vto3211.rtspSubtype.description = RTSP sub-type index: 0 = main stream, 1 = sub stream (default 0).
 thing-type.config.dahuadoor.vto3211.snapshotPath.label = Snapshot Path
 thing-type.config.dahuadoor.vto3211.snapshotPath.description = Path where snapshots will be saved (e.g., /var/lib/openhab/door-images)
+thing-type.config.dahuadoor.vto3211.stunServer.label = STUN Server
+thing-type.config.dahuadoor.vto3211.stunServer.description = STUN server for WebRTC NAT traversal in host:port format (default stun.l.google.com:19302).
 thing-type.config.dahuadoor.vto3211.useHttps.label = Use HTTPS
 thing-type.config.dahuadoor.vto3211.useHttps.description = Use HTTPS (port 443) for snapshot and door-open requests. Enable if the device has HTTPS turned on. Disable for plain HTTP (port 80).
 thing-type.config.dahuadoor.vto3211.username.label = Username
 thing-type.config.dahuadoor.vto3211.username.description = Username to access the device
+thing-type.config.dahuadoor.vto3211.webRtcPort.label = WebRTC Port
+thing-type.config.dahuadoor.vto3211.webRtcPort.description = UDP/TCP port for WebRTC data (default 8555). Must be unique per thing if multiple things run WebRTC.
 
 # channel types
 
@@ -57,8 +85,11 @@ channel-type.dahuadoor.door-image.label = Door Image
 channel-type.dahuadoor.door-image.description = Snapshot image taken when doorbell is pressed.
 channel-type.dahuadoor.open-door.label = Open Door
 channel-type.dahuadoor.open-door.description = Controls the door lock relay.
+channel-type.dahuadoor.webrtc-url.label = WebRTC URL
+channel-type.dahuadoor.webrtc-url.description = Proxy path for WebRTC SDP offer/answer exchange (POST form body data=<base64(SDP offer)> to this path on the openHAB HTTP port and receive base64(SDP answer) from go2rtc).
 
 # thing status descriptions
 
 offline.conf-error-missing-credentials = Hostname, username and password must be configured.
+offline.conf-error-missing-go2rtc-path = go2rtcPath must be configured when WebRTC is enabled.
 offline.conf-error-missing-snapshot-path = Snapshot path must be configured.

--- a/bundles/org.openhab.binding.dahuadoor/src/main/resources/OH-INF/i18n/dahuadoor.properties
+++ b/bundles/org.openhab.binding.dahuadoor/src/main/resources/OH-INF/i18n/dahuadoor.properties
@@ -85,8 +85,8 @@ channel-type.dahuadoor.door-image.label = Door Image
 channel-type.dahuadoor.door-image.description = Snapshot image taken when doorbell is pressed.
 channel-type.dahuadoor.open-door.label = Open Door
 channel-type.dahuadoor.open-door.description = Controls the door lock relay.
-channel-type.dahuadoor.webrtc-url.label = WebRTC URL
-channel-type.dahuadoor.webrtc-url.description = Base URL used by MainUI widgets to communicate with the binding.
+channel-type.dahuadoor.webrtc-url.label = WebRTC Proxy Path
+channel-type.dahuadoor.webrtc-url.description = Relative proxy path used by MainUI widgets to communicate with the binding.
 
 # thing status descriptions
 

--- a/bundles/org.openhab.binding.dahuadoor/src/main/resources/OH-INF/thing/channel-types.xml
+++ b/bundles/org.openhab.binding.dahuadoor/src/main/resources/OH-INF/thing/channel-types.xml
@@ -34,4 +34,12 @@
 		</tags>
 	</channel-type>
 
+	<channel-type id="webrtc-url">
+		<item-type>String</item-type>
+		<label>WebRTC URL</label>
+		<description>Proxy path for WebRTC SDP offer/answer exchange (POST form body data=&lt;base64(SDP offer)&gt; to this
+			path on the openHAB HTTP port and receive base64(SDP answer) from go2rtc).</description>
+		<state readOnly="true" pattern="%s"/>
+	</channel-type>
+
 </thing:thing-descriptions>

--- a/bundles/org.openhab.binding.dahuadoor/src/main/resources/OH-INF/thing/channel-types.xml
+++ b/bundles/org.openhab.binding.dahuadoor/src/main/resources/OH-INF/thing/channel-types.xml
@@ -37,8 +37,7 @@
 	<channel-type id="webrtc-url">
 		<item-type>String</item-type>
 		<label>WebRTC URL</label>
-		<description>Proxy path for WebRTC SDP offer/answer exchange (POST form body data=&lt;base64(SDP offer)&gt; to this
-			path on the openHAB HTTP port and receive base64(SDP answer) from go2rtc).</description>
+		<description>Base URL used by MainUI widgets to communicate with the binding.</description>
 		<state readOnly="true" pattern="%s"/>
 	</channel-type>
 

--- a/bundles/org.openhab.binding.dahuadoor/src/main/resources/OH-INF/thing/channel-types.xml
+++ b/bundles/org.openhab.binding.dahuadoor/src/main/resources/OH-INF/thing/channel-types.xml
@@ -36,8 +36,8 @@
 
 	<channel-type id="webrtc-url">
 		<item-type>String</item-type>
-		<label>WebRTC URL</label>
-		<description>Base URL used by MainUI widgets to communicate with the binding.</description>
+		<label>WebRTC Proxy Path</label>
+		<description>Relative proxy path used by MainUI widgets to communicate with the binding.</description>
 		<state readOnly="true" pattern="%s"/>
 	</channel-type>
 

--- a/bundles/org.openhab.binding.dahuadoor/src/main/resources/OH-INF/thing/vto2202.xml
+++ b/bundles/org.openhab.binding.dahuadoor/src/main/resources/OH-INF/thing/vto2202.xml
@@ -20,6 +20,7 @@
 				<label>Open Door 2</label>
 				<description>Controls door relay 2</description>
 			</channel>
+			<channel id="webrtc-url" typeId="webrtc-url"/>
 		</channels>
 		<representation-property>macAddress</representation-property>
 
@@ -48,6 +49,42 @@
 				<description>Use HTTPS (port 443) for snapshot and door-open requests. Enable if the device has HTTPS turned on.
 					Disable for plain HTTP (port 80).</description>
 				<default>false</default>
+			</parameter>
+			<parameter name="enableWebRTC" type="boolean">
+				<label>Enable WebRTC</label>
+				<description>Start a local go2rtc instance to bridge the RTSP stream to WebRTC. Requires go2rtcPath to be set.</description>
+				<default>false</default>
+			</parameter>
+			<parameter name="go2rtcPath" type="text">
+				<label>go2rtc Binary Path</label>
+				<description>Absolute path to the go2rtc binary (e.g. /opt/go2rtc). Required when Enable WebRTC is on.</description>
+				<default></default>
+			</parameter>
+			<parameter name="go2rtcApiPort" type="integer">
+				<label>go2rtc API Port</label>
+				<description>HTTP API port for the go2rtc instance (default 1984). Must be unique per thing if multiple things run
+					WebRTC.</description>
+				<default>1984</default>
+			</parameter>
+			<parameter name="webRtcPort" type="integer">
+				<label>WebRTC Port</label>
+				<description>UDP/TCP port for WebRTC data (default 8555). Must be unique per thing if multiple things run WebRTC.</description>
+				<default>8555</default>
+			</parameter>
+			<parameter name="stunServer" type="text">
+				<label>STUN Server</label>
+				<description>STUN server for WebRTC NAT traversal in host:port format (default stun.l.google.com:19302).</description>
+				<default>stun.l.google.com:19302</default>
+			</parameter>
+			<parameter name="rtspChannel" type="integer">
+				<label>RTSP Channel</label>
+				<description>RTSP channel index on the device (default 1).</description>
+				<default>1</default>
+			</parameter>
+			<parameter name="rtspSubtype" type="integer">
+				<label>RTSP Sub-type</label>
+				<description>RTSP sub-type index: 0 = main stream, 1 = sub stream (default 0).</description>
+				<default>0</default>
 			</parameter>
 		</config-description>
 	</thing-type>

--- a/bundles/org.openhab.binding.dahuadoor/src/main/resources/OH-INF/thing/vto2202.xml
+++ b/bundles/org.openhab.binding.dahuadoor/src/main/resources/OH-INF/thing/vto2202.xml
@@ -22,6 +22,9 @@
 			</channel>
 			<channel id="webrtc-url" typeId="webrtc-url"/>
 		</channels>
+		<properties>
+			<property name="thingTypeVersion">1</property>
+		</properties>
 		<representation-property>macAddress</representation-property>
 
 		<config-description>
@@ -61,27 +64,32 @@
 				<default></default>
 			</parameter>
 			<parameter name="go2rtcApiPort" type="integer">
+				<advanced>true</advanced>
 				<label>go2rtc API Port</label>
 				<description>HTTP API port for the go2rtc instance (default 1984). Must be unique per thing if multiple things run
 					WebRTC.</description>
 				<default>1984</default>
 			</parameter>
 			<parameter name="webRtcPort" type="integer">
+				<advanced>true</advanced>
 				<label>WebRTC Port</label>
 				<description>UDP/TCP port for WebRTC data (default 8555). Must be unique per thing if multiple things run WebRTC.</description>
 				<default>8555</default>
 			</parameter>
 			<parameter name="stunServer" type="text">
+				<advanced>true</advanced>
 				<label>STUN Server</label>
 				<description>STUN server for WebRTC NAT traversal in host:port format (default stun.l.google.com:19302).</description>
 				<default>stun.l.google.com:19302</default>
 			</parameter>
 			<parameter name="rtspChannel" type="integer">
+				<advanced>true</advanced>
 				<label>RTSP Channel</label>
 				<description>RTSP channel index on the device (default 1).</description>
 				<default>1</default>
 			</parameter>
 			<parameter name="rtspSubtype" type="integer">
+				<advanced>true</advanced>
 				<label>RTSP Sub-type</label>
 				<description>RTSP sub-type index: 0 = main stream, 1 = sub stream (default 0).</description>
 				<default>0</default>

--- a/bundles/org.openhab.binding.dahuadoor/src/main/resources/OH-INF/thing/vto3211.xml
+++ b/bundles/org.openhab.binding.dahuadoor/src/main/resources/OH-INF/thing/vto3211.xml
@@ -36,6 +36,9 @@
 			</channel>
 			<channel id="webrtc-url" typeId="webrtc-url"/>
 		</channels>
+		<properties>
+			<property name="thingTypeVersion">1</property>
+		</properties>
 		<representation-property>macAddress</representation-property>
 
 		<config-description>
@@ -75,27 +78,32 @@
 				<default></default>
 			</parameter>
 			<parameter name="go2rtcApiPort" type="integer">
+				<advanced>true</advanced>
 				<label>go2rtc API Port</label>
 				<description>HTTP API port for the go2rtc instance (default 1984). Must be unique per thing if multiple things run
 					WebRTC.</description>
 				<default>1984</default>
 			</parameter>
 			<parameter name="webRtcPort" type="integer">
+				<advanced>true</advanced>
 				<label>WebRTC Port</label>
 				<description>UDP/TCP port for WebRTC data (default 8555). Must be unique per thing if multiple things run WebRTC.</description>
 				<default>8555</default>
 			</parameter>
 			<parameter name="stunServer" type="text">
+				<advanced>true</advanced>
 				<label>STUN Server</label>
 				<description>STUN server for WebRTC NAT traversal in host:port format (default stun.l.google.com:19302).</description>
 				<default>stun.l.google.com:19302</default>
 			</parameter>
 			<parameter name="rtspChannel" type="integer">
+				<advanced>true</advanced>
 				<label>RTSP Channel</label>
 				<description>RTSP channel index on the device (default 1).</description>
 				<default>1</default>
 			</parameter>
 			<parameter name="rtspSubtype" type="integer">
+				<advanced>true</advanced>
 				<label>RTSP Sub-type</label>
 				<description>RTSP sub-type index: 0 = main stream, 1 = sub stream (default 0).</description>
 				<default>0</default>

--- a/bundles/org.openhab.binding.dahuadoor/src/main/resources/OH-INF/thing/vto3211.xml
+++ b/bundles/org.openhab.binding.dahuadoor/src/main/resources/OH-INF/thing/vto3211.xml
@@ -34,6 +34,7 @@
 				<label>Open Door 2</label>
 				<description>Relay control to open door 2</description>
 			</channel>
+			<channel id="webrtc-url" typeId="webrtc-url"/>
 		</channels>
 		<representation-property>macAddress</representation-property>
 
@@ -62,6 +63,42 @@
 				<description>Use HTTPS (port 443) for snapshot and door-open requests. Enable if the device has HTTPS turned on.
 					Disable for plain HTTP (port 80).</description>
 				<default>false</default>
+			</parameter>
+			<parameter name="enableWebRTC" type="boolean">
+				<label>Enable WebRTC</label>
+				<description>Start a local go2rtc instance to bridge the RTSP stream to WebRTC. Requires go2rtcPath to be set.</description>
+				<default>false</default>
+			</parameter>
+			<parameter name="go2rtcPath" type="text">
+				<label>go2rtc Binary Path</label>
+				<description>Absolute path to the go2rtc binary (e.g. /opt/go2rtc). Required when Enable WebRTC is on.</description>
+				<default></default>
+			</parameter>
+			<parameter name="go2rtcApiPort" type="integer">
+				<label>go2rtc API Port</label>
+				<description>HTTP API port for the go2rtc instance (default 1984). Must be unique per thing if multiple things run
+					WebRTC.</description>
+				<default>1984</default>
+			</parameter>
+			<parameter name="webRtcPort" type="integer">
+				<label>WebRTC Port</label>
+				<description>UDP/TCP port for WebRTC data (default 8555). Must be unique per thing if multiple things run WebRTC.</description>
+				<default>8555</default>
+			</parameter>
+			<parameter name="stunServer" type="text">
+				<label>STUN Server</label>
+				<description>STUN server for WebRTC NAT traversal in host:port format (default stun.l.google.com:19302).</description>
+				<default>stun.l.google.com:19302</default>
+			</parameter>
+			<parameter name="rtspChannel" type="integer">
+				<label>RTSP Channel</label>
+				<description>RTSP channel index on the device (default 1).</description>
+				<default>1</default>
+			</parameter>
+			<parameter name="rtspSubtype" type="integer">
+				<label>RTSP Sub-type</label>
+				<description>RTSP sub-type index: 0 = main stream, 1 = sub stream (default 0).</description>
+				<default>0</default>
 			</parameter>
 		</config-description>
 	</thing-type>

--- a/bundles/org.openhab.binding.dahuadoor/src/main/resources/OH-INF/update/instructions.xml
+++ b/bundles/org.openhab.binding.dahuadoor/src/main/resources/OH-INF/update/instructions.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<update:update-descriptions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:update="https://openhab.org/schemas/update-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/update-description/v1.0.0 https://openhab.org/schemas/update-description-1.0.0.xsd">
+
+	<thing-type uid="dahuadoor:vto2202">
+		<instruction-set targetVersion="1">
+			<add-channel id="webrtc-url">
+				<type>dahuadoor:webrtc-url</type>
+			</add-channel>
+		</instruction-set>
+	</thing-type>
+
+	<thing-type uid="dahuadoor:vto3211">
+		<instruction-set targetVersion="1">
+			<add-channel id="webrtc-url">
+				<type>dahuadoor:webrtc-url</type>
+			</add-channel>
+		</instruction-set>
+	</thing-type>
+
+</update:update-descriptions>


### PR DESCRIPTION
This PR series introduces a full intercom client for Dahua VTO devices based on go2rtc/WebRTC.

1st one adds WebRTC go2rtc foundation and handler wiring for Dahua intercom flow. Includes thing config, channels, i18n, and README updates for WebRTC usage.\nNo SIP call control or SDP parser logic included.