### PR TITLE
[ring] Detect dual batteries and report status correctly

### DIFF
--- a/bundles/org.openhab.binding.ring/src/main/java/org/openhab/binding/ring/RingBindingConstants.java
+++ b/bundles/org.openhab.binding.ring/src/main/java/org/openhab/binding/ring/RingBindingConstants.java
@@ -105,8 +105,8 @@ public class RingBindingConstants {
     // battery kinds
     public static final Set<String> BATTERY_KINDS = Stream
             .of(SPOTLIGHT_CAM_BATTERY_KINDS, STICKUP_CAM_KINDS, STICKUP_CAM_BATTERY_KINDS, STICKUP_CAM_GEN3_KINDS,
-                    DOORBELL_KINDS, DOORBELL_2_KINDS, DOORBELL_3_KINDS, DOORBELL_3_PLUS_KINDS, DOORBELL_4_KINDS,
-                    DOORBELL_GEN2_KINDS, DOORBELL_BATTERY_KINDS, PEEPHOLE_CAM_KINDS)
+                    SPOTLIGHT_CAM_PRO_KINDS, DOORBELL_KINDS, DOORBELL_2_KINDS, DOORBELL_3_KINDS, DOORBELL_3_PLUS_KINDS,
+                    DOORBELL_4_KINDS, DOORBELL_GEN2_KINDS, DOORBELL_BATTERY_KINDS, PEEPHOLE_CAM_KINDS)
             .flatMap(Set::stream).collect(Collectors.toUnmodifiableSet());
 
     // light kinds

--- a/bundles/org.openhab.binding.ring/src/main/java/org/openhab/binding/ring/internal/api/RingDeviceTO.java
+++ b/bundles/org.openhab.binding.ring/src/main/java/org/openhab/binding/ring/internal/api/RingDeviceTO.java
@@ -49,4 +49,7 @@ public class RingDeviceTO {
     public String battery = "";
 
     public OwnerTO owner = new OwnerTO();
+
+    @SerializedName("battery_life_2")
+    public String battery2 = "";
 }

--- a/bundles/org.openhab.binding.ring/src/main/java/org/openhab/binding/ring/internal/handler/StickupcamHandler.java
+++ b/bundles/org.openhab.binding.ring/src/main/java/org/openhab/binding/ring/internal/handler/StickupcamHandler.java
@@ -127,15 +127,22 @@ public class StickupcamHandler extends RingDeviceHandler {
 
         RingDeviceTO deviceTO = device.getDeviceStatus();
         if (batterySupport) {
-            if (deviceTO.health.batteryPercentage != lastBattery) {
-                logger.debug("Battery Level: {}", deviceTO.battery);
+            int battery = 0;
+            if (!deviceTO.battery.isEmpty() && !deviceTO.battery2.isEmpty()) {
+                battery = (Integer.parseInt(deviceTO.battery) + Integer.parseInt(deviceTO.battery2)) / 2;
+            } else if (!deviceTO.battery.isEmpty()) {
+                battery = Integer.parseInt(deviceTO.battery);
+            } else if (!deviceTO.battery2.isEmpty()) {
+                battery = Integer.parseInt(deviceTO.battery2);
+            }
+            if (battery != lastBattery) {
+                logger.debug("Battery Level: {}", battery);
                 ChannelUID channelUID = new ChannelUID(thing.getUID(), CHANNEL_STATUS_BATTERY);
-                updateState(channelUID, new DecimalType(deviceTO.health.batteryPercentage));
-                lastBattery = deviceTO.health.batteryPercentage;
+                updateState(channelUID, new DecimalType(battery));
+                lastBattery = battery;
             } else {
-                logger.debug("Battery Level Unchanged for {} - {} vs {}", getThing().getUID().getId(),
-                        deviceTO.health.batteryPercentage, lastBattery);
-
+                logger.debug("Battery Level Unchanged for {} - {} vs {}", getThing().getUID().getId(), battery,
+                        lastBattery);
             }
         }
 


### PR DESCRIPTION
Some models of Ring Cameras support a 2nd battery. The current version only detected battery 1, and if it was flat, reported that status - even if a second battery was installed.

This update reports the 2nd battery correctly, even if slot 1 is empty. If 2x batteries are installed, the binding reports the average of the two batteries.