### PR TITLE
[homeconnect] Update dependencies, fix deprecations and resolve compile warnings

### DIFF
--- a/bundles/org.openhab.binding.homeconnect/pom.xml
+++ b/bundles/org.openhab.binding.homeconnect/pom.xml
@@ -15,7 +15,7 @@
   <name>openHAB Add-ons :: Bundles :: Home Connect Binding</name>
 
   <properties>
-    <bnd.importpackage>android.*;resolution:="optional",com.android.*;resolution:="optional",dalvik.*;resolution:="optional",org.apache.harmony.*;resolution:="optional",org.conscrypt.*;resolution:="optional",sun.*;resolution:="optional",javax.annotation.meta.*;resolution:="optional",com.fasterxml.jackson.*;resolution:="optional",com.sun.jdi.*;resolution:="optional"</bnd.importpackage>
+    <bnd.importpackage>android.*;resolution:="optional",com.android.*;resolution:="optional",dalvik.*;resolution:="optional",org.apache.harmony.*;resolution:="optional",org.conscrypt.*;resolution:="optional",sun.*;resolution:="optional",javax.annotation.meta.*;resolution:="optional",com.fasterxml.jackson.*;resolution:="optional",com.sun.jdi.*;resolution:="optional",com.sun.tools.attach.*;resolution:="optional",jakarta.servlet.*;resolution:="optional",jdk.internal.module.*;resolution:="optional"</bnd.importpackage>
   </properties>
 
   <dependencies>
@@ -24,30 +24,25 @@
     <dependency>
       <groupId>org.thymeleaf</groupId>
       <artifactId>thymeleaf</artifactId>
-      <version>3.0.11.RELEASE</version>
+      <version>3.1.4.RELEASE</version>
       <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.thymeleaf.extras</groupId>
-      <artifactId>thymeleaf-extras-java8time</artifactId>
-      <version>3.0.4.RELEASE</version>
     </dependency>
     <dependency>
       <groupId>ognl</groupId>
       <artifactId>ognl</artifactId>
-      <version>3.1.12</version>
+      <version>3.3.4</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.javassist</groupId>
       <artifactId>javassist</artifactId>
-      <version>3.20.0-GA</version>
+      <version>3.29.0-GA</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.attoparser</groupId>
       <artifactId>attoparser</artifactId>
-      <version>2.0.5.RELEASE</version>
+      <version>2.0.7.RELEASE</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/bundles/org.openhab.binding.homeconnect/src/main/java/org/openhab/binding/homeconnect/internal/HomeConnectBindingConstants.java
+++ b/bundles/org.openhab.binding.homeconnect/src/main/java/org/openhab/binding/homeconnect/internal/HomeConnectBindingConstants.java
@@ -12,6 +12,8 @@
  */
 package org.openhab.binding.homeconnect.internal;
 
+import java.time.ZoneId;
+import java.util.Locale;
 import java.util.Set;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -28,7 +30,10 @@ public class HomeConnectBindingConstants {
 
     public static final String BINDING_ID = "homeconnect";
 
+    // Misc
     public static final String HA_ID = "haId";
+    public static final Locale DEFAULT_LOCALE = Locale.ENGLISH;
+    public static final ZoneId ZONE_ID = ZoneId.systemDefault();
 
     // List of all Thing Type UIDs
     public static final ThingTypeUID THING_TYPE_API_BRIDGE = new ThingTypeUID(BINDING_ID, "api_bridge");

--- a/bundles/org.openhab.binding.homeconnect/src/main/java/org/openhab/binding/homeconnect/internal/client/CircularQueue.java
+++ b/bundles/org.openhab.binding.homeconnect/src/main/java/org/openhab/binding/homeconnect/internal/client/CircularQueue.java
@@ -14,6 +14,7 @@ package org.openhab.binding.homeconnect.internal.client;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Objects;
 import java.util.concurrent.ArrayBlockingQueue;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -34,6 +35,7 @@ public class CircularQueue<E> {
     }
 
     public synchronized void add(E element) {
+        Objects.requireNonNull(element);
         ArrayBlockingQueue<E> myQueue = queue;
         if (myQueue.remainingCapacity() <= 0) {
             myQueue.poll();

--- a/bundles/org.openhab.binding.homeconnect/src/main/java/org/openhab/binding/homeconnect/internal/client/HomeConnectApiClient.java
+++ b/bundles/org.openhab.binding.homeconnect/src/main/java/org/openhab/binding/homeconnect/internal/client/HomeConnectApiClient.java
@@ -951,8 +951,8 @@ public class HomeConnectApiClient {
             trackAndLogApiRequest(haId, request, requestPayload, response, responseBody);
 
             responseBody = responseBody == null ? "" : responseBody;
-            if (code == HttpStatus.CONFLICT_409 && responseBody.toLowerCase().contains("error")
-                    && responseBody.toLowerCase().contains("offline")) {
+            if (code == HttpStatus.CONFLICT_409 && responseBody.toLowerCase(DEFAULT_LOCALE).contains("error")
+                    && responseBody.toLowerCase(DEFAULT_LOCALE).contains("offline")) {
                 throw new ApplianceOfflineException(code, message, responseBody);
             } else {
                 throw new CommunicationException(code, message, responseBody);
@@ -1130,7 +1130,7 @@ public class HomeConnectApiClient {
 
     private void trackApiRequest(HomeConnectRequest homeConnectRequest,
             @Nullable HomeConnectResponse homeConnectResponse) {
-        communicationQueue.add(new ApiRequest(ZonedDateTime.now(), homeConnectRequest, homeConnectResponse));
+        communicationQueue.add(new ApiRequest(ZonedDateTime.now(ZONE_ID), homeConnectRequest, homeConnectResponse));
     }
 
     private HomeConnectRequest map(Request request, @Nullable String requestBody) {

--- a/bundles/org.openhab.binding.homeconnect/src/main/java/org/openhab/binding/homeconnect/internal/client/HomeConnectEventSourceListener.java
+++ b/bundles/org.openhab.binding.homeconnect/src/main/java/org/openhab/binding/homeconnect/internal/client/HomeConnectEventSourceListener.java
@@ -13,6 +13,7 @@
 package org.openhab.binding.homeconnect.internal.client;
 
 import static java.time.LocalDateTime.now;
+import static org.openhab.binding.homeconnect.internal.HomeConnectBindingConstants.ZONE_ID;
 import static org.openhab.binding.homeconnect.internal.client.model.EventType.*;
 
 import java.time.Instant;
@@ -22,7 +23,6 @@ import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.TimeZone;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -86,7 +86,7 @@ public class HomeConnectEventSourceListener {
         String type = inboundEvent.getName();
         String data = inboundEvent.readData();
 
-        lastEventReceived = now();
+        lastEventReceived = now(ZONE_ID);
 
         EventType eventType = valueOfType(type);
         if (eventType != null) {
@@ -162,7 +162,7 @@ public class HomeConnectEventSourceListener {
             logger.trace("Check event source connection ({}). Last event package received at {}.", haId,
                     lastEventReceived);
             if (lastEventReceived != null && ChronoUnit.MINUTES.between(lastEventReceived,
-                    now()) > SSE_MONITOR_BROKEN_CONNECTION_TIMEOUT_MIN) {
+                    now(ZONE_ID)) > SSE_MONITOR_BROKEN_CONNECTION_TIMEOUT_MIN) {
                 logger.warn("Dead event source connection detected ({}).", haId);
 
                 client.unregisterEventListener(eventListener);
@@ -203,9 +203,9 @@ public class HomeConnectEventSourceListener {
                     EventLevel level = getJsonElementAsString(obj, "level").map(EventLevel::valueOfLevel).orElse(null);
                     EventHandling handling = getJsonElementAsString(obj, "handling").map(EventHandling::valueOfHandling)
                             .orElse(null);
-                    ZonedDateTime creation = getJsonElementAsLong(obj, "timestamp").map(timestamp -> ZonedDateTime
-                            .ofInstant(Instant.ofEpochSecond(timestamp), TimeZone.getDefault().toZoneId()))
-                            .orElse(ZonedDateTime.now());
+                    ZonedDateTime creation = getJsonElementAsLong(obj, "timestamp")
+                            .map(timestamp -> ZonedDateTime.ofInstant(Instant.ofEpochSecond(timestamp), ZONE_ID))
+                            .orElse(ZonedDateTime.now(ZONE_ID));
 
                     events.add(new Event(haId, type, key, name, uri, creation, level, handling, value, unit));
                 });

--- a/bundles/org.openhab.binding.homeconnect/src/main/java/org/openhab/binding/homeconnect/internal/client/HttpHelper.java
+++ b/bundles/org.openhab.binding.homeconnect/src/main/java/org/openhab/binding/homeconnect/internal/client/HttpHelper.java
@@ -61,7 +61,6 @@ public class HttpHelper {
     private static final String BEARER = "Bearer ";
     private static final int OAUTH_EXPIRE_BUFFER = 10;
     private static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
-    private static final JsonParser JSON_PARSER = new JsonParser();
     private static final Map<String, Bucket> BUCKET_MAP = new HashMap<>();
     private static final Object AUTHORIZATION_HEADER_MONITOR = new Object();
     private static final Object BUCKET_MONITOR = new Object();
@@ -139,7 +138,7 @@ public class HttpHelper {
     }
 
     public static JsonElement parseString(String json) {
-        return JSON_PARSER.parse(json);
+        return JsonParser.parseString(json);
     }
 
     private static Bucket getBucket(String clientId) {

--- a/bundles/org.openhab.binding.homeconnect/src/main/java/org/openhab/binding/homeconnect/internal/client/model/Event.java
+++ b/bundles/org.openhab.binding.homeconnect/src/main/java/org/openhab/binding/homeconnect/internal/client/model/Event.java
@@ -12,6 +12,7 @@
  */
 package org.openhab.binding.homeconnect.internal.client.model;
 
+import static org.openhab.binding.homeconnect.internal.HomeConnectBindingConstants.ZONE_ID;
 import static org.openhab.binding.homeconnect.internal.client.model.EventType.EVENT;
 import static org.openhab.binding.homeconnect.internal.client.model.EventType.NOTIFY;
 import static org.openhab.binding.homeconnect.internal.client.model.EventType.STATUS;
@@ -56,7 +57,7 @@ public class Event {
         this.key = null;
         this.name = null;
         this.uri = null;
-        this.creation = ZonedDateTime.now();
+        this.creation = ZonedDateTime.now(ZONE_ID);
         this.level = null;
         this.handling = null;
         this.value = null;

--- a/bundles/org.openhab.binding.homeconnect/src/main/java/org/openhab/binding/homeconnect/internal/client/model/PowerStateAccess.java
+++ b/bundles/org.openhab.binding.homeconnect/src/main/java/org/openhab/binding/homeconnect/internal/client/model/PowerStateAccess.java
@@ -12,6 +12,8 @@
  */
 package org.openhab.binding.homeconnect.internal.client.model;
 
+import static org.openhab.binding.homeconnect.internal.HomeConnectBindingConstants.DEFAULT_LOCALE;
+
 import org.eclipse.jdt.annotation.NonNullByDefault;
 
 /**
@@ -28,14 +30,12 @@ public enum PowerStateAccess {
     READ_WRITE;
 
     public static PowerStateAccess fromString(String access) {
-        switch (access.toLowerCase()) {
-            case "read":
-                return READ_ONLY;
-            case "readwrite":
-                return READ_WRITE;
-            default:
+        return switch (access.toLowerCase(DEFAULT_LOCALE)) {
+            case "read" -> READ_ONLY;
+            case "readwrite" -> READ_WRITE;
+            default ->
                 // Default to READ_ONLY if the access type is not recognized
-                return READ_ONLY;
-        }
+                READ_ONLY;
+        };
     }
 }

--- a/bundles/org.openhab.binding.homeconnect/src/main/java/org/openhab/binding/homeconnect/internal/discovery/HomeConnectDiscoveryService.java
+++ b/bundles/org.openhab.binding.homeconnect/src/main/java/org/openhab/binding/homeconnect/internal/discovery/HomeConnectDiscoveryService.java
@@ -72,7 +72,8 @@ public class HomeConnectDiscoveryService extends AbstractThingHandlerDiscoverySe
                 ThingTypeUID thingTypeUID = getThingTypeUID(appliance);
 
                 if (thingTypeUID != null) {
-                    logger.debug("Found {} ({}).", appliance.getHaId(), appliance.getType().toUpperCase());
+                    logger.debug("Found {} ({}).", appliance.getHaId(),
+                            appliance.getType().toUpperCase(DEFAULT_LOCALE));
 
                     Map<String, Object> properties = Map.of(HA_ID, appliance.getHaId());
                     String name = appliance.getBrand() + " " + appliance.getName() + " (" + appliance.getHaId() + ")";

--- a/bundles/org.openhab.binding.homeconnect/src/main/java/org/openhab/binding/homeconnect/internal/handler/AbstractHomeConnectThingHandler.java
+++ b/bundles/org.openhab.binding.homeconnect/src/main/java/org/openhab/binding/homeconnect/internal/handler/AbstractHomeConnectThingHandler.java
@@ -80,6 +80,7 @@ import org.openhab.core.types.RefreshType;
 import org.openhab.core.types.State;
 import org.openhab.core.types.StateOption;
 import org.openhab.core.types.UnDefType;
+import org.openhab.core.util.ColorUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -718,9 +719,10 @@ public abstract class AbstractHomeConnectThingHandler extends BaseThingHandler i
      * @return color code e.g. #001122
      */
     protected String mapColor(HSBType color) {
-        String redValue = String.format("%02X", (int) (color.getRed().floatValue() * 2.55));
-        String greenValue = String.format("%02X", (int) (color.getGreen().floatValue() * 2.55));
-        String blueValue = String.format("%02X", (int) (color.getBlue().floatValue() * 2.55));
+        int[] rgb = ColorUtil.hsbToRgb(color);
+        String redValue = String.format("%02X", rgb[0]);
+        String greenValue = String.format("%02X", rgb[1]);
+        String blueValue = String.format("%02X", rgb[2]);
         return "#" + redValue + greenValue + blueValue;
     }
 
@@ -1214,7 +1216,7 @@ public abstract class AbstractHomeConnectThingHandler extends BaseThingHandler i
     protected void handleTemperatureCommand(final ChannelUID channelUID, final Command command,
             final HomeConnectApiClient apiClient)
             throws CommunicationException, AuthorizationException, ApplianceOfflineException {
-        if (command instanceof QuantityType quantityCommand) {
+        if (command instanceof QuantityType<?> quantityCommand) {
             String value;
             String unit;
 
@@ -1225,8 +1227,7 @@ public abstract class AbstractHomeConnectThingHandler extends BaseThingHandler i
                     value = String.valueOf(quantityCommand.intValue());
                 } else {
                     logger.debug("Converting target temperature from {}{} to °C value. thing={}, haId={}",
-                            quantityCommand.intValue(), quantityCommand.getUnit().toString(), getThingLabel(),
-                            getThingHaId());
+                            quantityCommand.intValue(), quantityCommand.getUnit(), getThingLabel(), getThingHaId());
                     unit = "°C";
                     var celsius = quantityCommand.toUnit(SIUnits.CELSIUS);
                     if (celsius == null) {

--- a/bundles/org.openhab.binding.homeconnect/src/main/java/org/openhab/binding/homeconnect/internal/handler/HomeConnectBridgeHandler.java
+++ b/bundles/org.openhab.binding.homeconnect/src/main/java/org/openhab/binding/homeconnect/internal/handler/HomeConnectBridgeHandler.java
@@ -145,7 +145,8 @@ public class HomeConnectBridgeHandler extends BaseBridgeHandler {
                 }
             } catch (OAuthException | IOException | OAuthResponseException | CommunicationException
                     | AuthorizationException e) {
-                ZonedDateTime nextReinitializeDateTime = ZonedDateTime.now().plusSeconds(REINITIALIZATION_DELAY_SEC);
+                ZonedDateTime nextReinitializeDateTime = ZonedDateTime.now(ZONE_ID)
+                        .plusSeconds(REINITIALIZATION_DELAY_SEC);
 
                 String offlineMessage = String.format(
                         "Home Connect service is not reachable or a problem occurred! Retrying at %s (%s). bridge=%s",

--- a/bundles/org.openhab.binding.homeconnect/src/main/java/org/openhab/binding/homeconnect/internal/servlet/HomeConnectServlet.java
+++ b/bundles/org.openhab.binding.homeconnect/src/main/java/org/openhab/binding/homeconnect/internal/servlet/HomeConnectServlet.java
@@ -60,9 +60,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.thymeleaf.TemplateEngine;
 import org.thymeleaf.context.WebContext;
-import org.thymeleaf.extras.java8time.dialect.Java8TimeDialect;
 import org.thymeleaf.templatemode.TemplateMode;
-import org.thymeleaf.templateresolver.ServletContextTemplateResolver;
+import org.thymeleaf.templateresolver.WebApplicationTemplateResolver;
+import org.thymeleaf.web.IWebExchange;
+import org.thymeleaf.web.servlet.JavaxServletWebApplication;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -117,11 +118,12 @@ public class HomeConnectServlet extends HttpServlet {
     private final Logger logger = LoggerFactory.getLogger(HomeConnectServlet.class);
     private final HttpService httpService;
     private final TemplateEngine templateEngine;
+    private final JavaxServletWebApplication application;
     private final Set<HomeConnectBridgeHandler> bridgeHandlers;
     private final Gson gson;
 
     @Activate
-    public HomeConnectServlet(@Reference HttpService httpService) {
+    public HomeConnectServlet(@Reference HttpService httpService) throws ServletException, NamespaceException {
         bridgeHandlers = new CopyOnWriteArraySet<>();
         gson = new GsonBuilder().registerTypeAdapter(ZonedDateTime.class, (JsonSerializer<ZonedDateTime>) (src,
                 typeOfSrc, context) -> new JsonPrimitive(src.format(DateTimeFormatter.ISO_DATE_TIME))).create();
@@ -133,17 +135,18 @@ public class HomeConnectServlet extends HttpServlet {
             httpService.registerServlet(SERVLET_PATH, this, null, httpService.createDefaultHttpContext());
             httpService.registerResources(ASSETS_PATH, "assets", null);
         } catch (ServletException | NamespaceException e) {
-            logger.warn("Could not register Home Connect servlet! ({})", SERVLET_PATH, e);
+            logger.warn("Could not register Home Connect servlet! ({})", SERVLET_PATH);
+            throw e;
         }
 
         // setup template engine
-        ServletContextTemplateResolver templateResolver = new ServletContextTemplateResolver(getServletContext());
+        application = JavaxServletWebApplication.buildApplication(getServletContext());
+        WebApplicationTemplateResolver templateResolver = new WebApplicationTemplateResolver(application);
         templateResolver.setTemplateMode(TemplateMode.HTML);
         templateResolver.setPrefix("/templates/");
         templateResolver.setSuffix(".html");
         templateResolver.setCacheable(true);
         templateEngine = new TemplateEngine();
-        templateEngine.addDialect(new Java8TimeDialect());
         templateEngine.setTemplateResolver(templateResolver);
     }
 
@@ -252,7 +255,8 @@ public class HomeConnectServlet extends HttpServlet {
     }
 
     private void getAppliancesPage(HttpServletRequest request, HttpServletResponse response) throws IOException {
-        WebContext context = new WebContext(request, response, request.getServletContext());
+        IWebExchange exchange = application.buildExchange(request, response);
+        WebContext context = new WebContext(exchange);
         context.setVariable("bridgeHandlers", bridgeHandlers);
         templateEngine.process("appliances", context, response.getWriter());
     }
@@ -376,7 +380,8 @@ public class HomeConnectServlet extends HttpServlet {
     }
 
     private void getBridgesPage(HttpServletRequest request, HttpServletResponse response) throws IOException {
-        WebContext context = new WebContext(request, response, request.getServletContext());
+        IWebExchange exchange = application.buildExchange(request, response);
+        WebContext context = new WebContext(exchange);
         context.setVariable("bridgeHandlers", bridgeHandlers);
         templateEngine.process("bridges", context, response.getWriter());
     }
@@ -414,7 +419,8 @@ public class HomeConnectServlet extends HttpServlet {
                 }
                 bridgeHandler.reinitialize();
 
-                WebContext context = new WebContext(request, response, request.getServletContext());
+                IWebExchange exchange = application.buildExchange(request, response);
+                WebContext context = new WebContext(exchange);
                 context.setVariable("action",
                         bridgeHandler.getThing().getUID().getAsString() + ACTION_CLEAR_CREDENTIALS);
                 context.setVariable("bridgeHandlers", bridgeHandlers);
@@ -430,7 +436,8 @@ public class HomeConnectServlet extends HttpServlet {
         bridgeHandlers.forEach(homeConnectBridgeHandler -> requests
                 .addAll(homeConnectBridgeHandler.getApiClient().getLatestApiRequests()));
 
-        WebContext context = new WebContext(request, response, request.getServletContext());
+        IWebExchange exchange = application.buildExchange(request, response);
+        WebContext context = new WebContext(exchange);
         context.setVariable("bridgeHandlers", bridgeHandlers);
         context.setVariable("requests", gson.toJson(requests));
         templateEngine.process("log-requests", context, response.getWriter());
@@ -440,7 +447,7 @@ public class HomeConnectServlet extends HttpServlet {
         Optional<HomeConnectBridgeHandler> bridgeHandler = getBridgeHandler(bridgeId);
         if (bridgeHandler.isPresent()) {
             response.setContentType(MediaType.APPLICATION_JSON);
-            String fileName = String.format("%s__%s__requests.json", now().format(FILE_EXPORT_DTF),
+            String fileName = String.format("%s__%s__requests.json", now(ZONE_ID).format(FILE_EXPORT_DTF),
                     bridgeId.replaceAll("[^a-zA-Z0-9]", "_"));
             response.setHeader("Content-disposition", "attachment; filename=" + fileName);
 
@@ -464,7 +471,8 @@ public class HomeConnectServlet extends HttpServlet {
     }
 
     private void getEventLogPage(HttpServletRequest request, HttpServletResponse response) throws IOException {
-        WebContext context = new WebContext(request, response, request.getServletContext());
+        IWebExchange exchange = application.buildExchange(request, response);
+        WebContext context = new WebContext(exchange);
         context.setVariable("bridgeHandlers", bridgeHandlers);
         templateEngine.process("log-events", context, response.getWriter());
     }
@@ -473,7 +481,7 @@ public class HomeConnectServlet extends HttpServlet {
         Optional<HomeConnectBridgeHandler> bridgeHandler = getBridgeHandler(bridgeId);
         if (bridgeHandler.isPresent()) {
             response.setContentType(MediaType.APPLICATION_JSON);
-            String fileName = String.format("%s__%s__events.json", now().format(FILE_EXPORT_DTF),
+            String fileName = String.format("%s__%s__events.json", now(ZONE_ID).format(FILE_EXPORT_DTF),
                     bridgeId.replaceAll("[^a-zA-Z0-9]", "_"));
             response.setHeader("Content-disposition", "attachment; filename=" + fileName);
 
@@ -495,8 +503,9 @@ public class HomeConnectServlet extends HttpServlet {
         Optional<HomeConnectBridgeHandler> bridgeHandler = getBridgeHandler(state);
         if (bridgeHandler.isPresent()) {
             try {
-                String redirectUri = bridgeHandler.get().getConfiguration().isSimulator()
-                        ? request.getRequestURL().toString()
+                StringBuffer requestURL = request.getRequestURL();
+                String redirectUri = bridgeHandler.get().getConfiguration().isSimulator() && requestURL != null
+                        ? requestURL.toString()
                         : null;
                 AccessTokenResponse accessTokenResponse = bridgeHandler.get().getOAuthClientService()
                         .getAccessTokenResponseByAuthorizationCode(code, redirectUri);
@@ -506,7 +515,8 @@ public class HomeConnectServlet extends HttpServlet {
                 // inform bridge
                 bridgeHandler.get().reinitialize();
 
-                WebContext context = new WebContext(request, response, request.getServletContext());
+                IWebExchange exchange = application.buildExchange(request, response);
+                WebContext context = new WebContext(exchange);
                 context.setVariable("action", bridgeHandler.get().getThing().getUID().getAsString() + ACTION_AUTHORIZE);
                 context.setVariable("bridgeHandlers", bridgeHandlers);
                 templateEngine.process("bridges", context, response.getWriter());

--- a/bundles/org.openhab.binding.homeconnect/src/main/java/org/openhab/binding/homeconnect/internal/type/HomeConnectDynamicStateDescriptionProvider.java
+++ b/bundles/org.openhab.binding.homeconnect/src/main/java/org/openhab/binding/homeconnect/internal/type/HomeConnectDynamicStateDescriptionProvider.java
@@ -27,7 +27,6 @@ import org.openhab.core.thing.binding.BaseDynamicStateDescriptionProvider;
 import org.openhab.core.thing.events.ThingEventFactory;
 import org.openhab.core.thing.i18n.ChannelTypeI18nLocalizationService;
 import org.openhab.core.thing.link.ItemChannelLinkRegistry;
-import org.openhab.core.thing.type.ChannelType;
 import org.openhab.core.thing.type.DynamicStateDescriptionProvider;
 import org.openhab.core.types.StateDescription;
 import org.openhab.core.types.StateDescriptionFragmentBuilder;
@@ -57,8 +56,8 @@ public class HomeConnectDynamicStateDescriptionProvider extends BaseDynamicState
     }
 
     /**
-     * For a given {@link ChannelUID}, set a readyOnly flag that should be used for the channel, instead of the one
-     * defined statically in the {@link ChannelType}.
+     * For a given {@link ChannelUID}, set a readOnly flag that should be used for the channel, instead of the one
+     * defined statically in the {@link org.openhab.core.thing.type.ChannelType}.
      *
      * @param channelUID the {@link ChannelUID} of the channel
      * @param readOnly readOnly flag
@@ -67,8 +66,9 @@ public class HomeConnectDynamicStateDescriptionProvider extends BaseDynamicState
         Boolean oldReadOnly = channelReadOnlyMap.get(channelUID);
         if (oldReadOnly == null || oldReadOnly != readOnly) {
             channelReadOnlyMap.put(channelUID, readOnly);
+            ItemChannelLinkRegistry registry = itemChannelLinkRegistry;
             postEvent(ThingEventFactory.createChannelDescriptionChangedEvent(channelUID,
-                    itemChannelLinkRegistry != null ? itemChannelLinkRegistry.getLinkedItemNames(channelUID) : Set.of(),
+                    registry != null ? registry.getLinkedItemNames(channelUID) : Set.of(),
                     StateDescriptionFragmentBuilder.create().withReadOnly(readOnly).build(), null));
         }
     }

--- a/bundles/org.openhab.binding.homeconnect/src/main/resources/templates/appliances.html
+++ b/bundles/org.openhab.binding.homeconnect/src/main/resources/templates/appliances.html
@@ -2,14 +2,14 @@
 
 <html lang="en" xmlns:th="http://www.thymeleaf.org">
 
-<head th:replace="base :: head"></head>
+<head th:replace="~{base :: head}"></head>
 
 <body>
-<nav th:replace="base :: topNav"></nav>
+<nav th:replace="~{base :: topNav}"></nav>
 
 <div class="container-fluid">
     <div class="row">
-        <nav th:replace="base :: sidebarMenu (current='appliances')"></nav>
+        <nav th:replace="~{base :: sidebarMenu (current='appliances')}"></nav>
 
         <main role="main" class="col-md-9 ml-sm-auto col-lg-10 px-md-4">
             <div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 border-bottom">
@@ -202,7 +202,7 @@
 
 </div>
 
-<!--/*/ <th:block th:include="base :: js">
+<!--/*/ <th:block th:insert="~{base :: js}">
     </th:block> /*/-->
 
 </body>

--- a/bundles/org.openhab.binding.homeconnect/src/main/resources/templates/bridges.html
+++ b/bundles/org.openhab.binding.homeconnect/src/main/resources/templates/bridges.html
@@ -2,14 +2,14 @@
 
 <html lang="en" xmlns:th="http://www.thymeleaf.org">
 
-<head th:replace="base :: head"></head>
+<head th:replace="~{base :: head}"></head>
 
 <body>
-<nav th:replace="base :: topNav"></nav>
+<nav th:replace="~{base :: topNav}"></nav>
 
 <div class="container-fluid">
     <div class="row">
-        <nav th:replace="base :: sidebarMenu (current='bridges')"></nav>
+        <nav th:replace="~{base :: sidebarMenu (current='bridges')}"></nav>
 
         <main role="main" class="col-md-9 ml-sm-auto col-lg-10 px-md-4">
             <div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 border-bottom">
@@ -89,7 +89,7 @@
     </div>
 </div>
 
-<!--/*/ <th:block th:include="base :: js">
+<!--/*/ <th:block th:insert="~{base :: js}">
     </th:block> /*/-->
 
 </body>

--- a/bundles/org.openhab.binding.homeconnect/src/main/resources/templates/log-events.html
+++ b/bundles/org.openhab.binding.homeconnect/src/main/resources/templates/log-events.html
@@ -2,14 +2,14 @@
 
 <html lang="en" xmlns:th="http://www.thymeleaf.org">
 
-<head th:replace="base :: head"></head>
+<head th:replace="~{base :: head}"></head>
 
 <body>
-<nav th:replace="base :: topNav"></nav>
+<nav th:replace="~{base :: topNav}"></nav>
 
 <div class="container-fluid">
     <div class="row">
-        <nav th:replace="base :: sidebarMenu (current='log-events')"></nav>
+        <nav th:replace="~{base :: sidebarMenu (current='log-events')}"></nav>
 
         <main role="main" class="col-md-9 ml-sm-auto col-lg-10 px-md-4">
             <div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 border-bottom">
@@ -60,7 +60,7 @@
     </div>
 </div>
 
-<!--/*/ <th:block th:include="base :: js">
+<!--/*/ <th:block th:insert="~{base :: js}">
     </th:block> /*/-->
 
 </body>

--- a/bundles/org.openhab.binding.homeconnect/src/main/resources/templates/log-requests.html
+++ b/bundles/org.openhab.binding.homeconnect/src/main/resources/templates/log-requests.html
@@ -2,14 +2,14 @@
 
 <html lang="en" xmlns:th="http://www.thymeleaf.org">
 
-<head th:replace="base :: head"></head>
+<head th:replace="~{base :: head}"></head>
 
 <body>
-<nav th:replace="base :: topNav"></nav>
+<nav th:replace="~{base :: topNav}"></nav>
 
 <div class="container-fluid">
     <div class="row">
-        <nav th:replace="base :: sidebarMenu (current='log-requests')"></nav>
+        <nav th:replace="~{base :: sidebarMenu (current='log-requests')}"></nav>
 
         <main role="main" class="col-md-9 ml-sm-auto col-lg-10 px-md-4">
             <div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 border-bottom">
@@ -91,7 +91,7 @@
 
 </div>
 
-<!--/*/ <th:block th:include="base :: js">
+<!--/*/ <th:block th:insert="~{base :: js}">
     </th:block> /*/-->
 
 </body>


### PR DESCRIPTION
This pull request migrates the Home Connect binding to Thymeleaf 3.1 and addresses several technical debts and static analysis warnings.

**Classification:** Improvement / Technical Maintenance

**Motivation and Goal:**
The primary goal was to update the Thymeleaf dependency to version 3.1.4.RELEASE. Due to breaking changes in Thymeleaf's web abstraction layer (transition to IWebExchange), the internal configuration servlet required a migration.

**Key Changes:**
   - Thymeleaf 3.1 Migration: Updated `pom.xml ` and migrated `HomeConnectServlet` to use the new `WebApplicationTemplateResolver` and `JavaxServletWebApplication` APIs.
   - Dependency Updates: Updated GSON, OGNL, and Javassist to compatible versions.
   - Template Improvements: Fixed all Thymeleaf deprecation warnings by updating fragment expressions to the complete syntax `~{...}` and replacing `th:include` with `th:insert`.
   - Static Analysis & Bugfixes:
       - Resolved GSON `JsonParser` deprecation warnings.
       - Fixed potential NullPointerExceptions in `HomeConnectServlet` and `HomeConnectDynamicStateDescriptionProvider`.
       - Resolved null type safety warnings in `CircularQueue`.
       - Added necessary OSGi optional imports to `pom.xml` to ensure bundle resolution in Karaf.
       - Removed unused imports.

**Testing:**
   - The bundle was built locally using ./mvnw clean install -pl bundles/org.openhab.binding.homeconnect.
   - Static code analysis (SAT) was performed, and the mentioned warnings were verified as resolved.
   - Karaf feature verification (karaf-feature-verification) succeeded.
   - The configuration servlet templates were checked for correct rendering.