### PR TITLE
[GHA] Add new workflows resolver and maven wrapper

### DIFF
--- a/.github/workflows/resolver.yml
+++ b/.github/workflows/resolver.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Build and resolve dependencies
         id: build
-        # call mvnw directly to avoid filtering of the log by the wrapper,
+        # call mvnw directly instead of the repo's log-filtering wrapper script,
         # use more cores, safe to do so as we skip tests (which might depend on load)
         run: './mvnw verify -B -T 2.5C -U -DskipChecks -DskipTests -DwithResolver'
         env:

--- a/.github/workflows/resolver.yml
+++ b/.github/workflows/resolver.yml
@@ -1,0 +1,62 @@
+name: Resolve itest dependencies
+
+on:
+  schedule:
+    - cron: '0 19 * * *'
+  workflow_dispatch:
+
+jobs:
+  resolve:
+    name: Resolve itest dependencies
+    runs-on: 'ubuntu-24.04'
+    permissions:
+      contents: write
+      pull-requests: write
+    # typical duration is ~15min, set twice the amount as limit (default is 6h)
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Java 21
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+
+      - name: Set up Cache
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.m2/repository
+            !~/.m2/repository/org/openhab
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
+      - name: Build and resolve dependencies
+        id: build
+        # call mvnw directly to avoid filtering of the log by the wrapper,
+        # use more cores, safe to do so as we skip tests (which might depend on load)
+        run: './mvnw verify -B -T 2.5C -U -DskipChecks -DskipTests -DwithResolver'
+        env:
+          MAVEN_OPTS: >-
+            -Xmx8g
+            -Dmaven.wagon.http.retryHandler.count=5
+            -Dmaven.wagon.httpconnectionManager.ttlSeconds=25
+            -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+
+      - name: Show Resolver Status
+        run: |
+          git branch -v
+          git status
+          git diff
+
+      - name: Open PR if changed
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # 8.1.1
+        with:
+          commit-message: "Resolve itest dependencies"
+          title: "Resolve itest dependencies"
+          branch: "gha/resolver/${{ github.ref_name }}"
+          delete-branch: true
+          # labels: infrastructure

--- a/.github/workflows/update-maven.yml
+++ b/.github/workflows/update-maven.yml
@@ -1,0 +1,67 @@
+name: Update Maven Wrapper
+
+on:
+  schedule:
+    - cron: '0 19 * * 5'
+  workflow_dispatch:
+
+jobs:
+  update:
+    permissions:
+      contents: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-java@v5
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Get latest Maven version
+        # This fetches latest Maven release from maven.org - not the download page; it might be delayed a few days after releases.
+        # Note that the "gav" at the end of the URL is necessary to retrieve more than one version. jq will filter out rc versions.
+        id: maven
+        run: |
+          LATEST=$(curl -s "https://repo1.maven.org/maven2/org/apache/maven/apache-maven/maven-metadata.xml" \
+            | grep -oP '<version>\K[^<]+' \
+            | grep -viE 'rc|alpha|beta|snapshot|milestone' \
+            | tail -1)
+          if [[ -z "$LATEST" || ! "$LATEST" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Error: failed to determine a valid Maven version (got: '${LATEST}')" >&2
+            exit 1
+          fi
+          echo "version=$LATEST" >> $GITHUB_OUTPUT
+
+      - name: Update wrapper
+        # Update Maven wrapper scripts AND maven-wrapper.properties.
+        # Note that this removes the SHA from properties file.
+        env:
+          VERSION: ${{ steps.maven.outputs.version }}
+        run: ./mvnw wrapper:wrapper -Dmaven="${VERSION}"
+
+      - name: Patch SHA512 into wrapper properties
+        # Add the SHA to properties file.
+        # We might need the -L for curl, as after a new release all old SHA files will move to archive folder.
+        env:
+          VERSION: ${{ steps.maven.outputs.version }}
+        run: |
+          MAJOR=$(echo "$VERSION" | cut -d. -f1)
+          SHA=$(curl -sL "https://downloads.apache.org/maven/maven-${MAJOR}/${VERSION}/binaries/apache-maven-${VERSION}-bin.zip.sha512")
+          if [[ ! "$SHA" =~ ^[0-9a-f]{128}$ ]]; then
+            echo "Error: invalid SHA-512 checksum downloaded for Maven ${VERSION}" >&2
+            exit 1
+          fi
+          PROPS=".mvn/wrapper/maven-wrapper.properties"
+          sed -i '/^distributionSha512Sum=/d' "$PROPS"
+          echo "distributionSha512Sum=${SHA}" >> "$PROPS"
+
+      - name: Open PR if changed
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # 8.1.1
+        with:
+          commit-message: "Update maven wrapper to ${{ steps.maven.outputs.version }}"
+          title: "Update Maven Wrapper to ${{ steps.maven.outputs.version }}"
+          branch: gha/update-maven-wrapper
+          delete-branch: true
+          labels: infrastructure


### PR DESCRIPTION
This is a carry-over from core.
It needs an adaptation of the GH repo settings to allow action `peter-evans/create-pull-request` (and maybe in addition the permission of workflows to create PRs - let's see...)

* Add workflow to resolve itest dependencies

  Automate the process of building with option -DwithResolver and possibly opening a PR. This might not always be intended as the resolver does not do minimalistic changes, but removes older dependency versions and adds new ones at the end of the bndrun file. But it mitigates the problem that itests fail silently due to missing dependencies (which is still the case with bndtools 7.2.1).

This workflow will resolve the broken iTests after bc upgrade:
See my repo
https://github.com/holgerfriedrich/openhab-addons/pull/82


* Add workflow to upgrade Maven Wrapper

  This GHA workflow checks for new Maven Warper scripts and upgrades Maven to latest GA release (currently 3.x). It runs once a week and creates a PR for possible changes.

Once the workflow is triggered (either by cron or manually from the actions tab), it will create a new PR:
<img width="450" height="82" alt="grafik" src="https://github.com/user-attachments/assets/e428c524-bc45-4b91-a822-28dc2dfed695" />


<!--
Thanks for contributing to the openHAB project!
Please describe the goal and effect of your PR here.
Pay attention to the below notes and to *the guidelines* for this repository.
Feel free to delete any comment sections in the template (starting with "<!--").

ATTENTION: Don't use "git merge" when working with your pull request branch!
This can clutter your Git history and make your PR unusable.
Use "git rebase" instead. See this forum post for further details:
https://community.openhab.org/t/rebase-your-code-or-how-to-fix-your-git-history-before-requesting-a-pull/129358

All PRs should be created using the "main" branch as base.
Important bugfixes are cherry-picked by maintainers to the patch release branch after a PR has been merged.

Add one or more appropriate labels to make your PR show up in the release notes.
E.g. enhancement, bug, documentation, new binding
This can only be done by yourself if you already contributed to this repo.

If your PR's code is not backward compatible with previous releases (which
should be avoided), add a message to the release notes by filing another PR:
https://github.com/openhab/openhab-distro/blob/main/distributions/openhab/src/main/resources/bin/update.lst

# Title

Provide a short summary in the *Title* above. It will show up in the release notes.
For example:
- [homematic] Improve communication with weak signal devices
- [timemachine][WIP] Initial contribution

# Description

Please give a few sentences describing the overall goals of the pull request.
Give enough details to make the improvement and changes of the PR understandable
to both developers and tech-savy users.

Please keep the following in mind:
- What is the classification of the PR, e.g. Bugfix, Improvement, Novel Addition, ... ?
- Did you describe the PRs motivation and goal?
- Did you provide a link to any prior discussion, e.g. an issue or community forum thread?
- Did you describe new features for the end user?
- Did you describe any noteworthy changes in usage for the end user?
- Was the documentation updated accordingly, e.g. the add-on README?
- Does your contribution follow the coding guidelines:
  https://www.openhab.org/docs/developer/guidelines.html
- Did you check for any (relevant) issues from the static code analysis:
  https://www.openhab.org/docs/developer/bindings/#include-the-binding-in-the-build
- Did you sign-off your work:
  https://www.openhab.org/docs/developer/contributing.html#sign-your-work

# Testing

Your pull request will automatically be built and available under the following folder:
https://openhab.jfrog.io/ui/native/libs-pullrequest-local/org/openhab/addons/bundles/

It is a good practice to add a URL to your built JAR in this pull request description,
so it is easier for the community to test your Add-on.
If your pull request contains a new binding, it will likely take some time
before it is reviewed and processed by maintainers.
That said, consider submitting your Add-on in the Marketplace:
https://community.openhab.org/c/marketplace/69

Don't forget to submit a thread about your Add-on in the openHAB community:
https://community.openhab.org/c/add-ons 
-->
