### PR TITLE
[ring] Fix battery detection

### DIFF
--- a/bundles/org.openhab.binding.ring/src/main/java/org/openhab/binding/ring/RingBindingConstants.java
+++ b/bundles/org.openhab.binding.ring/src/main/java/org/openhab/binding/ring/RingBindingConstants.java
@@ -91,12 +91,11 @@ public class RingBindingConstants {
     public static final Set<String> INDOOR_CAM_KINDS = Set.of("stickup_cam_mini");
     public static final Set<String> INDOOR_CAM_GEN2_KINDS = Set.of("stickup_cam_mini_v2");
     public static final Set<String> INDOOR_CAM_PTZ_KINDS = Set.of("stickup_cam_mini_ptz_v1");
-    public static final Set<String> SPOTLIGHT_CAM_BATTERY_KINDS = Set.of("stickup_cam_v4");
+    public static final Set<String> SPOTLIGHT_CAM_BATTERY_KINDS = Set.of("stickup_cam_v4", "stickup_cam_lunar");
     public static final Set<String> SPOTLIGHT_CAM_WIRED_KINDS = Set.of("hp_cam_v2", "spotlightw_v2");
     public static final Set<String> SPOTLIGHT_CAM_PLUS_KINDS = Set.of("cocoa_spotlight");
     public static final Set<String> SPOTLIGHT_CAM_PRO_KINDS = Set.of("stickup_cam_longfin");
     public static final Set<String> STICKUP_CAM_KINDS = Set.of("stickup_cam", "stickup_cam_v3");
-    public static final Set<String> STICKUP_CAM_BATTERY_KINDS = Set.of("stickup_cam_lunar");
     public static final Set<String> STICKUP_CAM_ELITE_KINDS = Set.of("stickup_cam_elite", "stickup_cam_wired");
     public static final Set<String> STICKUP_CAM_GEN3_KINDS = Set.of("cocoa_camera");
     public static final Set<String> BEAM_KINDS = Set.of("beams_ct200_transformer");
@@ -105,9 +104,9 @@ public class RingBindingConstants {
 
     // battery kinds
     public static final Set<String> BATTERY_KINDS = Stream
-            .of(SPOTLIGHT_CAM_BATTERY_KINDS, STICKUP_CAM_KINDS, STICKUP_CAM_BATTERY_KINDS, STICKUP_CAM_GEN3_KINDS,
-                    SPOTLIGHT_CAM_PRO_KINDS, DOORBELL_KINDS, DOORBELL_2_KINDS, DOORBELL_3_KINDS, DOORBELL_3_PLUS_KINDS,
-                    DOORBELL_4_KINDS, DOORBELL_GEN2_KINDS, DOORBELL_BATTERY_KINDS, PEEPHOLE_CAM_KINDS)
+            .of(SPOTLIGHT_CAM_BATTERY_KINDS, STICKUP_CAM_KINDS, STICKUP_CAM_GEN3_KINDS, SPOTLIGHT_CAM_PRO_KINDS,
+                    DOORBELL_KINDS, DOORBELL_2_KINDS, DOORBELL_3_KINDS, DOORBELL_3_PLUS_KINDS, DOORBELL_4_KINDS,
+                    DOORBELL_GEN2_KINDS, DOORBELL_BATTERY_KINDS, PEEPHOLE_CAM_KINDS)
             .flatMap(Set::stream).collect(Collectors.toUnmodifiableSet());
 
     // light kinds
@@ -120,16 +119,16 @@ public class RingBindingConstants {
     public static final Set<String> SIREN_KINDS = Stream
             .of(FLOODLIGHT_CAM_KINDS, FLOODLIGHT_CAM_PRO_KINDS, FLOODLIGHT_CAM_PLUS_KINDS, INDOOR_CAM_KINDS,
                     INDOOR_CAM_GEN2_KINDS, INDOOR_CAM_PTZ_KINDS, SPOTLIGHT_CAM_BATTERY_KINDS, SPOTLIGHT_CAM_WIRED_KINDS,
-                    SPOTLIGHT_CAM_PLUS_KINDS, SPOTLIGHT_CAM_PRO_KINDS, STICKUP_CAM_BATTERY_KINDS,
-                    STICKUP_CAM_ELITE_KINDS, STICKUP_CAM_GEN3_KINDS)
+                    SPOTLIGHT_CAM_PLUS_KINDS, SPOTLIGHT_CAM_PRO_KINDS, STICKUP_CAM_ELITE_KINDS, STICKUP_CAM_GEN3_KINDS)
             .flatMap(Set::stream).collect(Collectors.toUnmodifiableSet());
 
     // motion detection kinds
-    public static final Set<String> MOTION_DETECTION_KINDS = Stream.of(FLOODLIGHT_CAM_KINDS, FLOODLIGHT_CAM_PRO_KINDS,
-            FLOODLIGHT_CAM_PLUS_KINDS, INDOOR_CAM_KINDS, INDOOR_CAM_GEN2_KINDS, INDOOR_CAM_PTZ_KINDS,
-            SPOTLIGHT_CAM_BATTERY_KINDS, SPOTLIGHT_CAM_WIRED_KINDS, SPOTLIGHT_CAM_PLUS_KINDS, SPOTLIGHT_CAM_PRO_KINDS,
-            STICKUP_CAM_KINDS, STICKUP_CAM_BATTERY_KINDS, STICKUP_CAM_ELITE_KINDS, STICKUP_CAM_GEN3_KINDS,
-            DOORBELL_KINDS, DOORBELL_2_KINDS, DOORBELL_3_KINDS, DOORBELL_3_PLUS_KINDS, DOORBELL_4_KINDS,
-            DOORBELL_PRO_KINDS, DOORBELL_PRO_2_KINDS, DOORBELL_WIRED_KINDS, DOORBELL_BATTERY_KINDS, DOORBELL_GEN2_KINDS,
-            DOORBELL_ELITE_KINDS, PEEPHOLE_CAM_KINDS).flatMap(Set::stream).collect(Collectors.toUnmodifiableSet());
+    public static final Set<String> MOTION_DETECTION_KINDS = Stream
+            .of(FLOODLIGHT_CAM_KINDS, FLOODLIGHT_CAM_PRO_KINDS, FLOODLIGHT_CAM_PLUS_KINDS, INDOOR_CAM_KINDS,
+                    INDOOR_CAM_GEN2_KINDS, INDOOR_CAM_PTZ_KINDS, SPOTLIGHT_CAM_BATTERY_KINDS, SPOTLIGHT_CAM_WIRED_KINDS,
+                    SPOTLIGHT_CAM_PLUS_KINDS, SPOTLIGHT_CAM_PRO_KINDS, STICKUP_CAM_KINDS, STICKUP_CAM_ELITE_KINDS,
+                    STICKUP_CAM_GEN3_KINDS, DOORBELL_KINDS, DOORBELL_2_KINDS, DOORBELL_3_KINDS, DOORBELL_3_PLUS_KINDS,
+                    DOORBELL_4_KINDS, DOORBELL_PRO_KINDS, DOORBELL_PRO_2_KINDS, DOORBELL_WIRED_KINDS,
+                    DOORBELL_BATTERY_KINDS, DOORBELL_GEN2_KINDS, DOORBELL_ELITE_KINDS, PEEPHOLE_CAM_KINDS)
+            .flatMap(Set::stream).collect(Collectors.toUnmodifiableSet());
 }

--- a/bundles/org.openhab.binding.ring/src/main/java/org/openhab/binding/ring/internal/api/RingDeviceTO.java
+++ b/bundles/org.openhab.binding.ring/src/main/java/org/openhab/binding/ring/internal/api/RingDeviceTO.java
@@ -13,6 +13,7 @@
 package org.openhab.binding.ring.internal.api;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 
 import com.google.gson.annotations.SerializedName;
 
@@ -46,7 +47,7 @@ public class RingDeviceTO {
     public HealthTO health = new HealthTO();
 
     @SerializedName("battery_life")
-    public String battery = "";
+    public @Nullable String battery = null;
 
     public OwnerTO owner = new OwnerTO();
 
@@ -54,5 +55,5 @@ public class RingDeviceTO {
     public DeviceSettingsTO deviceSettings = new DeviceSettingsTO();
 
     @SerializedName("battery_life_2")
-    public String battery2 = "";
+    public @Nullable String battery2 = null;
 }

--- a/bundles/org.openhab.binding.ring/src/main/java/org/openhab/binding/ring/internal/handler/StickupcamHandler.java
+++ b/bundles/org.openhab.binding.ring/src/main/java/org/openhab/binding/ring/internal/handler/StickupcamHandler.java
@@ -155,7 +155,8 @@ public class StickupcamHandler extends RingDeviceHandler {
         RingDeviceTO deviceTO = device.getDeviceStatus();
         if (batterySupport) {
             int battery = 0;
-            if (!deviceTO.battery.isEmpty() && !deviceTO.battery2.isEmpty()) {
+            if (deviceTO.battery != null && !deviceTO.battery.isEmpty() && deviceTO.battery2 != null
+                    && !deviceTO.battery2.isEmpty()) {
                 battery = (Integer.parseInt(deviceTO.battery) + Integer.parseInt(deviceTO.battery2)) / 2;
             } else if (!deviceTO.battery.isEmpty()) {
                 battery = Integer.parseInt(deviceTO.battery);

--- a/bundles/org.openhab.binding.ring/src/main/java/org/openhab/binding/ring/internal/handler/StickupcamHandler.java
+++ b/bundles/org.openhab.binding.ring/src/main/java/org/openhab/binding/ring/internal/handler/StickupcamHandler.java
@@ -18,6 +18,7 @@ import static org.openhab.binding.ring.internal.ApiConstants.*;
 import java.time.ZonedDateTime;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.jetty.http.HttpMethod;
 import org.openhab.binding.ring.internal.api.RingDeviceTO;
 import org.openhab.binding.ring.internal.device.Stickupcam;
@@ -155,7 +156,9 @@ public class StickupcamHandler extends RingDeviceHandler {
         RingDeviceTO deviceTO = device.getDeviceStatus();
         if (batterySupport) {
             int battery = 0;
+            @Nullable
             String b1Raw = deviceTO.battery;
+            @Nullable
             String b2Raw = deviceTO.battery2;
 
             Integer b1 = (b1Raw != null && !b1Raw.isEmpty()) ? Integer.parseInt(b1Raw) : null;

--- a/bundles/org.openhab.binding.ring/src/main/java/org/openhab/binding/ring/internal/handler/StickupcamHandler.java
+++ b/bundles/org.openhab.binding.ring/src/main/java/org/openhab/binding/ring/internal/handler/StickupcamHandler.java
@@ -155,13 +155,20 @@ public class StickupcamHandler extends RingDeviceHandler {
         RingDeviceTO deviceTO = device.getDeviceStatus();
         if (batterySupport) {
             int battery = 0;
-            if (deviceTO.battery != null && !deviceTO.battery.isEmpty() && deviceTO.battery2 != null
-                    && !deviceTO.battery2.isEmpty()) {
-                battery = (Integer.parseInt(deviceTO.battery) + Integer.parseInt(deviceTO.battery2)) / 2;
-            } else if (!deviceTO.battery.isEmpty()) {
-                battery = Integer.parseInt(deviceTO.battery);
-            } else if (!deviceTO.battery2.isEmpty()) {
-                battery = Integer.parseInt(deviceTO.battery2);
+            String b1Raw = deviceTO.battery;
+            String b2Raw = deviceTO.battery2;
+
+            Integer b1 = (b1Raw != null && !b1Raw.isEmpty()) ? Integer.parseInt(b1Raw) : null;
+            Integer b2 = (b2Raw != null && !b2Raw.isEmpty()) ? Integer.parseInt(b2Raw) : null;
+
+            if (b1 != null && b2 != null) {
+                battery = (b1 + b2) / 2;
+            } else if (b1 != null) {
+                battery = b1;
+            } else if (b2 != null) {
+                battery = b2;
+            } else {
+                battery = 0; // No battery data available
             }
             if (battery != lastBattery) {
                 logger.debug("Battery Level: {}", battery);

--- a/bundles/org.openhab.binding.ring/src/main/java/org/openhab/binding/ring/internal/handler/StickupcamHandler.java
+++ b/bundles/org.openhab.binding.ring/src/main/java/org/openhab/binding/ring/internal/handler/StickupcamHandler.java
@@ -18,7 +18,6 @@ import static org.openhab.binding.ring.internal.ApiConstants.*;
 import java.time.ZonedDateTime;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.jetty.http.HttpMethod;
 import org.openhab.binding.ring.internal.api.RingDeviceTO;
 import org.openhab.binding.ring.internal.device.Stickupcam;
@@ -156,9 +155,7 @@ public class StickupcamHandler extends RingDeviceHandler {
         RingDeviceTO deviceTO = device.getDeviceStatus();
         if (batterySupport) {
             int battery = 0;
-            @Nullable
             String b1Raw = deviceTO.battery;
-            @Nullable
             String b2Raw = deviceTO.battery2;
 
             Integer b1 = (b1Raw != null && !b1Raw.isEmpty()) ? Integer.parseInt(b1Raw) : null;


### PR DESCRIPTION
I removed a battery for charging and found a case where when the 2nd battery is removed, the API reports it as null rather than an empty string.

Also found an issue where stickup_cam_lunar had the wrong identifier so was missing some features.

This PR corrects these issues..

Ironically, spotless tells me this check is redundant (I had it in place and removed it!)
```
[WARNING] /home/psmedley/openhab-addons/bundles/org.openhab.binding.ring/src/main/java/org/openhab/binding/ring/internal/handler/StickupcamHandler.java:[158,26] Redundant null check: comparing '@NonNull String' against null
[WARNING] /home/psmedley/openhab-addons/bundles/org.openhab.binding.ring/src/main/java/org/openhab/binding/ring/internal/handler/StickupcamHandler.java:[158,85] Redundant null check: comparing '@NonNull String' against null

```

Edit: Regression of: #20572