### PR TITLE
[groheondus] Add Sense Guard pause duration channel

### DIFF
--- a/bundles/org.openhab.binding.groheondus/pom.xml
+++ b/bundles/org.openhab.binding.groheondus/pom.xml
@@ -34,7 +34,7 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
-      <version>3.20.0</version>
+      <version>3.18.0</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/bundles/org.openhab.binding.groheondus/src/main/java/org/openhab/binding/groheondus/internal/GroheOndusBindingConstants.java
+++ b/bundles/org.openhab.binding.groheondus/src/main/java/org/openhab/binding/groheondus/internal/GroheOndusBindingConstants.java
@@ -40,4 +40,6 @@ public class GroheOndusBindingConstants {
     public static final String CHANNEL_CONFIG_TIMEFRAME = "timeframe";
 
     public static final int DEFAULT_POLLING_INTERVAL = 900;
+
+    public static final String CHANNEL_SENSEGUARD_PAUSE = "pause_duration";
 }

--- a/bundles/org.openhab.binding.groheondus/src/main/java/org/openhab/binding/groheondus/internal/GroheOndusSnoozeService.java
+++ b/bundles/org.openhab.binding.groheondus/src/main/java/org/openhab/binding/groheondus/internal/GroheOndusSnoozeService.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.groheondus.internal;
+
+import java.io.IOException;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+import io.github.floriansw.ondus.api.OndusService;
+
+/**
+ * Service for controlling Sense Guard pause/snooze functionality via the Grohe API.
+ *
+ * @author Michael Parment - Initial contribution
+ */
+@NonNullByDefault
+public class GroheOndusSnoozeService {
+    private final OndusService ondusService;
+
+    public GroheOndusSnoozeService(OndusService ondusService) {
+        this.ondusService = ondusService;
+    }
+
+    /**
+     * Check if snooze/pause is currently active for the device
+     */
+    public boolean isSnoozeActive(String locationId, String roomId, String applianceId) throws IOException {
+        return ondusService.applianceCommand(locationId, roomId, applianceId).isPresent();
+    }
+
+    /**
+     * Set pause duration in minutes
+     */
+    public void setPause(String locationId, String roomId, String applianceId, int minutes) throws IOException {
+        ondusService.setSnooze(locationId, roomId, applianceId, minutes);
+    }
+
+    /**
+     * Delete/cancel the pause
+     */
+    public void deletePause(String locationId, String roomId, String applianceId) throws IOException {
+        ondusService.deleteSnooze(locationId, roomId, applianceId);
+    }
+}

--- a/bundles/org.openhab.binding.groheondus/src/main/java/org/openhab/binding/groheondus/internal/handler/GroheOndusSenseGuardHandler.java
+++ b/bundles/org.openhab.binding.groheondus/src/main/java/org/openhab/binding/groheondus/internal/handler/GroheOndusSenseGuardHandler.java
@@ -30,6 +30,9 @@ import javax.measure.quantity.Volume;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.groheondus.internal.GroheOndusApplianceConfiguration;
+import org.openhab.binding.groheondus.internal.GroheOndusSnoozeService;
+import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.library.types.QuantityType;
 import org.openhab.core.library.types.StringType;
@@ -105,6 +108,19 @@ public class GroheOndusSenseGuardHandler<T, M> extends GroheOndusBaseHandler<App
                 break;
             case CHANNEL_WATERCONSUMPTION_SINCE_MIDNIGHT:
                 newState = sumWaterConsumptionSinceMidnight(dataPoint);
+                break;
+            case CHANNEL_SENSEGUARD_PAUSE:
+                OndusService pauseQueryService = getOndusService();
+                GroheOndusApplianceConfiguration pauseConfig = config;
+                if (pauseQueryService != null && pauseConfig != null) {
+                    try {
+                        boolean active = new GroheOndusSnoozeService(pauseQueryService)
+                                .isSnoozeActive(pauseConfig.locationId, pauseConfig.roomId, pauseConfig.applianceId);
+                        updateState(channelUID, active ? new DecimalType(1) : new DecimalType(0));
+                    } catch (IOException e) {
+                        logger.warn("Failed to query pause status: {}", e.getMessage());
+                    }
+                }
                 break;
             default:
                 throw new IllegalArgumentException("Channel " + channelUID + " not supported.");
@@ -234,30 +250,61 @@ public class GroheOndusSenseGuardHandler<T, M> extends GroheOndusBaseHandler<App
             return;
         }
 
-        if (!CHANNEL_VALVE_OPEN.equals(channelUID.getIdWithoutGroup())) {
-            return;
+        String channelId = channelUID.getIdWithoutGroup();
+        if (CHANNEL_VALVE_OPEN.equals(channelId)) {
+            if (!(command instanceof OnOffType)) {
+                logger.debug("Invalid command received for channel. Expected OnOffType, received {}.",
+                        command.getClass().getName());
+                return;
+            }
+            OnOffType openClosedCommand = (OnOffType) command;
+            boolean openState = openClosedCommand == OnOffType.ON;
+
+            OndusService service = getOndusService();
+            if (service == null) {
+                return;
+            }
+            Appliance appliance = getAppliance(service);
+            if (appliance == null) {
+                return;
+            }
+            try {
+                service.setValveOpen(appliance, openState);
+                updateChannels();
+            } catch (IOException e) {
+                logger.debug("Could not update valve open state", e);
+            }
+        } else if (CHANNEL_SENSEGUARD_PAUSE.equals(channelId)) {
+            handlePauseCommand(command);
         }
-        if (!(command instanceof OnOffType)) {
-            logger.debug("Invalid command received for channel. Expected OnOffType, received {}.",
-                    command.getClass().getName());
+    }
+
+    private void handlePauseCommand(Command command) {
+        if (!(command instanceof DecimalType))
             return;
-        }
-        OnOffType openClosedCommand = (OnOffType) command;
-        boolean openState = openClosedCommand == OnOffType.ON;
 
         OndusService service = getOndusService();
-        if (service == null) {
+        if (service == null)
             return;
-        }
-        Appliance appliance = getAppliance(service);
-        if (appliance == null) {
+
+        GroheOndusApplianceConfiguration cfg = getConfigAs(GroheOndusApplianceConfiguration.class);
+        if (cfg == null)
             return;
-        }
+
+        int minutes = ((DecimalType) command).intValue();
+        GroheOndusSnoozeService snoozeService = new GroheOndusSnoozeService(service);
+
         try {
-            service.setValveOpen(appliance, openState);
-            updateChannels();
+            if (minutes <= 0) {
+                snoozeService.deletePause(cfg.locationId, cfg.roomId, cfg.applianceId);
+                updateState(CHANNEL_SENSEGUARD_PAUSE, new DecimalType(0));
+            } else {
+                int clamped = Math.min(minutes, 240);
+                snoozeService.setPause(cfg.locationId, cfg.roomId, cfg.applianceId, clamped);
+                updateState(CHANNEL_SENSEGUARD_PAUSE, new DecimalType(clamped));
+            }
         } catch (IOException e) {
-            logger.debug("Could not update valve open state", e);
+            logger.warn("Failed to set Grohe Guard pause: {}", e.getMessage());
         }
     }
 }

--- a/bundles/org.openhab.binding.groheondus/src/main/resources/OH-INF/i18n/groheondus.properties
+++ b/bundles/org.openhab.binding.groheondus/src/main/resources/OH-INF/i18n/groheondus.properties
@@ -42,6 +42,8 @@ channel-type.groheondus.temperature_guard.label=Temperature
 channel-type.groheondus.temperature_guard.description=The ambient temperature of the appliance
 channel-type.groheondus.valve_open.label=Valve Open
 channel-type.groheondus.valve_open.description=Valve switch
+channel-type.groheondus.pause_duration.label=Pause Duration
+channel-type.groheondus.pause_duration.description=Set or query the pause/snooze duration in minutes (0-240). Set to 0 to cancel pause.
 channel-type.groheondus.waterconsumption.label=Water Consumption
 channel-type.groheondus.waterconsumption.description=The amount of water consumed in the given time period.
 # channel types config

--- a/bundles/org.openhab.binding.groheondus/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.groheondus/src/main/resources/OH-INF/thing/thing-types.xml
@@ -38,6 +38,7 @@
 			<channel id="waterconsumption" typeId="waterconsumption"/>
 			<channel id="waterconsumption_since_midnight" typeId="waterconsumption_since_midnight"/>
 			<channel id="valve_open" typeId="valve_open"/>
+			<channel id="pause_duration" typeId="pause_duration"/>
 		</channels>
 
 		<representation-property>applianceId</representation-property>
@@ -177,5 +178,14 @@
 			<tag>Water</tag>
 		</tags>
 		<state readOnly="true" pattern="%.1f %unit%"/>
+	</channel-type>
+	<channel-type id="pause_duration">
+		<item-type>Number</item-type>
+		<label>Pause Duration</label>
+		<description>Set or query the pause/snooze duration in minutes (0-240). Set to 0 to cancel pause.</description>
+		<tags>
+			<tag>Control</tag>
+		</tags>
+		<state min="0" max="240" step="1" pattern="%d" />
 	</channel-type>
 </thing:thing-descriptions>


### PR DESCRIPTION
Adds a new Number-type pause_duration channel for controlling pause/snooze functionality.

## Changes
- New GroheOndusSnoozeService class for pause control
- pause_duration Number channel (0-240 minutes)
- Updated handler to support pause command and status polling
- Channel-type definition with constraints
- i18n translations
- Fixed commons-lang3 version (3.20.0 -> 3.18.0)

## Testing
- Pause activation (1-240 minutes)
- Pause cancellation (set to 0)
- Channel status polling