### PR TITLE
[iaqualink] Fix updates to Filter_Pump/Production

### DIFF
--- a/bundles/org.openhab.binding.iaqualink/src/main/java/org/openhab/binding/iaqualink/internal/v2/IAqualinkV2Handler.java
+++ b/bundles/org.openhab.binding.iaqualink/src/main/java/org/openhab/binding/iaqualink/internal/v2/IAqualinkV2Handler.java
@@ -276,6 +276,9 @@ public class IAqualinkV2Handler extends BaseThingHandler implements IAqualinkDev
 
     @Override
     public void onUpdateAccepted(String deviceId, String msg) {
+
+        logger.trace("onUpdateAccepted[{}]: {}", deviceId, msg);
+
         DeviceState partialState = DeviceState.parse(msg);
 
         Collection<ChannelDef> channelDefs = this.channelDefs;

--- a/bundles/org.openhab.binding.iaqualink/src/main/java/org/openhab/binding/iaqualink/internal/v2/IAqualinkV2Handler.java
+++ b/bundles/org.openhab.binding.iaqualink/src/main/java/org/openhab/binding/iaqualink/internal/v2/IAqualinkV2Handler.java
@@ -276,7 +276,6 @@ public class IAqualinkV2Handler extends BaseThingHandler implements IAqualinkDev
 
     @Override
     public void onUpdateAccepted(String deviceId, String msg) {
-
         logger.trace("onUpdateAccepted[{}]: {}", deviceId, msg);
 
         DeviceState partialState = DeviceState.parse(msg);

--- a/bundles/org.openhab.binding.iaqualink/src/main/java/org/openhab/binding/iaqualink/internal/v2/api/IAqualinkClient.java
+++ b/bundles/org.openhab.binding.iaqualink/src/main/java/org/openhab/binding/iaqualink/internal/v2/api/IAqualinkClient.java
@@ -130,8 +130,12 @@ public class IAqualinkClient implements Mqtt5ClientOptions.LifecycleEvents, Mqtt
     private final PropertyStorage propertyStorage;
 
     public CompletableFuture<PublishResult> publishUpdate(String deviceId, String msg) {
-        return getMqttClient().publish(mqttMessage(String.format(TOPIC_THINGS_SHADOW + TOPIC_SUFFIX_UPDATE, deviceId),
-                msg.getBytes(StandardCharsets.UTF_8)));
+
+        String topic = String.format(TOPIC_THINGS_SHADOW + TOPIC_SUFFIX_UPDATE, deviceId);
+
+        logger.trace("MQTT message published on {}: {}", topic, msg);
+
+        return getMqttClient().publish(mqttMessage(topic, msg.getBytes(StandardCharsets.UTF_8)));
     }
 
     @SuppressWarnings("serial")
@@ -294,8 +298,7 @@ public class IAqualinkClient implements Mqtt5ClientOptions.LifecycleEvents, Mqtt
 
             String payload = new String(publishReturn.getPublishPacket().getPayload(), StandardCharsets.UTF_8);
 
-            logger.debug("MQTT message received on {}: {}", topic,
-                    Arrays.toString(publishReturn.getPublishPacket().getPayload()));
+            logger.trace("MQTT message received on {}: {}", topic, payload);
 
             String[] parts = topic.split("/");
             if (parts.length != 6) {

--- a/bundles/org.openhab.binding.iaqualink/src/main/java/org/openhab/binding/iaqualink/internal/v2/api/mapping/ChannelDef.java
+++ b/bundles/org.openhab.binding.iaqualink/src/main/java/org/openhab/binding/iaqualink/internal/v2/api/mapping/ChannelDef.java
@@ -32,20 +32,24 @@ import net.minidev.json.JSONArray;
  */
 @NonNullByDefault
 public record ChannelDef(String id, String label, String itemType, String typeId, JsonPath valuePath,
-        @Nullable JsonPath appliesPath) {
+        JsonPath updatePath, @Nullable JsonPath appliesPath) {
 
-    public ChannelDef(String id, String label, String itemType, String typeId, String valuePath,
-            @Nullable String appliesPath) {
-        this(id, label, itemType, typeId, JsonPath.compile(valuePath),
-                appliesPath != null ? JsonPath.compile(appliesPath) : null);
+    private static final String READ_PREFIX = "$.state.reported.";
+    private static final String WRITE_PREFIX = "$.state.desired.";
+
+    public ChannelDef(String id, String label, String itemType, String typeId, String relativePath,
+            @Nullable String appliesRelativePath) {
+        this(id, label, itemType, typeId, JsonPath.compile(READ_PREFIX + relativePath),
+                JsonPath.compile(WRITE_PREFIX + relativePath),
+                appliesRelativePath != null ? JsonPath.compile(READ_PREFIX + appliesRelativePath) : null);
 
         if (!this.valuePath.isDefinite()) {
-            throw new IllegalArgumentException("valuePath must be definite: " + valuePath);
+            throw new IllegalArgumentException("valuePath must be definite: " + relativePath);
         }
     }
 
-    public ChannelDef(String id, String label, String itemType, String typeId, String valuePath) {
-        this(id, label, itemType, typeId, valuePath, null);
+    public ChannelDef(String id, String label, String itemType, String typeId, String relativePath) {
+        this(id, label, itemType, typeId, relativePath, null);
     }
 
     public @Nullable Object value(DeviceState deviceState) {
@@ -59,7 +63,7 @@ public record ChannelDef(String id, String label, String itemType, String typeId
 
     public DeviceState updateJson(Object value) {
         DocumentContext ctx = JsonPath.parse("{}");
-        String[] segments = valuePath.getPath().split("(?=\\[)");
+        String[] segments = updatePath.getPath().split("(?=\\[)");
 
         for (int i = 1; i < segments.length; i++) {
             String subpath = String.join("", Arrays.copyOfRange(segments, 0, i));

--- a/bundles/org.openhab.binding.iaqualink/src/main/java/org/openhab/binding/iaqualink/internal/v2/api/mapping/Channels.java
+++ b/bundles/org.openhab.binding.iaqualink/src/main/java/org/openhab/binding/iaqualink/internal/v2/api/mapping/Channels.java
@@ -48,8 +48,7 @@ public class Channels {
 
     public static Collection<ChannelDef> sensorById(int swcId, int id) {
         ChannelDefBuilder builder = new ChannelDefBuilder("SWC%d_".formatted(swcId),
-                "Salt Water Chlorinator %d ".formatted(swcId),
-                "$.state.reported.equipment.swc_%d.sns_%d".formatted(swcId, id));
+                "Salt Water Chlorinator %d ".formatted(swcId), "equipment.swc_%d.sns_%d".formatted(swcId, id));
 
         return List.of(
                 builder.build("TempSensor" + id, "Temperature Sensor " + id, "Number:Temperature", "temperature",
@@ -60,21 +59,21 @@ public class Channels {
 
     public static Collection<ChannelDef> swcById(int id) {
         ChannelDefBuilder builder = new ChannelDefBuilder("SWC%d_".formatted(id),
-                "Salt Water Chlorinator %d ".formatted(id), "$.state.reported.equipment.swc_%d.".formatted(id));
+                "Salt Water Chlorinator %d ".formatted(id), "equipment.swc_%d.".formatted(id));
 
         return Stream.concat(
                 Stream.of(builder.build("Boost", "Boost", "Switch", "equipment-switch", "boost"),
                         builder.build("Boost_Time", "Boost Time", "Number:Time", "duration", "boost_time"),
                         builder.build("Low", "Low", "Switch", "equipment-switch", "low"),
-                        builder.build("Production", "Production", "Switch", "readonly-switch", "production"),
-                        builder.build("Filter_Pump", "Filter Pump", "Switch", "equipment-switch", "filter_pump.state"),
+                        builder.build("Production", "Production", "Switch", "equipment-switch", "production"),
+                        builder.build("Filter_Pump", "Filter Pump", "Switch", "readonly-switch", "filter_pump.state"),
                         builder.build("SaltLevel", "Salt Level", "Number", "chemical", "swc")),
                 sensorsForSwc(id).stream()).toList();
     }
 
     public static Collection<ChannelDef> scheduleById(int id) {
         ChannelDefBuilder builder = new ChannelDefBuilder("Schedule%d_".formatted(id),
-                "Salt Water Chlorinator Schedule %d ".formatted(id), "$.state.reported.schedules.sch%d.".formatted(id));
+                "Salt Water Chlorinator Schedule %d ".formatted(id), "schedules.sch%d.".formatted(id));
 
         return List.of(builder.build("Active", "Active", "Switch", "readonly-switch", "active"),
                 builder.build("Enabled", "Enabled", "Switch", "equipment-switch", "enabled"),

--- a/bundles/org.openhab.binding.iaqualink/src/test/java/org/openhab/binding/iaqualink/internal/v2/api/mapping/ChannelMapperTest.java
+++ b/bundles/org.openhab.binding.iaqualink/src/test/java/org/openhab/binding/iaqualink/internal/v2/api/mapping/ChannelMapperTest.java
@@ -42,9 +42,9 @@ class ChannelMapperTest {
 
     @Test
     void testSimpleChannelUpdate() {
-        ChannelDef testChannel = new ChannelDef("test", "test", "Switch", "test", "$.state.val");
+        ChannelDef testChannel = new ChannelDef("test", "test", "Switch", "test", "equipment.swc_0.boost");
         String updateJson = testChannel.updateJson(2).jsonString();
-        assertEquals("{\"state\":{\"val\":2}}", updateJson);
+        assertEquals("{\"state\":{\"desired\":{\"equipment\":{\"swc_0\":{\"boost\":2}}}}}", updateJson);
     }
 
     String sampleJson = """


### PR DESCRIPTION
# Fix IAqualink(v2) Pump Update Failures

Initial code failed to update Filter Pumps as it assumed that they were R/W. In fact it is the Production channel which is R/W (not R/O as assumed), and Filter Pump is R/O. Additionally, the code now follows the AWS IOT shadow device pattern of sending 'desired' for updates and receiving 'status'.

As part of the debugging I improved the logging, which I have also left in.