### PR TITLE
[broadlink] Fix RM4 Pro RF frequency learning logic

### DIFF
--- a/bundles/org.openhab.binding.broadlink/src/main/java/org/openhab/binding/broadlink/internal/handler/BroadlinkRemoteHandler.java
+++ b/bundles/org.openhab.binding.broadlink/src/main/java/org/openhab/binding/broadlink/internal/handler/BroadlinkRemoteHandler.java
@@ -293,6 +293,7 @@ public abstract class BroadlinkRemoteHandler extends BroadlinkBaseThingHandler {
                         break;
                     }
                 }
+                break;
             }
             default:
                 logger.debug("Thing {} has unknown channel type '{}'", getThing().getLabel(), channelTypeUID.getId());
@@ -371,7 +372,7 @@ public abstract class BroadlinkRemoteHandler extends BroadlinkBaseThingHandler {
         HexFormat hex = HexFormat.of();
 
         try {
-            while ((System.currentTimeMillis() < timeout) && (freqFound)) {
+            while ((System.currentTimeMillis() < timeout) && (!freqFound)) {
                 TimeUnit.MILLISECONDS.sleep(500);
                 logger.trace("Checking rf frequency");
                 byte[] resp = (sendCommand(COMMAND_BYTE_CHECK_RF_FREQ_LEARNING, "check rf frequency"));
@@ -389,7 +390,7 @@ public abstract class BroadlinkRemoteHandler extends BroadlinkBaseThingHandler {
             freqFound = false;
         }
 
-        if (freqFound) {
+        if (!freqFound) {
             sendCommand(COMMAND_BYTE_EXIT_RF_FREQ_LEARNING, "exit remote rf frequency learning mode");
             logger.info("No RF frequency found.");
             updateState(BroadlinkBindingConstants.RF_LEARNING_CONTROL_CHANNEL, new StringType("NULL"));

--- a/bundles/org.openhab.binding.broadlink/src/main/java/org/openhab/binding/broadlink/internal/handler/BroadlinkRemoteHandler.java
+++ b/bundles/org.openhab.binding.broadlink/src/main/java/org/openhab/binding/broadlink/internal/handler/BroadlinkRemoteHandler.java
@@ -288,8 +288,7 @@ public abstract class BroadlinkRemoteHandler extends BroadlinkBaseThingHandler {
                         break;
                     }
                     default: {
-                        logger.debug("Thing {} has unknown channel type '{}'", getThing().getLabel(),
-                                channelTypeUID.getId());
+                        logger.debug("Thing {} has unknown RF learning command '{}'", getThing().getLabel(), command);
                         break;
                     }
                 }
@@ -385,8 +384,12 @@ public abstract class BroadlinkRemoteHandler extends BroadlinkBaseThingHandler {
                     }
                 }
             }
-        } catch (IOException | InterruptedException e) {
-            logger.warn("RF learning unexpected interrupted:{}", e.getMessage());
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            logger.warn("RF learning interrupted: {}", e.getMessage());
+            freqFound = false;
+        } catch (IOException e) {
+            logger.warn("RF learning unexpected interrupted: {}", e.getMessage());
             freqFound = false;
         }
 


### PR DESCRIPTION
Fixes #20641

Two bugs in RF frequency learning for RM4 Pro devices.

The while loop condition was checking `freqFound` instead of `!freqFound`, so it would skip the frequency scanning entirely. Same issue with the exit condition below, it was sending the exit command when frequency was actually found instead of when it wasn't. Also added a missing `break` in the channel type switch that was causing fallthrough to the default case.

Tested with RM4 Pro, RF learning works correctly now.

Signed-off-by: Caglar Eker <ekercaglar@gmail.com>