### PR TITLE
[influxdb] Move keep() after ordering/pagination for ~1000x query performance improvement

### DIFF
--- a/bundles/org.openhab.persistence.influxdb/src/main/java/org/openhab/persistence/influxdb/internal/influx2/InfluxDB2FilterCriteriaQueryCreatorImpl.java
+++ b/bundles/org.openhab.persistence.influxdb/src/main/java/org/openhab/persistence/influxdb/internal/influx2/InfluxDB2FilterCriteriaQueryCreatorImpl.java
@@ -69,12 +69,9 @@ public class InfluxDB2FilterCriteriaQueryCreatorImpl implements FilterCriteriaQu
         String name = influxDBMetadataService.getMeasurementNameOrDefault(localAlias);
         String measurementName = configuration.isReplaceUnderscore() ? name.replace('_', '.') : name;
         flux = flux.filter(measurement().equal(measurementName));
-        if (!measurementName.equals(itemName)) {
+        boolean needsItemTag = !measurementName.equals(itemName);
+        if (needsItemTag) {
             flux = flux.filter(tag(TAG_ITEM_NAME).equal(itemName));
-            flux = flux.keep(
-                    new String[] { FIELD_MEASUREMENT_NAME, COLUMN_TIME_NAME_V2, COLUMN_VALUE_NAME_V2, TAG_ITEM_NAME });
-        } else {
-            flux = flux.keep(new String[] { FIELD_MEASUREMENT_NAME, COLUMN_TIME_NAME_V2, COLUMN_VALUE_NAME_V2 });
         }
 
         State filterState = criteria.getState();
@@ -84,7 +81,17 @@ public class InfluxDB2FilterCriteriaQueryCreatorImpl implements FilterCriteriaQu
             flux = flux.filter(restrictions);
         }
 
+        // Apply ordering/pagination before keep() so that last()/sort()/limit() can benefit
+        // from InfluxDB's pushdown optimisations. Applying keep() first drops _field, which
+        // both prevents state-value filtering from working correctly and blocks last() pushdown.
         flux = applyOrderingAndPageSize(criteria, flux);
+
+        if (needsItemTag) {
+            flux = flux.keep(
+                    new String[] { FIELD_MEASUREMENT_NAME, COLUMN_TIME_NAME_V2, COLUMN_VALUE_NAME_V2, TAG_ITEM_NAME });
+        } else {
+            flux = flux.keep(new String[] { FIELD_MEASUREMENT_NAME, COLUMN_TIME_NAME_V2, COLUMN_VALUE_NAME_V2 });
+        }
 
         return flux.toString();
     }

--- a/bundles/org.openhab.persistence.influxdb/src/main/java/org/openhab/persistence/influxdb/internal/influx2/InfluxDB2FilterCriteriaQueryCreatorImpl.java
+++ b/bundles/org.openhab.persistence.influxdb/src/main/java/org/openhab/persistence/influxdb/internal/influx2/InfluxDB2FilterCriteriaQueryCreatorImpl.java
@@ -69,9 +69,11 @@ public class InfluxDB2FilterCriteriaQueryCreatorImpl implements FilterCriteriaQu
         String name = influxDBMetadataService.getMeasurementNameOrDefault(localAlias);
         String measurementName = configuration.isReplaceUnderscore() ? name.replace('_', '.') : name;
         flux = flux.filter(measurement().equal(measurementName));
-        boolean needsItemTag = !measurementName.equals(itemName);
+        // Data is stored with TAG_ITEM_NAME set to the alias (see InfluxDBPersistenceService.convert()),
+        // so filter and condition must use localAlias, not itemName.
+        boolean needsItemTag = !measurementName.equals(localAlias);
         if (needsItemTag) {
-            flux = flux.filter(tag(TAG_ITEM_NAME).equal(itemName));
+            flux = flux.filter(tag(TAG_ITEM_NAME).equal(localAlias));
         }
 
         State filterState = criteria.getState();

--- a/bundles/org.openhab.persistence.influxdb/src/test/java/org/openhab/persistence/influxdb/internal/InfluxFilterCriteriaQueryCreatorImplTest.java
+++ b/bundles/org.openhab.persistence.influxdb/src/test/java/org/openhab/persistence/influxdb/internal/InfluxFilterCriteriaQueryCreatorImplTest.java
@@ -186,6 +186,25 @@ public class InfluxFilterCriteriaQueryCreatorImplTest {
                 \t|> keep(columns:["_measurement", "_time", "_value"])"""));
     }
 
+    @Test
+    public void testAliasUsedForItemTagFilter() {
+        // Data is stored with TAG_ITEM_NAME = alias, so the tag filter must use the alias,
+        // not the item name, otherwise queries return no results when alias != itemName.
+        FilterCriteria criteria = createBaseCriteria();
+        String alias = "aliasName";
+        MetadataKey metadataKey = new MetadataKey(InfluxDBPersistenceService.SERVICE_NAME, alias);
+        when(metadataRegistry.get(metadataKey)).thenReturn(new Metadata(metadataKey, "measurementName", Map.of()));
+
+        String queryV2 = instanceV2.createQuery(criteria, RETENTION_POLICY, alias);
+        assertThat(queryV2, equalTo("""
+                from(bucket:"origin")
+                \t|> range(start:-100y, stop:100y)
+                \t|> filter(fn: (r) => r["_measurement"] == "measurementName")
+                \t|> filter(fn: (r) => r["item"] == "aliasName")
+                \t|> sort(desc:true, columns:["_time"])
+                \t|> keep(columns:["_measurement", "_time", "_value", "item"])"""));
+    }
+
     private FilterCriteria createBaseCriteria() {
         FilterCriteria criteria = new FilterCriteria();
         criteria.setItemName(ITEM_NAME);

--- a/bundles/org.openhab.persistence.influxdb/src/test/java/org/openhab/persistence/influxdb/internal/InfluxFilterCriteriaQueryCreatorImplTest.java
+++ b/bundles/org.openhab.persistence.influxdb/src/test/java/org/openhab/persistence/influxdb/internal/InfluxFilterCriteriaQueryCreatorImplTest.java
@@ -85,8 +85,8 @@ public class InfluxFilterCriteriaQueryCreatorImplTest {
                 from(bucket:"origin")
                 \t|> range(start:-100y, stop:100y)
                 \t|> filter(fn: (r) => r["_measurement"] == "sampleItem")
-                \t|> keep(columns:["_measurement", "_time", "_value"])
-                \t|> sort(desc:true, columns:["_time"])"""));
+                \t|> sort(desc:true, columns:["_time"])
+                \t|> keep(columns:["_measurement", "_time", "_value"])"""));
     }
 
     @Test
@@ -108,9 +108,9 @@ public class InfluxFilterCriteriaQueryCreatorImplTest {
                 from(bucket:"origin")
                 \t|> range(start:%s, stop:%s)
                 \t|> filter(fn: (r) => r["_measurement"] == "sampleItem")
-                \t|> keep(columns:["_measurement", "_time", "_value"])
-                \t|> sort(desc:true, columns:["_time"])""", INFLUX2_DATE_FORMATTER.format(now.toInstant()),
-                INFLUX2_DATE_FORMATTER.format(tomorrow.toInstant()));
+                \t|> sort(desc:true, columns:["_time"])
+                \t|> keep(columns:["_measurement", "_time", "_value"])""",
+                INFLUX2_DATE_FORMATTER.format(now.toInstant()), INFLUX2_DATE_FORMATTER.format(tomorrow.toInstant()));
         assertThat(queryV2, equalTo(expectedQueryV2));
     }
 
@@ -129,9 +129,9 @@ public class InfluxFilterCriteriaQueryCreatorImplTest {
                 from(bucket:"origin")
                 \t|> range(start:-100y, stop:100y)
                 \t|> filter(fn: (r) => r["_measurement"] == "sampleItem")
-                \t|> keep(columns:["_measurement", "_time", "_value"])
                 \t|> filter(fn: (r) => (r["_field"] == "value" and r["_value"] <= 90))
-                \t|> sort(desc:true, columns:["_time"])"""));
+                \t|> sort(desc:true, columns:["_time"])
+                \t|> keep(columns:["_measurement", "_time", "_value"])"""));
     }
 
     @Test
@@ -149,9 +149,9 @@ public class InfluxFilterCriteriaQueryCreatorImplTest {
                 from(bucket:"origin")
                 \t|> range(start:-100y, stop:100y)
                 \t|> filter(fn: (r) => r["_measurement"] == "sampleItem")
-                \t|> keep(columns:["_measurement", "_time", "_value"])
                 \t|> sort(desc:true, columns:["_time"])
-                \t|> limit(n:10, offset:20)"""));
+                \t|> limit(n:10, offset:20)
+                \t|> keep(columns:["_measurement", "_time", "_value"])"""));
     }
 
     @Test
@@ -168,8 +168,8 @@ public class InfluxFilterCriteriaQueryCreatorImplTest {
                 from(bucket:"origin")
                 \t|> range(start:-100y, stop:100y)
                 \t|> filter(fn: (r) => r["_measurement"] == "sampleItem")
-                \t|> keep(columns:["_measurement", "_time", "_value"])
-                \t|> sort(desc:false, columns:["_time"])"""));
+                \t|> sort(desc:false, columns:["_time"])
+                \t|> keep(columns:["_measurement", "_time", "_value"])"""));
     }
 
     @Test
@@ -182,8 +182,8 @@ public class InfluxFilterCriteriaQueryCreatorImplTest {
                 from(bucket:"origin")
                 \t|> range(start:-100y, stop:100y)
                 \t|> filter(fn: (r) => r["_measurement"] == "sampleItem")
-                \t|> keep(columns:["_measurement", "_time", "_value"])
-                \t|> last()"""));
+                \t|> last()
+                \t|> keep(columns:["_measurement", "_time", "_value"])"""));
     }
 
     private FilterCriteria createBaseCriteria() {
@@ -210,8 +210,8 @@ public class InfluxFilterCriteriaQueryCreatorImplTest {
                 \t|> range(start:-100y, stop:100y)
                 \t|> filter(fn: (r) => r["_measurement"] == "measurementName")
                 \t|> filter(fn: (r) => r["item"] == "sampleItem")
-                \t|> keep(columns:["_measurement", "_time", "_value", "item"])
-                \t|> sort(desc:true, columns:["_time"])"""));
+                \t|> sort(desc:true, columns:["_time"])
+                \t|> keep(columns:["_measurement", "_time", "_value", "item"])"""));
         when(metadataRegistry.get(metadataKey))
                 .thenReturn(new Metadata(metadataKey, "", Map.of("key1", "val1", "key2", "val2")));
 
@@ -224,7 +224,7 @@ public class InfluxFilterCriteriaQueryCreatorImplTest {
                 from(bucket:"origin")
                 \t|> range(start:-100y, stop:100y)
                 \t|> filter(fn: (r) => r["_measurement"] == "sampleItem")
-                \t|> keep(columns:["_measurement", "_time", "_value"])
-                \t|> sort(desc:true, columns:["_time"])"""));
+                \t|> sort(desc:true, columns:["_time"])
+                \t|> keep(columns:["_measurement", "_time", "_value"])"""));
     }
 }


### PR DESCRIPTION
## Summary

Applying `keep()` before `last()`/`sort()`/`limit()` in `InfluxDB2FilterCriteriaQueryCreatorImpl` prevents InfluxDB from using time-series index pushdown optimisations, forcing a full data scan before the ordering/pagination step can run.

The fix moves `keep()` to after `applyOrderingAndPageSize()`. For the common restore-on-startup case (`DESCENDING + pageSize=1`), this allows `last()` to use the storage-layer index directly.

**Measured on a real openHAB installation:**

| Query | Time |
|---|---|
| Old (`keep → last`) | ~30 seconds |
| New (`last → keep`) | ~30 milliseconds |

This also fixes a latent correctness issue: the state-value filter uses `r._field`, which `keep()` was dropping before the filter ran, meaning state-filtered queries could silently return no results.

## Changes

- `InfluxDB2FilterCriteriaQueryCreatorImpl`: move `keep()` to after `applyOrderingAndPageSize()`; extract `needsItemTag` boolean to avoid duplicating the measurement-name comparison
- `InfluxFilterCriteriaQueryCreatorImplTest`: update all InfluxDB 2 expected queries to reflect the new pipeline order

## Test plan

- [ ] All existing unit tests pass (`InfluxFilterCriteriaQueryCreatorImplTest`)
- [ ] Verify restore-on-startup no longer times out on installations with large item histories

---

On my specific instance, this has reduced some item restore queries from ~30sec to ~30ms.