### PR TITLE
[telegram] Persist message and callback IDs across restarts

### DIFF
--- a/bundles/org.openhab.binding.telegram/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.telegram/src/main/feature/feature.xml
@@ -4,7 +4,6 @@
 
 	<feature name="openhab-binding-telegram" description="Telegram Binding" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
-		<bundle dependency="true">mvn:org.ow2.asm/asm/9.9.1</bundle>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.telegram/${project.version}</bundle>
 	</feature>
 </features>

--- a/bundles/org.openhab.binding.telegram/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.telegram/src/main/feature/feature.xml
@@ -4,6 +4,7 @@
 
 	<feature name="openhab-binding-telegram" description="Telegram Binding" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
+		<bundle dependency="true">mvn:org.ow2.asm/asm/9.9.1</bundle>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.telegram/${project.version}</bundle>
 	</feature>
 </features>

--- a/bundles/org.openhab.binding.telegram/src/main/java/org/openhab/binding/telegram/internal/TelegramHandler.java
+++ b/bundles/org.openhab.binding.telegram/src/main/java/org/openhab/binding/telegram/internal/TelegramHandler.java
@@ -526,6 +526,16 @@ public class TelegramHandler extends BaseThingHandler {
     }
 
     /**
+     * Removes the persisted Telegram callback ID for (chatId, replyId).
+     *
+     * @param chatId Telegram chat ID
+     * @param replyId application-level reply identifier
+     */
+    public void removeCallbackId(Long chatId, String replyId) {
+        messageStore.removeCallbackId(chatId, replyId);
+    }
+
+    /**
      * Retrieves and removes the persisted Telegram message ID for (chatId, replyId).
      * Returns {@code null} if none is stored.
      *

--- a/bundles/org.openhab.binding.telegram/src/main/java/org/openhab/binding/telegram/internal/TelegramHandler.java
+++ b/bundles/org.openhab.binding.telegram/src/main/java/org/openhab/binding/telegram/internal/TelegramHandler.java
@@ -23,10 +23,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -73,6 +70,11 @@ import okhttp3.OkHttpClient;
  * The {@link TelegramHandler} is responsible for handling commands, which are
  * sent to one of the channels.
  *
+ * <p>
+ * Message IDs and callback IDs are now persisted via {@link TelegramMessageStore}
+ * so that inline-keyboard messages can still be edited or deleted after an
+ * openHAB restart.
+ *
  * @author Jens Runge - Initial contribution
  * @author Alexander Krasnogolowy - using Telegram library from pengrad
  * @author Jan N. Klug - handle file attachments
@@ -81,59 +83,38 @@ import okhttp3.OkHttpClient;
 @NonNullByDefault
 public class TelegramHandler extends BaseThingHandler {
 
-    private class ReplyKey {
-        final Long chatId;
-        final String replyId;
-
-        public ReplyKey(Long chatId, String replyId) {
-            this.chatId = chatId;
-            this.replyId = replyId;
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hash(chatId, replyId);
-        }
-
-        @Override
-        public boolean equals(@Nullable Object obj) {
-            if (this == obj) {
-                return true;
-            }
-            if (obj == null) {
-                return false;
-            }
-            if (getClass() != obj.getClass()) {
-                return false;
-            }
-            ReplyKey other = (ReplyKey) obj;
-            return Objects.equals(chatId, other.chatId) && Objects.equals(replyId, other.replyId);
-        }
-    }
-
     private static Gson gson = new Gson();
     private final List<Long> authorizedSenderChatId = new ArrayList<>();
     private final List<Long> receiverChatId = new ArrayList<>();
     private final Logger logger = LoggerFactory.getLogger(TelegramHandler.class);
     private @Nullable ScheduledFuture<?> thingOnlineStatusJob;
 
-    // Keep track of the callback id created by Telegram. This must be sent back in
-    // the answerCallbackQuery
-    // to stop the progress bar in the Telegram client
-    private final Map<ReplyKey, String> replyIdToCallbackId = new HashMap<>();
-    // Keep track of message id sent with reply markup because we want to remove the
-    // markup after the user provided an
-    // answer and need the id of the original message
-    private final Map<ReplyKey, Integer> replyIdToMessageId = new HashMap<>();
+    /**
+     * Persistent store for (chatId, replyId) → message-ID and callback-ID mappings.
+     *
+     * <p>
+     * Previously these were plain in-memory {@code HashMap}s ({@code replyIdToMessageId}
+     * and {@code replyIdToCallbackId}). They are now backed by openHAB's
+     * {@link org.openhab.core.storage.StorageService} so entries survive restarts.
+     */
+    private final TelegramMessageStore messageStore;
 
     private @Nullable TelegramBot bot;
     private @Nullable OkHttpClient botLibClient;
     private @Nullable HttpClient downloadDataClient;
     private @Nullable ParseMode parseMode;
 
-    public TelegramHandler(Thing thing, @Nullable HttpClient httpClient) {
+    /**
+     * Creates a new handler.
+     *
+     * @param thing the Thing this handler belongs to
+     * @param httpClient shared Jetty {@link HttpClient} for file downloads
+     * @param messageStore persistent store for message and callback IDs
+     */
+    public TelegramHandler(Thing thing, @Nullable HttpClient httpClient, TelegramMessageStore messageStore) {
         super(thing);
-        downloadDataClient = httpClient;
+        this.downloadDataClient = httpClient;
+        this.messageStore = messageStore;
     }
 
     @Override
@@ -413,7 +394,9 @@ public class TelegramHandler extends BaseThingHandler {
                     lastMessageLastName = callbackQuery.from().lastName();
                     lastMessageUsername = callbackQuery.from().username();
                     chatId = cbMessage.chat().id();
-                    replyIdToCallbackId.put(new ReplyKey(chatId, replyId), callbackQuery.id());
+
+                    // Persist callback ID so it can be answered (acknowledged) after a restart.
+                    messageStore.putCallbackId(chatId, replyId, callbackQuery.id());
 
                     // build and publish callbackEvent trigger channel payload
                     JsonObject callbackRaw = JsonParser.parseString(gson.toJson(callbackQuery)).getAsJsonObject();
@@ -499,7 +482,7 @@ public class TelegramHandler extends BaseThingHandler {
     }
 
     /**
-     * get the list of all authorized senders
+     * Returns the list of all authorized sender chat IDs.
      *
      * @return list of chatIds
      */
@@ -508,7 +491,7 @@ public class TelegramHandler extends BaseThingHandler {
     }
 
     /**
-     * get the list of all receivers
+     * Returns the list of all receiver chat IDs.
      *
      * @return list of chatIds
      */
@@ -516,17 +499,42 @@ public class TelegramHandler extends BaseThingHandler {
         return receiverChatId;
     }
 
+    /**
+     * Persists the Telegram message ID for the given (chatId, replyId) pair.
+     * Called by {@link TelegramActions} after successfully sending a query with
+     * an inline keyboard.
+     *
+     * @param chatId Telegram chat ID
+     * @param replyId application-level reply identifier
+     * @param messageId Telegram message ID returned by the send API
+     */
     public void addMessageId(Long chatId, String replyId, Integer messageId) {
-        replyIdToMessageId.put(new ReplyKey(chatId, replyId), messageId);
+        messageStore.putMessageId(chatId, replyId, messageId);
     }
 
+    /**
+     * Retrieves the persisted Telegram callback ID for (chatId, replyId).
+     * Returns {@code null} if none is stored.
+     *
+     * @param chatId Telegram chat ID
+     * @param replyId application-level reply identifier
+     * @return Telegram callback ID or {@code null}
+     */
     @Nullable
     public String getCallbackId(Long chatId, String replyId) {
-        return replyIdToCallbackId.get(new ReplyKey(chatId, replyId));
+        return messageStore.getCallbackId(chatId, replyId);
     }
 
+    /**
+     * Retrieves and removes the persisted Telegram message ID for (chatId, replyId).
+     * Returns {@code null} if none is stored.
+     *
+     * @param chatId Telegram chat ID
+     * @param replyId application-level reply identifier
+     * @return Telegram message ID or {@code null}
+     */
     public @Nullable Integer removeMessageId(Long chatId, String replyId) {
-        return replyIdToMessageId.remove(new ReplyKey(chatId, replyId));
+        return messageStore.removeMessageId(chatId, replyId);
     }
 
     @Nullable

--- a/bundles/org.openhab.binding.telegram/src/main/java/org/openhab/binding/telegram/internal/TelegramHandlerFactory.java
+++ b/bundles/org.openhab.binding.telegram/src/main/java/org/openhab/binding/telegram/internal/TelegramHandlerFactory.java
@@ -31,14 +31,14 @@ import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
 /**
- * The {@link TelegramHandlerFactory} is responsible for creating things and
- * thing handlers.
+ * The {@link TelegramHandlerFactory} is responsible for creating things and thing handlers.
  *
  * <p>
- * A single {@link TelegramMessageStore} is created per factory (= per binding
- * instance) and shared across all {@link TelegramHandler}s. This is safe
- * because the store is keyed by {@code chatId + replyId}, which is globally
- * unique within one Telegram bot.
+ * A dedicated {@link TelegramMessageStore} is created for each {@link TelegramHandler}
+ * and scoped to that handler's {@link org.openhab.core.thing.ThingUID}. This guarantees
+ * that two Telegram Things backed by different bot tokens can never share or overwrite
+ * each other's persisted message/callback IDs even if their chat IDs and reply IDs are
+ * identical.
  *
  * @author Jens Runge - Initial contribution
  */
@@ -49,23 +49,13 @@ public class TelegramHandlerFactory extends BaseThingHandlerFactory {
     private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Set.of(TELEGRAM_THING);
 
     private final HttpClient httpClient;
-
-    /**
-     * Shared persistent store for message IDs and callback IDs.
-     *
-     * <p>
-     * Backed by openHAB's {@link StorageService}, which writes entries to disk
-     * (MapDB by default). All handlers that belong to this factory share the
-     * same store so that multi-thing setups with the same bot still work
-     * correctly.
-     */
-    private final TelegramMessageStore messageStore;
+    private final StorageService storageService;
 
     @Activate
     public TelegramHandlerFactory(@Reference final HttpClientFactory httpClientFactory,
             @Reference final StorageService storageService) {
         this.httpClient = httpClientFactory.getCommonHttpClient();
-        this.messageStore = new TelegramMessageStore(storageService);
+        this.storageService = storageService;
     }
 
     @Override
@@ -75,11 +65,12 @@ public class TelegramHandlerFactory extends BaseThingHandlerFactory {
 
     @Override
     protected @Nullable ThingHandler createHandler(Thing thing) {
-        ThingTypeUID thingTypeUID = thing.getThingTypeUID();
-
-        if (TELEGRAM_THING.equals(thingTypeUID)) {
-            return new TelegramHandler(thing, httpClient, messageStore);
+        if (!TELEGRAM_THING.equals(thing.getThingTypeUID())) {
+            return null;
         }
-        return null;
+        // Each handler gets its own store scoped to the Thing UID so that
+        // multiple bots with overlapping chatId/replyId values never collide.
+        TelegramMessageStore messageStore = new TelegramMessageStore(storageService, thing.getUID());
+        return new TelegramHandler(thing, httpClient, messageStore);
     }
 }

--- a/bundles/org.openhab.binding.telegram/src/main/java/org/openhab/binding/telegram/internal/TelegramHandlerFactory.java
+++ b/bundles/org.openhab.binding.telegram/src/main/java/org/openhab/binding/telegram/internal/TelegramHandlerFactory.java
@@ -20,6 +20,7 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.jetty.client.HttpClient;
 import org.openhab.core.io.net.http.HttpClientFactory;
+import org.openhab.core.storage.StorageService;
 import org.openhab.core.thing.Thing;
 import org.openhab.core.thing.ThingTypeUID;
 import org.openhab.core.thing.binding.BaseThingHandlerFactory;
@@ -33,6 +34,12 @@ import org.osgi.service.component.annotations.Reference;
  * The {@link TelegramHandlerFactory} is responsible for creating things and
  * thing handlers.
  *
+ * <p>
+ * A single {@link TelegramMessageStore} is created per factory (= per binding
+ * instance) and shared across all {@link TelegramHandler}s. This is safe
+ * because the store is keyed by {@code chatId + replyId}, which is globally
+ * unique within one Telegram bot.
+ *
  * @author Jens Runge - Initial contribution
  */
 @NonNullByDefault
@@ -43,9 +50,22 @@ public class TelegramHandlerFactory extends BaseThingHandlerFactory {
 
     private final HttpClient httpClient;
 
+    /**
+     * Shared persistent store for message IDs and callback IDs.
+     *
+     * <p>
+     * Backed by openHAB's {@link StorageService}, which writes entries to disk
+     * (MapDB by default). All handlers that belong to this factory share the
+     * same store so that multi-thing setups with the same bot still work
+     * correctly.
+     */
+    private final TelegramMessageStore messageStore;
+
     @Activate
-    public TelegramHandlerFactory(@Reference final HttpClientFactory httpClientFactory) {
+    public TelegramHandlerFactory(@Reference final HttpClientFactory httpClientFactory,
+            @Reference final StorageService storageService) {
         this.httpClient = httpClientFactory.getCommonHttpClient();
+        this.messageStore = new TelegramMessageStore(storageService);
     }
 
     @Override
@@ -58,7 +78,7 @@ public class TelegramHandlerFactory extends BaseThingHandlerFactory {
         ThingTypeUID thingTypeUID = thing.getThingTypeUID();
 
         if (TELEGRAM_THING.equals(thingTypeUID)) {
-            return new TelegramHandler(thing, httpClient);
+            return new TelegramHandler(thing, httpClient, messageStore);
         }
         return null;
     }

--- a/bundles/org.openhab.binding.telegram/src/main/java/org/openhab/binding/telegram/internal/TelegramMessageStore.java
+++ b/bundles/org.openhab.binding.telegram/src/main/java/org/openhab/binding/telegram/internal/TelegramMessageStore.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ */
+
+package org.openhab.binding.telegram.internal;
+
+import java.util.Collection;
+import java.util.List;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.core.storage.Storage;
+import org.openhab.core.storage.StorageService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Persistent store for Telegram message IDs and callback IDs.
+ *
+ * <p>
+ * openHAB's {@link StorageService} backs this class, so all entries survive
+ * a restart of openHAB. The two logical maps are:
+ * <ul>
+ * <li><b>messageId store</b> – maps (chatId, replyId) → Telegram message ID.
+ * Required to edit or delete an inline-keyboard message after a restart.</li>
+ * <li><b>callbackId store</b> – maps (chatId, replyId) → Telegram callback
+ * query ID. Required to answer (acknowledge) a button press after a restart.
+ * Note: Telegram callback IDs expire after ~10 min, so entries in this store
+ * are automatically removed once they have been used.</li>
+ * </ul>
+ *
+ * <p>
+ * Keys are composite strings {@code "<chatId>:<replyId>"} to allow a flat
+ * key-value store without nested structures.
+ *
+ * @author Christoph Pfarrherr - Initial contribution
+ */
+@NonNullByDefault
+public class TelegramMessageStore {
+
+    /** Storage name for the replyId → message-ID mapping. */
+    static final String MESSAGE_ID_STORAGE_NAME = "telegram.replyIdToMessageId";
+
+    /** Storage name for the replyId → callback-ID mapping. */
+    static final String CALLBACK_ID_STORAGE_NAME = "telegram.replyIdToCallbackId";
+
+    private final Logger logger = LoggerFactory.getLogger(TelegramMessageStore.class);
+
+    // Both maps use String values to avoid Gson round-trip issues with Integer → Double.
+    private final Storage<String> messageIdStorage;
+    private final Storage<String> callbackIdStorage;
+
+    /**
+     * Creates a new store backed by the given {@link StorageService}.
+     *
+     * @param storageService the openHAB storage service (OSGi injected)
+     */
+    public TelegramMessageStore(StorageService storageService) {
+        this.messageIdStorage = storageService.getStorage(MESSAGE_ID_STORAGE_NAME, String.class.getClassLoader());
+        this.callbackIdStorage = storageService.getStorage(CALLBACK_ID_STORAGE_NAME, String.class.getClassLoader());
+    }
+
+    // -------------------------------------------------------------------------
+    // Internal helpers
+    // -------------------------------------------------------------------------
+
+    /**
+     * Builds the composite storage key.
+     *
+     * @param chatId Telegram chat ID
+     * @param replyId application-level reply identifier (must not contain ':')
+     * @return composite key {@code "<chatId>:<replyId>"}
+     */
+    static String buildKey(Long chatId, String replyId) {
+        return chatId + ":" + replyId;
+    }
+
+    // -------------------------------------------------------------------------
+    // Message-ID operations
+    // -------------------------------------------------------------------------
+
+    /**
+     * Persists the Telegram {@code messageId} for the given (chatId, replyId) pair.
+     *
+     * @param chatId Telegram chat ID
+     * @param replyId application-level reply identifier
+     * @param messageId Telegram message ID returned by the send API
+     */
+    public void putMessageId(Long chatId, String replyId, Integer messageId) {
+        String key = buildKey(chatId, replyId);
+        logger.debug("Persisting messageId {} for key '{}'", messageId, key);
+        messageIdStorage.put(key, messageId.toString());
+    }
+
+    /**
+     * Retrieves and <b>removes</b> the stored Telegram message ID for
+     * (chatId, replyId). Returns {@code null} if no entry exists.
+     *
+     * @param chatId Telegram chat ID
+     * @param replyId application-level reply identifier
+     * @return the Telegram message ID, or {@code null}
+     */
+    public @Nullable Integer removeMessageId(Long chatId, String replyId) {
+        String key = buildKey(chatId, replyId);
+        String value = messageIdStorage.remove(key);
+        return parseIntOrNull(value, key, "messageId");
+    }
+
+    /**
+     * Retrieves the stored Telegram message ID for (chatId, replyId) without
+     * removing it. Returns {@code null} if no entry exists.
+     *
+     * @param chatId Telegram chat ID
+     * @param replyId application-level reply identifier
+     * @return the Telegram message ID, or {@code null}
+     */
+    public @Nullable Integer getMessageId(Long chatId, String replyId) {
+        String value = messageIdStorage.get(buildKey(chatId, replyId));
+        return parseIntOrNull(value, buildKey(chatId, replyId), "messageId");
+    }
+
+    /**
+     * Returns all keys currently stored in the message-ID store.
+     * Useful for diagnostics and testing.
+     *
+     * @return collection of composite keys
+     */
+    public Collection<String> allMessageIdKeys() {
+        return List.copyOf(messageIdStorage.getKeys());
+    }
+
+    // -------------------------------------------------------------------------
+    // Callback-ID operations
+    // -------------------------------------------------------------------------
+
+    /**
+     * Persists the Telegram {@code callbackId} for the given (chatId, replyId) pair.
+     *
+     * @param chatId Telegram chat ID
+     * @param replyId application-level reply identifier
+     * @param callbackId Telegram callback query ID
+     */
+    public void putCallbackId(Long chatId, String replyId, String callbackId) {
+        String key = buildKey(chatId, replyId);
+        logger.debug("Persisting callbackId '{}' for key '{}'", callbackId, key);
+        callbackIdStorage.put(key, callbackId);
+    }
+
+    /**
+     * Retrieves the stored Telegram callback ID for (chatId, replyId).
+     * The entry is <b>not</b> removed; call {@link #removeCallbackId} after use.
+     *
+     * @param chatId Telegram chat ID
+     * @param replyId application-level reply identifier
+     * @return the Telegram callback ID, or {@code null}
+     */
+    public @Nullable String getCallbackId(Long chatId, String replyId) {
+        return callbackIdStorage.get(buildKey(chatId, replyId));
+    }
+
+    /**
+     * Removes the stored Telegram callback ID for (chatId, replyId).
+     *
+     * @param chatId Telegram chat ID
+     * @param replyId application-level reply identifier
+     */
+    public void removeCallbackId(Long chatId, String replyId) {
+        String key = buildKey(chatId, replyId);
+        logger.debug("Removing callbackId for key '{}'", key);
+        callbackIdStorage.remove(key);
+    }
+
+    // -------------------------------------------------------------------------
+    // Private utilities
+    // -------------------------------------------------------------------------
+
+    private @Nullable Integer parseIntOrNull(@Nullable String value, String key, String fieldName) {
+        if (value == null) {
+            return null;
+        }
+        try {
+            return Integer.valueOf(value);
+        } catch (NumberFormatException e) {
+            logger.warn("Stored {} '{}' for key '{}' is not a valid integer – ignoring entry", fieldName, value, key);
+            return null;
+        }
+    }
+}

--- a/bundles/org.openhab.binding.telegram/src/main/java/org/openhab/binding/telegram/internal/TelegramMessageStore.java
+++ b/bundles/org.openhab.binding.telegram/src/main/java/org/openhab/binding/telegram/internal/TelegramMessageStore.java
@@ -9,9 +9,7 @@
  * http://www.eclipse.org/legal/epl-2.0
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
  */
-
 package org.openhab.binding.telegram.internal;
 
 import java.util.Collection;
@@ -21,38 +19,59 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.storage.Storage;
 import org.openhab.core.storage.StorageService;
+import org.openhab.core.thing.ThingUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Persistent store for Telegram message IDs and callback IDs.
+ * Persistent store for Telegram message IDs and callback IDs, scoped to a
+ * single {@link org.openhab.core.thing.Thing}.
  *
  * <p>
  * openHAB's {@link StorageService} backs this class, so all entries survive
- * a restart of openHAB. The two logical maps are:
+ * a restart of openHAB. Each {@link TelegramHandler} instance owns exactly one
+ * {@code TelegramMessageStore}; the storage namespaces include the Thing UID so
+ * that multiple Telegram Things (each with its own bot token) can never
+ * interfere with each other even if they happen to share the same
+ * {@code chatId}/{@code replyId} values.
+ *
+ * <p>
+ * The two logical maps are:
  * <ul>
  * <li><b>messageId store</b> – maps (chatId, replyId) → Telegram message ID.
  * Required to edit or delete an inline-keyboard message after a restart.</li>
  * <li><b>callbackId store</b> – maps (chatId, replyId) → Telegram callback
  * query ID. Required to answer (acknowledge) a button press after a restart.
- * Note: Telegram callback IDs expire after ~10 min, so entries in this store
- * are automatically removed once they have been used.</li>
+ * Telegram callback IDs expire after approximately 10 minutes, so entries in
+ * this store are removed once they have been used.</li>
  * </ul>
  *
  * <p>
- * Keys are composite strings {@code "<chatId>:<replyId>"} to allow a flat
- * key-value store without nested structures.
+ * Within each store, keys are composite strings {@code "<chatId>:<replyId>"}
+ * to allow a flat key-value layout without nested structures.
+ *
+ * <p>
+ * Storage namespace pattern:
+ *
+ * <pre>
+ *   telegram.&lt;thingUID&gt;.replyIdToMessageId
+ *   telegram.&lt;thingUID&gt;.replyIdToCallbackId
+ * </pre>
  *
  * @author Christoph Pfarrherr - Initial contribution
  */
+
 @NonNullByDefault
 public class TelegramMessageStore {
 
-    /** Storage name for the replyId → message-ID mapping. */
-    static final String MESSAGE_ID_STORAGE_NAME = "telegram.replyIdToMessageId";
+    /** Prefix shared by both storage namespace names. */
+    static final String STORAGE_NAME_PREFIX = "telegram.";
 
-    /** Storage name for the replyId → callback-ID mapping. */
-    static final String CALLBACK_ID_STORAGE_NAME = "telegram.replyIdToCallbackId";
+    /** Suffix for the replyId → message-ID storage namespace. */
+    static final String MESSAGE_ID_STORAGE_SUFFIX = ".replyIdToMessageId";
+
+    /** Suffix for the replyId → callback-ID storage namespace. */
+    static final String CALLBACK_ID_STORAGE_SUFFIX = ".replyIdToCallbackId";
 
     private final Logger logger = LoggerFactory.getLogger(TelegramMessageStore.class);
 
@@ -61,27 +80,63 @@ public class TelegramMessageStore {
     private final Storage<String> callbackIdStorage;
 
     /**
-     * Creates a new store backed by the given {@link StorageService}.
+     * Creates a new store scoped to the given Thing.
      *
-     * @param storageService the openHAB storage service (OSGi injected)
+     * <p>
+     * Using the {@link ThingUID} as part of the storage namespace guarantees
+     * that two {@link TelegramHandler} instances with different bot tokens
+     * never share storage entries, even when their chat IDs and reply IDs are
+     * identical.
+     *
+     * @param storageService the openHAB storage service (injected by
+     *            {@link TelegramHandlerFactory})
+     * @param thingUID the UID of the Thing that owns this store; used
+     *            to build the storage namespace
      */
-    public TelegramMessageStore(StorageService storageService) {
-        this.messageIdStorage = storageService.getStorage(MESSAGE_ID_STORAGE_NAME, String.class.getClassLoader());
-        this.callbackIdStorage = storageService.getStorage(CALLBACK_ID_STORAGE_NAME, String.class.getClassLoader());
+    public TelegramMessageStore(StorageService storageService, ThingUID thingUID) {
+        String uid = thingUID.getAsString();
+        this.messageIdStorage = storageService.getStorage(STORAGE_NAME_PREFIX + uid + MESSAGE_ID_STORAGE_SUFFIX,
+                String.class.getClassLoader());
+        this.callbackIdStorage = storageService.getStorage(STORAGE_NAME_PREFIX + uid + CALLBACK_ID_STORAGE_SUFFIX,
+                String.class.getClassLoader());
     }
 
     // -------------------------------------------------------------------------
-    // Internal helpers
+    // Package-visible helpers (used by tests)
     // -------------------------------------------------------------------------
 
     /**
-     * Builds the composite storage key.
+     * Returns the full message-ID storage namespace for the given Thing UID.
+     *
+     * @param thingUID the Thing UID
+     * @return storage namespace string
+     */
+    static String messageIdStorageName(ThingUID thingUID) {
+        return STORAGE_NAME_PREFIX + thingUID.getAsString() + MESSAGE_ID_STORAGE_SUFFIX;
+    }
+
+    /**
+     * Returns the full callback-ID storage namespace for the given Thing UID.
+     *
+     * @param thingUID the Thing UID
+     * @return storage namespace string
+     */
+    static String callbackIdStorageName(ThingUID thingUID) {
+        return STORAGE_NAME_PREFIX + thingUID.getAsString() + CALLBACK_ID_STORAGE_SUFFIX;
+    }
+
+    /**
+     * Builds the composite storage key from a chat ID and a reply ID.
      *
      * @param chatId Telegram chat ID
      * @param replyId application-level reply identifier (must not contain ':')
      * @return composite key {@code "<chatId>:<replyId>"}
+     * @throws IllegalArgumentException if {@code replyId} contains ':'
      */
     static String buildKey(Long chatId, String replyId) {
+        if (replyId.indexOf(':') >= 0) {
+            throw new IllegalArgumentException("replyId must not contain ':': " + replyId);
+        }
         return chatId + ":" + replyId;
     }
 
@@ -112,8 +167,7 @@ public class TelegramMessageStore {
      */
     public @Nullable Integer removeMessageId(Long chatId, String replyId) {
         String key = buildKey(chatId, replyId);
-        String value = messageIdStorage.remove(key);
-        return parseIntOrNull(value, key, "messageId");
+        return parseIntOrNull(messageIdStorage.remove(key), key, "messageId");
     }
 
     /**
@@ -125,15 +179,15 @@ public class TelegramMessageStore {
      * @return the Telegram message ID, or {@code null}
      */
     public @Nullable Integer getMessageId(Long chatId, String replyId) {
-        String value = messageIdStorage.get(buildKey(chatId, replyId));
-        return parseIntOrNull(value, buildKey(chatId, replyId), "messageId");
+        String key = buildKey(chatId, replyId);
+        return parseIntOrNull(messageIdStorage.get(key), key, "messageId");
     }
 
     /**
      * Returns all keys currently stored in the message-ID store.
-     * Useful for diagnostics and testing.
+     * Intended for diagnostics and testing.
      *
-     * @return collection of composite keys
+     * @return unmodifiable collection of composite keys
      */
     public Collection<String> allMessageIdKeys() {
         return List.copyOf(messageIdStorage.getKeys());
@@ -158,7 +212,7 @@ public class TelegramMessageStore {
 
     /**
      * Retrieves the stored Telegram callback ID for (chatId, replyId).
-     * The entry is <b>not</b> removed; call {@link #removeCallbackId} after use.
+     * The entry is automatically removed after use in {@link TelegramActions#sendTelegramAnswer}.
      *
      * @param chatId Telegram chat ID
      * @param replyId application-level reply identifier

--- a/bundles/org.openhab.binding.telegram/src/main/java/org/openhab/binding/telegram/internal/TelegramMessageStore.java
+++ b/bundles/org.openhab.binding.telegram/src/main/java/org/openhab/binding/telegram/internal/TelegramMessageStore.java
@@ -12,6 +12,8 @@
  */
 package org.openhab.binding.telegram.internal;
 
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.Collection;
 import java.util.List;
 
@@ -47,7 +49,7 @@ import org.slf4j.LoggerFactory;
  * </ul>
  *
  * <p>
- * Within each store, keys are composite strings {@code "<chatId>:<replyId>"}
+ * Within each store, keys are composite strings {@code "<chatId>:<encodedReplyId>"}
  * to allow a flat key-value layout without nested structures.
  *
  * <p>
@@ -129,15 +131,15 @@ public class TelegramMessageStore {
      * Builds the composite storage key from a chat ID and a reply ID.
      *
      * @param chatId Telegram chat ID
-     * @param replyId application-level reply identifier (must not contain ':')
-     * @return composite key {@code "<chatId>:<replyId>"}
-     * @throws IllegalArgumentException if {@code replyId} contains ':'
+     * @param replyId application-level reply identifier
+     * @return composite key {@code "<chatId>:<encodedReplyId>"}
      */
     static String buildKey(Long chatId, String replyId) {
-        if (replyId.indexOf(':') >= 0) {
-            throw new IllegalArgumentException("replyId must not contain ':': " + replyId);
-        }
-        return chatId + ":" + replyId;
+        return chatId + ":" + encodeReplyId(replyId);
+    }
+
+    private static String encodeReplyId(String replyId) {
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(replyId.getBytes(StandardCharsets.UTF_8));
     }
 
     // -------------------------------------------------------------------------

--- a/bundles/org.openhab.binding.telegram/src/main/java/org/openhab/binding/telegram/internal/TelegramMessageStore.java
+++ b/bundles/org.openhab.binding.telegram/src/main/java/org/openhab/binding/telegram/internal/TelegramMessageStore.java
@@ -98,9 +98,9 @@ public class TelegramMessageStore {
     public TelegramMessageStore(StorageService storageService, ThingUID thingUID) {
         String uid = thingUID.getAsString();
         this.messageIdStorage = storageService.getStorage(STORAGE_NAME_PREFIX + uid + MESSAGE_ID_STORAGE_SUFFIX,
-                String.class.getClassLoader());
+                TelegramMessageStore.class.getClassLoader());
         this.callbackIdStorage = storageService.getStorage(STORAGE_NAME_PREFIX + uid + CALLBACK_ID_STORAGE_SUFFIX,
-                String.class.getClassLoader());
+                TelegramMessageStore.class.getClassLoader());
     }
 
     // -------------------------------------------------------------------------

--- a/bundles/org.openhab.binding.telegram/src/main/java/org/openhab/binding/telegram/internal/TelegramMessageStore.java
+++ b/bundles/org.openhab.binding.telegram/src/main/java/org/openhab/binding/telegram/internal/TelegramMessageStore.java
@@ -247,7 +247,9 @@ public class TelegramMessageStore {
         try {
             return Integer.valueOf(value);
         } catch (NumberFormatException e) {
-            logger.warn("Stored {} '{}' for key '{}' is not a valid integer – ignoring entry", fieldName, value, key);
+            logger.warn("Stored {} '{}' for key '{}' is not a valid integer - removing corrupt entry", fieldName, value,
+                    key);
+            messageIdStorage.remove(key);
             return null;
         }
     }

--- a/bundles/org.openhab.binding.telegram/src/main/java/org/openhab/binding/telegram/internal/TelegramMessageStore.java
+++ b/bundles/org.openhab.binding.telegram/src/main/java/org/openhab/binding/telegram/internal/TelegramMessageStore.java
@@ -249,7 +249,13 @@ public class TelegramMessageStore {
         } catch (NumberFormatException e) {
             logger.warn("Stored {} '{}' for key '{}' is not a valid integer - removing corrupt entry", fieldName, value,
                     key);
-            messageIdStorage.remove(key);
+            String currentValue = messageIdStorage.get(key);
+            if (value.equals(currentValue)) {
+                messageIdStorage.remove(key);
+            } else {
+                logger.debug("Skipping removal of key '{}' because stored value changed while handling invalid {}", key,
+                        fieldName);
+            }
             return null;
         }
     }

--- a/bundles/org.openhab.binding.telegram/src/main/java/org/openhab/binding/telegram/internal/action/TelegramActions.java
+++ b/bundles/org.openhab.binding.telegram/src/main/java/org/openhab/binding/telegram/internal/action/TelegramActions.java
@@ -181,7 +181,13 @@ public class TelegramActions implements ThingActions {
             Integer messageId = localHandler.removeMessageId(chatId, replyId);
             logger.debug("remove messageId {} for chatId {} and replyId {}", messageId, chatId, replyId);
 
-            return sendTelegramAnswer(chatId, callbackId, messageId != null ? Long.valueOf(messageId) : null, message);
+            boolean result = sendTelegramAnswer(chatId, callbackId, messageId != null ? Long.valueOf(messageId) : null,
+                    message);
+            if (result && callbackId != null) {
+                localHandler.removeCallbackId(chatId, replyId);
+                logger.debug("remove callbackId for chatId {} and replyId {}", chatId, replyId);
+            }
+            return result;
         }
         return false;
     }

--- a/bundles/org.openhab.binding.telegram/src/main/java/org/openhab/binding/telegram/internal/action/TelegramActions.java
+++ b/bundles/org.openhab.binding.telegram/src/main/java/org/openhab/binding/telegram/internal/action/TelegramActions.java
@@ -24,6 +24,7 @@ import java.nio.file.Path;
 import java.util.Base64;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
@@ -72,6 +73,7 @@ import com.pengrad.telegrambot.response.SendResponse;
  * Provides the actions for the Telegram API.
  *
  * @author Alexander Krasnogolowy - Initial contribution
+ * @author Christoph Pfarrherr - fixing message "Avoid method with implicit default Locale: xxx.toLowerCase()"
  */
 @Component(scope = ServiceScope.PROTOTYPE, service = TelegramActions.class)
 @ThingActionsScope(name = "telegram")
@@ -423,7 +425,7 @@ public class TelegramActions implements ThingActions {
             logger.warn("chatId not defined; action skipped.");
             return false;
         }
-        String lowercasePhotoUrl = photoURL.toLowerCase();
+        String lowercasePhotoUrl = photoURL.toLowerCase(Locale.ROOT);
         TelegramHandler localHandler = handler;
         if (localHandler != null) {
             final SendPhoto sendPhoto;
@@ -583,7 +585,7 @@ public class TelegramActions implements ThingActions {
 
             for (int i = 0; i < mediaUrls.size(); i++) {
                 String url = mediaUrls.get(i);
-                String type = mediaTypes.get(i).toLowerCase();
+                String type = mediaTypes.get(i).toLowerCase(Locale.ROOT);
 
                 try {
                     InputMedia<?> media = switch (type) {
@@ -664,7 +666,7 @@ public class TelegramActions implements ThingActions {
         TelegramHandler localHandler = handler;
         if (localHandler != null) {
             final SendAnimation sendAnimation;
-            if (animationURL.toLowerCase().startsWith("http")) {
+            if (animationURL.toLowerCase(Locale.ROOT).startsWith("http")) {
                 // load image from url
                 logger.debug("Animation URL provided.");
                 HttpClient client = localHandler.getClient();
@@ -692,7 +694,7 @@ public class TelegramActions implements ThingActions {
                 }
             } else {
                 String temp = animationURL;
-                if (!animationURL.toLowerCase().startsWith("file:")) {
+                if (!animationURL.toLowerCase(Locale.ROOT).startsWith("file:")) {
                     temp = "file://" + animationURL;
                 }
                 // Load video from local file system
@@ -746,7 +748,7 @@ public class TelegramActions implements ThingActions {
         }
         TelegramHandler localHandler = handler;
         if (localHandler != null) {
-            if (videoURL.toLowerCase().startsWith("http")) {
+            if (videoURL.toLowerCase(Locale.ROOT).startsWith("http")) {
                 logger.debug("Video http://URL provided.");
                 HttpClient client = localHandler.getClient();
                 if (client == null) {
@@ -778,7 +780,7 @@ public class TelegramActions implements ThingActions {
                 }
             } else {
                 String temp = videoURL;
-                if (!videoURL.toLowerCase().startsWith("file:")) {
+                if (!videoURL.toLowerCase(Locale.ROOT).startsWith("file:")) {
                     temp = "file://" + videoURL;
                 }
                 // Load video from local file system with file://path

--- a/bundles/org.openhab.binding.telegram/src/main/java/org/openhab/binding/telegram/internal/action/TelegramActions.java
+++ b/bundles/org.openhab.binding.telegram/src/main/java/org/openhab/binding/telegram/internal/action/TelegramActions.java
@@ -183,7 +183,8 @@ public class TelegramActions implements ThingActions {
 
             boolean result = sendTelegramAnswer(chatId, callbackId, messageId != null ? Long.valueOf(messageId) : null,
                     message);
-            if (result && callbackId != null) {
+            if (callbackId != null) 
+            {
                 localHandler.removeCallbackId(chatId, replyId);
                 logger.debug("remove callbackId for chatId {} and replyId {}", chatId, replyId);
             }

--- a/bundles/org.openhab.binding.telegram/src/main/java/org/openhab/binding/telegram/internal/action/TelegramActions.java
+++ b/bundles/org.openhab.binding.telegram/src/main/java/org/openhab/binding/telegram/internal/action/TelegramActions.java
@@ -183,8 +183,7 @@ public class TelegramActions implements ThingActions {
 
             boolean result = sendTelegramAnswer(chatId, callbackId, messageId != null ? Long.valueOf(messageId) : null,
                     message);
-            if (callbackId != null) 
-            {
+            if (callbackId != null) {
                 localHandler.removeCallbackId(chatId, replyId);
                 logger.debug("remove callbackId for chatId {} and replyId {}", chatId, replyId);
             }

--- a/bundles/org.openhab.binding.telegram/src/test/java/org/openhab/binding/telegram/internal/TelegramMessageStoreTest.java
+++ b/bundles/org.openhab.binding.telegram/src/test/java/org/openhab/binding/telegram/internal/TelegramMessageStoreTest.java
@@ -18,6 +18,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
@@ -25,22 +26,28 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openhab.core.storage.Storage;
 import org.openhab.core.storage.StorageService;
+import org.openhab.core.thing.ThingTypeUID;
+import org.openhab.core.thing.ThingUID;
 
 /**
  * Unit tests for {@link TelegramMessageStore}.
  *
  * <p>
- * No OSGi runtime or Mockito required. The {@link StorageService}
- * is replaced by a simple anonymous implementation that internally
- * uses {@link HashMap}s. This enables full round-trip coverage
- * without external dependencies.
+ * No OSGi runtime and no Mockito required. The {@link StorageService} is
+ * replaced by an anonymous in-memory implementation backed by {@link HashMap}s,
+ * one per storage namespace. This gives full round-trip coverage without any
+ * container dependency.
  */
 @NonNullByDefault
 class TelegramMessageStoreTest {
 
     // -----------------------------------------------------------------------
-    // Test-Fixtures
+    // Fixtures
     // -----------------------------------------------------------------------
+
+    private static final ThingTypeUID THING_TYPE_UID = new ThingTypeUID("telegram", "telegramBot");
+    private static final ThingUID THING_UID = new ThingUID(THING_TYPE_UID, "bot1");
+    private static final ThingUID THING_UID_2 = new ThingUID(THING_TYPE_UID, "bot2");
 
     private static final Long CHAT_ID = 123456789L;
     private static final Long CHAT_ID_2 = 987654321L;
@@ -49,11 +56,11 @@ class TelegramMessageStoreTest {
     private static final int MESSAGE_ID = 42;
     private static final String CALLBACK_ID = "abc-callback-xyz";
 
-    /** An in-memory map that simulates the persistent messageId store. */
-    private final Map<String, @Nullable String> messageIdBackingMap = new HashMap<>();
-
-    /** An in-memory map that simulates the persistent callbackId store. */
-    private final Map<String, @Nullable String> callbackIdBackingMap = new HashMap<>();
+    /**
+     * In-memory backing: namespace → (key → value).
+     * Shared across store instances to simulate a real persistent backend.
+     */
+    private final Map<String, Map<String, @Nullable String>> namespaceMap = new HashMap<>();
 
     @NonNullByDefault({})
     private TelegramMessageStore store;
@@ -64,9 +71,79 @@ class TelegramMessageStoreTest {
 
     @BeforeEach
     void setUp() {
-        messageIdBackingMap.clear();
-        callbackIdBackingMap.clear();
-        store = new TelegramMessageStore(createStorageService());
+        namespaceMap.clear();
+        store = new TelegramMessageStore(createStorageService(), THING_UID);
+    }
+
+    // -----------------------------------------------------------------------
+    // Storage namespace naming
+    // -----------------------------------------------------------------------
+
+    @Test
+    void messageIdStorageName_containsThingUID() {
+        String name = TelegramMessageStore.messageIdStorageName(THING_UID);
+        assertTrue(name.contains(THING_UID.getAsString()),
+                "Storage name must contain the Thing UID to prevent cross-bot collisions");
+        assertTrue(name.startsWith(TelegramMessageStore.STORAGE_NAME_PREFIX));
+        assertTrue(name.endsWith(TelegramMessageStore.MESSAGE_ID_STORAGE_SUFFIX));
+    }
+
+    @Test
+    void callbackIdStorageName_containsThingUID() {
+        String name = TelegramMessageStore.callbackIdStorageName(THING_UID);
+        assertTrue(name.contains(THING_UID.getAsString()));
+        assertTrue(name.startsWith(TelegramMessageStore.STORAGE_NAME_PREFIX));
+        assertTrue(name.endsWith(TelegramMessageStore.CALLBACK_ID_STORAGE_SUFFIX));
+    }
+
+    @Test
+    void storageNames_differBetweenThings() {
+        assertNotEquals(TelegramMessageStore.messageIdStorageName(THING_UID),
+                TelegramMessageStore.messageIdStorageName(THING_UID_2),
+                "Two different Things must use different storage namespaces");
+        assertNotEquals(TelegramMessageStore.callbackIdStorageName(THING_UID),
+                TelegramMessageStore.callbackIdStorageName(THING_UID_2));
+    }
+
+    // -----------------------------------------------------------------------
+    // Cross-Thing isolation (the critical Copilot finding)
+    // -----------------------------------------------------------------------
+
+    @Test
+    void messageId_isolatedBetweenThings_sameChatIdAndReplyId() {
+        // Two bots – same chatId, same replyId, but different Things
+        TelegramMessageStore store2 = new TelegramMessageStore(createStorageService(), THING_UID_2);
+
+        store.putMessageId(CHAT_ID, REPLY_ID, MESSAGE_ID);
+        store2.putMessageId(CHAT_ID, REPLY_ID, 999);
+
+        // Each store must only see its own value
+        assertEquals(MESSAGE_ID, store.getMessageId(CHAT_ID, REPLY_ID));
+        assertEquals(999, store2.getMessageId(CHAT_ID, REPLY_ID));
+    }
+
+    @Test
+    void callbackId_isolatedBetweenThingsSameChatIdAndReplyId() {
+        TelegramMessageStore store2 = new TelegramMessageStore(createStorageService(), THING_UID_2);
+
+        store.putCallbackId(CHAT_ID, REPLY_ID, CALLBACK_ID);
+        store2.putCallbackId(CHAT_ID, REPLY_ID, "other-callback");
+
+        assertEquals(CALLBACK_ID, store.getCallbackId(CHAT_ID, REPLY_ID));
+        assertEquals("other-callback", store2.getCallbackId(CHAT_ID, REPLY_ID));
+    }
+
+    @Test
+    void removeMessageIdOnOneThingDoesNotAffectOtherThing() {
+        TelegramMessageStore store2 = new TelegramMessageStore(createStorageService(), THING_UID_2);
+
+        store.putMessageId(CHAT_ID, REPLY_ID, MESSAGE_ID);
+        store2.putMessageId(CHAT_ID, REPLY_ID, 999);
+
+        store.removeMessageId(CHAT_ID, REPLY_ID);
+
+        assertNull(store.getMessageId(CHAT_ID, REPLY_ID));
+        assertEquals(999, store2.getMessageId(CHAT_ID, REPLY_ID));
     }
 
     // -----------------------------------------------------------------------
@@ -97,8 +174,9 @@ class TelegramMessageStoreTest {
     @Test
     void putMessageIdStoresValueInBackingMap() {
         store.putMessageId(CHAT_ID, REPLY_ID, MESSAGE_ID);
+        String namespace = TelegramMessageStore.messageIdStorageName(THING_UID);
         assertEquals(String.valueOf(MESSAGE_ID),
-                messageIdBackingMap.get(TelegramMessageStore.buildKey(CHAT_ID, REPLY_ID)));
+                namespaceMap.getOrDefault(namespace, Map.of()).get(TelegramMessageStore.buildKey(CHAT_ID, REPLY_ID)));
     }
 
     @Test
@@ -208,7 +286,9 @@ class TelegramMessageStoreTest {
     @Test
     void putCallbackIdStoresValueInBackingMap() {
         store.putCallbackId(CHAT_ID, REPLY_ID, CALLBACK_ID);
-        assertEquals(CALLBACK_ID, callbackIdBackingMap.get(TelegramMessageStore.buildKey(CHAT_ID, REPLY_ID)));
+        String namespace = TelegramMessageStore.callbackIdStorageName(THING_UID);
+        assertEquals(CALLBACK_ID,
+                namespaceMap.getOrDefault(namespace, Map.of()).get(TelegramMessageStore.buildKey(CHAT_ID, REPLY_ID)));
     }
 
     @Test
@@ -269,7 +349,7 @@ class TelegramMessageStoreTest {
     }
 
     // -----------------------------------------------------------------------
-    // Cross-Store-Isolation
+    // Cross-store isolation (messageId vs callbackId)
     // -----------------------------------------------------------------------
 
     @Test
@@ -285,81 +365,78 @@ class TelegramMessageStoreTest {
     }
 
     // -----------------------------------------------------------------------
-    // Robustness: corrupt value in the backing store
+    // Robustness: corrupt stored value
     // -----------------------------------------------------------------------
 
     @Test
     void getMessageIdReturnsNullForCorruptValue() {
-        messageIdBackingMap.put(TelegramMessageStore.buildKey(CHAT_ID, REPLY_ID), "NOT_A_NUMBER");
+        Map<String, @Nullable String> map = namespaceMap
+                .computeIfAbsent(TelegramMessageStore.messageIdStorageName(THING_UID), k -> new HashMap<>());
+        map.put(TelegramMessageStore.buildKey(CHAT_ID, REPLY_ID), "NOT_A_NUMBER");
         assertNull(store.getMessageId(CHAT_ID, REPLY_ID));
     }
 
     @Test
     void removeMessageIdReturnsNullForCorruptValue() {
-        messageIdBackingMap.put(TelegramMessageStore.buildKey(CHAT_ID, REPLY_ID), "NOT_A_NUMBER");
+        Map<String, @Nullable String> map = namespaceMap
+                .computeIfAbsent(TelegramMessageStore.messageIdStorageName(THING_UID), k -> new HashMap<>());
+        map.put(TelegramMessageStore.buildKey(CHAT_ID, REPLY_ID), "NOT_A_NUMBER");
         assertNull(store.removeMessageId(CHAT_ID, REPLY_ID));
     }
 
     // -----------------------------------------------------------------------
-    // Persistency Simulation: new Store, same Backing-Maps
+    // Persistence simulation: new store instance, same backing maps
     // -----------------------------------------------------------------------
 
     @Test
     void messageIdSurvivesStoreReinit() {
         store.putMessageId(CHAT_ID, REPLY_ID, MESSAGE_ID);
-        // Neustart: neuer TelegramMessageStore, selbe Maps
-        assertEquals(MESSAGE_ID, new TelegramMessageStore(createStorageService()).getMessageId(CHAT_ID, REPLY_ID));
+        TelegramMessageStore reloaded = new TelegramMessageStore(createStorageService(), THING_UID);
+        assertEquals(MESSAGE_ID, reloaded.getMessageId(CHAT_ID, REPLY_ID));
     }
 
     @Test
     void callbackIdSurvivesStoreReinit() {
         store.putCallbackId(CHAT_ID, REPLY_ID, CALLBACK_ID);
-        assertEquals(CALLBACK_ID, new TelegramMessageStore(createStorageService()).getCallbackId(CHAT_ID, REPLY_ID));
+        TelegramMessageStore reloaded = new TelegramMessageStore(createStorageService(), THING_UID);
+        assertEquals(CALLBACK_ID, reloaded.getCallbackId(CHAT_ID, REPLY_ID));
     }
 
     @Test
     void removedEntryIsAbsentAfterStoreReinit() {
         store.putMessageId(CHAT_ID, REPLY_ID, MESSAGE_ID);
         store.removeMessageId(CHAT_ID, REPLY_ID);
-        assertNull(new TelegramMessageStore(createStorageService()).getMessageId(CHAT_ID, REPLY_ID));
+        TelegramMessageStore reloaded = new TelegramMessageStore(createStorageService(), THING_UID);
+        assertNull(reloaded.getMessageId(CHAT_ID, REPLY_ID));
     }
 
     // -----------------------------------------------------------------------
-    // Helper Methods
+    // Helpers
     // -----------------------------------------------------------------------
 
     /**
-     * Creates a {@link StorageService}, which uses the two HashMap fields of this
-     * test class as backing store, allowing multiple
-     * {@link TelegramMessageStore} instances within the same test to access the same data
-     * (persistency simulation without real disk).
+     * Creates a {@link StorageService} backed by the per-test {@link #namespaceMap}.
+     * Multiple {@link TelegramMessageStore} instances in the same test share the
+     * same physical maps, simulating persistence across "restarts".
      */
     private StorageService createStorageService() {
-        // Fields as local variables for use in the anonymous class
-        Map<String, @Nullable String> msgMap = messageIdBackingMap;
-        Map<String, @Nullable String> cbMap = callbackIdBackingMap;
-
+        Map<String, Map<String, @Nullable String>> backing = namespaceMap;
         return new StorageService() {
             @Override
             public <T> Storage<T> getStorage(String name) {
                 return getStorage(name, null);
             }
 
-            @SuppressWarnings("unchecked")
+            @SuppressWarnings({ "unchecked", "null" })
             @Override
             public <T> Storage<T> getStorage(String name, @Nullable ClassLoader classLoader) {
-                Map<String, @Nullable String> backing = TelegramMessageStore.MESSAGE_ID_STORAGE_NAME.equals(name)
-                        ? msgMap
-                        : cbMap;
-                return (Storage<T>) mapBackedStorage(backing);
+                Map<String, @Nullable String> ns = Objects
+                        .requireNonNull(backing.computeIfAbsent(name, k -> new HashMap<>()));
+                return (Storage<T>) mapBackedStorage(ns);
             }
         };
     }
 
-    /**
-     * Creates a {@link Storage}-implementation, which operates directly on the
-     * provided {@link Map}.
-     */
     private static Storage<String> mapBackedStorage(Map<String, @Nullable String> backing) {
         return new Storage<>() {
             @Override

--- a/bundles/org.openhab.binding.telegram/src/test/java/org/openhab/binding/telegram/internal/TelegramMessageStoreTest.java
+++ b/bundles/org.openhab.binding.telegram/src/test/java/org/openhab/binding/telegram/internal/TelegramMessageStoreTest.java
@@ -1,0 +1,396 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.openhab.binding.telegram.internal;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openhab.core.storage.Storage;
+import org.openhab.core.storage.StorageService;
+
+/**
+ * Unit tests for {@link TelegramMessageStore}.
+ *
+ * <p>
+ * No OSGi runtime or Mockito required. The {@link StorageService}
+ * is replaced by a simple anonymous implementation that internally
+ * uses {@link HashMap}s. This enables full round-trip coverage
+ * without external dependencies.
+ */
+@NonNullByDefault
+class TelegramMessageStoreTest {
+
+    // -----------------------------------------------------------------------
+    // Test-Fixtures
+    // -----------------------------------------------------------------------
+
+    private static final Long CHAT_ID = 123456789L;
+    private static final Long CHAT_ID_2 = 987654321L;
+    private static final String REPLY_ID = "myReply";
+    private static final String REPLY_ID_2 = "otherReply";
+    private static final int MESSAGE_ID = 42;
+    private static final String CALLBACK_ID = "abc-callback-xyz";
+
+    /** An in-memory map that simulates the persistent messageId store. */
+    private final Map<String, @Nullable String> messageIdBackingMap = new HashMap<>();
+
+    /** An in-memory map that simulates the persistent callbackId store. */
+    private final Map<String, @Nullable String> callbackIdBackingMap = new HashMap<>();
+
+    @NonNullByDefault({})
+    private TelegramMessageStore store;
+
+    // -----------------------------------------------------------------------
+    // Setup
+    // -----------------------------------------------------------------------
+
+    @BeforeEach
+    void setUp() {
+        messageIdBackingMap.clear();
+        callbackIdBackingMap.clear();
+        store = new TelegramMessageStore(createStorageService());
+    }
+
+    // -----------------------------------------------------------------------
+    // buildKey
+    // -----------------------------------------------------------------------
+
+    @Test
+    void buildKeyCombinesChatIdAndReplyIdWithColon() {
+        assertEquals(CHAT_ID + ":" + REPLY_ID, TelegramMessageStore.buildKey(CHAT_ID, REPLY_ID));
+    }
+
+    @Test
+    void buildKeyDifferentChatIdProducesDifferentKey() {
+        assertNotEquals(TelegramMessageStore.buildKey(CHAT_ID, REPLY_ID),
+                TelegramMessageStore.buildKey(CHAT_ID_2, REPLY_ID));
+    }
+
+    @Test
+    void buildKeyDifferentReplyIdProducesDifferentKey() {
+        assertNotEquals(TelegramMessageStore.buildKey(CHAT_ID, REPLY_ID),
+                TelegramMessageStore.buildKey(CHAT_ID, REPLY_ID_2));
+    }
+
+    // -----------------------------------------------------------------------
+    // Message-ID – put / get
+    // -----------------------------------------------------------------------
+
+    @Test
+    void putMessageIdStoresValueInBackingMap() {
+        store.putMessageId(CHAT_ID, REPLY_ID, MESSAGE_ID);
+        assertEquals(String.valueOf(MESSAGE_ID),
+                messageIdBackingMap.get(TelegramMessageStore.buildKey(CHAT_ID, REPLY_ID)));
+    }
+
+    @Test
+    void getMessageIdReturnsStoredValue() {
+        store.putMessageId(CHAT_ID, REPLY_ID, MESSAGE_ID);
+        assertEquals(MESSAGE_ID, store.getMessageId(CHAT_ID, REPLY_ID));
+    }
+
+    @Test
+    void getMessageIdReturnsNullWhenAbsent() {
+        assertNull(store.getMessageId(CHAT_ID, REPLY_ID));
+    }
+
+    @Test
+    void getMessageIdDoesNotRemoveEntry() {
+        store.putMessageId(CHAT_ID, REPLY_ID, MESSAGE_ID);
+        store.getMessageId(CHAT_ID, REPLY_ID);
+        assertEquals(MESSAGE_ID, store.getMessageId(CHAT_ID, REPLY_ID));
+    }
+
+    @Test
+    void putMessageIdOverwritesPreviousValue() {
+        store.putMessageId(CHAT_ID, REPLY_ID, MESSAGE_ID);
+        store.putMessageId(CHAT_ID, REPLY_ID, 99);
+        assertEquals(99, store.getMessageId(CHAT_ID, REPLY_ID));
+    }
+
+    @Test
+    void putMessageIdIsolatesByChatId() {
+        store.putMessageId(CHAT_ID, REPLY_ID, MESSAGE_ID);
+        store.putMessageId(CHAT_ID_2, REPLY_ID, 77);
+        assertEquals(MESSAGE_ID, store.getMessageId(CHAT_ID, REPLY_ID));
+        assertEquals(77, store.getMessageId(CHAT_ID_2, REPLY_ID));
+    }
+
+    @Test
+    void putMessageIdIsolatesByReplyId() {
+        store.putMessageId(CHAT_ID, REPLY_ID, MESSAGE_ID);
+        store.putMessageId(CHAT_ID, REPLY_ID_2, 55);
+        assertEquals(MESSAGE_ID, store.getMessageId(CHAT_ID, REPLY_ID));
+        assertEquals(55, store.getMessageId(CHAT_ID, REPLY_ID_2));
+    }
+
+    // -----------------------------------------------------------------------
+    // Message-ID – removeMessageId
+    // -----------------------------------------------------------------------
+
+    @Test
+    void removeMessageIdReturnsValueAndRemovesEntry() {
+        store.putMessageId(CHAT_ID, REPLY_ID, MESSAGE_ID);
+        assertEquals(MESSAGE_ID, store.removeMessageId(CHAT_ID, REPLY_ID));
+        assertNull(store.getMessageId(CHAT_ID, REPLY_ID));
+    }
+
+    @Test
+    void removeMessageIdReturnsNullWhenAbsent() {
+        assertNull(store.removeMessageId(CHAT_ID, REPLY_ID));
+    }
+
+    @Test
+    void removeMessageIdDoesNotAffectOtherEntries() {
+        store.putMessageId(CHAT_ID, REPLY_ID, MESSAGE_ID);
+        store.putMessageId(CHAT_ID, REPLY_ID_2, 77);
+        store.removeMessageId(CHAT_ID, REPLY_ID);
+        assertNull(store.getMessageId(CHAT_ID, REPLY_ID));
+        assertEquals(77, store.getMessageId(CHAT_ID, REPLY_ID_2));
+    }
+
+    @Test
+    void removeMessageIdIdempotentOnSecondCall() {
+        store.putMessageId(CHAT_ID, REPLY_ID, MESSAGE_ID);
+        store.removeMessageId(CHAT_ID, REPLY_ID);
+        assertNull(store.removeMessageId(CHAT_ID, REPLY_ID));
+    }
+
+    // -----------------------------------------------------------------------
+    // Message-ID – allMessageIdKeys
+    // -----------------------------------------------------------------------
+
+    @Test
+    void allMessageIdKeysEmptyWhenNothingStored() {
+        assertTrue(store.allMessageIdKeys().isEmpty());
+    }
+
+    @Test
+    void allMessageIdKeysListsAllStoredKeys() {
+        store.putMessageId(CHAT_ID, REPLY_ID, MESSAGE_ID);
+        store.putMessageId(CHAT_ID_2, REPLY_ID_2, 55);
+
+        Collection<String> keys = store.allMessageIdKeys();
+        assertTrue(keys.contains(TelegramMessageStore.buildKey(CHAT_ID, REPLY_ID)));
+        assertTrue(keys.contains(TelegramMessageStore.buildKey(CHAT_ID_2, REPLY_ID_2)));
+        assertEquals(2, keys.size());
+    }
+
+    @Test
+    void allMessageIdKeysDoesNotContainRemovedKey() {
+        store.putMessageId(CHAT_ID, REPLY_ID, MESSAGE_ID);
+        store.removeMessageId(CHAT_ID, REPLY_ID);
+        assertFalse(store.allMessageIdKeys().contains(TelegramMessageStore.buildKey(CHAT_ID, REPLY_ID)));
+    }
+
+    // -----------------------------------------------------------------------
+    // Callback-ID – put / get
+    // -----------------------------------------------------------------------
+
+    @Test
+    void putCallbackIdStoresValueInBackingMap() {
+        store.putCallbackId(CHAT_ID, REPLY_ID, CALLBACK_ID);
+        assertEquals(CALLBACK_ID, callbackIdBackingMap.get(TelegramMessageStore.buildKey(CHAT_ID, REPLY_ID)));
+    }
+
+    @Test
+    void getCallbackIdReturnsStoredValue() {
+        store.putCallbackId(CHAT_ID, REPLY_ID, CALLBACK_ID);
+        assertEquals(CALLBACK_ID, store.getCallbackId(CHAT_ID, REPLY_ID));
+    }
+
+    @Test
+    void getCallbackIdReturnsNullWhenAbsent() {
+        assertNull(store.getCallbackId(CHAT_ID, REPLY_ID));
+    }
+
+    @Test
+    void getCallbackIdDoesNotRemoveEntry() {
+        store.putCallbackId(CHAT_ID, REPLY_ID, CALLBACK_ID);
+        store.getCallbackId(CHAT_ID, REPLY_ID);
+        assertEquals(CALLBACK_ID, store.getCallbackId(CHAT_ID, REPLY_ID));
+    }
+
+    @Test
+    void putCallbackIdOverwritesPreviousValue() {
+        store.putCallbackId(CHAT_ID, REPLY_ID, CALLBACK_ID);
+        store.putCallbackId(CHAT_ID, REPLY_ID, "new-callback");
+        assertEquals("new-callback", store.getCallbackId(CHAT_ID, REPLY_ID));
+    }
+
+    @Test
+    void putCallbackIdIsolatesByChatId() {
+        store.putCallbackId(CHAT_ID, REPLY_ID, CALLBACK_ID);
+        store.putCallbackId(CHAT_ID_2, REPLY_ID, "other-callback");
+        assertEquals(CALLBACK_ID, store.getCallbackId(CHAT_ID, REPLY_ID));
+        assertEquals("other-callback", store.getCallbackId(CHAT_ID_2, REPLY_ID));
+    }
+
+    // -----------------------------------------------------------------------
+    // Callback-ID – removeCallbackId
+    // -----------------------------------------------------------------------
+
+    @Test
+    void removeCallbackIdRemovesEntry() {
+        store.putCallbackId(CHAT_ID, REPLY_ID, CALLBACK_ID);
+        store.removeCallbackId(CHAT_ID, REPLY_ID);
+        assertNull(store.getCallbackId(CHAT_ID, REPLY_ID));
+    }
+
+    @Test
+    void removeCallbackIdDoesNotThrowWhenAbsent() {
+        assertDoesNotThrow(() -> store.removeCallbackId(CHAT_ID, REPLY_ID));
+    }
+
+    @Test
+    void removeCallbackIdDoesNotAffectOtherEntries() {
+        store.putCallbackId(CHAT_ID, REPLY_ID, CALLBACK_ID);
+        store.putCallbackId(CHAT_ID, REPLY_ID_2, "other");
+        store.removeCallbackId(CHAT_ID, REPLY_ID);
+        assertEquals("other", store.getCallbackId(CHAT_ID, REPLY_ID_2));
+    }
+
+    // -----------------------------------------------------------------------
+    // Cross-Store-Isolation
+    // -----------------------------------------------------------------------
+
+    @Test
+    void messageIdAndCallbackIdStoragesAreIndependent() {
+        store.putMessageId(CHAT_ID, REPLY_ID, MESSAGE_ID);
+        store.putCallbackId(CHAT_ID, REPLY_ID, CALLBACK_ID);
+
+        store.removeMessageId(CHAT_ID, REPLY_ID);
+        assertEquals(CALLBACK_ID, store.getCallbackId(CHAT_ID, REPLY_ID));
+
+        store.removeCallbackId(CHAT_ID, REPLY_ID);
+        assertNull(store.getMessageId(CHAT_ID, REPLY_ID));
+    }
+
+    // -----------------------------------------------------------------------
+    // Robustness: corrupt value in the backing store
+    // -----------------------------------------------------------------------
+
+    @Test
+    void getMessageIdReturnsNullForCorruptValue() {
+        messageIdBackingMap.put(TelegramMessageStore.buildKey(CHAT_ID, REPLY_ID), "NOT_A_NUMBER");
+        assertNull(store.getMessageId(CHAT_ID, REPLY_ID));
+    }
+
+    @Test
+    void removeMessageIdReturnsNullForCorruptValue() {
+        messageIdBackingMap.put(TelegramMessageStore.buildKey(CHAT_ID, REPLY_ID), "NOT_A_NUMBER");
+        assertNull(store.removeMessageId(CHAT_ID, REPLY_ID));
+    }
+
+    // -----------------------------------------------------------------------
+    // Persistency Simulation: new Store, same Backing-Maps
+    // -----------------------------------------------------------------------
+
+    @Test
+    void messageIdSurvivesStoreReinit() {
+        store.putMessageId(CHAT_ID, REPLY_ID, MESSAGE_ID);
+        // Neustart: neuer TelegramMessageStore, selbe Maps
+        assertEquals(MESSAGE_ID, new TelegramMessageStore(createStorageService()).getMessageId(CHAT_ID, REPLY_ID));
+    }
+
+    @Test
+    void callbackIdSurvivesStoreReinit() {
+        store.putCallbackId(CHAT_ID, REPLY_ID, CALLBACK_ID);
+        assertEquals(CALLBACK_ID, new TelegramMessageStore(createStorageService()).getCallbackId(CHAT_ID, REPLY_ID));
+    }
+
+    @Test
+    void removedEntryIsAbsentAfterStoreReinit() {
+        store.putMessageId(CHAT_ID, REPLY_ID, MESSAGE_ID);
+        store.removeMessageId(CHAT_ID, REPLY_ID);
+        assertNull(new TelegramMessageStore(createStorageService()).getMessageId(CHAT_ID, REPLY_ID));
+    }
+
+    // -----------------------------------------------------------------------
+    // Helper Methods
+    // -----------------------------------------------------------------------
+
+    /**
+     * Creates a {@link StorageService}, which uses the two HashMap fields of this
+     * test class as backing store, allowing multiple
+     * {@link TelegramMessageStore} instances within the same test to access the same data
+     * (persistency simulation without real disk).
+     */
+    private StorageService createStorageService() {
+        // Fields as local variables for use in the anonymous class
+        Map<String, @Nullable String> msgMap = messageIdBackingMap;
+        Map<String, @Nullable String> cbMap = callbackIdBackingMap;
+
+        return new StorageService() {
+            @Override
+            public <T> Storage<T> getStorage(String name) {
+                return getStorage(name, null);
+            }
+
+            @SuppressWarnings("unchecked")
+            @Override
+            public <T> Storage<T> getStorage(String name, @Nullable ClassLoader classLoader) {
+                Map<String, @Nullable String> backing = TelegramMessageStore.MESSAGE_ID_STORAGE_NAME.equals(name)
+                        ? msgMap
+                        : cbMap;
+                return (Storage<T>) mapBackedStorage(backing);
+            }
+        };
+    }
+
+    /**
+     * Creates a {@link Storage}-implementation, which operates directly on the
+     * provided {@link Map}.
+     */
+    private static Storage<String> mapBackedStorage(Map<String, @Nullable String> backing) {
+        return new Storage<>() {
+            @Override
+            public @Nullable String put(String key, @Nullable String value) {
+                return backing.put(key, value);
+            }
+
+            @Override
+            public @Nullable String remove(String key) {
+                return backing.remove(key);
+            }
+
+            @Override
+            public boolean containsKey(String key) {
+                return backing.containsKey(key);
+            }
+
+            @Override
+            public @Nullable String get(String key) {
+                return backing.get(key);
+            }
+
+            @Override
+            public Collection<String> getKeys() {
+                return backing.keySet();
+            }
+
+            @Override
+            public Collection<@Nullable String> getValues() {
+                return backing.values();
+            }
+        };
+    }
+}

--- a/bundles/org.openhab.binding.telegram/src/test/java/org/openhab/binding/telegram/internal/TelegramMessageStoreTest.java
+++ b/bundles/org.openhab.binding.telegram/src/test/java/org/openhab/binding/telegram/internal/TelegramMessageStoreTest.java
@@ -80,7 +80,7 @@ class TelegramMessageStoreTest {
     // -----------------------------------------------------------------------
 
     @Test
-    void messageIdStorageName_containsThingUID() {
+    void messageIdStorageNameContainsThingUID() {
         String name = TelegramMessageStore.messageIdStorageName(THING_UID);
         assertTrue(name.contains(THING_UID.getAsString()),
                 "Storage name must contain the Thing UID to prevent cross-bot collisions");
@@ -89,7 +89,7 @@ class TelegramMessageStoreTest {
     }
 
     @Test
-    void callbackIdStorageName_containsThingUID() {
+    void callbackIdStorageNameContainsThingUID() {
         String name = TelegramMessageStore.callbackIdStorageName(THING_UID);
         assertTrue(name.contains(THING_UID.getAsString()));
         assertTrue(name.startsWith(TelegramMessageStore.STORAGE_NAME_PREFIX));
@@ -97,7 +97,7 @@ class TelegramMessageStoreTest {
     }
 
     @Test
-    void storageNames_differBetweenThings() {
+    void storageNamesDifferBetweenThings() {
         assertNotEquals(TelegramMessageStore.messageIdStorageName(THING_UID),
                 TelegramMessageStore.messageIdStorageName(THING_UID_2),
                 "Two different Things must use different storage namespaces");
@@ -110,7 +110,7 @@ class TelegramMessageStoreTest {
     // -----------------------------------------------------------------------
 
     @Test
-    void messageId_isolatedBetweenThings_sameChatIdAndReplyId() {
+    void messageIdIsolatedBetweenThingsSameChatIdAndReplyId() {
         // Two bots – same chatId, same replyId, but different Things
         TelegramMessageStore store2 = new TelegramMessageStore(createStorageService(), THING_UID_2);
 
@@ -123,7 +123,7 @@ class TelegramMessageStoreTest {
     }
 
     @Test
-    void callbackId_isolatedBetweenThingsSameChatIdAndReplyId() {
+    void callbackIdIsolatedBetweenThingsSameChatIdAndReplyId() {
         TelegramMessageStore store2 = new TelegramMessageStore(createStorageService(), THING_UID_2);
 
         store.putCallbackId(CHAT_ID, REPLY_ID, CALLBACK_ID);
@@ -370,16 +370,16 @@ class TelegramMessageStoreTest {
 
     @Test
     void getMessageIdReturnsNullForCorruptValue() {
-        Map<String, @Nullable String> map = namespaceMap
-                .computeIfAbsent(TelegramMessageStore.messageIdStorageName(THING_UID), k -> new HashMap<>());
+        Map<String, @Nullable String> map = Objects.requireNonNull(namespaceMap
+                .computeIfAbsent(TelegramMessageStore.messageIdStorageName(THING_UID), k -> new HashMap<>()));
         map.put(TelegramMessageStore.buildKey(CHAT_ID, REPLY_ID), "NOT_A_NUMBER");
         assertNull(store.getMessageId(CHAT_ID, REPLY_ID));
     }
 
     @Test
     void removeMessageIdReturnsNullForCorruptValue() {
-        Map<String, @Nullable String> map = namespaceMap
-                .computeIfAbsent(TelegramMessageStore.messageIdStorageName(THING_UID), k -> new HashMap<>());
+        Map<String, @Nullable String> map = Objects.requireNonNull(namespaceMap
+                .computeIfAbsent(TelegramMessageStore.messageIdStorageName(THING_UID), k -> new HashMap<>()));
         map.put(TelegramMessageStore.buildKey(CHAT_ID, REPLY_ID), "NOT_A_NUMBER");
         assertNull(store.removeMessageId(CHAT_ID, REPLY_ID));
     }

--- a/bundles/org.openhab.binding.telegram/src/test/java/org/openhab/binding/telegram/internal/TelegramMessageStoreTest.java
+++ b/bundles/org.openhab.binding.telegram/src/test/java/org/openhab/binding/telegram/internal/TelegramMessageStoreTest.java
@@ -151,8 +151,16 @@ class TelegramMessageStoreTest {
     // -----------------------------------------------------------------------
 
     @Test
-    void buildKeyCombinesChatIdAndReplyIdWithColon() {
-        assertEquals(CHAT_ID + ":" + REPLY_ID, TelegramMessageStore.buildKey(CHAT_ID, REPLY_ID));
+    void buildKeyEncodesReplyIdToAvoidDelimiterCollisions() {
+        String key = TelegramMessageStore.buildKey(CHAT_ID, REPLY_ID);
+
+        assertTrue(key.startsWith(CHAT_ID + ":"), "Composite keys must start with the chat ID and a colon");
+        assertNotEquals(CHAT_ID + ":" + REPLY_ID, key, "Reply IDs are encoded in the composite key");
+    }
+
+    @Test
+    void buildKeyAllowsReplyIdContainingColon() {
+        assertDoesNotThrow(() -> TelegramMessageStore.buildKey(CHAT_ID, "action:confirm"));
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -67,24 +67,25 @@
     <maven.compiler.release>${oh.java.version}</maven.compiler.release>
 
     <ohc.version>5.2.0-SNAPSHOT</ohc.version>
-    <bnd.version>7.2.1</bnd.version>
+    <asm.version>9.9.1</asm.version>
+    <bnd.version>7.2.3</bnd.version>
     <commons.codec.version>1.17.1</commons.codec.version>
     <commons.net.version>3.9.0</commons.net.version>
     <eea.version>2.4.0</eea.version>
     <jackson.annotations.version>2.21</jackson.annotations.version>
-    <jackson.version>2.21.1</jackson.version>
+    <jackson.version>2.21.3</jackson.version>
     <jna.version>5.18.1</jna.version>
     <json.version>20251224</json.version>
-    <karaf.version>4.4.10</karaf.version>
-    <mockito.version>5.21.0</mockito.version>
-    <netty.version>4.1.130.Final</netty.version>
+    <karaf.version>4.4.11</karaf.version>
+    <mockito.version>5.23.0</mockito.version>
+    <netty.version>4.1.133.Final</netty.version>
     <graalvm.version>25.0.1</graalvm.version>
     <okhttp3.version>4.12.0</okhttp3.version>
     <okio.version>3.9.0</okio.version>
     <gson.version>2.13.2</gson.version>
     <kotlin.version>1.9.23</kotlin.version>
     <sat.version>0.18.0</sat.version>
-    <slf4j.version>2.0.12</slf4j.version>
+    <slf4j.version>2.0.17</slf4j.version>
     <spotless.version>2.44.3</spotless.version>
     <!-- Eclipse Java formatter version 4.26+ does not check test files -->
     <spotless.eclipse.version>4.25</spotless.eclipse.version>


### PR DESCRIPTION
### Summary

`deleteTelegramQuery()` and `sendTelegramAnswer()` silently failed after
an openHAB restart because the internal `replyId → messageId` and
`replyId → callbackId` maps in `TelegramHandler` were plain in-memory
`HashMap`s that were reset on every restart.

This PR fixes the problem by persisting both maps through openHAB's
`StorageService`, which is already available as an OSGi service and
requires no new dependencies.
It is an improvement for: https://github.com/openhab/openhab-addons/pull/16631

### Problem

When a rule sends an inline-keyboard message via `sendTelegramQuery()`,
the Telegram message ID is stored in `replyIdToMessageId`. If openHAB is
restarted before the user presses a button (or before the rule calls
`deleteTelegramQuery()`), the entry is gone and subsequent delete/answer
calls do nothing.

### Solution

A new class `TelegramMessageStore` wraps two `Storage<String>` instances
provided by `StorageService`:

| Storage name | Key | Value |
|---|---|---|
| `telegram.replyIdToMessageId` | `<chatId>:<replyId>` | Telegram message ID |
| `telegram.replyIdToCallbackId` | `<chatId>:<replyId>` | Telegram callback ID |

`TelegramHandlerFactory` receives `StorageService` via an additional
`@Reference` parameter in its `@Activate` constructor and passes the
store to every `TelegramHandler` it creates.

### Files changed

| File | Change |
|---|---|
| `TelegramMessageStore.java` | **New** – persistent store with full Javadoc |
| `TelegramHandler.java` | Replace in-memory `HashMaps` with `TelegramMessageStore` |
| `TelegramHandlerFactory.java` | Inject `StorageService`; create and share `TelegramMessageStore` |
| `TelegramMessageStoreTest.java` | **New** – 35 unit tests, no OSGi runtime required |

### Testing

- Unit tests cover: CRUD for both namespaces, key isolation by `chatId`
  and `replyId`, cross-store independence, graceful handling of corrupt
  stored values, and a persistence simulation (a second store instance
  backed by the same in-memory maps still reads previously written data).
- Manual test: send an inline-keyboard message, restart openHAB, press
  the button → `deleteTelegramQuery()` successfully removes the keyboard.


### Code Maintenance

Additionally, I updated `TelegramActions.java` to fix some code analysis issues.