### PR TITLE
[dahuadoor] Add proper attribution for Go2RtcManager and PlayStreamServlet

### DIFF
--- a/bundles/org.openhab.binding.dahuadoor/src/main/java/org/openhab/binding/dahuadoor/internal/media/Go2RtcManager.java
+++ b/bundles/org.openhab.binding.dahuadoor/src/main/java/org/openhab/binding/dahuadoor/internal/media/Go2RtcManager.java
@@ -42,7 +42,12 @@ import org.slf4j.LoggerFactory;
  * configuration parameter.
  * </p>
  *
- * @author Sven Schad - Initial contribution
+ * <p>
+ * Based on the go2rtc integration in the UniFi Protect binding.
+ * </p>
+ *
+ * @author Dan Cunningham - Initial contribution
+ * @author Sven Schad - Adapted for DahuaDoor binding
  */
 @NonNullByDefault
 public class Go2RtcManager {

--- a/bundles/org.openhab.binding.dahuadoor/src/main/java/org/openhab/binding/dahuadoor/internal/media/PlayStreamServlet.java
+++ b/bundles/org.openhab.binding.dahuadoor/src/main/java/org/openhab/binding/dahuadoor/internal/media/PlayStreamServlet.java
@@ -60,7 +60,12 @@ import org.slf4j.LoggerFactory;
  *   Body: base64(SDP answer)
  * </pre>
  *
- * @author Sven Schad - Initial contribution
+ * <p>
+ * Based on the WebRTC servlet in the UniFi Protect binding.
+ * </p>
+ *
+ * @author Dan Cunningham - Initial contribution
+ * @author Sven Schad - Adapted for DahuaDoor binding
  */
 @NonNullByDefault
 public class PlayStreamServlet extends HttpServlet {


### PR DESCRIPTION
## Description

The `Go2RtcManager` and `PlayStreamServlet` classes in the DahuaDoor binding were derived from the equivalent classes in the UniFi Protect binding (PR #19411) authored by @digitaldan. This PR adds the missing attribution.

Changes:
- Added `@author Dan Cunningham - Initial contribution` to both classes
- Updated `@author Sven Schad` description to `Adapted for DahuaDoor binding`
- Added `Based on the go2rtc integration in the UniFi Protect binding.` / `Based on the WebRTC servlet in the UniFi Protect binding.` to the Javadoc class description

This was noted in the discussion on PR #19411.

## Classification

Bugfix (missing attribution / copyright)

## Testing

No functional change, build verified with `mvn clean install -DskipChecks -DskipTests`.
