### PR TITLE
[icloud] Implement iMessage/SMS-based 2FA verification codes

### DIFF
--- a/bundles/org.openhab.binding.icloud/src/main/java/org/openhab/binding/icloud/internal/ICloudService.java
+++ b/bundles/org.openhab.binding.icloud/src/main/java/org/openhab/binding/icloud/internal/ICloudService.java
@@ -63,6 +63,10 @@ public class ICloudService {
 
     private ICloudSession session;
 
+    private boolean smsCodeRequested = false;
+
+    private @Nullable Map<String, Object> cachedSmsPhoneNumber = null;
+
     /**
      *
      * The constructor.
@@ -116,6 +120,10 @@ public class ICloudService {
                     return false;
                 } else {
                     getMfaAuthOptions();
+                    // Automatically request SMS code if trusted phone number is available
+                    if (canRequestSmsCode()) {
+                        requestSmsCode();
+                    }
                 }
             }
         }
@@ -132,6 +140,141 @@ public class ICloudService {
         if (localSessionData != null) {
             data = localSessionData;
         }
+    }
+
+    /**
+     * Check if SMS 2FA code can be requested.
+     * This checks if a trusted phone number with SMS push mode is available in the auth data.
+     *
+     * @return {@code true} if SMS code can be requested
+     */
+    private boolean canRequestSmsCode() {
+        if (!data.containsKey("phoneNumberVerification")) {
+            return false;
+        }
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> phoneVerification = (@Nullable Map<String, Object>) data.get("phoneNumberVerification");
+        if (phoneVerification == null) {
+            return false;
+        }
+
+        // Check single trustedPhoneNumber with SMS mode
+        if (phoneVerification.containsKey("trustedPhoneNumber")) {
+            @SuppressWarnings("unchecked")
+            Map<String, Object> phoneNumber = (@Nullable Map<String, Object>) phoneVerification
+                    .get("trustedPhoneNumber");
+            if (phoneNumber != null && "sms".equals(phoneNumber.get("pushMode"))) {
+                return true;
+            }
+        }
+
+        // Check trustedPhoneNumbers array for any phone with SMS mode
+        if (phoneVerification.containsKey("trustedPhoneNumbers")) {
+            @SuppressWarnings("unchecked")
+            List<Map<String, Object>> phoneNumbers = (@Nullable List<Map<String, Object>>) phoneVerification
+                    .get("trustedPhoneNumbers");
+            if (phoneNumbers != null) {
+                for (Map<String, Object> phone : phoneNumbers) {
+                    if ("sms".equals(phone.get("pushMode"))) {
+                        return true;
+                    }
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Request SMS code to be sent to user's phone.
+     *
+     * @throws IOException if I/O error occurred
+     * @throws InterruptedException if this request was interrupted
+     * @throws ICloudApiResponseException if the request failed (e.g. not OK HTTP return code)
+     */
+    private void requestSmsCode() throws IOException, InterruptedException, ICloudApiResponseException {
+        logger.debug("Requesting SMS code to be sent to phone");
+
+        // Get the trusted phone number from auth data
+        Map<String, Object> phoneNumber = getTrustedPhoneNumber();
+        if (phoneNumber == null) {
+            logger.warn("No trusted phone number available for SMS 2FA");
+            return;
+        }
+
+        // Build phone number payload with only required fields (id and optionally nonFTEU)
+        // Convert id from Double to Integer as Apple expects integer type
+        Map<String, Object> phonePayload = new HashMap<>();
+        Object idValue = phoneNumber.get("id");
+        if (idValue instanceof Double) {
+            phonePayload.put("id", ((Double) idValue).intValue());
+        } else if (idValue != null) {
+            phonePayload.put("id", idValue);
+        }
+
+        if (phoneNumber.containsKey("nonFTEU")) {
+            Object nonFTEUValue = phoneNumber.get("nonFTEU");
+            if (nonFTEUValue != null) {
+                phonePayload.put("nonFTEU", nonFTEUValue);
+            }
+        }
+
+        Map<String, Object> requestBody = Map.of("phoneNumber", phonePayload, "mode", "sms");
+
+        List<Pair<String, String>> headers = ListUtil.replaceEntries(getAuthHeaders(),
+                List.of(Pair.of("Accept", "application/json")));
+        addSessionHeaders(headers);
+
+        session.put(AUTH_ENDPOINT + "/verify/phone", JsonUtils.toJson(requestBody), headers);
+
+        // Cache the phone payload for later validation
+        cachedSmsPhoneNumber = phonePayload;
+        smsCodeRequested = true;
+        logger.debug("SMS code request sent successfully");
+    }
+
+    /**
+     * Get the first available trusted phone number with SMS mode from auth data.
+     *
+     * @return Phone number map with id and numberWithDialCode, or null if not available
+     */
+    private @Nullable Map<String, Object> getTrustedPhoneNumber() {
+        if (!data.containsKey("phoneNumberVerification")) {
+            return null;
+        }
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> phoneVerification = (@Nullable Map<String, Object>) data.get("phoneNumberVerification");
+        if (phoneVerification == null) {
+            return null;
+        }
+
+        // Try single trustedPhoneNumber with SMS mode first
+        if (phoneVerification.containsKey("trustedPhoneNumber")) {
+            @SuppressWarnings("unchecked")
+            Map<String, Object> phoneNumber = (@Nullable Map<String, Object>) phoneVerification
+                    .get("trustedPhoneNumber");
+            if (phoneNumber != null && "sms".equals(phoneNumber.get("pushMode"))) {
+                return phoneNumber;
+            }
+        }
+
+        // Try trustedPhoneNumbers array, find first with SMS mode
+        if (phoneVerification.containsKey("trustedPhoneNumbers")) {
+            @SuppressWarnings("unchecked")
+            List<Map<String, Object>> phoneNumbers = (@Nullable List<Map<String, Object>>) phoneVerification
+                    .get("trustedPhoneNumbers");
+            if (phoneNumbers != null) {
+                for (Map<String, Object> phone : phoneNumbers) {
+                    if ("sms".equals(phone.get("pushMode"))) {
+                        return phone;
+                    }
+                }
+            }
+        }
+
+        return null;
     }
 
     /**
@@ -245,7 +388,26 @@ public class ICloudService {
      * @throws ICloudApiResponseException if the request failed (e.g. not OK HTTP return code)
      */
     public boolean validate2faCode(String code) throws IOException, InterruptedException, ICloudApiResponseException {
-        Map<String, Object> requestBody = Map.of("securityCode", Map.of("code", code));
+        String endpoint;
+        Map<String, Object> requestBody;
+
+        if (smsCodeRequested) {
+            // SMS verification requires phone number in request - use cached phone from SMS request
+            final Map<String, Object> phonePayload = cachedSmsPhoneNumber;
+            if (phonePayload == null) {
+                logger.warn("No cached phone number available for SMS code validation");
+                return false;
+            }
+
+            requestBody = Map.of("phoneNumber", phonePayload, "securityCode", Map.of("code", code), "mode", "sms");
+            endpoint = AUTH_ENDPOINT + "/verify/phone/securitycode";
+            logger.debug("Validating SMS 2FA code");
+        } else {
+            // Trusted device verification
+            requestBody = Map.of("securityCode", Map.of("code", code));
+            endpoint = AUTH_ENDPOINT + "/verify/trusteddevice/securitycode";
+            logger.debug("Validating trusted device 2FA code");
+        }
 
         List<Pair<String, String>> headers = ListUtil.replaceEntries(getAuthHeaders(),
                 List.of(Pair.of("Accept", "application/json")));
@@ -253,8 +415,7 @@ public class ICloudService {
         addSessionHeaders(headers);
 
         try {
-            this.session.post(AUTH_ENDPOINT + "/verify/trusteddevice/securitycode", JsonUtils.toJson(requestBody),
-                    headers);
+            this.session.post(endpoint, JsonUtils.toJson(requestBody), headers);
         } catch (ICloudApiResponseException ex) {
             logger.trace("Exception on code verification with HTTP status {}. Verification might still be successful.",
                     ex.getStatusCode(), ex);
@@ -262,11 +423,15 @@ public class ICloudService {
             // currently 400 seems to show that verification "really" failed.
             if (ex.getStatusCode() == 400 || ex.getStatusCode() >= 500) {
                 this.logger.debug("Verification failed with HTTP status {}.", ex.getStatusCode());
+                smsCodeRequested = false; // Reset flag on failure
+                cachedSmsPhoneNumber = null; // Clear cached phone
                 return false;
             }
         }
 
         logger.debug("Code verification successful.");
+        smsCodeRequested = false; // Reset flag after successful verification
+        cachedSmsPhoneNumber = null; // Clear cached phone
 
         trustSession();
         return true;

--- a/bundles/org.openhab.binding.icloud/src/main/java/org/openhab/binding/icloud/internal/ICloudService.java
+++ b/bundles/org.openhab.binding.icloud/src/main/java/org/openhab/binding/icloud/internal/ICloudService.java
@@ -396,6 +396,7 @@ public class ICloudService {
             final Map<String, Object> phonePayload = cachedSmsPhoneNumber;
             if (phonePayload == null) {
                 logger.warn("No cached phone number available for SMS code validation");
+                smsCodeRequested = false; // Reset flag to allow new SMS code request
                 return false;
             }
 

--- a/bundles/org.openhab.binding.icloud/src/main/java/org/openhab/binding/icloud/internal/ICloudSession.java
+++ b/bundles/org.openhab.binding.icloud/src/main/java/org/openhab/binding/icloud/internal/ICloudSession.java
@@ -115,6 +115,23 @@ public class ICloudSession {
         return request("GET", url, null, overrideHeaders);
     }
 
+    /**
+     * Invoke an HTTP PUT request to the given url and body.
+     *
+     * @param url URL to call.
+     * @param body Body for the request
+     * @param overrideHeaders  If not null the given headers are used instead of the standard headers set via
+     *            {@link #setDefaultHeaders(Pair...)} (optional)
+     * @return Result body as {@link String}.
+     * @throws IOException if I/O error occurred
+     * @throws InterruptedException if this blocking request was interrupted
+     * @throws ICloudApiResponseException if the request failed (e.g. not OK HTTP return code)
+     */
+    public String put(String url, @Nullable String body, @Nullable List<Pair<String, String>> overrideHeaders)
+            throws IOException, InterruptedException, ICloudApiResponseException {
+        return request("PUT", url, body, overrideHeaders);
+    }
+
     private String request(String method, String url, @Nullable String body,
             @Nullable List<Pair<String, String>> overrideHeaders)
             throws IOException, InterruptedException, ICloudApiResponseException {

--- a/bundles/org.openhab.binding.icloud/src/main/java/org/openhab/binding/icloud/internal/ICloudSession.java
+++ b/bundles/org.openhab.binding.icloud/src/main/java/org/openhab/binding/icloud/internal/ICloudSession.java
@@ -120,7 +120,7 @@ public class ICloudSession {
      *
      * @param url URL to call.
      * @param body Body for the request
-     * @param overrideHeaders  If not null the given headers are used instead of the standard headers set via
+     * @param overrideHeaders If not null the given headers are used instead of the standard headers set via
      *            {@link #setDefaultHeaders(Pair...)} (optional)
      * @return Result body as {@link String}.
      * @throws IOException if I/O error occurred

--- a/bundles/org.openhab.binding.icloud/src/main/java/org/openhab/binding/icloud/internal/ICloudSession.java
+++ b/bundles/org.openhab.binding.icloud/src/main/java/org/openhab/binding/icloud/internal/ICloudSession.java
@@ -147,6 +147,8 @@ public class ICloudSession {
 
         if (body != null) {
             builder.method(method, BodyPublishers.ofString(body));
+        } else {
+            builder.method(method, BodyPublishers.noBody());
         }
 
         HttpRequest request = builder.build();

--- a/bundles/org.openhab.binding.icloud/src/main/java/org/openhab/binding/icloud/internal/SrpAuthentication.java
+++ b/bundles/org.openhab.binding.icloud/src/main/java/org/openhab/binding/icloud/internal/SrpAuthentication.java
@@ -176,7 +176,12 @@ public class SrpAuthentication {
         requestBody.put("m1", b64Encode(M1));
         requestBody.put("m2", b64Encode(M2));
         requestBody.put("rememberMe", true);
-        requestBody.put("trustTokens", new String[] { httpClient.getTrustToken() });
+        String trustToken = httpClient.getTrustToken();
+        if (trustToken != null && !trustToken.isEmpty()) {
+            requestBody.put("trustTokens", new String[] { trustToken });
+        } else {
+            requestBody.put("trustTokens", new String[] {});
+        }
         httpClient.post(authEndpoint + "/signin/complete?isRememberMeEnabled=true", JsonUtils.toJson(requestBody),
                 sessionHeaders);
     }

--- a/bundles/org.openhab.binding.icloud/src/main/java/org/openhab/binding/icloud/internal/handler/ICloudAccountBridgeHandler.java
+++ b/bundles/org.openhab.binding.icloud/src/main/java/org/openhab/binding/icloud/internal/handler/ICloudAccountBridgeHandler.java
@@ -184,7 +184,9 @@ public class ICloudAccountBridgeHandler extends BaseBridgeHandler {
                 } catch (ICloudApiResponseException e) {
                     logger.debug("ICloudApiResponseException with status code {}", e.getStatusCode());
                     lastException = e;
-                    if (e.getStatusCode() == 450) {
+                    if (e.getStatusCode() == 421 || e.getStatusCode() == 450 || e.getStatusCode() == 500) {
+                        logger.debug("Authentication error detected (code {}), triggering re-authentication",
+                                e.getStatusCode());
                         checkLogin();
                     }
                 } catch (IllegalStateException e) {

--- a/bundles/org.openhab.binding.icloud/src/main/java/org/openhab/binding/icloud/internal/handler/ICloudAccountBridgeHandler.java
+++ b/bundles/org.openhab.binding.icloud/src/main/java/org/openhab/binding/icloud/internal/handler/ICloudAccountBridgeHandler.java
@@ -209,7 +209,7 @@ public class ICloudAccountBridgeHandler extends BaseBridgeHandler {
                 } catch (InterruptedException e) {
                     Thread.interrupted();
                 }
-            } while (!success && retryCount < 3);
+            } while (retryCount < 3);
             throw new RetryException(lastException);
         }
     }

--- a/bundles/org.openhab.binding.icloud/src/test/java/org/openhab/binding/icloud/TestICloud.java
+++ b/bundles/org.openhab.binding.icloud/src/test/java/org/openhab/binding/icloud/TestICloud.java
@@ -79,7 +79,7 @@ public class TestICloud {
     public void setUp() {
         final Logger logger = LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
         if (logger instanceof ch.qos.logback.classic.Logger qLogger) {
-            qLogger.setLevel(ch.qos.logback.classic.Level.TRACE);
+            qLogger.setLevel(ch.qos.logback.classic.Level.DEBUG);
         }
     }
 

--- a/bundles/org.openhab.binding.icloud/src/test/java/org/openhab/binding/icloud/TestICloud.java
+++ b/bundles/org.openhab.binding.icloud/src/test/java/org/openhab/binding/icloud/TestICloud.java
@@ -79,7 +79,7 @@ public class TestICloud {
     public void setUp() {
         final Logger logger = LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
         if (logger instanceof ch.qos.logback.classic.Logger qLogger) {
-            qLogger.setLevel(ch.qos.logback.classic.Level.DEBUG);
+            qLogger.setLevel(ch.qos.logback.classic.Level.TRACE);
         }
     }
 


### PR DESCRIPTION
# Title

Fix iCloud authentication by implementing SMS based 2-FA codes.

# Description

This PR modifies the iCloud binding.
Apple changed the authentication scheme for iCloud again.
The current implementation in OH stopped working. The new preferred version from Apple is based on websockets which is not supported by the current iCloud binding.
As an intermediate solution this fix implements requesting iMessage/SMS based 2-FA codes

This bug is documented in #20425 