### PR TITLE
[solax] Add handler integration tests and fix missing X3 Mic/Pro G2 temperature channels

### DIFF
--- a/bundles/org.openhab.binding.solax/src/main/java/org/openhab/binding/solax/internal/handlers/SolaxLocalAccessInverterHandler.java
+++ b/bundles/org.openhab.binding.solax/src/main/java/org/openhab/binding/solax/internal/handlers/SolaxLocalAccessInverterHandler.java
@@ -192,6 +192,11 @@ public class SolaxLocalAccessInverterHandler extends SolaxLocalAccessAbstractHan
         updateChannel(SolaxBindingConstants.CHANNEL_INVERTER_OUTPUT_FREQUENCY_PHASE3, inverterData.getFrequencyPhase3(),
                 Units.HERTZ, supportedChannels);
 
+        updateChannel(SolaxBindingConstants.CHANNEL_INVERTER_TEMPERATURE1, inverterData.getInverterTemperature1(),
+                SIUnits.CELSIUS, supportedChannels);
+        updateChannel(SolaxBindingConstants.CHANNEL_INVERTER_TEMPERATURE2, inverterData.getInverterTemperature2(),
+                SIUnits.CELSIUS, supportedChannels);
+
         // Binding provided data
         updateState(SolaxBindingConstants.CHANNEL_TIMESTAMP, new DateTimeType());
     }

--- a/bundles/org.openhab.binding.solax/src/test/java/org/openhab/binding/solax/internal/local/handlers/AbstractChargerHandlerTest.java
+++ b/bundles/org.openhab.binding.solax/src/test/java/org/openhab/binding/solax/internal/local/handlers/AbstractChargerHandlerTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.solax.internal.local.handlers;
+
+import static org.mockito.Mockito.*;
+
+import java.util.TimeZone;
+
+import javax.measure.Quantity;
+import javax.measure.Unit;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.openhab.binding.solax.internal.SolaxBindingConstants;
+import org.openhab.binding.solax.internal.exceptions.SolaxUpdateException;
+import org.openhab.binding.solax.internal.handlers.SolaxLocalAccessChargerHandler;
+import org.openhab.core.i18n.TimeZoneProvider;
+import org.openhab.core.i18n.TranslationProvider;
+import org.openhab.core.library.types.QuantityType;
+import org.openhab.core.library.types.StringType;
+import org.openhab.core.thing.ChannelUID;
+import org.openhab.core.thing.Thing;
+import org.openhab.core.thing.ThingUID;
+import org.openhab.core.thing.binding.ThingHandlerCallback;
+
+/**
+ * The {@link AbstractChargerHandlerTest} is the abstract base for handler-level tests that verify the full flow from
+ * raw JSON API data through parsing to channel state updates on {@link SolaxLocalAccessChargerHandler}.
+ *
+ * @author Konstantin Polihronov - Initial contribution
+ */
+@ExtendWith(MockitoExtension.class)
+@NonNullByDefault
+public abstract class AbstractChargerHandlerTest {
+
+    protected static final ThingUID THING_UID = new ThingUID(SolaxBindingConstants.THING_TYPE_LOCAL_CONNECT_CHARGER,
+            "test");
+
+    @Mock
+    @NonNullByDefault({})
+    protected ThingHandlerCallback callbackMock;
+
+    @Mock
+    @NonNullByDefault({})
+    protected Thing thingMock;
+
+    @Mock
+    @NonNullByDefault({})
+    protected TranslationProvider i18nProvider;
+
+    @Mock
+    @NonNullByDefault({})
+    protected TimeZoneProvider timeZoneProvider;
+
+    @NonNullByDefault({})
+    protected TestableChargerHandler handler;
+
+    /**
+     * Subclass of {@link SolaxLocalAccessChargerHandler} that exposes the protected {@code updateFromData} method for
+     * direct invocation in tests, bypassing the HTTP retrieval layer.
+     */
+    protected static class TestableChargerHandler extends SolaxLocalAccessChargerHandler {
+        public TestableChargerHandler(Thing thing, TranslationProvider i18nProvider,
+                TimeZoneProvider timeZoneProvider) {
+            super(thing, i18nProvider, timeZoneProvider);
+        }
+
+        @Override
+        public void updateFromData(String rawJsonData) throws SolaxUpdateException {
+            super.updateFromData(rawJsonData);
+        }
+    }
+
+    @BeforeEach
+    public void setUp() {
+        when(thingMock.getUID()).thenReturn(THING_UID);
+        when(timeZoneProvider.getTimeZone()).thenReturn(TimeZone.getDefault().toZoneId());
+
+        handler = new TestableChargerHandler(thingMock, i18nProvider, timeZoneProvider);
+        handler.setCallback(callbackMock);
+    }
+
+    @Test
+    public void testChannelUpdates() throws SolaxUpdateException {
+        handler.updateFromData(getRawData());
+        assertChannels();
+    }
+
+    protected abstract String getRawData();
+
+    protected abstract void assertChannels();
+
+    protected <T extends Quantity<T>> void assertQuantityChannel(String channelId, double expectedValue, Unit<T> unit) {
+        verify(callbackMock).stateUpdated(eq(new ChannelUID(THING_UID, channelId)),
+                eq(new QuantityType<>(expectedValue, unit)));
+    }
+
+    protected void assertStringChannel(String channelId, String expectedValue) {
+        verify(callbackMock).stateUpdated(eq(new ChannelUID(THING_UID, channelId)), eq(new StringType(expectedValue)));
+    }
+}

--- a/bundles/org.openhab.binding.solax/src/test/java/org/openhab/binding/solax/internal/local/handlers/AbstractInverterHandlerTest.java
+++ b/bundles/org.openhab.binding.solax/src/test/java/org/openhab/binding/solax/internal/local/handlers/AbstractInverterHandlerTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.solax.internal.local.handlers;
+
+import static org.mockito.Mockito.*;
+
+import java.util.List;
+import java.util.TimeZone;
+
+import javax.measure.Quantity;
+import javax.measure.Unit;
+
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.openhab.binding.solax.internal.SolaxBindingConstants;
+import org.openhab.binding.solax.internal.handlers.SolaxLocalAccessInverterHandler;
+import org.openhab.core.i18n.TimeZoneProvider;
+import org.openhab.core.i18n.TranslationProvider;
+import org.openhab.core.library.types.QuantityType;
+import org.openhab.core.library.types.StringType;
+import org.openhab.core.thing.ChannelUID;
+import org.openhab.core.thing.Thing;
+import org.openhab.core.thing.ThingUID;
+import org.openhab.core.thing.binding.ThingHandlerCallback;
+
+/**
+ * The {@link AbstractInverterHandlerTest} is the abstract base for handler-level tests that verify the full flow from
+ * raw JSON API data through parsing to channel state updates on {@link SolaxLocalAccessInverterHandler}.
+ *
+ * @author Konstantin Polihronov - Initial contribution
+ */
+@ExtendWith(MockitoExtension.class)
+@NonNullByDefault
+public abstract class AbstractInverterHandlerTest {
+
+    protected static final ThingUID THING_UID = new ThingUID(SolaxBindingConstants.THING_TYPE_LOCAL_CONNECT_INVERTER,
+            "test");
+
+    @Mock
+    @NonNullByDefault({})
+    protected ThingHandlerCallback callbackMock;
+
+    @Mock
+    @NonNullByDefault({})
+    protected Thing thingMock;
+
+    @Mock
+    @NonNullByDefault({})
+    protected TranslationProvider i18nProvider;
+
+    @Mock
+    @NonNullByDefault({})
+    protected TimeZoneProvider timeZoneProvider;
+
+    @NonNullByDefault({})
+    protected TestableInverterHandler handler;
+
+    /**
+     * Subclass of {@link SolaxLocalAccessInverterHandler} that exposes the protected {@code updateFromData} method for
+     * direct invocation in tests, bypassing the HTTP retrieval layer.
+     */
+    protected static class TestableInverterHandler extends SolaxLocalAccessInverterHandler {
+        public TestableInverterHandler(Thing thing, TranslationProvider i18nProvider,
+                TimeZoneProvider timeZoneProvider) {
+            super(thing, i18nProvider, timeZoneProvider);
+        }
+
+        @Override
+        public void updateFromData(@NonNull String rawJsonData) {
+            super.updateFromData(rawJsonData);
+        }
+    }
+
+    @BeforeEach
+    public void setUp() {
+        when(thingMock.getUID()).thenReturn(THING_UID);
+        when(thingMock.getChannels()).thenReturn(List.of());
+        when(timeZoneProvider.getTimeZone()).thenReturn(TimeZone.getDefault().toZoneId());
+
+        handler = new TestableInverterHandler(thingMock, i18nProvider, timeZoneProvider);
+        handler.setCallback(callbackMock);
+    }
+
+    @Test
+    public void testChannelUpdates() {
+        handler.updateFromData(getRawData());
+        assertChannels();
+    }
+
+    protected abstract String getRawData();
+
+    protected abstract void assertChannels();
+
+    protected <T extends Quantity<T>> void assertQuantityChannel(String channelId, double expectedValue, Unit<T> unit) {
+        verify(callbackMock).stateUpdated(eq(new ChannelUID(THING_UID, channelId)),
+                eq(new QuantityType<>(expectedValue, unit)));
+    }
+
+    protected void assertStringChannel(String channelId, String expectedValue) {
+        verify(callbackMock).stateUpdated(eq(new ChannelUID(THING_UID, channelId)), eq(new StringType(expectedValue)));
+    }
+}

--- a/bundles/org.openhab.binding.solax/src/test/java/org/openhab/binding/solax/internal/local/handlers/TestEvChargerHandlerTest.java
+++ b/bundles/org.openhab.binding.solax/src/test/java/org/openhab/binding/solax/internal/local/handlers/TestEvChargerHandlerTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.solax.internal.local.handlers;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.binding.solax.internal.SolaxBindingConstants;
+import org.openhab.core.library.unit.SIUnits;
+import org.openhab.core.library.unit.Units;
+
+/**
+ * The {@link TestEvChargerHandlerTest} verifies the full flow from raw JSON API data through the
+ * {@link org.openhab.binding.solax.internal.handlers.SolaxLocalAccessChargerHandler} to channel state updates for the
+ * EV Charger.
+ *
+ * @author Konstantin Polihronov - Initial contribution
+ */
+@NonNullByDefault
+public class TestEvChargerHandlerTest extends AbstractChargerHandlerTest {
+
+    private static final String RAW_DATA = """
+            {
+                "SN":"SQBLABLA",
+                "ver":"3.004.11",
+                "type":1,
+                "Data":[
+                    2,2,23914,23991,23895,1517,1513,1519,3654,3657,
+                    3656,10968,44,0,346,0,65434,35463,65459,65508,
+                    65513,27,402,0,43,0,2,15,0,0,
+                    0,0,0,5004,5000,4996,10518,1547,6150,4,
+                    0,0,0,0,0,0,0,0,1,100,
+                    0,0,0,0,0,0,0,0,0,0,
+                    0,0,0,0,0,0,0,0,0,0,
+                    0,0,0,0,0,0,0,0,0,0,
+                    1717,0,3114,1547,6150,0,1,1,1,0,
+                    0,121,584,266,0,50,0,0,1,1,0],
+                "Information":[11.000,1,"CXXXXXXXXXX",1,1.13,1.01,0.00,0.00,0.00,1],
+                "OCPPServer":"",
+                "OCPPChargerId":""
+            }
+            """;
+
+    @Override
+    protected String getRawData() {
+        return RAW_DATA;
+    }
+
+    @Override
+    protected void assertChannels() {
+        assertStringChannel(SolaxBindingConstants.CHANNEL_CHARGER_STATE, "2");
+        assertStringChannel(SolaxBindingConstants.CHANNEL_CHARGER_MODE, "2");
+
+        assertQuantityChannel(SolaxBindingConstants.CHANNEL_CHARGER_EQ_SINGLE_SESSION, 4.4, Units.KILOWATT_HOUR);
+        assertQuantityChannel(SolaxBindingConstants.CHANNEL_CHARGER_EQ_TOTAL, 34.6, Units.KILOWATT_HOUR);
+
+        assertQuantityChannel(SolaxBindingConstants.CHANNEL_CHARGER_OUTPUT_CURRENT_PHASE1, 15.17, Units.AMPERE);
+        assertQuantityChannel(SolaxBindingConstants.CHANNEL_CHARGER_OUTPUT_CURRENT_PHASE2, 15.13, Units.AMPERE);
+        assertQuantityChannel(SolaxBindingConstants.CHANNEL_CHARGER_OUTPUT_CURRENT_PHASE3, 15.19, Units.AMPERE);
+
+        assertQuantityChannel(SolaxBindingConstants.CHANNEL_CHARGER_OUTPUT_VOLTAGE_PHASE1, 239.14, Units.VOLT);
+        assertQuantityChannel(SolaxBindingConstants.CHANNEL_CHARGER_OUTPUT_VOLTAGE_PHASE2, 239.91, Units.VOLT);
+        assertQuantityChannel(SolaxBindingConstants.CHANNEL_CHARGER_OUTPUT_VOLTAGE_PHASE3, 238.95, Units.VOLT);
+
+        assertQuantityChannel(SolaxBindingConstants.CHANNEL_CHARGER_OUTPUT_POWER_PHASE1, 3654, Units.WATT);
+        assertQuantityChannel(SolaxBindingConstants.CHANNEL_CHARGER_OUTPUT_POWER_PHASE2, 3657, Units.WATT);
+        assertQuantityChannel(SolaxBindingConstants.CHANNEL_CHARGER_OUTPUT_POWER_PHASE3, 3656, Units.WATT);
+        assertQuantityChannel(SolaxBindingConstants.CHANNEL_CHARGER_TOTAL_OUTPUT_POWER, 10968, Units.WATT);
+
+        assertQuantityChannel(SolaxBindingConstants.CHANNEL_CHARGER_EXTERNAL_CURRENT_PHASE1, -1.02, Units.AMPERE);
+        assertQuantityChannel(SolaxBindingConstants.CHANNEL_CHARGER_EXTERNAL_CURRENT_PHASE2, -300.73, Units.AMPERE);
+        assertQuantityChannel(SolaxBindingConstants.CHANNEL_CHARGER_EXTERNAL_CURRENT_PHASE3, -0.77, Units.AMPERE);
+
+        assertQuantityChannel(SolaxBindingConstants.CHANNEL_CHARGER_EXTERNAL_POWER_PHASE1, -28, Units.WATT);
+        assertQuantityChannel(SolaxBindingConstants.CHANNEL_CHARGER_EXTERNAL_POWER_PHASE2, -23, Units.WATT);
+        assertQuantityChannel(SolaxBindingConstants.CHANNEL_CHARGER_EXTERNAL_POWER_PHASE3, 27, Units.WATT);
+        assertQuantityChannel(SolaxBindingConstants.CHANNEL_CHARGER_TOTAL_EXTERNAL_POWER, 402, Units.WATT);
+
+        assertQuantityChannel(SolaxBindingConstants.CHANNEL_CHARGER_PLUG_TEMPERATURE, 0, SIUnits.CELSIUS);
+        assertQuantityChannel(SolaxBindingConstants.CHANNEL_CHARGER_INTERNAL_TEMPERATURE, 43, SIUnits.CELSIUS);
+    }
+}

--- a/bundles/org.openhab.binding.solax/src/test/java/org/openhab/binding/solax/internal/local/handlers/TestX1BoostAirMiniHandlerTest.java
+++ b/bundles/org.openhab.binding.solax/src/test/java/org/openhab/binding/solax/internal/local/handlers/TestX1BoostAirMiniHandlerTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.solax.internal.local.handlers;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.binding.solax.internal.SolaxBindingConstants;
+import org.openhab.core.library.unit.Units;
+
+/**
+ * The {@link TestX1BoostAirMiniHandlerTest} verifies the full flow from raw JSON API data through the
+ * {@link org.openhab.binding.solax.internal.handlers.SolaxLocalAccessInverterHandler} to channel state updates for the
+ * X1 Boost / Air / Mini inverter.
+ *
+ * @author Konstantin Polihronov - Initial contribution
+ */
+@NonNullByDefault
+public class TestX1BoostAirMiniHandlerTest extends AbstractInverterHandlerTest {
+
+    private static final String RAW_DATA = """
+            {
+                sn:SR***,
+                ver:3.006.04,
+                type:4,
+                Data:[
+                    2263,7,128,1519,0,9,0,138,0,5000,
+                    2,15569,0,7,0,0,0,0,0,0,
+                    0,0,0,0,0,0,0,0,0,0,
+                    0,0,0,0,0,0,0,0,0,13,
+                    0,4071,0,3456,0,0,0,0,0,0,
+                    0,0,0,0,0,23,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
+                ],
+                Information:[1.500,4,XM3A15IA669518,8,2.27,0.00,1.43,0.00,0.00,1]}
+            """;
+
+    @Override
+    protected String getRawData() {
+        return RAW_DATA;
+    }
+
+    @Override
+    protected void assertChannels() {
+        assertQuantityChannel(SolaxBindingConstants.CHANNEL_INVERTER_OUTPUT_VOLTAGE, 226.3, Units.VOLT);
+        assertQuantityChannel(SolaxBindingConstants.CHANNEL_INVERTER_OUTPUT_CURRENT, 0.7, Units.AMPERE);
+        assertQuantityChannel(SolaxBindingConstants.CHANNEL_INVERTER_OUTPUT_POWER, 128, Units.WATT);
+
+        assertQuantityChannel(SolaxBindingConstants.CHANNEL_INVERTER_PV1_VOLTAGE, 151.9, Units.VOLT);
+        assertQuantityChannel(SolaxBindingConstants.CHANNEL_INVERTER_PV2_VOLTAGE, 0, Units.VOLT);
+        assertQuantityChannel(SolaxBindingConstants.CHANNEL_INVERTER_PV1_CURRENT, 0.9, Units.AMPERE);
+        assertQuantityChannel(SolaxBindingConstants.CHANNEL_INVERTER_PV2_CURRENT, 0, Units.AMPERE);
+        assertQuantityChannel(SolaxBindingConstants.CHANNEL_INVERTER_PV1_POWER, 138, Units.WATT);
+        assertQuantityChannel(SolaxBindingConstants.CHANNEL_INVERTER_PV2_POWER, 0, Units.WATT);
+
+        assertQuantityChannel(SolaxBindingConstants.CHANNEL_INVERTER_OUTPUT_FREQUENCY, 50.0, Units.HERTZ);
+
+        assertQuantityChannel(SolaxBindingConstants.CHANNEL_TOTAL_ENERGY, 1556.9, Units.KILOWATT_HOUR);
+        assertQuantityChannel(SolaxBindingConstants.CHANNEL_TODAY_ENERGY, 0.7, Units.KILOWATT_HOUR);
+
+        assertQuantityChannel(SolaxBindingConstants.CHANNEL_POWER_USAGE, 346, Units.WATT);
+    }
+}

--- a/bundles/org.openhab.binding.solax/src/test/java/org/openhab/binding/solax/internal/local/handlers/TestX1HybridG4HandlerTest.java
+++ b/bundles/org.openhab.binding.solax/src/test/java/org/openhab/binding/solax/internal/local/handlers/TestX1HybridG4HandlerTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.solax.internal.local.handlers;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.binding.solax.internal.SolaxBindingConstants;
+import org.openhab.core.library.unit.SIUnits;
+import org.openhab.core.library.unit.Units;
+
+/**
+ * The {@link TestX1HybridG4HandlerTest} verifies the full flow from raw JSON API data through the
+ * {@link org.openhab.binding.solax.internal.handlers.SolaxLocalAccessInverterHandler} to channel state updates for the
+ * X1 Hybrid G4 inverter.
+ *
+ * @author Konstantin Polihronov - Initial contribution
+ */
+@NonNullByDefault
+public class TestX1HybridG4HandlerTest extends AbstractInverterHandlerTest {
+
+    private static final String RAW_DATA = """
+            {
+                sn:SOME_SERIAL_NUMBER,
+                ver:3.008.10,
+                type:15,
+                Data:[
+                    2388,21,460,4998,4483,4483,10,1,487,65,
+                    2,59781,0,70,12180,500,605,33,99,12000,
+                    0,23159,0,57,100,0,39,4501,0,0,
+                    0,0,12,0,13240,0,63348,2,448,43,
+                    256,1314,900,0,350,311,279,33,33,279,1,1,652,0,708,1,65077,65535,65386,65535,0,0,0,0,0,0,0,0,0,0,0,0,65068,65535,4500,0,61036,65535,10,0,90,0,0,12,0,116,7,57,0,0,2320,0,110,0,0,0,0,0,0,12544,7440,5896,594,521,9252,0,0,0,0,0,1,1201,0,0,3342,3336,7296,54,21302,14389,18753,12852,16692,12355,13618,21302,14389,18753,12852,16692,12355,13618,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,1025,4609,1026,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],
+                Information:[7.500,15,H4752TI1063020,8,1.24,0.00,1.21,1.03,0.00,1]}
+            """;
+
+    @Override
+    protected String getRawData() {
+        return RAW_DATA;
+    }
+
+    @Override
+    protected void assertChannels() {
+        assertQuantityChannel(SolaxBindingConstants.CHANNEL_INVERTER_OUTPUT_VOLTAGE, 238.8, Units.VOLT);
+        assertQuantityChannel(SolaxBindingConstants.CHANNEL_INVERTER_OUTPUT_CURRENT, 2.1, Units.AMPERE);
+        assertQuantityChannel(SolaxBindingConstants.CHANNEL_INVERTER_OUTPUT_POWER, 460, Units.WATT);
+        assertQuantityChannel(SolaxBindingConstants.CHANNEL_INVERTER_OUTPUT_FREQUENCY, 49.98, Units.HERTZ);
+
+        assertQuantityChannel(SolaxBindingConstants.CHANNEL_INVERTER_PV1_VOLTAGE, 448.3, Units.VOLT);
+        assertQuantityChannel(SolaxBindingConstants.CHANNEL_INVERTER_PV2_VOLTAGE, 448.3, Units.VOLT);
+        assertQuantityChannel(SolaxBindingConstants.CHANNEL_INVERTER_PV1_CURRENT, 1.0, Units.AMPERE);
+        assertQuantityChannel(SolaxBindingConstants.CHANNEL_INVERTER_PV2_CURRENT, 0.1, Units.AMPERE);
+        assertQuantityChannel(SolaxBindingConstants.CHANNEL_INVERTER_PV1_POWER, 487, Units.WATT);
+        assertQuantityChannel(SolaxBindingConstants.CHANNEL_INVERTER_PV2_POWER, 65, Units.WATT);
+
+        assertQuantityChannel(SolaxBindingConstants.CHANNEL_BATTERY_VOLTAGE, 121.8, Units.VOLT);
+        assertQuantityChannel(SolaxBindingConstants.CHANNEL_BATTERY_CURRENT, 5.0, Units.AMPERE);
+        assertQuantityChannel(SolaxBindingConstants.CHANNEL_BATTERY_POWER, 605, Units.WATT);
+        assertQuantityChannel(SolaxBindingConstants.CHANNEL_BATTERY_TEMPERATURE, 33, SIUnits.CELSIUS);
+        assertQuantityChannel(SolaxBindingConstants.CHANNEL_BATTERY_STATE_OF_CHARGE, 99, Units.PERCENT);
+
+        assertQuantityChannel(SolaxBindingConstants.CHANNEL_FEED_IN_POWER, 12, Units.WATT);
+        assertQuantityChannel(SolaxBindingConstants.CHANNEL_POWER_USAGE, 448, Units.WATT);
+
+        assertStringChannel(SolaxBindingConstants.CHANNEL_INVERTER_WORKMODE, "2");
+
+        assertQuantityChannel(SolaxBindingConstants.CHANNEL_TODAY_ENERGY, 7.0, Units.KILOWATT_HOUR);
+        assertQuantityChannel(SolaxBindingConstants.CHANNEL_TOTAL_PV_ENERGY, 5978.1, Units.KILOWATT_HOUR);
+        assertQuantityChannel(SolaxBindingConstants.CHANNEL_TOTAL_FEED_IN_ENERGY, 132.4, Units.KILOWATT_HOUR);
+        assertQuantityChannel(SolaxBindingConstants.CHANNEL_TOTAL_CONSUMPTION, 1944.2, Units.KILOWATT_HOUR);
+        assertQuantityChannel(SolaxBindingConstants.CHANNEL_TODAY_FEED_IN_ENERGY, 4.3, Units.KILOWATT_HOUR);
+        assertQuantityChannel(SolaxBindingConstants.CHANNEL_TODAY_BATTERY_DISCHARGE_ENERGY, 5.7, Units.KILOWATT_HOUR);
+        assertQuantityChannel(SolaxBindingConstants.CHANNEL_TODAY_BATTERY_CHARGE_ENERGY, 11.6, Units.KILOWATT_HOUR);
+    }
+}

--- a/bundles/org.openhab.binding.solax/src/test/java/org/openhab/binding/solax/internal/local/handlers/TestX3HybridG4HandlerTest.java
+++ b/bundles/org.openhab.binding.solax/src/test/java/org/openhab/binding/solax/internal/local/handlers/TestX3HybridG4HandlerTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.solax.internal.local.handlers;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.binding.solax.internal.SolaxBindingConstants;
+import org.openhab.core.library.unit.SIUnits;
+import org.openhab.core.library.unit.Units;
+
+/**
+ * The {@link TestX3HybridG4HandlerTest} verifies the full flow from raw JSON API data through the
+ * {@link org.openhab.binding.solax.internal.handlers.SolaxLocalAccessInverterHandler} to channel state updates for the
+ * X3 Hybrid G4 inverter.
+ *
+ * @author Konstantin Polihronov - Initial contribution
+ */
+@NonNullByDefault
+public class TestX3HybridG4HandlerTest extends AbstractInverterHandlerTest {
+
+    private static final String RAW_DATA = """
+            {
+                sn:XYZ,
+                ver:3.005.01,
+                type:14,
+                Data:[
+                    2316,2329,2315,18,18,18,372,363,365,1100,
+                    12,23,34,45,56,67,4996,4996,4996,2,
+                    0,0,0,0,0,0,0,0,0,0,
+                    0,0,0,1,65494,65535,0,0,0,31330,
+                    320,1034,3078,1,44,1100,256,1294,0,0,
+                    7445,5895,100,0,38,0,0,0,0,0,
+                    0,0,0,0,0,0,0,0,588,1,
+                    396,0,0,0,102,0,142,0,62,110,
+                    570,0,463,0,0,0,1925,0,369,0,
+                    506,1925,304,309,0,0,0,0,0,0,
+                    0,0,0,45,1,59,1,34,54,256,
+                    3504,2400,300,300,295,276,33,33,2,1620,779,15163,15163,14906,0,0,0,3270,3264,45581,0,20564,12339,18753,12353,18742,12356,13625,20564,12339,18754,12866,18743,14151,13104,20564,12339,18754,12866,18743,14151,12592,20564,12339,18754,12865,18738,12871,13620,0,0,0,0,0,0,0,1025,8195,769,259,0,31460,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],
+                Information:[12.000,14,XY,8,1.23,0.00,1.24,1.09,0.00,1]
+             }
+            """;
+
+    @Override
+    protected String getRawData() {
+        return RAW_DATA;
+    }
+
+    @Override
+    protected void assertChannels() {
+        assertQuantityChannel(SolaxBindingConstants.CHANNEL_INVERTER_OUTPUT_VOLTAGE_PHASE1, 231.6, Units.VOLT);
+        assertQuantityChannel(SolaxBindingConstants.CHANNEL_INVERTER_OUTPUT_VOLTAGE_PHASE2, 232.9, Units.VOLT);
+        assertQuantityChannel(SolaxBindingConstants.CHANNEL_INVERTER_OUTPUT_VOLTAGE_PHASE3, 231.5, Units.VOLT);
+
+        assertQuantityChannel(SolaxBindingConstants.CHANNEL_INVERTER_OUTPUT_CURRENT_PHASE1, 1.8, Units.AMPERE);
+        assertQuantityChannel(SolaxBindingConstants.CHANNEL_INVERTER_OUTPUT_CURRENT_PHASE2, 1.8, Units.AMPERE);
+        assertQuantityChannel(SolaxBindingConstants.CHANNEL_INVERTER_OUTPUT_CURRENT_PHASE3, 1.8, Units.AMPERE);
+
+        assertQuantityChannel(SolaxBindingConstants.CHANNEL_INVERTER_OUTPUT_POWER_PHASE1, 372, Units.WATT);
+        assertQuantityChannel(SolaxBindingConstants.CHANNEL_INVERTER_OUTPUT_POWER_PHASE2, 363, Units.WATT);
+        assertQuantityChannel(SolaxBindingConstants.CHANNEL_INVERTER_OUTPUT_POWER_PHASE3, 365, Units.WATT);
+        assertQuantityChannel(SolaxBindingConstants.CHANNEL_INVERTER_TOTAL_OUTPUT_POWER, 1100, Units.WATT);
+
+        assertQuantityChannel(SolaxBindingConstants.CHANNEL_INVERTER_PV1_VOLTAGE, 1.2, Units.VOLT);
+        assertQuantityChannel(SolaxBindingConstants.CHANNEL_INVERTER_PV2_VOLTAGE, 2.3, Units.VOLT);
+        assertQuantityChannel(SolaxBindingConstants.CHANNEL_INVERTER_PV1_CURRENT, 3.4, Units.AMPERE);
+        assertQuantityChannel(SolaxBindingConstants.CHANNEL_INVERTER_PV2_CURRENT, 4.5, Units.AMPERE);
+        assertQuantityChannel(SolaxBindingConstants.CHANNEL_INVERTER_PV1_POWER, 56, Units.WATT);
+        assertQuantityChannel(SolaxBindingConstants.CHANNEL_INVERTER_PV2_POWER, 67, Units.WATT);
+
+        assertQuantityChannel(SolaxBindingConstants.CHANNEL_INVERTER_OUTPUT_FREQUENCY_PHASE1, 49.96, Units.HERTZ);
+        assertQuantityChannel(SolaxBindingConstants.CHANNEL_INVERTER_OUTPUT_FREQUENCY_PHASE2, 49.96, Units.HERTZ);
+        assertQuantityChannel(SolaxBindingConstants.CHANNEL_INVERTER_OUTPUT_FREQUENCY_PHASE3, 49.96, Units.HERTZ);
+
+        assertStringChannel(SolaxBindingConstants.CHANNEL_INVERTER_WORKMODE, "2");
+
+        assertQuantityChannel(SolaxBindingConstants.CHANNEL_FEED_IN_POWER, -42, Units.WATT);
+
+        assertQuantityChannel(SolaxBindingConstants.CHANNEL_BATTERY_VOLTAGE, 2.59, Units.VOLT);
+        assertQuantityChannel(SolaxBindingConstants.CHANNEL_BATTERY_CURRENT, 3.2, Units.AMPERE);
+        assertQuantityChannel(SolaxBindingConstants.CHANNEL_BATTERY_POWER, 1034, Units.WATT);
+        assertQuantityChannel(SolaxBindingConstants.CHANNEL_BATTERY_STATE_OF_CHARGE, 45, Units.PERCENT);
+        assertQuantityChannel(SolaxBindingConstants.CHANNEL_BATTERY_TEMPERATURE, 59, SIUnits.CELSIUS);
+
+        assertQuantityChannel(SolaxBindingConstants.CHANNEL_POWER_USAGE, 1294, Units.WATT);
+        assertQuantityChannel(SolaxBindingConstants.CHANNEL_TOTAL_ENERGY, 6612.4, Units.KILOWATT_HOUR);
+        assertQuantityChannel(SolaxBindingConstants.CHANNEL_TOTAL_BATTERY_DISCHARGE_ENERGY, 10.2, Units.KILOWATT_HOUR);
+        assertQuantityChannel(SolaxBindingConstants.CHANNEL_TOTAL_BATTERY_CHARGE_ENERGY, 14.2, Units.KILOWATT_HOUR);
+        assertQuantityChannel(SolaxBindingConstants.CHANNEL_TOTAL_PV_ENERGY, 57, Units.KILOWATT_HOUR);
+        assertQuantityChannel(SolaxBindingConstants.CHANNEL_TOTAL_FEED_IN_ENERGY, 19.25, Units.KILOWATT_HOUR);
+        assertQuantityChannel(SolaxBindingConstants.CHANNEL_TOTAL_CONSUMPTION, 3.69, Units.KILOWATT_HOUR);
+        assertQuantityChannel(SolaxBindingConstants.CHANNEL_TODAY_ENERGY, 39.6, Units.KILOWATT_HOUR);
+        assertQuantityChannel(SolaxBindingConstants.CHANNEL_TODAY_FEED_IN_ENERGY, 1261573.06, Units.KILOWATT_HOUR);
+        assertQuantityChannel(SolaxBindingConstants.CHANNEL_TODAY_CONSUMPTION, 202509.28, Units.KILOWATT_HOUR);
+        assertQuantityChannel(SolaxBindingConstants.CHANNEL_TODAY_BATTERY_DISCHARGE_ENERGY, 6.2, Units.KILOWATT_HOUR);
+        assertQuantityChannel(SolaxBindingConstants.CHANNEL_TODAY_BATTERY_CHARGE_ENERGY, 11, Units.KILOWATT_HOUR);
+    }
+}

--- a/bundles/org.openhab.binding.solax/src/test/java/org/openhab/binding/solax/internal/local/handlers/TestX3MicOrProG2HandlerTest.java
+++ b/bundles/org.openhab.binding.solax/src/test/java/org/openhab/binding/solax/internal/local/handlers/TestX3MicOrProG2HandlerTest.java
@@ -14,6 +14,7 @@ package org.openhab.binding.solax.internal.local.handlers;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.binding.solax.internal.SolaxBindingConstants;
+import org.openhab.core.library.unit.SIUnits;
 import org.openhab.core.library.unit.Units;
 
 /**
@@ -79,5 +80,8 @@ public class TestX3MicOrProG2HandlerTest extends AbstractInverterHandlerTest {
 
         assertQuantityChannel(SolaxBindingConstants.CHANNEL_TOTAL_ENERGY, 1903.5, Units.KILOWATT_HOUR);
         assertQuantityChannel(SolaxBindingConstants.CHANNEL_TODAY_ENERGY, 5.0, Units.KILOWATT_HOUR);
+
+        assertQuantityChannel(SolaxBindingConstants.CHANNEL_INVERTER_TEMPERATURE1, 5, SIUnits.CELSIUS);
+        assertQuantityChannel(SolaxBindingConstants.CHANNEL_INVERTER_TEMPERATURE2, 9, SIUnits.CELSIUS);
     }
 }

--- a/bundles/org.openhab.binding.solax/src/test/java/org/openhab/binding/solax/internal/local/handlers/TestX3MicOrProG2HandlerTest.java
+++ b/bundles/org.openhab.binding.solax/src/test/java/org/openhab/binding/solax/internal/local/handlers/TestX3MicOrProG2HandlerTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.solax.internal.local.handlers;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.binding.solax.internal.SolaxBindingConstants;
+import org.openhab.core.library.unit.Units;
+
+/**
+ * The {@link TestX3MicOrProG2HandlerTest} verifies the full flow from raw JSON API data through the
+ * {@link org.openhab.binding.solax.internal.handlers.SolaxLocalAccessInverterHandler} to channel state updates for the
+ * X3 Mic / Pro G2 inverter.
+ *
+ * @author Konstantin Polihronov - Initial contribution
+ */
+@NonNullByDefault
+public class TestX3MicOrProG2HandlerTest extends AbstractInverterHandlerTest {
+
+    private static final String RAW_DATA = """
+            {
+                sn:XYZ,
+                ver:3.003.02,
+                type:16,Data:[
+                    2515,2449,2484,5,5,9,54,44,20,4080,4340,
+                    0,1,2,0,67,102,0,4999,4999,4999,2,19035,
+                    0,50,8000,5,9,
+                    0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+                    0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,0,
+                    0,0,0,0,0,0,0,0,120,40,1,6,5,0,6772,0,0,0,
+                    0,0,0,0,0,0,0,0,0,0,0,0
+                    ],
+                Information:[8.000,16,XY,8,1.15,0.00,1.11,1.01,0.00,1]
+             }
+            """;
+
+    @Override
+    protected String getRawData() {
+        return RAW_DATA;
+    }
+
+    @Override
+    protected void assertChannels() {
+        assertQuantityChannel(SolaxBindingConstants.CHANNEL_INVERTER_OUTPUT_VOLTAGE_PHASE1, 251.5, Units.VOLT);
+        assertQuantityChannel(SolaxBindingConstants.CHANNEL_INVERTER_OUTPUT_VOLTAGE_PHASE2, 244.9, Units.VOLT);
+        assertQuantityChannel(SolaxBindingConstants.CHANNEL_INVERTER_OUTPUT_VOLTAGE_PHASE3, 248.4, Units.VOLT);
+
+        assertQuantityChannel(SolaxBindingConstants.CHANNEL_INVERTER_OUTPUT_CURRENT_PHASE1, 0.5, Units.AMPERE);
+        assertQuantityChannel(SolaxBindingConstants.CHANNEL_INVERTER_OUTPUT_CURRENT_PHASE2, 0.5, Units.AMPERE);
+        assertQuantityChannel(SolaxBindingConstants.CHANNEL_INVERTER_OUTPUT_CURRENT_PHASE3, 0.9, Units.AMPERE);
+
+        assertQuantityChannel(SolaxBindingConstants.CHANNEL_INVERTER_OUTPUT_POWER_PHASE1, 54, Units.WATT);
+        assertQuantityChannel(SolaxBindingConstants.CHANNEL_INVERTER_OUTPUT_POWER_PHASE2, 44, Units.WATT);
+        assertQuantityChannel(SolaxBindingConstants.CHANNEL_INVERTER_OUTPUT_POWER_PHASE3, 20, Units.WATT);
+
+        assertQuantityChannel(SolaxBindingConstants.CHANNEL_INVERTER_PV1_VOLTAGE, 408.0, Units.VOLT);
+        assertQuantityChannel(SolaxBindingConstants.CHANNEL_INVERTER_PV2_VOLTAGE, 434.0, Units.VOLT);
+        assertQuantityChannel(SolaxBindingConstants.CHANNEL_INVERTER_PV1_CURRENT, 0.1, Units.AMPERE);
+        assertQuantityChannel(SolaxBindingConstants.CHANNEL_INVERTER_PV2_CURRENT, 0.2, Units.AMPERE);
+        assertQuantityChannel(SolaxBindingConstants.CHANNEL_INVERTER_PV1_POWER, 67, Units.WATT);
+        assertQuantityChannel(SolaxBindingConstants.CHANNEL_INVERTER_PV2_POWER, 102, Units.WATT);
+
+        assertQuantityChannel(SolaxBindingConstants.CHANNEL_INVERTER_OUTPUT_FREQUENCY_PHASE1, 49.99, Units.HERTZ);
+        assertQuantityChannel(SolaxBindingConstants.CHANNEL_INVERTER_OUTPUT_FREQUENCY_PHASE2, 49.99, Units.HERTZ);
+        assertQuantityChannel(SolaxBindingConstants.CHANNEL_INVERTER_OUTPUT_FREQUENCY_PHASE3, 49.99, Units.HERTZ);
+
+        assertStringChannel(SolaxBindingConstants.CHANNEL_INVERTER_WORKMODE, "2");
+
+        assertQuantityChannel(SolaxBindingConstants.CHANNEL_INVERTER_TOTAL_OUTPUT_POWER, 120, Units.WATT);
+
+        assertQuantityChannel(SolaxBindingConstants.CHANNEL_TOTAL_ENERGY, 1903.5, Units.KILOWATT_HOUR);
+        assertQuantityChannel(SolaxBindingConstants.CHANNEL_TODAY_ENERGY, 5.0, Units.KILOWATT_HOUR);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds Mockito-based handler integration tests that verify the full data flow from raw JSON API response through parsing and inverter type detection to channel state updates — for all supported device types: X1 Hybrid G4, X1 Boost Air Mini, X3 Hybrid G4, X3 Mic/Pro G2, and the EV charger.
- Fixes `CHANNEL_INVERTER_TEMPERATURE1` and `CHANNEL_INVERTER_TEMPERATURE2` not being populated for X3 Mic/Pro G2 — the register mappings (indices 26/27) and supported-channel declarations were already correct, but the `updateChannel()` calls were missing from `SolaxLocalAccessInverterHandler`.

## New test structure

Two abstract base classes (`AbstractInverterHandlerTest`, `AbstractChargerHandlerTest`) expose the protected `updateFromData()` method via an inner subclass, bypassing HTTP entirely. Each concrete test class provides raw JSON identical to the existing parser tests and asserts every channel the inverter/charger type supports.

## Test plan

- [ ] All 17 tests pass: `mvn test -pl bundles/org.openhab.binding.solax`
- [ ] X3 Mic/Pro G2 temperature channels now assert 5°C / 9°C from the test data