### PR TITLE
[paradoxalarm] Fix binding not polling data correctly after restart

### DIFF
--- a/bundles/org.openhab.binding.paradoxalarm/src/main/java/org/openhab/binding/paradoxalarm/internal/communication/CommunicationState.java
+++ b/bundles/org.openhab.binding.paradoxalarm/src/main/java/org/openhab/binding/paradoxalarm/internal/communication/CommunicationState.java
@@ -314,9 +314,11 @@ public enum CommunicationState implements IResponseReceiver {
         @Override
         protected void runPhase(IParadoxInitialLoginCommunicator communicator, Object... args) {
             if (communicator instanceof IParadoxCommunicator comm) {
+                // initializeData() only queues requests — responses arrive asynchronously.
+                // Transition to ONLINE is deferred until the first complete RAM read cycle
+                // completes (see EvoCommunicator.receiveRamResponse).
                 comm.initializeData();
             }
-            nextState().runPhase(communicator);
         }
     },
     ONLINE {

--- a/bundles/org.openhab.binding.paradoxalarm/src/main/java/org/openhab/binding/paradoxalarm/internal/communication/CommunicationState.java
+++ b/bundles/org.openhab.binding.paradoxalarm/src/main/java/org/openhab/binding/paradoxalarm/internal/communication/CommunicationState.java
@@ -318,6 +318,8 @@ public enum CommunicationState implements IResponseReceiver {
                 // Transition to ONLINE is deferred until the first complete RAM read cycle
                 // completes (see EvoCommunicator.receiveRamResponse).
                 comm.initializeData();
+            } else {
+                nextState().runPhase(communicator);
             }
         }
     },

--- a/bundles/org.openhab.binding.paradoxalarm/src/main/java/org/openhab/binding/paradoxalarm/internal/communication/EvoCommunicator.java
+++ b/bundles/org.openhab.binding.paradoxalarm/src/main/java/org/openhab/binding/paradoxalarm/internal/communication/EvoCommunicator.java
@@ -94,6 +94,11 @@ public class EvoCommunicator extends GenericCommunicator implements IParadoxComm
 
             // Trigger listeners update when last memory page update is received
             if (ramBlockNumber == panelType.getRamPagesNumber()) {
+                // Transition to ONLINE on the first completed RAM read cycle so that
+                // the bridge handler is not marked online before real data is available.
+                if (!isOnline()) {
+                    CommunicationState.ONLINE.runPhase(this);
+                }
                 updateListeners();
             }
         } else {
@@ -277,7 +282,10 @@ public class EvoCommunicator extends GenericCommunicator implements IParadoxComm
             logger.debug("Attempt to refresh memory map was made, but communicator is not online. Skipping update.");
             return;
         }
+        submitRamRequests();
+    }
 
+    private void submitRamRequests() {
         SyncQueue queue = SyncQueue.getInstance();
         synchronized (queue) {
             for (int i = 1; i <= panelType.getRamPagesNumber(); i++) {
@@ -346,7 +354,7 @@ public class EvoCommunicator extends GenericCommunicator implements IParadoxComm
     public void initializeData() {
         synchronized (SyncQueue.getInstance()) {
             initializeEpromData();
-            refreshMemoryMap();
+            submitRamRequests();
         }
     }
 


### PR DESCRIPTION
## Problem

After an openHAB restart, the Paradox alarm binding would appear to connect successfully (bridge shows Online) but all channel states — zone states, partition states, panel timestamp and voltages — would remain stale and never update.

The only workaround was to manually send a `LOGOUT` command followed by `RESET` to the bridge, sometimes requiring multiple attempts.

## Root Cause

The issue is a two-part initialization bug in the startup sequence:

**1. `initializeData()` requests were silently dropped**

`CommunicationState.INITIALIZE_DATA` called `comm.initializeData()`, which internally called `refreshMemoryMap()` to queue the initial RAM read requests. However, `refreshMemoryMap()` has an `isOnline()` guard that silently skips the requests if the communicator is not yet online — which it never is at that point in the login sequence. The initial RAM requests were therefore never sent.

**2. ONLINE transition fired immediately with an empty memory map**

`INITIALIZE_DATA` called `nextState().runPhase()` immediately after `initializeData()` returned, transitioning to ONLINE before any RAM responses had been received. The bridge was marked online with a completely empty memory map.

The result: polling would only start 5 seconds later via the scheduled refresh. On a clean connection this was usually enough to recover, but on a slow or marginal IP150 connection the first scheduled poll could also fail, leaving channels permanently stale.

This was confirmed in the logs:
```
[DEBUG] Attempt to refresh memory map was made, but communicator is not online. Skipping update.
[DEBUG] Phase ONLINE. Setting communicator to status ONLINE.
[DEBUG] Scheduling cache update. Refresh interval: 3s. Starts after: 5s.
```

## Fix

Two targeted changes in `EvoCommunicator` and `CommunicationState`:

1. **Extract `submitRamRequests()`** — a new private method that submits RAM read requests directly to the `SyncQueue`, bypassing the `isOnline()` guard. `initializeData()` now calls this instead of `refreshMemoryMap()`, so the initial RAM requests are always submitted regardless of online state.

2. **Defer ONLINE transition** — removed the immediate `nextState().runPhase()` call from `INITIALIZE_DATA`. Instead, `receiveRamResponse()` now triggers `CommunicationState.ONLINE.runPhase(this)` when the last RAM page of the first complete read cycle is received (and only if not already online). The bridge is marked online only after real data is available.

After the fix the log shows:
```
[DEBUG] Phase ONLINE. Setting communicator to status ONLINE.
[DEBUG] Zone PIR-CORRIDOR state updated to: ZoneState [...]   ← same millisecond
[DEBUG] Scheduling cache update. Refresh interval: 3s. Starts after: 5s.
[DEBUG] Communicator created successfully.
```

Zone states now populate at the exact moment ONLINE is set, before the scheduler even starts.

## Testing

Verified by deploying to a live openHAB 5.1.4 instance with an EVO192 panel connected via IP150 and performing multiple Docker container restarts. In all cases the binding came up with correct zone and partition states immediately, with no manual intervention required.