### PR TITLE
[dahuadoor] Multi-client SIP handling and WebRTC session routing

### DIFF
--- a/bundles/org.openhab.binding.dahuadoor/README.md
+++ b/bundles/org.openhab.binding.dahuadoor/README.md
@@ -24,25 +24,25 @@ Devices in a different subnet or VLAN will not be found automatically and must b
 
 VTO2202 is a single-button outdoor station; VTO3211 is a dual-button outdoor station.
 
-| Parameter     | Type    | Required | Default                 | Description                                                                                                                                                              |
-| ------------- | ------- | -------- | ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| hostname      | text    | Yes      |                         | Hostname or IP address of the device (e.g., 192.168.1.100)                                                                                                               |
-| username      | text    | Yes      |                         | Username to access the device                                                                                                                                            |
-| password      | text    | Yes      |                         | Password to access the device                                                                                                                                            |
-| snapshotPath  | text    | Yes      |                         | Linux path where image files are stored (e.g., /var/lib/openhab/door-images)                                                                                             |
-| useHttps      | boolean | No       | false                   | Use HTTPS (port 443) for snapshot and door-open requests. Enable if the device has HTTPS turned on in its network settings. When disabled, plain HTTP (port 80) is used. |
-| enableWebRTC  | boolean | No       | false                   | Enables local go2rtc sidecar management and publishes a `webrtc-url` channel.                                                                                            |
-| go2rtcPath    | text    | No       |                         | Absolute path to the go2rtc binary (required when `enableWebRTC=true`).                                                                                                  |
-| go2rtcApiPort | integer | No       | 1984                    | HTTP API port used by go2rtc for SDP exchange.                                                                                                                           |
-| webRtcPort    | integer | No       | 8555                    | Port used by go2rtc for WebRTC media transport.                                                                                                                          |
-| stunServer    | text    | No       | stun.l.google.com:19302 | STUN server in `host:port` format used by go2rtc.                                                                                                                        |
-| rtspChannel   | integer | No       | 1                       | RTSP channel index on the Dahua device.                                                                                                                                  |
-| rtspSubtype   | integer | No       | 0                       | RTSP stream subtype (`0` main stream, `1` sub stream).                                                                                                                   |
-| enableSip     | boolean | No       | false                   | Enables local SIP client registration for call/doorbell signaling.                                                                                                       |
+| Parameter     | Type    | Required | Default                 | Description                                                                                                                                                                                  |
+| ------------- | ------- | -------- | ----------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| hostname      | text    | Yes      |                         | Hostname or IP address of the device (e.g., 192.168.1.100)                                                                                                                                   |
+| username      | text    | Yes      |                         | Username to access the device                                                                                                                                                                |
+| password      | text    | Yes      |                         | Password to access the device                                                                                                                                                                |
+| snapshotPath  | text    | Yes      |                         | Linux path where image files are stored (e.g., /var/lib/openhab/door-images)                                                                                                                 |
+| useHttps      | boolean | No       | false                   | Use HTTPS (port 443) for snapshot and door-open requests. Enable if the device has HTTPS turned on in its network settings. When disabled, plain HTTP (port 80) is used.                     |
+| enableWebRTC  | boolean | No       | false                   | Enables local go2rtc sidecar management and publishes a `webrtc-url` channel.                                                                                                                |
+| go2rtcPath    | text    | No       |                         | Absolute path to the go2rtc binary (required when `enableWebRTC=true`).                                                                                                                      |
+| go2rtcApiPort | integer | No       | 1984                    | HTTP API port used by go2rtc for SDP exchange.                                                                                                                                               |
+| webRtcPort    | integer | No       | 8555                    | Port used by go2rtc for WebRTC media transport.                                                                                                                                              |
+| stunServer    | text    | No       | stun.l.google.com:19302 | STUN server in `host:port` format used by go2rtc.                                                                                                                                            |
+| rtspChannel   | integer | No       | 1                       | RTSP channel index on the Dahua device.                                                                                                                                                      |
+| rtspSubtype   | integer | No       | 0                       | RTSP stream subtype (`0` main stream, `1` sub stream).                                                                                                                                       |
+| enableSip     | boolean | No       | false                   | Enables local SIP client registration for call/doorbell signaling.                                                                                                                           |
 | sipExtension  | text    | No       |                         | Comma-separated list of SIP extensions, e.g. `9901#2,9901#3`. A single value is also allowed. Each extension is used as its own SIP username and can handle one parallel SIP/WebRTC session. |
-| sipPassword   | text    | No       |                         | SIP password; if empty, the binding falls back to `password`.                                                                                                            |
-| localSipPort  | integer | No       | 5060                    | Local UDP SIP listening port.                                                                                                                                            |
-| sipRealm      | text    | No       | VDP                     | SIP authentication realm (default for Dahua VTO devices).                                                                                                                |
+| sipPassword   | text    | No       |                         | SIP password; if empty, the binding falls back to `password`.                                                                                                                                |
+| localSipPort  | integer | No       | 5060                    | Local UDP SIP listening port.                                                                                                                                                                |
+| sipRealm      | text    | No       | VDP                     | SIP authentication realm (default for Dahua VTO devices).                                                                                                                                    |
 
 **Note on SIP configuration:**
 To enable SIP call signaling, set `enableSip=true` and configure at least one value in `sipExtension`.
@@ -185,7 +185,7 @@ end
 Intercom operation is implemented with WebRTC via the `go2rtc` binary.
 It converts the Dahua RTP audio/video stream into browser-compatible WebRTC. The audio stream is transcoded using `ffmpeg`. Hence both tools are needed.
 When `enableWebRTC=true`, the binding starts everything automatically when a call is received.
-The binding registers itself at the VTO. Define one or more terminals (for example `9901#2` or `9901#2,9901#3`, type `public`) and use those accounts in `sipExtension` plus the corresponding `sipPassword`.
+The binding registers itself at the VTO. Define one or more terminals (for example `9901#2` or `9901#2,9901#3`, type `public`) and list those accounts in `sipExtension` as a comma-separated list. Use the matching `sipPassword` (single password for all accounts).
 You can try Dahua's default password for initial testing, but do not use it in production. Consult your VTO manual for setup details.
 
 ### Tool installation
@@ -242,7 +242,7 @@ Thing dahuadoor:vto2202:frontdoor "Front Door Station" @ "Entrance" [
   webRtcPort=8555,
   stunServer="stun.l.google.com:19302",
   enableSip=true,
-  sipExtension="9901#2",
+  sipExtension="9901#2,9901#3",
   sipPassword="123456",
   localSipPort=5060,
   sipRealm="VDP"

--- a/bundles/org.openhab.binding.dahuadoor/README.md
+++ b/bundles/org.openhab.binding.dahuadoor/README.md
@@ -39,13 +39,13 @@ VTO2202 is a single-button outdoor station; VTO3211 is a dual-button outdoor sta
 | rtspChannel   | integer | No       | 1                       | RTSP channel index on the Dahua device.                                                                                                                                  |
 | rtspSubtype   | integer | No       | 0                       | RTSP stream subtype (`0` main stream, `1` sub stream).                                                                                                                   |
 | enableSip     | boolean | No       | false                   | Enables local SIP client registration for call/doorbell signaling.                                                                                                       |
-| sipExtension  | text    | No       |                         | SIP extension (also used as SIP username), e.g. `9901#2`.                                                                                                                |
+| sipExtension  | text    | No       |                         | Comma-separated list of SIP extensions, e.g. `9901#2,9901#3`. A single value is also allowed. Each extension is used as its own SIP username and can handle one parallel SIP/WebRTC session. |
 | sipPassword   | text    | No       |                         | SIP password; if empty, the binding falls back to `password`.                                                                                                            |
 | localSipPort  | integer | No       | 5060                    | Local UDP SIP listening port.                                                                                                                                            |
 | sipRealm      | text    | No       | VDP                     | SIP authentication realm (default for Dahua VTO devices).                                                                                                                |
 
 **Note on SIP configuration:**
-To enable SIP call signaling, set `enableSip=true` and configure at least `sipExtension`.
+To enable SIP call signaling, set `enableSip=true` and configure at least one value in `sipExtension`.
 If your VTO requires a dedicated SIP password, set `sipPassword`; otherwise the binding uses `password`.
 `localSipPort` and `sipRealm` usually work with their defaults (`5060` and `VDP`).
 
@@ -185,7 +185,7 @@ end
 Intercom operation is implemented with WebRTC via the `go2rtc` binary.
 It converts the Dahua RTP audio/video stream into browser-compatible WebRTC. The audio stream is transcoded using `ffmpeg`. Hence both tools are needed.
 When `enableWebRTC=true`, the binding starts everything automatically when a call is received.
-The binding registers itself at the VTO. Define a new terminal (for example `9901#2`, type `public`) and use that account as `sipExtension` plus the corresponding `sipPassword`.
+The binding registers itself at the VTO. Define one or more terminals (for example `9901#2` or `9901#2,9901#3`, type `public`) and use those accounts in `sipExtension` plus the corresponding `sipPassword`.
 You can try Dahua's default password for initial testing, but do not use it in production. Consult your VTO manual for setup details.
 
 ### Tool installation
@@ -222,7 +222,7 @@ Intercom operation provides these channels:
 
 SIP parameters used in the example below:
 
-- `enableSip=true` and `sipExtension` are required to register the local SIP client.
+- `enableSip=true` and at least one value in `sipExtension` are required to register the local SIP clients.
 - `sipPassword` is optional; when empty, the binding uses `password` from the thing.
 - `localSipPort=5060` and `sipRealm="VDP"` are the typical defaults for Dahua VTO setups.
 

--- a/bundles/org.openhab.binding.dahuadoor/src/main/java/org/openhab/binding/dahuadoor/internal/DahuaDoorBaseHandler.java
+++ b/bundles/org.openhab.binding.dahuadoor/src/main/java/org/openhab/binding/dahuadoor/internal/DahuaDoorBaseHandler.java
@@ -884,8 +884,8 @@ public abstract class DahuaDoorBaseHandler extends BaseThingHandler implements D
             outgoingReRegisterJobs.put(extension, job);
         } catch (IOException | PeerUnavailableException | TransportNotSupportedException | InvalidArgumentException
                 | ObjectInUseException | TooManyListenersException | RuntimeException e) {
-            logger.warn("Failed to start outgoing SIP client {} on SIP {} / RTP {}: {}", extension, sipPort,
-                    backchannelPort, e.getMessage(), e);
+            logger.warn("Failed to start outgoing SIP client {} on SIP {} / RTP {} ({}): {}", extension, sipPort,
+                    backchannelPort, e.getClass().getSimpleName(), e.getMessage(), e);
             registrationState.put(extension, false);
             outgoingSipClients.remove(extension);
             ScheduledFuture<?> job = outgoingReRegisterJobs.remove(extension);

--- a/bundles/org.openhab.binding.dahuadoor/src/main/java/org/openhab/binding/dahuadoor/internal/DahuaDoorBaseHandler.java
+++ b/bundles/org.openhab.binding.dahuadoor/src/main/java/org/openhab/binding/dahuadoor/internal/DahuaDoorBaseHandler.java
@@ -20,14 +20,17 @@ import java.io.IOException;
 import java.net.DatagramSocket;
 import java.net.InetAddress;
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.TooManyListenersException;
-import java.util.TreeSet;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledFuture;
@@ -89,10 +92,14 @@ public abstract class DahuaDoorBaseHandler extends BaseThingHandler implements D
     private @Nullable Future<?> webRtcStartupJob;
     private @Nullable Future<?> sipStartupJob;
     private @Nullable ScheduledFuture<?> sipReRegisterJob;
+    private volatile List<String> configuredOutgoingExtensions = List.of();
     private final Map<String, String> sessionToClientId = new ConcurrentHashMap<>();
-    private final Map<String, SipClient> sipClients = new ConcurrentHashMap<>();
+    private final Map<String, SipClient> outgoingSipClients = new ConcurrentHashMap<>();
+    private final Map<String, SipBackchannelRtpRelay> outgoingRelays = new ConcurrentHashMap<>();
+    private final Map<String, ScheduledFuture<?>> outgoingReRegisterJobs = new ConcurrentHashMap<>();
+    private final Map<String, String> outgoingStreamNames = new ConcurrentHashMap<>();
+    private final Map<String, Boolean> registrationState = new ConcurrentHashMap<>();
     private final Map<String, SipBackchannelSession> backchannelSessionsByHttpSession = new ConcurrentHashMap<>();
-    private static final String[] AVAILABLE_CLIENT_IDS = { "client-1", "client-2", "client-3" };
     private static final int SIP_BACKCHANNEL_LISTEN_PORT_OFFSET = 20000;
     private static final long SIP_INVITE_DEDUP_MS = 1500;
     private static final long SESSION_TTL_MS = TimeUnit.MINUTES.toMillis(30);
@@ -184,6 +191,9 @@ public abstract class DahuaDoorBaseHandler extends BaseThingHandler implements D
     }
 
     private void startSipBackchannelRelay(DahuaDoorConfiguration cfg) {
+        if (!parseSipExtensions(cfg.sipExtension).isEmpty()) {
+            return;
+        }
         int listenPort = cfg.go2rtcApiPort + SIP_BACKCHANNEL_LISTEN_PORT_OFFSET;
         if (!isValidPort(listenPort)) {
             logger.warn(
@@ -222,16 +232,32 @@ public abstract class DahuaDoorBaseHandler extends BaseThingHandler implements D
      * @param cfg current configuration snapshot
      */
     private void startWebRtc(DahuaDoorConfiguration cfg) {
-        // Derive a URL-safe stream name from the thing UID (replace special chars with _)
         String thingUidSafe = getThing().getUID().toString().replace(":", "_").replace("-", "_").replace(".", "_");
-        String streamName = GO2RTC_STREAM_PREFIX + thingUidSafe;
+        String defaultStreamName = GO2RTC_STREAM_PREFIX + thingUidSafe;
+        List<Go2RtcManager.StreamEntry> streamEntries = new ArrayList<>();
+
+        outgoingStreamNames.clear();
+        List<String> extensions = parseSipExtensions(cfg.sipExtension);
+        if (extensions.isEmpty()) {
+            streamEntries.add(new Go2RtcManager.StreamEntry(defaultStreamName,
+                    cfg.go2rtcApiPort + SIP_BACKCHANNEL_LISTEN_PORT_OFFSET));
+        } else {
+            for (int i = 0; i < extensions.size(); i++) {
+                String extension = extensions.get(i);
+                String streamName = GO2RTC_STREAM_PREFIX + thingUidSafe + "_sip" + i;
+                int backchannelPort = cfg.go2rtcApiPort + SIP_BACKCHANNEL_LISTEN_PORT_OFFSET + i;
+                streamEntries.add(new Go2RtcManager.StreamEntry(streamName, backchannelPort));
+                outgoingStreamNames.put(extension, streamName);
+            }
+        }
+
+        String mainStreamName = streamEntries.getFirst().streamName();
 
         Go2RtcManager manager = new Go2RtcManager(cfg.go2rtcPath, cfg.go2rtcApiPort, cfg.webRtcPort, cfg.stunServer,
-                streamName, cfg.hostname, cfg.username, cfg.password, cfg.rtspChannel, cfg.rtspSubtype);
+                cfg.hostname, cfg.username, cfg.password, cfg.rtspChannel, cfg.rtspSubtype, streamEntries);
         go2rtcManager = manager;
 
-        // Publish the proxy URL immediately so the UI shows the path even before go2rtc is ready
-        String proxyPath = WEBRTC_SERVLET_PATH + "/" + streamName;
+        String proxyPath = WEBRTC_SERVLET_PATH + "/" + mainStreamName;
         updateState(CHANNEL_WEBRTC_URL, new StringType(proxyPath));
 
         webRtcStartupJob = scheduler.submit(() -> {
@@ -248,13 +274,14 @@ public abstract class DahuaDoorBaseHandler extends BaseThingHandler implements D
                     return;
                 }
 
-                // 3. Register stream with the SDP proxy servlet
-                playStreamServlet.registerStream(streamName, cfg.go2rtcApiPort);
-                logger.info("WebRTC streaming active for {} at {}", streamName, proxyPath);
+                for (Go2RtcManager.StreamEntry streamEntry : streamEntries) {
+                    playStreamServlet.registerStream(streamEntry.streamName(), cfg.go2rtcApiPort);
+                }
+                logger.info("WebRTC streaming active for {} at {}", mainStreamName, proxyPath);
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
             } catch (IOException e) {
-                logger.warn("Failed to start WebRTC streaming for {}: {}", streamName, e.getMessage(), e);
+                logger.warn("Failed to start WebRTC streaming for {}: {}", mainStreamName, e.getMessage(), e);
                 if (!disposed && Objects.equals(go2rtcManager, manager)) {
                     updateState(CHANNEL_WEBRTC_URL, UnDefType.UNDEF);
                     updateStatus(ThingStatus.ONLINE, ThingStatusDetail.COMMUNICATION_ERROR,
@@ -289,7 +316,9 @@ public abstract class DahuaDoorBaseHandler extends BaseThingHandler implements D
         Go2RtcManager localManager = go2rtcManager;
         go2rtcManager = null;
         if (localManager != null) {
-            playStreamServlet.unregisterStream(localManager.getStreamName());
+            for (String streamName : localManager.getStreamNames()) {
+                playStreamServlet.unregisterStream(streamName);
+            }
             localManager.stop();
         }
         stopSipBackchannelRelay();
@@ -654,12 +683,12 @@ public abstract class DahuaDoorBaseHandler extends BaseThingHandler implements D
     protected void handleSIPRegisterResult(JsonObject eventList, JsonObject eventData) {
         if ("Pulse".equals(eventList.get("Action").getAsString())) {
             boolean success = eventData.get("Success").getAsBoolean();
-            updateState(CHANNEL_SIP_REGISTERED, OnOffType.from(success));
+            DahuaDoorConfiguration localConfig = config;
             if (success) {
                 logger.debug("Event SIPRegisterResult, Success");
-                DahuaDoorConfiguration localConfig = config;
                 DahuaEventClient localClient = client;
-                if (localConfig != null && localConfig.enableWebRTC && localClient != null) {
+                if (localConfig != null && localConfig.enableWebRTC && localClient != null
+                        && !parseSipExtensions(localConfig.sipExtension).isEmpty()) {
                     scheduler.submit(localClient::fixAudioCodec);
                 }
             } else {
@@ -788,8 +817,11 @@ public abstract class DahuaDoorBaseHandler extends BaseThingHandler implements D
      * @param cfg current configuration snapshot
      */
     private void startSip(DahuaDoorConfiguration cfg) {
-        if (cfg.sipExtension.isBlank()) {
-            logger.warn("SIP enabled but sipExtension not configured - skipping SIP registration");
+        List<String> sipExtensions = parseSipExtensions(cfg.sipExtension);
+        configuredOutgoingExtensions = sipExtensions;
+
+        if (sipExtensions.isEmpty()) {
+            logger.warn("SIP enabled but sipExtension is empty - skipping SIP startup");
             updateState(CHANNEL_SIP_REGISTERED, UnDefType.UNDEF);
             updateState(CHANNEL_SIP_CALL_STATE, UnDefType.UNDEF);
             return;
@@ -804,60 +836,17 @@ public abstract class DahuaDoorBaseHandler extends BaseThingHandler implements D
                     return;
                 }
 
-                // Use sipExtension as SIP username (extension == username in Dahua VTO)
-                // Use separate SIP password if provided, otherwise fall back to API password
-                String sipPass = !cfg.sipPassword.isEmpty() ? cfg.sipPassword : cfg.password;
-                int localAudioPort = 0;
-                SipBackchannelRtpRelay relay = sipBackchannelRelay;
-                if (relay != null) {
-                    localAudioPort = relay.getSourcePort();
-                    if (!isValidPort(localAudioPort)) {
-                        logger.warn("SIP backchannel relay source port {} is outside valid range - disabling SDP audio",
-                                localAudioPort);
-                        localAudioPort = 0;
-                    }
+                for (int i = 0; i < sipExtensions.size(); i++) {
+                    String extension = sipExtensions.get(i);
+                    int sipPort = cfg.localSipPort + i;
+                    int backchannelPort = cfg.go2rtcApiPort + SIP_BACKCHANNEL_LISTEN_PORT_OFFSET + i;
+                    startOutgoingSipClient(cfg, extension, sipPort, backchannelPort, localIp);
                 }
 
-                SipClient newSipClient = new SipClient(cfg.hostname, cfg.sipExtension, cfg.sipExtension, sipPass,
-                        cfg.localSipPort, localIp, cfg.sipRealm, localAudioPort, sipBackchannelRelay, this,
-                        this::errorInformer);
-
-                if (disposed) {
-                    newSipClient.dispose();
-                    return;
+                if (outgoingSipClients.isEmpty()) {
+                    updateState(CHANNEL_SIP_REGISTERED, UnDefType.UNDEF);
                 }
-
-                sipClient = newSipClient;
-                sipClients.put("client-1", newSipClient);
-
-                // initializeSipStack() already called in constructor
-                newSipClient.sendRegister();
-
-                if (disposed || !Objects.equals(sipClient, newSipClient)) {
-                    newSipClient.dispose();
-                    return;
-                }
-
-                // Schedule re-REGISTER every 50 seconds (VTO expires after 60s)
-                sipReRegisterJob = scheduler.scheduleWithFixedDelay(() -> {
-                    SipClient localClient = sipClient;
-                    if (disposed || localClient == null || !Objects.equals(localClient, newSipClient)) {
-                        return;
-                    }
-                    try {
-                        localClient.sendRegister();
-                    } catch (RuntimeException e) {
-                        logger.warn("Failed to re-register SIP client: {}", e.getMessage());
-                    }
-                }, 50, 50, TimeUnit.SECONDS);
-
-                logger.info("SIP client started for extension {} at {}:{}", cfg.sipExtension, localIp,
-                        cfg.localSipPort);
             } catch (IOException e) {
-                logger.warn("Failed to start SIP client: {}", e.getMessage(), e);
-                updateState(CHANNEL_SIP_REGISTERED, OnOffType.OFF);
-            } catch (PeerUnavailableException | TransportNotSupportedException | InvalidArgumentException
-                    | ObjectInUseException | TooManyListenersException e) {
                 logger.warn("Failed to start SIP client: {}", e.getMessage(), e);
                 updateState(CHANNEL_SIP_REGISTERED, OnOffType.OFF);
             } catch (RuntimeException e) {
@@ -865,6 +854,50 @@ public abstract class DahuaDoorBaseHandler extends BaseThingHandler implements D
                 updateState(CHANNEL_SIP_REGISTERED, OnOffType.OFF);
             }
         });
+    }
+
+    private void startOutgoingSipClient(DahuaDoorConfiguration cfg, String extension, int sipPort, int backchannelPort,
+            String localIp) {
+        SipBackchannelRtpRelay relay = null;
+        try {
+            relay = new SipBackchannelRtpRelay(backchannelPort, 0);
+            relay.start();
+
+            String sipPass = !cfg.sipPassword.isEmpty() ? cfg.sipPassword : cfg.password;
+            SipClient client = new SipClient(cfg.hostname, extension, extension, sipPass, sipPort, localIp,
+                    cfg.sipRealm, relay.getSourcePort(), relay, new PooledSipAdapter(extension), this::errorInformer);
+
+            outgoingRelays.put(extension, relay);
+            outgoingSipClients.put(extension, client);
+            if (sipClient == null) {
+                sipClient = client;
+            }
+            registrationState.put(extension, false);
+            client.sendRegister();
+
+            ScheduledFuture<?> job = scheduler.scheduleWithFixedDelay(() -> {
+                SipClient localClient = outgoingSipClients.get(extension);
+                if (localClient != null && !disposed) {
+                    localClient.sendRegister();
+                }
+            }, 45, 45, TimeUnit.SECONDS);
+            outgoingReRegisterJobs.put(extension, job);
+        } catch (IOException | PeerUnavailableException | TransportNotSupportedException | InvalidArgumentException
+                | ObjectInUseException | TooManyListenersException | RuntimeException e) {
+            logger.warn("Failed to start outgoing SIP client {} on SIP {} / RTP {}: {}", extension, sipPort,
+                    backchannelPort, e.getMessage(), e);
+            registrationState.put(extension, false);
+            outgoingSipClients.remove(extension);
+            ScheduledFuture<?> job = outgoingReRegisterJobs.remove(extension);
+            if (job != null) {
+                job.cancel(true);
+            }
+            outgoingStreamNames.remove(extension);
+            if (relay != null) {
+                relay.stop();
+            }
+            outgoingRelays.remove(extension);
+        }
     }
 
     /**
@@ -883,16 +916,21 @@ public abstract class DahuaDoorBaseHandler extends BaseThingHandler implements D
             localJob.cancel(true);
         }
 
-        SipClient localClient = sipClient;
         sipClient = null;
-        if (localClient != null) {
-            localClient.dispose();
-            logger.debug("SIP client stopped");
-        }
+
+        outgoingReRegisterJobs.values().forEach(job -> job.cancel(true));
+        outgoingReRegisterJobs.clear();
+        outgoingSipClients.values().forEach(SipClient::dispose);
+        outgoingSipClients.clear();
+        outgoingRelays.values().forEach(SipBackchannelRtpRelay::stop);
+        outgoingRelays.clear();
+
         stopSipBackchannelRelay();
+        configuredOutgoingExtensions = List.of();
         sessionToClientId.clear();
         backchannelSessionsByHttpSession.clear();
-        sipClients.clear();
+        outgoingStreamNames.clear();
+        registrationState.clear();
         updateState(CHANNEL_SIP_REGISTERED, UnDefType.UNDEF);
         updateState(CHANNEL_SIP_CALL_STATE, UnDefType.UNDEF);
     }
@@ -920,6 +958,37 @@ public abstract class DahuaDoorBaseHandler extends BaseThingHandler implements D
         return port > 0 && port <= 65535;
     }
 
+    private List<String> parseSipExtensions(String sipExtension) {
+        if (sipExtension.isBlank()) {
+            return List.of();
+        }
+
+        List<String> rawExtensions = Arrays.stream(sipExtension.split(",")).map(String::trim)
+                .filter(entry -> !entry.isBlank()).toList();
+
+        LinkedHashSet<String> uniqueExtensions = new LinkedHashSet<>(rawExtensions);
+        if (uniqueExtensions.size() < rawExtensions.size()) {
+            logger.warn("Duplicate sipExtension entries removed: {}", sipExtension);
+        }
+
+        List<String> limitedExtensions = uniqueExtensions.stream().limit(10).toList();
+        if (limitedExtensions.size() < uniqueExtensions.size()) {
+            logger.warn("sipExtension list capped at 10 entries");
+        }
+        return limitedExtensions;
+    }
+
+    private synchronized void updateRegistrationState(String extension, boolean success) {
+        registrationState.put(extension, success);
+
+        int expectedClients = outgoingSipClients.size();
+        boolean allRegistered = expectedClients > 0 && registrationState.size() >= expectedClients
+                && registrationState.entrySet().stream().filter(entry -> outgoingSipClients.containsKey(entry.getKey()))
+                        .allMatch(Map.Entry::getValue);
+
+        updateState(CHANNEL_SIP_REGISTERED, allRegistered ? OnOffType.ON : OnOffType.OFF);
+    }
+
     // ============================================================================
     // SipEventListener Implementation
     // ============================================================================
@@ -927,13 +996,13 @@ public abstract class DahuaDoorBaseHandler extends BaseThingHandler implements D
     @Override
     public void onRegistrationSuccess() {
         logger.debug("SIP registration successful");
-        updateState(CHANNEL_SIP_REGISTERED, OnOffType.ON);
+        updateAggregateSipCallState();
     }
 
     @Override
     public void onRegistrationFailed(String reason) {
         logger.warn("SIP registration failed: {}", reason);
-        updateState(CHANNEL_SIP_REGISTERED, OnOffType.OFF);
+        updateAggregateSipCallState();
     }
 
     @Override
@@ -942,84 +1011,145 @@ public abstract class DahuaDoorBaseHandler extends BaseThingHandler implements D
         if (!shouldProcessSipInvite("SIP")) {
             return;
         }
-        updateState(CHANNEL_SIP_CALL_STATE, new StringType(SipClient.SipCallState.RINGING.name()));
+        updateAggregateSipCallState();
     }
 
     @Override
     public void onCallCancelled() {
         logger.debug("SIP CANCEL received - transitioning call state to IDLE");
-        updateState(CHANNEL_SIP_CALL_STATE, new StringType(SipClient.SipCallState.IDLE.name()));
+        updateAggregateSipCallState();
     }
 
     @Override
     public void onCallActive() {
         logger.debug("SIP call is now ACTIVE (ACK received)");
-        updateState(CHANNEL_SIP_CALL_STATE, new StringType(SipClient.SipCallState.ACTIVE.name()));
+        updateAggregateSipCallState();
     }
 
     @Override
     public void onCallTerminating() {
         logger.debug("SIP call is TERMINATING");
-        updateState(CHANNEL_SIP_CALL_STATE, new StringType(SipClient.SipCallState.TERMINATING.name()));
+        updateAggregateSipCallState();
     }
 
     @Override
     public void onCallEnded() {
         logger.debug("SIP call ended, setting state to IDLE");
-        updateState(CHANNEL_SIP_CALL_STATE, new StringType(SipClient.SipCallState.IDLE.name()));
+        updateAggregateSipCallState();
     }
 
-    public synchronized String assignClientForSession(String sessionId) {
+    public synchronized @Nullable String assignClientForSession(String sessionId) {
         cleanupExpiredSessions();
 
-        Set<String> availableClientIds = !sipClients.isEmpty() ? new TreeSet<>(sipClients.keySet())
-                : Set.of(AVAILABLE_CLIENT_IDS[0]);
+        List<String> availableClientIds = configuredOutgoingExtensions.stream().filter(outgoingSipClients::containsKey)
+                .toList();
+
+        if (availableClientIds.isEmpty()) {
+            return null;
+        }
 
         @Nullable
         String existingClientId = sessionToClientId.get(sessionId);
         if (existingClientId != null && availableClientIds.contains(existingClientId)) {
-            updateBackchannelSession(sessionId, existingClientId, getSipClientForClientId(existingClientId));
+            updateBackchannelSession(sessionId, existingClientId, getSipClientForExtension(existingClientId));
             return existingClientId;
         }
 
         Set<String> usedClientIds = new HashSet<>(sessionToClientId.values());
+        @Nullable
+        String activeIncomingClientId = findUnassignedActiveClientId(availableClientIds, usedClientIds);
+        if (activeIncomingClientId != null) {
+            sessionToClientId.put(sessionId, activeIncomingClientId);
+            updateBackchannelSession(sessionId, activeIncomingClientId,
+                    getSipClientForExtension(activeIncomingClientId));
+            return activeIncomingClientId;
+        }
+
         for (String clientId : availableClientIds) {
             if (!usedClientIds.contains(clientId)) {
                 sessionToClientId.put(sessionId, clientId);
-                updateBackchannelSession(sessionId, clientId, getSipClientForClientId(clientId));
+                updateBackchannelSession(sessionId, clientId, getSipClientForExtension(clientId));
                 return clientId;
             }
         }
 
-        String fallbackClientId = availableClientIds.iterator().next();
-        sessionToClientId.put(sessionId, fallbackClientId);
-        updateBackchannelSession(sessionId, fallbackClientId, getSipClientForClientId(fallbackClientId));
-        return fallbackClientId;
+        logger.debug("All {} outgoing extensions are occupied for session {}", availableClientIds.size(), sessionId);
+        return null;
     }
 
-    private @Nullable SipClient getSipClientForClientId(String clientId) {
-        SipClient client = sipClients.get(clientId);
-        if (client != null) {
-            return client;
+    private @Nullable SipClient getSipClientForExtension(String extensionOrClientId) {
+        return outgoingSipClients.get(extensionOrClientId);
+    }
+
+    private @Nullable String findUnassignedActiveClientId(List<String> availableClientIds, Set<String> usedClientIds) {
+        for (SipClient.SipCallState state : List.of(SipClient.SipCallState.RINGING, SipClient.SipCallState.ANSWERING,
+                SipClient.SipCallState.ACTIVE, SipClient.SipCallState.TERMINATING,
+                SipClient.SipCallState.OUTGOING_RINGING)) {
+            for (String clientId : availableClientIds) {
+                if (usedClientIds.contains(clientId)) {
+                    continue;
+                }
+                SipClient client = outgoingSipClients.get(clientId);
+                if (client != null && state.name().equals(client.getCallState())) {
+                    return clientId;
+                }
+            }
         }
-        return sipClients.isEmpty() ? sipClient : null;
+        return null;
+    }
+
+    private void updateAggregateSipCallState() {
+        updateState(CHANNEL_SIP_CALL_STATE, new StringType(determineAggregateSipCallState().name()));
+    }
+
+    private SipClient.SipCallState determineAggregateSipCallState() {
+        List<SipClient.SipCallState> priority = List.of(SipClient.SipCallState.ACTIVE, SipClient.SipCallState.ANSWERING,
+                SipClient.SipCallState.OUTGOING_RINGING, SipClient.SipCallState.RINGING,
+                SipClient.SipCallState.TERMINATING, SipClient.SipCallState.HUNGUP, SipClient.SipCallState.IDLE);
+
+        for (SipClient.SipCallState state : priority) {
+            boolean hasState = outgoingSipClients.values().stream()
+                    .anyMatch(client -> state.name().equals(client.getCallState()));
+            if (hasState) {
+                return state;
+            }
+        }
+        return SipClient.SipCallState.IDLE;
+    }
+
+    public synchronized @Nullable String getAssignedClientForSession(String sessionId) {
+        cleanupExpiredSessions();
+        return sessionToClientId.get(sessionId);
     }
 
     public synchronized String getSipCallStateForSession(String sessionId) {
-        String clientId = assignClientForSession(sessionId);
         @Nullable
-        SipClient client = getSipClientForClientId(clientId);
+        String clientId = sessionToClientId.get(sessionId);
+        if (clientId == null) {
+            clientId = assignClientForSession(sessionId);
+        }
+        if (clientId == null) {
+            return SipClient.SipCallState.IDLE.name();
+        }
+        @Nullable
+        SipClient client = getSipClientForExtension(clientId);
         String state = client != null ? client.getCallState() : SipClient.SipCallState.IDLE.name();
         updateBackchannelSession(sessionId, clientId, client);
         logger.debug("SIP state request: sessionId={}, clientId={}, state={}", sessionId, clientId, state);
-        updateState(CHANNEL_SIP_CALL_STATE, new StringType(state));
         return state;
     }
 
     public synchronized @Nullable String getSipCallerForSession(String sessionId) {
-        String clientId = assignClientForSession(sessionId);
         @Nullable
-        SipClient client = getSipClientForClientId(clientId);
+        String clientId = sessionToClientId.get(sessionId);
+        if (clientId == null) {
+            clientId = assignClientForSession(sessionId);
+        }
+        if (clientId == null) {
+            return null;
+        }
+        @Nullable
+        SipClient client = getSipClientForExtension(clientId);
         updateBackchannelSession(sessionId, clientId, client);
         logger.debug("SIP caller request: sessionId={}, clientId={}, hasClient={}", sessionId, clientId,
                 client != null);
@@ -1027,9 +1157,13 @@ public abstract class DahuaDoorBaseHandler extends BaseThingHandler implements D
     }
 
     public synchronized boolean answerSipCallForSession(String sessionId) {
-        String clientId = assignClientForSession(sessionId);
         @Nullable
-        SipClient client = getSipClientForClientId(clientId);
+        String clientId = assignClientForSession(sessionId);
+        if (clientId == null) {
+            return false;
+        }
+        @Nullable
+        SipClient client = getSipClientForExtension(clientId);
         if (client == null) {
             logger.debug("SIP answer request: sessionId={}, clientId={} has no assigned client", sessionId, clientId);
             return false;
@@ -1038,14 +1172,18 @@ public abstract class DahuaDoorBaseHandler extends BaseThingHandler implements D
         updateBackchannelSession(sessionId, clientId, client);
         logger.debug("SIP answer request: sessionId={}, clientId={}, success={}, state={}", sessionId, clientId,
                 success, client.getCallState());
-        updateState(CHANNEL_SIP_CALL_STATE, new StringType(client.getCallState()));
+        updateAggregateSipCallState();
         return success;
     }
 
     public synchronized boolean hangupSipCallForSession(String sessionId) {
-        String clientId = assignClientForSession(sessionId);
         @Nullable
-        SipClient client = getSipClientForClientId(clientId);
+        String clientId = assignClientForSession(sessionId);
+        if (clientId == null) {
+            return false;
+        }
+        @Nullable
+        SipClient client = getSipClientForExtension(clientId);
         if (client == null) {
             logger.debug("SIP hangup request: sessionId={}, clientId={} has no assigned client", sessionId, clientId);
             return false;
@@ -1054,8 +1192,44 @@ public abstract class DahuaDoorBaseHandler extends BaseThingHandler implements D
         updateBackchannelSession(sessionId, clientId, client);
         logger.debug("SIP hangup request: sessionId={}, clientId={}, success={}, state={}", sessionId, clientId,
                 success, client.getCallState());
-        updateState(CHANNEL_SIP_CALL_STATE, new StringType(client.getCallState()));
+        updateAggregateSipCallState();
         return success;
+    }
+
+    public record OutgoingCallResult(boolean success, @Nullable String clientId, String callState) {
+    }
+
+    public synchronized OutgoingCallResult startOutgoingCallForSession(String sessionId, String target) {
+        @Nullable
+        String extension = assignClientForSession(sessionId);
+        if (extension == null) {
+            return new OutgoingCallResult(false, null, "NO_FREE_CLIENT");
+        }
+
+        SipClient client = getSipClientForExtension(extension);
+        if (client == null) {
+            logger.warn("No SIP client for extension {} (session {})", extension, sessionId);
+            return new OutgoingCallResult(false, extension, "UNAVAILABLE");
+        }
+
+        boolean sent = client.sendInvite(target);
+        if (sent) {
+            updateBackchannelSession(sessionId, extension, client);
+        }
+        updateAggregateSipCallState();
+        return new OutgoingCallResult(sent, extension, getSipCallStateForSession(sessionId));
+    }
+
+    public synchronized @Nullable String getWebRtcUrlForClientId(String clientId) {
+        String streamName = outgoingStreamNames.get(clientId);
+        if (streamName == null) {
+            Go2RtcManager localManager = go2rtcManager;
+            if (localManager == null) {
+                return null;
+            }
+            streamName = localManager.getStreamName();
+        }
+        return WEBRTC_SERVLET_PATH + "/" + streamName;
     }
 
     public synchronized @Nullable SipBackchannelSession getSipBackchannelSessionForSession(String sessionId) {
@@ -1119,5 +1293,57 @@ public abstract class DahuaDoorBaseHandler extends BaseThingHandler implements D
                 getThing().getUID().toString(), callerId, callState, inviteSdp, createdAtMs, now));
 
         cleanupExpiredSessions();
+    }
+
+    private class PooledSipAdapter implements SipEventListener {
+        private final String extension;
+
+        private PooledSipAdapter(String extension) {
+            this.extension = extension;
+        }
+
+        @Override
+        public void onRegistrationSuccess() {
+            logger.debug("Outgoing SIP {} registered", extension);
+            updateRegistrationState(extension, true);
+        }
+
+        @Override
+        public void onRegistrationFailed(String reason) {
+            logger.warn("Outgoing SIP {} registration failed: {}", extension, reason);
+            updateRegistrationState(extension, false);
+        }
+
+        @Override
+        public void onInviteReceived(String callerId) {
+            logger.info("SIP {} received incoming call from {}", extension, callerId);
+            if (shouldProcessSipInvite("SIP " + extension)) {
+                updateAggregateSipCallState();
+            }
+        }
+
+        @Override
+        public void onCallCancelled() {
+            logger.debug("SIP {} call cancelled", extension);
+            updateAggregateSipCallState();
+        }
+
+        @Override
+        public void onCallActive() {
+            logger.debug("SIP {} call active", extension);
+            updateAggregateSipCallState();
+        }
+
+        @Override
+        public void onCallTerminating() {
+            logger.debug("SIP {} call terminating", extension);
+            updateAggregateSipCallState();
+        }
+
+        @Override
+        public void onCallEnded() {
+            logger.debug("SIP {} call ended", extension);
+            updateAggregateSipCallState();
+        }
     }
 }

--- a/bundles/org.openhab.binding.dahuadoor/src/main/java/org/openhab/binding/dahuadoor/internal/DahuaDoorBaseHandler.java
+++ b/bundles/org.openhab.binding.dahuadoor/src/main/java/org/openhab/binding/dahuadoor/internal/DahuaDoorBaseHandler.java
@@ -1064,15 +1064,20 @@ public abstract class DahuaDoorBaseHandler extends BaseThingHandler implements D
         String activeIncomingClientId = findUnassignedActiveClientId(availableClientIds, usedClientIds);
         if (activeIncomingClientId != null) {
             sessionToClientId.put(sessionId, activeIncomingClientId);
-            updateBackchannelSession(sessionId, activeIncomingClientId,
-                    getSipClientForExtension(activeIncomingClientId));
+            SipClient activeClient = getSipClientForExtension(activeIncomingClientId);
+            logger.debug("Session {} assigned to active SipClient {} (state={})", sessionId, activeIncomingClientId,
+                    activeClient != null ? activeClient.getCallState() : "unknown");
+            updateBackchannelSession(sessionId, activeIncomingClientId, activeClient);
             return activeIncomingClientId;
         }
 
         for (String clientId : availableClientIds) {
             if (!usedClientIds.contains(clientId)) {
                 sessionToClientId.put(sessionId, clientId);
-                updateBackchannelSession(sessionId, clientId, getSipClientForExtension(clientId));
+                SipClient idleClient = getSipClientForExtension(clientId);
+                logger.debug("Session {} assigned to idle SipClient {} (state={})", sessionId, clientId,
+                        idleClient != null ? idleClient.getCallState() : "unknown");
+                updateBackchannelSession(sessionId, clientId, idleClient);
                 return clientId;
             }
         }

--- a/bundles/org.openhab.binding.dahuadoor/src/main/java/org/openhab/binding/dahuadoor/internal/DahuaDoorBaseHandler.java
+++ b/bundles/org.openhab.binding.dahuadoor/src/main/java/org/openhab/binding/dahuadoor/internal/DahuaDoorBaseHandler.java
@@ -279,7 +279,7 @@ public abstract class DahuaDoorBaseHandler extends BaseThingHandler implements D
                 }
 
                 for (Go2RtcManager.StreamEntry streamEntry : streamEntries) {
-                    playStreamServlet.registerStream(streamEntry.streamName(), cfg.go2rtcApiPort);
+                    playStreamServlet.registerStream(streamEntry.streamName(), cfg.go2rtcApiPort, this);
                 }
                 logger.info("WebRTC streaming active for {} at {}", mainStreamName, proxyPath);
             } catch (InterruptedException e) {

--- a/bundles/org.openhab.binding.dahuadoor/src/main/java/org/openhab/binding/dahuadoor/internal/DahuaDoorBaseHandler.java
+++ b/bundles/org.openhab.binding.dahuadoor/src/main/java/org/openhab/binding/dahuadoor/internal/DahuaDoorBaseHandler.java
@@ -172,6 +172,10 @@ public abstract class DahuaDoorBaseHandler extends BaseThingHandler implements D
             return;
         }
 
+        if ((localConfig.enableWebRTC || localConfig.enableSip) && !validateBackchannelPorts(localConfig)) {
+            return;
+        }
+
         client = new DahuaEventClient(localConfig.hostname, localConfig.username, localConfig.password,
                 localConfig.useHttps, this, this::errorInformer);
 
@@ -193,7 +197,7 @@ public abstract class DahuaDoorBaseHandler extends BaseThingHandler implements D
     }
 
     private void startSipBackchannelRelay(DahuaDoorConfiguration cfg) {
-        if (!parseSipExtensions(cfg.sipExtension).isEmpty()) {
+        if (parseSipExtensions(cfg.sipExtension).isEmpty()) {
             return;
         }
         int listenPort = cfg.go2rtcApiPort + SIP_BACKCHANNEL_LISTEN_PORT_OFFSET;
@@ -960,6 +964,52 @@ public abstract class DahuaDoorBaseHandler extends BaseThingHandler implements D
 
     private static boolean isValidPort(int port) {
         return port > 0 && port <= 65535;
+    }
+
+    private boolean validateBackchannelPorts(DahuaDoorConfiguration cfg) {
+        List<String> extensions = parseSipExtensions(cfg.sipExtension);
+        boolean useWebRtcBackchannel = cfg.enableWebRTC;
+        boolean useSipBackchannel = cfg.enableSip && !extensions.isEmpty();
+        if (!useWebRtcBackchannel && !useSipBackchannel) {
+            return true;
+        }
+
+        int backchannelCount = useWebRtcBackchannel ? Math.max(1, extensions.size()) : extensions.size();
+        int backchannelBase = cfg.go2rtcApiPort + SIP_BACKCHANNEL_LISTEN_PORT_OFFSET;
+        int backchannelMax = backchannelBase + backchannelCount - 1;
+
+        if (!isValidPort(backchannelBase) || !isValidPort(backchannelMax)) {
+            String detail = String.format("Invalid backchannel port range %d-%d (go2rtcApiPort=%d, sipExtensions=%d)",
+                    backchannelBase, backchannelMax, cfg.go2rtcApiPort, extensions.size());
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, detail);
+            logger.warn(detail);
+            return false;
+        }
+
+        if (useSipBackchannel) {
+            int sipBase = cfg.localSipPort;
+            int sipMax = sipBase + extensions.size() - 1;
+            if (!isValidPort(sipBase) || !isValidPort(sipMax)) {
+                String detail = String.format("Invalid SIP port range %d-%d (localSipPort=%d, sipExtensions=%d)",
+                        sipBase, sipMax, cfg.localSipPort, extensions.size());
+                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, detail);
+                logger.warn(detail);
+                return false;
+            }
+
+            if (rangesOverlap(sipBase, sipMax, backchannelBase, backchannelMax)) {
+                String detail = String.format("SIP/backchannel port ranges overlap (sip=%d-%d, backchannel=%d-%d)",
+                        sipBase, sipMax, backchannelBase, backchannelMax);
+                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, detail);
+                logger.warn(detail);
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static boolean rangesOverlap(int startA, int endA, int startB, int endB) {
+        return Math.max(startA, startB) <= Math.min(endA, endB);
     }
 
     private List<String> parseSipExtensions(String sipExtension) {

--- a/bundles/org.openhab.binding.dahuadoor/src/main/java/org/openhab/binding/dahuadoor/internal/DahuaDoorBaseHandler.java
+++ b/bundles/org.openhab.binding.dahuadoor/src/main/java/org/openhab/binding/dahuadoor/internal/DahuaDoorBaseHandler.java
@@ -203,7 +203,7 @@ public abstract class DahuaDoorBaseHandler extends BaseThingHandler implements D
                     listenPort, cfg.go2rtcApiPort, SIP_BACKCHANNEL_LISTEN_PORT_OFFSET);
             return;
         }
-        SipBackchannelRtpRelay relay = new SipBackchannelRtpRelay(listenPort, 0);
+        SipBackchannelRtpRelay relay = new SipBackchannelRtpRelay(getThing().getUID() + "/default", listenPort, 0);
         try {
             relay.start();
             int sourcePort = relay.getSourcePort();
@@ -246,8 +246,8 @@ public abstract class DahuaDoorBaseHandler extends BaseThingHandler implements D
         } else {
             for (int i = 0; i < extensions.size(); i++) {
                 String extension = extensions.get(i);
-                String streamName = GO2RTC_STREAM_PREFIX + thingUidSafe + "_sip" + i;
                 int backchannelPort = cfg.go2rtcApiPort + SIP_BACKCHANNEL_LISTEN_PORT_OFFSET + i;
+                String streamName = GO2RTC_STREAM_PREFIX + thingUidSafe + "_sip" + i;
                 streamEntries.add(new Go2RtcManager.StreamEntry(streamName, backchannelPort));
                 outgoingStreamNames.put(extension, streamName);
             }
@@ -864,7 +864,7 @@ public abstract class DahuaDoorBaseHandler extends BaseThingHandler implements D
             String localIp) {
         SipBackchannelRtpRelay relay = null;
         try {
-            relay = new SipBackchannelRtpRelay(backchannelPort, 0);
+            relay = new SipBackchannelRtpRelay(getThing().getUID() + "/" + extension, backchannelPort, 0);
             relay.start();
 
             String sipPass = !cfg.sipPassword.isEmpty() ? cfg.sipPassword : cfg.password;
@@ -1243,6 +1243,19 @@ public abstract class DahuaDoorBaseHandler extends BaseThingHandler implements D
             return null;
         }
         return localManager.getStreamName();
+    }
+
+    public synchronized @Nullable String allocateWebRtcStreamNameForClientId(String clientId) {
+        return getWebRtcStreamNameForClientId(clientId);
+    }
+
+    public synchronized @Nullable String getOrAllocateWebRtcStreamNameForSession(String sessionId, String clientId) {
+        return allocateWebRtcStreamNameForClientId(clientId);
+    }
+
+    public synchronized int getRelayListenPortForClientId(String clientId) {
+        SipBackchannelRtpRelay relay = outgoingRelays.get(clientId);
+        return relay != null ? relay.getListenPort() : -1;
     }
 
     public synchronized @Nullable SipBackchannelSession getSipBackchannelSessionForSession(String sessionId) {

--- a/bundles/org.openhab.binding.dahuadoor/src/main/java/org/openhab/binding/dahuadoor/internal/DahuaDoorBaseHandler.java
+++ b/bundles/org.openhab.binding.dahuadoor/src/main/java/org/openhab/binding/dahuadoor/internal/DahuaDoorBaseHandler.java
@@ -19,6 +19,8 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.net.DatagramSocket;
 import java.net.InetAddress;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -257,7 +259,9 @@ public abstract class DahuaDoorBaseHandler extends BaseThingHandler implements D
                 cfg.hostname, cfg.username, cfg.password, cfg.rtspChannel, cfg.rtspSubtype, streamEntries);
         go2rtcManager = manager;
 
-        String proxyPath = WEBRTC_SERVLET_PATH + "/" + mainStreamName;
+        String proxyPath = extensions.isEmpty() ? WEBRTC_SERVLET_PATH + "/" + mainStreamName
+                : WEBRTC_SERVLET_PATH + "/session?thing="
+                        + URLEncoder.encode(getThing().getUID().toString(), StandardCharsets.UTF_8);
         updateState(CHANNEL_WEBRTC_URL, new StringType(proxyPath));
 
         webRtcStartupJob = scheduler.submit(() -> {
@@ -1221,15 +1225,24 @@ public abstract class DahuaDoorBaseHandler extends BaseThingHandler implements D
     }
 
     public synchronized @Nullable String getWebRtcUrlForClientId(String clientId) {
-        String streamName = outgoingStreamNames.get(clientId);
+        String streamName = getWebRtcStreamNameForClientId(clientId);
         if (streamName == null) {
-            Go2RtcManager localManager = go2rtcManager;
-            if (localManager == null) {
-                return null;
-            }
-            streamName = localManager.getStreamName();
+            return null;
         }
         return WEBRTC_SERVLET_PATH + "/" + streamName;
+    }
+
+    public synchronized @Nullable String getWebRtcStreamNameForClientId(String clientId) {
+        String streamName = outgoingStreamNames.get(clientId);
+        if (streamName != null) {
+            return streamName;
+        }
+
+        Go2RtcManager localManager = go2rtcManager;
+        if (localManager == null) {
+            return null;
+        }
+        return localManager.getStreamName();
     }
 
     public synchronized @Nullable SipBackchannelSession getSipBackchannelSessionForSession(String sessionId) {

--- a/bundles/org.openhab.binding.dahuadoor/src/main/java/org/openhab/binding/dahuadoor/internal/DahuaDoorHandlerFactory.java
+++ b/bundles/org.openhab.binding.dahuadoor/src/main/java/org/openhab/binding/dahuadoor/internal/DahuaDoorHandlerFactory.java
@@ -51,7 +51,7 @@ public class DahuaDoorHandlerFactory extends BaseThingHandlerFactory {
 
     @Activate
     public DahuaDoorHandlerFactory(@Reference HttpService httpService) {
-        this.playStreamServlet = new PlayStreamServlet(httpService);
+        this.playStreamServlet = new PlayStreamServlet(httpService, this);
         this.sipCallControlServlet = new SipCallControlServlet(httpService, this);
         this.sipCallControlServlet.activate();
     }

--- a/bundles/org.openhab.binding.dahuadoor/src/main/java/org/openhab/binding/dahuadoor/internal/media/Go2RtcManager.java
+++ b/bundles/org.openhab.binding.dahuadoor/src/main/java/org/openhab/binding/dahuadoor/internal/media/Go2RtcManager.java
@@ -26,6 +26,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.attribute.PosixFilePermissions;
 import java.util.List;
+import java.util.Locale;
 import java.util.concurrent.TimeUnit;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -81,6 +82,7 @@ public class Go2RtcManager {
     private @Nullable Process process;
     private @Nullable File configFile;
     private @Nullable Thread logThread;
+    private @Nullable Thread exitWatcherThread;
 
     /**
      * Creates a new Go2RtcManager.
@@ -165,6 +167,8 @@ public class Go2RtcManager {
 
         ProcessBuilder pb = new ProcessBuilder(go2rtcBinary, "-config", localConfigFile.getAbsolutePath());
         pb.redirectErrorStream(true);
+        LOGGER.debug("Starting go2rtc for streams {} with API port {}, WebRTC port {}, backchannel RTP ports {}",
+                getStreamNames(), apiPort, webRtcPort, getBackchannelPortsSummary());
         Process startedProcess = pb.start();
         process = startedProcess;
         LOGGER.info("go2rtc started (streams={}, apiPort={}, PID={})", getStreamNames(), apiPort, startedProcess.pid());
@@ -184,6 +188,19 @@ public class Go2RtcManager {
         logTh.setDaemon(true);
         logTh.start();
         logThread = logTh;
+
+        Thread exitWatcher = new Thread(() -> {
+            try {
+                int exitCode = startedProcess.waitFor();
+                LOGGER.debug("go2rtc process exited (streams={}, PID={}, exitCode={})", getStreamNames(),
+                        startedProcess.pid(), exitCode);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }, "go2rtc-exit-" + getLogThreadNameSuffix());
+        exitWatcher.setDaemon(true);
+        exitWatcher.start();
+        exitWatcherThread = exitWatcher;
 
         waitForHealthy();
     }
@@ -211,6 +228,11 @@ public class Go2RtcManager {
         if (localLogThread != null) {
             localLogThread.interrupt();
             logThread = null;
+        }
+        Thread localExitWatcherThread = exitWatcherThread;
+        if (localExitWatcherThread != null) {
+            localExitWatcherThread.interrupt();
+            exitWatcherThread = null;
         }
         File localConfig = configFile;
         if (localConfig != null && localConfig.exists()) {
@@ -259,7 +281,7 @@ public class Go2RtcManager {
                 + "&subtype=" + rtspSubtype + "#backchannel=0";
 
         StringBuilder yaml = new StringBuilder();
-        yaml.append("log:\n  level: debug\n");
+        yaml.append("log:\n  level: ").append(resolveGo2RtcLogLevel()).append("\n");
         yaml.append("streams:\n");
         for (StreamEntry entry : streams) {
             yaml.append("  ").append(entry.streamName()).append(":\n");
@@ -274,9 +296,39 @@ public class Go2RtcManager {
     }
 
     private String buildBackchannelExec(int backchannelRtpPort) {
-        return "exec:ffmpeg -f alaw -ar 8000 -ac 1 -i - -c:a pcm_s16le -ar 16000 -ac 1 "
+        return "exec:ffmpeg -hide_banner -loglevel " + resolveFfmpegLogLevel()
+                + " -fflags nobuffer -f alaw -ar 8000 -ac 1 " + "-i - -vn -map 0:a:0 -c:a pcm_s16le -ar 16000 -ac 1 "
                 + "-payload_type 97 -ssrc 12345 -f rtp rtp://127.0.0.1:" + backchannelRtpPort
                 + "#backchannel=1#audio=pcma/8000";
+    }
+
+    private String resolveGo2RtcLogLevel() {
+        if (LOGGER.isTraceEnabled()) {
+            return "trace";
+        }
+        if (LOGGER.isDebugEnabled()) {
+            return "debug";
+        }
+        if (LOGGER.isInfoEnabled()) {
+            return "info";
+        }
+        if (LOGGER.isWarnEnabled()) {
+            return "warn";
+        }
+        return "error";
+    }
+
+    private String resolveFfmpegLogLevel() {
+        if (LOGGER.isTraceEnabled() || LOGGER.isDebugEnabled()) {
+            return "debug";
+        }
+        if (LOGGER.isInfoEnabled()) {
+            return "info";
+        }
+        if (LOGGER.isWarnEnabled()) {
+            return "warning";
+        }
+        return "error";
     }
 
     private String getLogContext(String line) {
@@ -329,11 +381,52 @@ public class Go2RtcManager {
     private File writeConfig() throws IOException {
         File cfg = File.createTempFile("go2rtc_" + getStreamName() + "_", ".yaml");
         cfg.deleteOnExit();
+        String yaml = buildYaml();
         try (FileWriter fw = new FileWriter(cfg, StandardCharsets.UTF_8)) {
-            fw.write(buildYaml());
+            fw.write(yaml);
         }
         LOGGER.debug("go2rtc config written to {}", cfg.getAbsolutePath());
+        LOGGER.debug("go2rtc config summary: rtspSource={}, backchannelSource={}, candidates={}", sanitizeRtspSource(),
+                summarizeBackchannelExec(), summarizeCandidates(yaml));
         return cfg;
+    }
+
+    private String sanitizeRtspSource() {
+        return String.format(Locale.ROOT, "rtsp://***:***@%s:554/cam/realmonitor?channel=%d&subtype=%d#backchannel=0",
+                hostname, rtspChannel, rtspSubtype);
+    }
+
+    private String summarizeBackchannelExec() {
+        return String.format(Locale.ROOT,
+                "exec:ffmpeg -f alaw -ar 8000 -ac 1 -i - -map 0:a:0 ... -f rtp rtp://127.0.0.1:ports%s #audio=pcma/8000",
+                getBackchannelPortsSummary());
+    }
+
+    private String getBackchannelPortsSummary() {
+        return streams.stream().map(StreamEntry::backchannelRtpPort).map(String::valueOf).toList().toString();
+    }
+
+    private static String summarizeCandidates(String yaml) {
+        int candidatesIndex = yaml.indexOf("  candidates:\n");
+        if (candidatesIndex < 0) {
+            return "[]";
+        }
+        String tail = yaml.substring(candidatesIndex + "  candidates:\n".length());
+        String[] lines = tail.split("\\n");
+        StringBuilder summary = new StringBuilder("[");
+        boolean first = true;
+        for (String line : lines) {
+            if (!line.startsWith("    - ")) {
+                break;
+            }
+            if (!first) {
+                summary.append(", ");
+            }
+            summary.append(line.substring("    - ".length()));
+            first = false;
+        }
+        summary.append(']');
+        return summary.toString();
     }
 
     /**

--- a/bundles/org.openhab.binding.dahuadoor/src/main/java/org/openhab/binding/dahuadoor/internal/media/Go2RtcManager.java
+++ b/bundles/org.openhab.binding.dahuadoor/src/main/java/org/openhab/binding/dahuadoor/internal/media/Go2RtcManager.java
@@ -175,12 +175,12 @@ public class Go2RtcManager {
                     new InputStreamReader(startedProcess.getInputStream(), StandardCharsets.UTF_8))) {
                 String line;
                 while ((line = reader.readLine()) != null) {
-                    LOGGER.debug("go2rtc [{}]: {}", getStreamName(), line);
+                    LOGGER.debug("go2rtc [{}]: {}", getLogContext(line), line);
                 }
             } catch (IOException e) {
-                LOGGER.trace("go2rtc [{}] output reader closed: {}", getStreamName(), e.getMessage());
+                LOGGER.trace("go2rtc [{}] output reader closed: {}", getDefaultLogContext(), e.getMessage());
             }
-        }, "go2rtc-log-" + getStreamName());
+        }, "go2rtc-log-" + getLogThreadNameSuffix());
         logTh.setDaemon(true);
         logTh.start();
         logThread = logTh;
@@ -277,6 +277,29 @@ public class Go2RtcManager {
         return "exec:ffmpeg -f alaw -ar 8000 -ac 1 -i - -c:a pcm_s16le -ar 16000 -ac 1 "
                 + "-payload_type 97 -ssrc 12345 -f rtp rtp://127.0.0.1:" + backchannelRtpPort
                 + "#backchannel=1#audio=pcma/8000";
+    }
+
+    private String getLogContext(String line) {
+        String inferredStreamName = inferStreamNameFromLogLine(line);
+        return inferredStreamName.isEmpty() ? getDefaultLogContext() : inferredStreamName;
+    }
+
+    private String getDefaultLogContext() {
+        return streams.size() == 1 ? getStreamName() : "shared:" + String.join(",", getStreamNames());
+    }
+
+    private String getLogThreadNameSuffix() {
+        return streams.size() == 1 ? getStreamName() : "multi";
+    }
+
+    private String inferStreamNameFromLogLine(String line) {
+        for (StreamEntry entry : streams) {
+            String rtpMarker = "rtp://127.0.0.1:" + entry.backchannelRtpPort();
+            if (line.contains(rtpMarker)) {
+                return entry.streamName();
+            }
+        }
+        return "";
     }
 
     /**

--- a/bundles/org.openhab.binding.dahuadoor/src/main/java/org/openhab/binding/dahuadoor/internal/media/Go2RtcManager.java
+++ b/bundles/org.openhab.binding.dahuadoor/src/main/java/org/openhab/binding/dahuadoor/internal/media/Go2RtcManager.java
@@ -25,6 +25,7 @@ import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.attribute.PosixFilePermissions;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -52,6 +53,9 @@ import org.slf4j.LoggerFactory;
 @NonNullByDefault
 public class Go2RtcManager {
 
+    public record StreamEntry(String streamName, int backchannelRtpPort) {
+    }
+
     private static final Logger LOGGER = LoggerFactory.getLogger(Go2RtcManager.class);
 
     /** Health-check timeout in milliseconds. */
@@ -72,8 +76,7 @@ public class Go2RtcManager {
     private final String password;
     private final int rtspChannel;
     private final int rtspSubtype;
-    private final int backchannelRtpPort;
-    private final String streamName;
+    private final List<StreamEntry> streams;
 
     private @Nullable Process process;
     private @Nullable File configFile;
@@ -95,17 +98,22 @@ public class Go2RtcManager {
      */
     public Go2RtcManager(String go2rtcBinary, int apiPort, int webRtcPort, String stunServer, String streamName,
             String hostname, String username, String password, int rtspChannel, int rtspSubtype) {
+        this(go2rtcBinary, apiPort, webRtcPort, stunServer, hostname, username, password, rtspChannel, rtspSubtype,
+                List.of(new StreamEntry(streamName, apiPort + 20000)));
+    }
+
+    public Go2RtcManager(String go2rtcBinary, int apiPort, int webRtcPort, String stunServer, String hostname,
+            String username, String password, int rtspChannel, int rtspSubtype, List<StreamEntry> streams) {
         this.go2rtcBinary = go2rtcBinary;
         this.apiPort = apiPort;
         this.webRtcPort = webRtcPort;
         this.stunServer = stunServer;
-        this.streamName = streamName;
         this.hostname = hostname;
         this.username = username;
         this.password = password;
         this.rtspChannel = rtspChannel;
         this.rtspSubtype = rtspSubtype;
-        this.backchannelRtpPort = apiPort + 20000;
+        this.streams = List.copyOf(streams);
     }
 
     /**
@@ -114,7 +122,11 @@ public class Go2RtcManager {
      * @return stream name string
      */
     public String getStreamName() {
-        return streamName;
+        return streams.getFirst().streamName();
+    }
+
+    public List<String> getStreamNames() {
+        return streams.stream().map(StreamEntry::streamName).toList();
     }
 
     /**
@@ -155,7 +167,7 @@ public class Go2RtcManager {
         pb.redirectErrorStream(true);
         Process startedProcess = pb.start();
         process = startedProcess;
-        LOGGER.info("go2rtc started (stream={}, apiPort={}, PID={})", streamName, apiPort, startedProcess.pid());
+        LOGGER.info("go2rtc started (streams={}, apiPort={}, PID={})", getStreamNames(), apiPort, startedProcess.pid());
 
         // Pipe go2rtc stdout+stderr into the openHAB log at DEBUG level so problems are visible.
         Thread logTh = new Thread(() -> {
@@ -163,12 +175,12 @@ public class Go2RtcManager {
                     new InputStreamReader(startedProcess.getInputStream(), StandardCharsets.UTF_8))) {
                 String line;
                 while ((line = reader.readLine()) != null) {
-                    LOGGER.debug("go2rtc [{}]: {}", streamName, line);
+                    LOGGER.debug("go2rtc [{}]: {}", getStreamName(), line);
                 }
             } catch (IOException e) {
-                LOGGER.trace("go2rtc [{}] output reader closed: {}", streamName, e.getMessage());
+                LOGGER.trace("go2rtc [{}] output reader closed: {}", getStreamName(), e.getMessage());
             }
-        }, "go2rtc-log-" + streamName);
+        }, "go2rtc-log-" + getStreamName());
         logTh.setDaemon(true);
         logTh.start();
         logThread = logTh;
@@ -182,12 +194,12 @@ public class Go2RtcManager {
     public void stop() {
         Process localProcess = process;
         if (localProcess != null) {
-            LOGGER.info("Stopping go2rtc (stream={}, PID={})", streamName, localProcess.pid());
+            LOGGER.info("Stopping go2rtc (streams={}, PID={})", getStreamNames(), localProcess.pid());
             localProcess.destroy();
             try {
                 if (!localProcess.waitFor(STOP_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
-                    LOGGER.warn("go2rtc did not terminate in {}s, forcing shutdown (stream={})", STOP_TIMEOUT_SECONDS,
-                            streamName);
+                    LOGGER.warn("go2rtc did not terminate in {}s, forcing shutdown (streams={})", STOP_TIMEOUT_SECONDS,
+                            getStreamNames());
                     localProcess.destroyForcibly();
                 }
             } catch (InterruptedException e) {
@@ -235,15 +247,6 @@ public class Go2RtcManager {
     private String buildYaml() {
         String userInfo = URLEncoder.encode(username, StandardCharsets.UTF_8) + ":"
                 + URLEncoder.encode(password, StandardCharsets.UTF_8);
-        String rtspUrl = "rtsp://" + userInfo + "@" + hostname + ":554/cam/realmonitor?channel=" + rtspChannel
-                + "&subtype=" + rtspSubtype + "#backchannel=0";
-        String backchannelExec = "exec:ffmpeg -f alaw -ar 8000 -ac 1 -i - -c:a pcm_s16le -ar 16000 -ac 1 "
-                + "-payload_type 97 -ssrc 12345 -f rtp rtp://127.0.0.1:" + backchannelRtpPort
-                + "#backchannel=1#audio=pcma/8000";
-
-        String safeRtspUrl = rtspUrl.replace("'", "''");
-        String safeBackchannelExec = backchannelExec.replace("'", "''");
-
         StringBuilder candidates = new StringBuilder();
         String localIp = detectLocalIp();
         if (localIp != null) {
@@ -252,9 +255,28 @@ public class Go2RtcManager {
         }
         candidates.append("    - stun:").append(stunServer).append("\n");
 
-        return "log:\n" + "  level: debug\n" + "streams:\n" + "  " + streamName + ":\n" + "    - '" + safeRtspUrl
-                + "'\n" + "    - '" + safeBackchannelExec + "'\n" + "api:\n" + "  listen: \"127.0.0.1:" + apiPort
-                + "\"\n" + "webrtc:\n" + "  listen: \":" + webRtcPort + "\"\n" + "  candidates:\n" + candidates;
+        String rtspUrl = "rtsp://" + userInfo + "@" + hostname + ":554/cam/realmonitor?channel=" + rtspChannel
+                + "&subtype=" + rtspSubtype + "#backchannel=0";
+
+        StringBuilder yaml = new StringBuilder();
+        yaml.append("log:\n  level: debug\n");
+        yaml.append("streams:\n");
+        for (StreamEntry entry : streams) {
+            yaml.append("  ").append(entry.streamName()).append(":\n");
+            yaml.append("    - '").append(rtspUrl.replace("'", "''")).append("'\n");
+            yaml.append("    - '").append(buildBackchannelExec(entry.backchannelRtpPort()).replace("'", "''"))
+                    .append("'\n");
+        }
+        yaml.append("api:\n  listen: \"127.0.0.1:").append(apiPort).append("\"\n");
+        yaml.append("webrtc:\n  listen: \":").append(webRtcPort).append("\"\n");
+        yaml.append("  candidates:\n").append(candidates);
+        return yaml.toString();
+    }
+
+    private String buildBackchannelExec(int backchannelRtpPort) {
+        return "exec:ffmpeg -f alaw -ar 8000 -ac 1 -i - -c:a pcm_s16le -ar 16000 -ac 1 "
+                + "-payload_type 97 -ssrc 12345 -f rtp rtp://127.0.0.1:" + backchannelRtpPort
+                + "#backchannel=1#audio=pcma/8000";
     }
 
     /**
@@ -282,7 +304,7 @@ public class Go2RtcManager {
      * Writes the YAML config to a temporary file and returns that file.
      */
     private File writeConfig() throws IOException {
-        File cfg = File.createTempFile("go2rtc_" + streamName + "_", ".yaml");
+        File cfg = File.createTempFile("go2rtc_" + getStreamName() + "_", ".yaml");
         cfg.deleteOnExit();
         try (FileWriter fw = new FileWriter(cfg, StandardCharsets.UTF_8)) {
             fw.write(buildYaml());

--- a/bundles/org.openhab.binding.dahuadoor/src/main/java/org/openhab/binding/dahuadoor/internal/media/PlayStreamServlet.java
+++ b/bundles/org.openhab.binding.dahuadoor/src/main/java/org/openhab/binding/dahuadoor/internal/media/PlayStreamServlet.java
@@ -284,11 +284,7 @@ public class PlayStreamServlet extends HttpServlet {
             }
 
             byte[] encoded = Base64.getEncoder().encode(sdpAnswer);
-
-            resp.setStatus(HttpServletResponse.SC_OK);
-            resp.setContentType("text/plain");
-            resp.setCharacterEncoding(StandardCharsets.UTF_8.name());
-            resp.getOutputStream().write(encoded);
+            sendEncodedAnswer(resp, encoded);
         } catch (IOException e) {
             sendBase64Message(resp, HttpServletResponse.SC_BAD_GATEWAY,
                     "Failed to reach go2rtc API: " + e.getMessage());
@@ -339,6 +335,13 @@ public class PlayStreamServlet extends HttpServlet {
         resp.setHeader("Access-Control-Allow-Headers", "Content-Type");
     }
 
+    private static void sendEncodedAnswer(HttpServletResponse resp, byte[] encodedAnswer) throws IOException {
+        resp.setStatus(HttpServletResponse.SC_OK);
+        resp.setContentType("text/plain");
+        resp.setCharacterEncoding(StandardCharsets.UTF_8.name());
+        resp.getOutputStream().write(encodedAnswer);
+    }
+
     private @Nullable String resolveSessionStreamName(HttpServletRequest req, HttpServletResponse resp)
             throws IOException {
         String thingUid = getQueryParameter(req, "thing");
@@ -363,11 +366,18 @@ public class PlayStreamServlet extends HttpServlet {
         }
 
         @Nullable
-        String streamName = handler.getWebRtcStreamNameForClientId(clientId);
+        String streamName = handler.getOrAllocateWebRtcStreamNameForSession(sessionId, clientId);
         if (streamName == null || streamName.isBlank()) {
             sendBase64Message(resp, HttpServletResponse.SC_NOT_FOUND,
                     "No WebRTC stream available for SIP client: " + clientId);
             return null;
+        }
+
+        int relayListenPort = handler.getRelayListenPortForClientId(clientId);
+
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("Allocated WebRTC stream '{}' for session '{}' clientId='{}' relayListenPort={}", streamName,
+                    sessionId, clientId, relayListenPort);
         }
         return streamName;
     }

--- a/bundles/org.openhab.binding.dahuadoor/src/main/java/org/openhab/binding/dahuadoor/internal/media/PlayStreamServlet.java
+++ b/bundles/org.openhab.binding.dahuadoor/src/main/java/org/openhab/binding/dahuadoor/internal/media/PlayStreamServlet.java
@@ -566,14 +566,17 @@ public class PlayStreamServlet extends HttpServlet {
             return;
         }
 
-        String dahuaClientId = handler.assignClientForSession(sessionId);
+        @Nullable
+        String dahuaClientId = handler.getAssignedClientForSession(sessionId);
+        String safeClientId = dahuaClientId != null ? dahuaClientId : "unassigned";
+        String safeRequestedClientId = requestedClientId != null ? requestedClientId : "";
         String mappingKey = buildStreamClientKey(streamName, sessionId);
-        String mappingValue = dahuaClientId + "|" + (requestedClientId != null ? requestedClientId : "");
+        String mappingValue = safeClientId + "|" + safeRequestedClientId;
         String previous = lastLoggedSessionClientMapping.put(mappingKey, mappingValue);
 
         if (!mappingValue.equals(previous)) {
             LOGGER.info("WebRTC session mapping: stream='{}' sessionId='{}' dahuaClientId='{}' requestedClientId='{}'",
-                    streamName, sessionId, dahuaClientId, requestedClientId != null ? requestedClientId : "");
+                    streamName, sessionId, safeClientId, safeRequestedClientId);
         }
     }
 

--- a/bundles/org.openhab.binding.dahuadoor/src/main/java/org/openhab/binding/dahuadoor/internal/media/PlayStreamServlet.java
+++ b/bundles/org.openhab.binding.dahuadoor/src/main/java/org/openhab/binding/dahuadoor/internal/media/PlayStreamServlet.java
@@ -33,7 +33,10 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.dahuadoor.internal.DahuaDoorBaseHandler;
 import org.openhab.binding.dahuadoor.internal.DahuaDoorBindingConstants;
+import org.openhab.binding.dahuadoor.internal.DahuaDoorHandlerFactory;
 import org.osgi.service.http.HttpService;
 import org.osgi.service.http.NamespaceException;
 import org.slf4j.Logger;
@@ -77,8 +80,10 @@ public class PlayStreamServlet extends HttpServlet {
     private static final int GO2RTC_API_TIMEOUT_MS = 10_000;
     /** Maximum accepted size for incoming request body. */
     private static final int MAX_REQUEST_BODY_BYTES = 64 * 1024;
+    private static final String SESSION_STREAM_PATH = "session";
 
     private final HttpService httpService;
+    private final DahuaDoorHandlerFactory handlerFactory;
 
     /**
      * Map from go2rtc stream name (e.g. {@code dahua_vto2202_living}) to API port.
@@ -89,8 +94,9 @@ public class PlayStreamServlet extends HttpServlet {
     /** Number of currently registered streams; used to decide when to unregister the servlet. */
     private volatile int registrationCount = 0;
 
-    public PlayStreamServlet(HttpService httpService) {
+    public PlayStreamServlet(HttpService httpService, DahuaDoorHandlerFactory handlerFactory) {
         this.httpService = httpService;
+        this.handlerFactory = handlerFactory;
     }
 
     // -------------------------------------------------------------------------
@@ -156,6 +162,14 @@ public class PlayStreamServlet extends HttpServlet {
             return;
         }
         String streamName = pathInfo.substring(1); // strip leading /
+        if (SESSION_STREAM_PATH.equals(streamName)) {
+            @Nullable
+            String resolvedStreamName = resolveSessionStreamName(req, resp);
+            if (resolvedStreamName == null) {
+                return;
+            }
+            streamName = resolvedStreamName;
+        }
 
         Integer apiPort = streamApiPorts.get(streamName);
         if (apiPort == null) {
@@ -323,6 +337,59 @@ public class PlayStreamServlet extends HttpServlet {
     private static void addCorsHeaders(HttpServletResponse resp) {
         resp.setHeader("Access-Control-Allow-Methods", "POST, OPTIONS");
         resp.setHeader("Access-Control-Allow-Headers", "Content-Type");
+    }
+
+    private @Nullable String resolveSessionStreamName(HttpServletRequest req, HttpServletResponse resp)
+            throws IOException {
+        String thingUid = getQueryParameter(req, "thing");
+        if (thingUid == null || thingUid.isBlank()) {
+            sendBase64Message(resp, HttpServletResponse.SC_BAD_REQUEST, "Missing thing parameter");
+            return null;
+        }
+
+        DahuaDoorBaseHandler handler = handlerFactory.getDahuaHandler(thingUid);
+        if (handler == null) {
+            sendBase64Message(resp, HttpServletResponse.SC_NOT_FOUND,
+                    "Thing not found or not initialized: " + thingUid);
+            return null;
+        }
+
+        String sessionId = req.getSession().getId();
+        @Nullable
+        String clientId = handler.assignClientForSession(sessionId);
+        if (clientId == null) {
+            sendBase64Message(resp, HttpServletResponse.SC_CONFLICT, "No free outgoing SIP client available");
+            return null;
+        }
+
+        @Nullable
+        String streamName = handler.getWebRtcStreamNameForClientId(clientId);
+        if (streamName == null || streamName.isBlank()) {
+            sendBase64Message(resp, HttpServletResponse.SC_NOT_FOUND,
+                    "No WebRTC stream available for SIP client: " + clientId);
+            return null;
+        }
+        return streamName;
+    }
+
+    private static @Nullable String getQueryParameter(HttpServletRequest req, String name) {
+        String query = req.getQueryString();
+        if (query == null || query.isBlank()) {
+            return null;
+        }
+
+        for (String segment : query.split("&")) {
+            int separator = segment.indexOf('=');
+            String key = separator >= 0 ? segment.substring(0, separator) : segment;
+            if (!name.equals(URLDecoder.decode(key, StandardCharsets.UTF_8))) {
+                continue;
+            }
+
+            String value = separator >= 0 ? segment.substring(separator + 1) : "";
+            return URLDecoder.decode(value, StandardCharsets.UTF_8);
+        }
+
+        return null;
     }
 
     private static void sendBase64Message(HttpServletResponse resp, int statusCode, String message) throws IOException {

--- a/bundles/org.openhab.binding.dahuadoor/src/main/java/org/openhab/binding/dahuadoor/internal/media/PlayStreamServlet.java
+++ b/bundles/org.openhab.binding.dahuadoor/src/main/java/org/openhab/binding/dahuadoor/internal/media/PlayStreamServlet.java
@@ -38,6 +38,7 @@ import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.dahuadoor.internal.DahuaDoorBaseHandler;
 import org.openhab.binding.dahuadoor.internal.DahuaDoorBindingConstants;
 import org.openhab.binding.dahuadoor.internal.DahuaDoorHandlerFactory;
+import org.openhab.binding.dahuadoor.internal.sip.SipClient;
 import org.osgi.service.http.HttpService;
 import org.osgi.service.http.NamespaceException;
 import org.slf4j.Logger;
@@ -84,6 +85,10 @@ public class PlayStreamServlet extends HttpServlet {
     private static final String SESSION_STREAM_PATH = "session";
     /** Correlation id generator for WebRTC proxy requests. */
     private static final AtomicLong REQUEST_SEQUENCE = new AtomicLong();
+    /** How long a request may stay in CONNECTING before the lock is treated as stale. */
+    private static final long CONNECTING_STALE_MS = 30_000L;
+    /** Fallback timeout for ACTIVE locks if SIP state callbacks are not observed. */
+    private static final long ACTIVE_STALE_MS = 30 * 60_000L;
 
     private final HttpService httpService;
     private final DahuaDoorHandlerFactory handlerFactory;
@@ -93,6 +98,20 @@ public class PlayStreamServlet extends HttpServlet {
      * Modified from multiple threads → ConcurrentHashMap.
      */
     private final Map<String, Integer> streamApiPorts = new ConcurrentHashMap<>();
+
+    /** Map from stream name to handler for SIP state lookup. */
+    private final Map<String, DahuaDoorBaseHandler> streamHandlers = new ConcurrentHashMap<>();
+
+    /**
+     * Per stream+client request guard.
+     *
+     * Key format: {@code <streamName>|<clientKey>} where clientKey is either explicit clientId
+     * query parameter or HTTP session id.
+     */
+    private final Map<String, OfferGateState> offerGateByStreamAndClient = new ConcurrentHashMap<>();
+
+    /** Last logged mapping per stream+HTTP session to avoid repeated log spam. */
+    private final Map<String, String> lastLoggedSessionClientMapping = new ConcurrentHashMap<>();
 
     /** Number of currently registered streams; used to decide when to unregister the servlet. */
     private volatile int registrationCount = 0;
@@ -111,12 +130,15 @@ public class PlayStreamServlet extends HttpServlet {
      *
      * @param streamName go2rtc stream name
      * @param apiPort go2rtc API port for that stream
+     * @param handler owning thing handler used to resolve SIP session state for this stream
      */
-    public synchronized void registerStream(String streamName, int apiPort) {
+    public synchronized void registerStream(String streamName, int apiPort, DahuaDoorBaseHandler handler) {
         Integer previous = streamApiPorts.put(streamName, apiPort);
+        streamHandlers.put(streamName, handler);
         if (previous == null && registrationCount == 0) {
             if (!activate()) {
                 streamApiPorts.remove(streamName);
+                streamHandlers.remove(streamName);
                 LOGGER.warn("Could not register stream '{}' because servlet activation failed", streamName);
                 return;
             }
@@ -134,17 +156,23 @@ public class PlayStreamServlet extends HttpServlet {
      */
     public synchronized void unregisterStream(String streamName) {
         Integer removed = streamApiPorts.remove(streamName);
+        streamHandlers.remove(streamName);
         if (removed != null) {
             registrationCount = Math.max(0, registrationCount - 1);
             if (registrationCount == 0) {
                 deactivate();
             }
         }
+        offerGateByStreamAndClient.keySet().removeIf(key -> key.startsWith(streamName + "|"));
+        lastLoggedSessionClientMapping.keySet().removeIf(key -> key.startsWith(streamName + "|"));
         LOGGER.debug("Unregistered WebRTC stream '{}'", streamName);
     }
 
     public synchronized void deactivateAll() {
         streamApiPorts.clear();
+        streamHandlers.clear();
+        offerGateByStreamAndClient.clear();
+        lastLoggedSessionClientMapping.clear();
         registrationCount = 0;
         deactivate();
     }
@@ -176,8 +204,23 @@ public class PlayStreamServlet extends HttpServlet {
         long requestId = REQUEST_SEQUENCE.incrementAndGet();
         long startedAtNanos = System.nanoTime();
 
+        String clientIdParam = req.getParameter("clientId");
+        String sessionId = req.getSession().getId();
+        String clientKey = clientIdParam != null && !clientIdParam.isBlank() ? clientIdParam : sessionId;
+        String streamClientKey = buildStreamClientKey(streamName, clientKey);
+
+        logSessionToDahuaClientMapping(streamName, sessionId, clientIdParam);
+
+        if (!tryAcquireOfferGate(streamName, streamClientKey, sessionId)) {
+            sendBase64Message(resp, HttpServletResponse.SC_CONFLICT,
+                    "Duplicate WebRTC request rejected for same client while setup/connection is active.");
+            LOGGER.warn("Rejected duplicate WebRTC offer for stream '{}' (clientKey={})", streamName, clientKey);
+            return;
+        }
+
         Integer apiPort = streamApiPorts.get(streamName);
         if (apiPort == null) {
+            releaseOfferGate(streamClientKey);
             sendBase64Message(resp, HttpServletResponse.SC_NOT_FOUND,
                     "Unknown stream: " + streamName + ". Is the thing online with WebRTC enabled?");
             LOGGER.warn("WebRTC proxy [{}] rejected: unknown stream '{}'", requestId, streamName);
@@ -188,6 +231,7 @@ public class PlayStreamServlet extends HttpServlet {
         try (InputStream in = req.getInputStream()) {
             requestBody = new String(readLimitedBytes(in, MAX_REQUEST_BODY_BYTES), StandardCharsets.UTF_8);
         } catch (RequestTooLargeException e) {
+            releaseOfferGate(streamClientKey);
             sendBase64Message(resp, HttpServletResponse.SC_REQUEST_ENTITY_TOO_LARGE,
                     "Request body too large. Maximum supported size is " + MAX_REQUEST_BODY_BYTES + " bytes.");
             LOGGER.warn("Rejected request for stream '{}': request body exceeded {} bytes", streamName,
@@ -195,18 +239,21 @@ public class PlayStreamServlet extends HttpServlet {
             return;
         }
         if (requestBody.isBlank()) {
+            releaseOfferGate(streamClientKey);
             sendBase64Message(resp, HttpServletResponse.SC_BAD_REQUEST, "Empty request body");
             LOGGER.warn("Rejected request for stream '{}': empty body", streamName);
             return;
         }
 
         if (!requestBody.startsWith("data=")) {
+            releaseOfferGate(streamClientKey);
             sendBase64Message(resp, HttpServletResponse.SC_BAD_REQUEST,
                     "Unsupported request format. Expected form body: data=<base64(sdp)>.");
             LOGGER.warn("Rejected request for stream '{}': unsupported input mode", streamName);
             return;
         }
         if (requestBody.indexOf('&') >= 0) {
+            releaseOfferGate(streamClientKey);
             sendBase64Message(resp, HttpServletResponse.SC_BAD_REQUEST,
                     "Unsupported request format. Only one form field is allowed: data=<base64(sdp)>.");
             LOGGER.warn("Rejected request for stream '{}': additional form fields present", streamName);
@@ -215,6 +262,7 @@ public class PlayStreamServlet extends HttpServlet {
 
         String decodedFormValue = URLDecoder.decode(requestBody.substring(5), StandardCharsets.UTF_8);
         if (decodedFormValue.isBlank()) {
+            releaseOfferGate(streamClientKey);
             sendBase64Message(resp, HttpServletResponse.SC_BAD_REQUEST, "Missing SDP payload in form field 'data'.");
             LOGGER.warn("Rejected request for stream '{}': empty data field", streamName);
             return;
@@ -224,11 +272,13 @@ public class PlayStreamServlet extends HttpServlet {
         try {
             sdpOffer = new String(Base64.getDecoder().decode(decodedFormValue), StandardCharsets.UTF_8);
         } catch (IllegalArgumentException e) {
+            releaseOfferGate(streamClientKey);
             sendBase64Message(resp, HttpServletResponse.SC_BAD_REQUEST, "Invalid Base64 payload in form field 'data'.");
             LOGGER.warn("Rejected request for stream '{}': invalid base64 payload", streamName);
             return;
         }
         if (sdpOffer.isBlank()) {
+            releaseOfferGate(streamClientKey);
             sendBase64Message(resp, HttpServletResponse.SC_BAD_REQUEST, "Decoded SDP offer is empty.");
             LOGGER.warn("Rejected request for stream '{}': decoded SDP is empty", streamName);
             return;
@@ -281,6 +331,7 @@ public class PlayStreamServlet extends HttpServlet {
                 }
                 String message = errorBody.isEmpty() ? "go2rtc API returned HTTP " + status
                         : "go2rtc API returned HTTP " + status + ": " + errorBody;
+                releaseOfferGate(streamClientKey);
                 sendBase64Message(resp, HttpServletResponse.SC_BAD_GATEWAY, message);
                 LOGGER.warn(
                         "WebRTC proxy [{}] upstream error stream='{}' status={} bodyBytes={} durationMs={} body='{}'",
@@ -304,7 +355,9 @@ public class PlayStreamServlet extends HttpServlet {
 
             byte[] encoded = Base64.getEncoder().encode(sdpAnswer);
             sendEncodedAnswer(resp, encoded);
+            markOfferGateActive(streamClientKey);
         } catch (IOException e) {
+            releaseOfferGate(streamClientKey);
             sendBase64Message(resp, HttpServletResponse.SC_BAD_GATEWAY,
                     "Failed to reach go2rtc API: " + e.getMessage());
             LOGGER.warn("WebRTC proxy [{}] upstream communication failure stream='{}' after {} ms: {}", requestId,
@@ -428,6 +481,89 @@ public class PlayStreamServlet extends HttpServlet {
         resp.setContentType("text/plain");
         resp.setCharacterEncoding(StandardCharsets.UTF_8.name());
         resp.getOutputStream().write(encoded);
+    }
+
+    private static String buildStreamClientKey(String streamName, String clientKey) {
+        return streamName + "|" + clientKey;
+    }
+
+    private boolean tryAcquireOfferGate(String streamName, String streamClientKey, String sessionId) {
+        // Primary release signal: SIP call control transitioned to a terminal state.
+        if (isSipTerminalState(streamName, sessionId)) {
+            releaseOfferGate(streamClientKey);
+        }
+
+        long now = System.currentTimeMillis();
+        OfferGateState state = offerGateByStreamAndClient.compute(streamClientKey, (key, current) -> {
+            if (current == null) {
+                return new OfferGateState(OfferGatePhase.CONNECTING, now);
+            }
+            long ageMs = now - current.lastUpdateMs;
+            if (current.phase == OfferGatePhase.CONNECTING && ageMs > CONNECTING_STALE_MS) {
+                return new OfferGateState(OfferGatePhase.CONNECTING, now);
+            }
+            if (current.phase == OfferGatePhase.ACTIVE && ageMs > ACTIVE_STALE_MS) {
+                return new OfferGateState(OfferGatePhase.CONNECTING, now);
+            }
+            return current;
+        });
+        return state != null && state.phase == OfferGatePhase.CONNECTING && state.lastUpdateMs == now;
+    }
+
+    private void markOfferGateActive(String streamClientKey) {
+        long now = System.currentTimeMillis();
+        offerGateByStreamAndClient.computeIfPresent(streamClientKey,
+                (key, current) -> new OfferGateState(OfferGatePhase.ACTIVE, now));
+    }
+
+    private void releaseOfferGate(String streamClientKey) {
+        offerGateByStreamAndClient.remove(streamClientKey);
+    }
+
+    private boolean isSipTerminalState(String streamName, String sessionId) {
+        DahuaDoorBaseHandler handler = streamHandlers.get(streamName);
+        if (handler == null) {
+            return false;
+        }
+
+        @Nullable
+        String callState = handler.getSipCallStateForSession(sessionId);
+        return SipClient.SipCallState.IDLE.name().equals(callState)
+                || SipClient.SipCallState.HUNGUP.name().equals(callState)
+                || SipClient.SipCallState.TERMINATING.name().equals(callState);
+    }
+
+    private void logSessionToDahuaClientMapping(String streamName, String sessionId,
+            @Nullable String requestedClientId) {
+        DahuaDoorBaseHandler handler = streamHandlers.get(streamName);
+        if (handler == null) {
+            return;
+        }
+
+        String dahuaClientId = handler.assignClientForSession(sessionId);
+        String mappingKey = buildStreamClientKey(streamName, sessionId);
+        String mappingValue = dahuaClientId + "|" + (requestedClientId != null ? requestedClientId : "");
+        String previous = lastLoggedSessionClientMapping.put(mappingKey, mappingValue);
+
+        if (!mappingValue.equals(previous)) {
+            LOGGER.info("WebRTC session mapping: stream='{}' sessionId='{}' dahuaClientId='{}' requestedClientId='{}'",
+                    streamName, sessionId, dahuaClientId, requestedClientId != null ? requestedClientId : "");
+        }
+    }
+
+    private enum OfferGatePhase {
+        CONNECTING,
+        ACTIVE
+    }
+
+    private static final class OfferGateState {
+        private final OfferGatePhase phase;
+        private final long lastUpdateMs;
+
+        private OfferGateState(OfferGatePhase phase, long lastUpdateMs) {
+            this.phase = phase;
+            this.lastUpdateMs = lastUpdateMs;
+        }
     }
 
     private static String summarizeAudioSdpDirection(String sdp) {

--- a/bundles/org.openhab.binding.dahuadoor/src/main/java/org/openhab/binding/dahuadoor/internal/media/PlayStreamServlet.java
+++ b/bundles/org.openhab.binding.dahuadoor/src/main/java/org/openhab/binding/dahuadoor/internal/media/PlayStreamServlet.java
@@ -26,6 +26,7 @@ import java.util.Dictionary;
 import java.util.Hashtable;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
@@ -81,6 +82,8 @@ public class PlayStreamServlet extends HttpServlet {
     /** Maximum accepted size for incoming request body. */
     private static final int MAX_REQUEST_BODY_BYTES = 64 * 1024;
     private static final String SESSION_STREAM_PATH = "session";
+    /** Correlation id generator for WebRTC proxy requests. */
+    private static final AtomicLong REQUEST_SEQUENCE = new AtomicLong();
 
     private final HttpService httpService;
     private final DahuaDoorHandlerFactory handlerFactory;
@@ -170,12 +173,14 @@ public class PlayStreamServlet extends HttpServlet {
             }
             streamName = resolvedStreamName;
         }
+        long requestId = REQUEST_SEQUENCE.incrementAndGet();
+        long startedAtNanos = System.nanoTime();
 
         Integer apiPort = streamApiPorts.get(streamName);
         if (apiPort == null) {
             sendBase64Message(resp, HttpServletResponse.SC_NOT_FOUND,
                     "Unknown stream: " + streamName + ". Is the thing online with WebRTC enabled?");
-            LOGGER.warn("Rejected request: unknown stream '{}'", streamName);
+            LOGGER.warn("WebRTC proxy [{}] rejected: unknown stream '{}'", requestId, streamName);
             return;
         }
 
@@ -229,8 +234,15 @@ public class PlayStreamServlet extends HttpServlet {
             return;
         }
 
+        String remote = firstNonBlank(req.getHeader("X-Forwarded-For"), req.getRemoteAddr());
+        String origin = firstNonBlank(req.getHeader("Origin"), "-");
+        String userAgent = abbreviate(req.getHeader("User-Agent"), 160);
         if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug("WebRTC offer for stream '{}' audio={}", streamName, summarizeAudioSdpDirection(sdpOffer));
+            LOGGER.debug(
+                    "WebRTC proxy [{}] incoming POST stream='{}' remote='{}' origin='{}' userAgent='{}' bodyBytes={} offerBytes={} audio={} audioLines={}",
+                    requestId, streamName, remote, origin, userAgent, requestBody.length(),
+                    sdpOffer.getBytes(StandardCharsets.UTF_8).length, summarizeAudioSdpDirection(sdpOffer),
+                    extractAudioSdpLines(sdpOffer));
         }
 
         // Forward to go2rtc API
@@ -246,6 +258,8 @@ public class PlayStreamServlet extends HttpServlet {
             conn.setRequestProperty("Content-Type", "application/sdp");
             byte[] offerBytes = sdpOffer.getBytes(StandardCharsets.UTF_8);
             conn.setRequestProperty("Content-Length", String.valueOf(offerBytes.length));
+            LOGGER.debug("WebRTC proxy [{}] forwarding POST to {} (stream='{}', offerBytes={})", requestId, go2rtcUrl,
+                    streamName, offerBytes.length);
             try (OutputStream out = conn.getOutputStream()) {
                 out.write(offerBytes);
             }
@@ -268,8 +282,10 @@ public class PlayStreamServlet extends HttpServlet {
                 String message = errorBody.isEmpty() ? "go2rtc API returned HTTP " + status
                         : "go2rtc API returned HTTP " + status + ": " + errorBody;
                 sendBase64Message(resp, HttpServletResponse.SC_BAD_GATEWAY, message);
-                LOGGER.warn("Upstream error for stream '{}': mapped to 502 (status={}, bodyBytes={})", streamName,
-                        status, errorBodyBytes.length);
+                LOGGER.warn(
+                        "WebRTC proxy [{}] upstream error stream='{}' status={} bodyBytes={} durationMs={} body='{}'",
+                        requestId, streamName, status, errorBodyBytes.length, elapsedMillis(startedAtNanos),
+                        abbreviate(errorBody, 300));
                 return;
             }
 
@@ -279,8 +295,11 @@ public class PlayStreamServlet extends HttpServlet {
             }
 
             if (LOGGER.isDebugEnabled()) {
-                LOGGER.debug("WebRTC answer for stream '{}' audio={}", streamName,
-                        summarizeAudioSdpDirection(new String(sdpAnswer, StandardCharsets.UTF_8)));
+                String answerText = new String(sdpAnswer, StandardCharsets.UTF_8);
+                LOGGER.debug(
+                        "WebRTC proxy [{}] upstream answer stream='{}' status={} answerBytes={} durationMs={} audio={} audioLines={}",
+                        requestId, streamName, status, sdpAnswer.length, elapsedMillis(startedAtNanos),
+                        summarizeAudioSdpDirection(answerText), extractAudioSdpLines(answerText));
             }
 
             byte[] encoded = Base64.getEncoder().encode(sdpAnswer);
@@ -288,7 +307,8 @@ public class PlayStreamServlet extends HttpServlet {
         } catch (IOException e) {
             sendBase64Message(resp, HttpServletResponse.SC_BAD_GATEWAY,
                     "Failed to reach go2rtc API: " + e.getMessage());
-            LOGGER.warn("Upstream communication failure for stream '{}': {}", streamName, e.getMessage());
+            LOGGER.warn("WebRTC proxy [{}] upstream communication failure stream='{}' after {} ms: {}", requestId,
+                    streamName, elapsedMillis(startedAtNanos), e.getMessage());
         } finally {
             conn.disconnect();
         }
@@ -457,6 +477,54 @@ public class PlayStreamServlet extends HttpServlet {
                 ? ("media=" + mediaDirection + ", session=" + sessionDirection + ", effective=" + effective + ", msid="
                         + audioHasMsid + ", ssrc=" + audioHasSsrc + ", codecs=[" + audioCodecs + "]")
                 : "no-audio-media";
+    }
+
+    private static String extractAudioSdpLines(String sdp) {
+        StringBuilder linesSummary = new StringBuilder();
+        boolean inAudioSection = false;
+        for (String rawLine : sdp.split("\\r?\\n")) {
+            String line = rawLine.trim();
+            if (line.startsWith("m=")) {
+                inAudioSection = line.startsWith("m=audio ");
+                if (inAudioSection) {
+                    appendSdpLine(linesSummary, line);
+                }
+                continue;
+            }
+            if (!inAudioSection) {
+                continue;
+            }
+            if (line.startsWith("a=rtpmap:") || "a=sendrecv".equals(line) || "a=sendonly".equals(line)
+                    || "a=recvonly".equals(line) || "a=inactive".equals(line) || line.startsWith("a=fmtp:")) {
+                appendSdpLine(linesSummary, line);
+            }
+        }
+        return linesSummary.length() == 0 ? "[]" : '[' + linesSummary.toString() + ']';
+    }
+
+    private static void appendSdpLine(StringBuilder linesSummary, String line) {
+        if (linesSummary.length() > 0) {
+            linesSummary.append(" | ");
+        }
+        linesSummary.append(line);
+    }
+
+    private static String firstNonBlank(@Nullable String value, String fallback) {
+        return value == null || value.isBlank() ? fallback : value;
+    }
+
+    private static String abbreviate(@Nullable String value, int maxLen) {
+        if (value == null || value.isBlank()) {
+            return "-";
+        }
+        if (value.length() <= maxLen) {
+            return value;
+        }
+        return value.substring(0, Math.max(0, maxLen - 3)) + "...";
+    }
+
+    private static long elapsedMillis(long startedAtNanos) {
+        return (System.nanoTime() - startedAtNanos) / 1_000_000L;
     }
 
     private static byte[] readLimitedBytes(InputStream in, int maxBytes) throws IOException, RequestTooLargeException {

--- a/bundles/org.openhab.binding.dahuadoor/src/main/java/org/openhab/binding/dahuadoor/internal/media/PlayStreamServlet.java
+++ b/bundles/org.openhab.binding.dahuadoor/src/main/java/org/openhab/binding/dahuadoor/internal/media/PlayStreamServlet.java
@@ -32,6 +32,7 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
@@ -193,6 +194,7 @@ public class PlayStreamServlet extends HttpServlet {
             return;
         }
         String streamName = pathInfo.substring(1); // strip leading /
+        boolean sessionEndpointRequest = SESSION_STREAM_PATH.equals(streamName);
         if (SESSION_STREAM_PATH.equals(streamName)) {
             @Nullable
             String resolvedStreamName = resolveSessionStreamName(req, resp);
@@ -204,18 +206,32 @@ public class PlayStreamServlet extends HttpServlet {
         long requestId = REQUEST_SEQUENCE.incrementAndGet();
         long startedAtNanos = System.nanoTime();
 
-        String clientIdParam = req.getParameter("clientId");
-        String sessionId = req.getSession().getId();
+        @Nullable
+        String clientIdParam = getQueryParameter(req, "clientId");
+        @Nullable
+        String sessionId = resolveSessionId(req);
+        if (sessionId == null || sessionId.isBlank()) {
+            sendBase64Message(resp, HttpServletResponse.SC_SERVICE_UNAVAILABLE,
+                    "No usable HTTP session id available for WebRTC request.");
+            LOGGER.warn("WebRTC proxy [{}] rejected: missing session id for stream '{}'", requestId, streamName);
+            return;
+        }
         String clientKey = clientIdParam != null && !clientIdParam.isBlank() ? clientIdParam : sessionId;
         String streamClientKey = buildStreamClientKey(streamName, clientKey);
 
         logSessionToDahuaClientMapping(streamName, sessionId, clientIdParam);
 
         if (!tryAcquireOfferGate(streamName, streamClientKey, sessionId)) {
-            sendBase64Message(resp, HttpServletResponse.SC_CONFLICT,
-                    "Duplicate WebRTC request rejected for same client while setup/connection is active.");
-            LOGGER.warn("Rejected duplicate WebRTC offer for stream '{}' (clientKey={})", streamName, clientKey);
-            return;
+            if (sessionEndpointRequest) {
+                // Accept /webrtc/session requests instead of returning a hard 409.
+                LOGGER.trace("/webrtc/session accepted stream='{}' clientKey='{}' sessionId='{}'", streamName,
+                        clientKey, sessionId);
+            } else {
+                sendBase64Message(resp, HttpServletResponse.SC_CONFLICT,
+                        "Duplicate WebRTC request rejected for same client while setup/connection is active.");
+                LOGGER.warn("Rejected duplicate WebRTC offer for stream '{}' (clientKey={})", streamName, clientKey);
+                return;
+            }
         }
 
         Integer apiPort = streamApiPorts.get(streamName);
@@ -485,6 +501,16 @@ public class PlayStreamServlet extends HttpServlet {
 
     private static String buildStreamClientKey(String streamName, String clientKey) {
         return streamName + "|" + clientKey;
+    }
+
+    private static @Nullable String resolveSessionId(HttpServletRequest req) {
+        try {
+            HttpSession session = req.getSession();
+            return session.getId();
+        } catch (IllegalStateException e) {
+            LOGGER.warn("WebRTC request failed to access session id: {}", e.getMessage());
+            return null;
+        }
     }
 
     private boolean tryAcquireOfferGate(String streamName, String streamClientKey, String sessionId) {

--- a/bundles/org.openhab.binding.dahuadoor/src/main/java/org/openhab/binding/dahuadoor/internal/media/SipBackchannelRtpRelay.java
+++ b/bundles/org.openhab.binding.dahuadoor/src/main/java/org/openhab/binding/dahuadoor/internal/media/SipBackchannelRtpRelay.java
@@ -335,7 +335,7 @@ public class SipBackchannelRtpRelay {
     private static byte @Nullable [] transcodePcm16LeToG711(byte[] packet, int payloadOffset, int length,
             RelayTarget target) {
         int payloadLength = length - payloadOffset;
-        if (payloadLength < 4 || (payloadLength % 2) != 0) {
+        if (payloadLength < 4 || (payloadLength % 4) != 0) {
             return null;
         }
 

--- a/bundles/org.openhab.binding.dahuadoor/src/main/java/org/openhab/binding/dahuadoor/internal/media/SipBackchannelRtpRelay.java
+++ b/bundles/org.openhab.binding.dahuadoor/src/main/java/org/openhab/binding/dahuadoor/internal/media/SipBackchannelRtpRelay.java
@@ -70,6 +70,7 @@ public class SipBackchannelRtpRelay {
         }
     }
 
+    private final String label;
     private final int listenPort;
     private final int sourcePort;
     private final Object lifecycleLock = new Object();
@@ -90,7 +91,8 @@ public class SipBackchannelRtpRelay {
     private volatile long targetSetAtMillis;
     private volatile long lastNoInputWarningAtMillis;
 
-    public SipBackchannelRtpRelay(int listenPort, int sourcePort) {
+    public SipBackchannelRtpRelay(String label, int listenPort, int sourcePort) {
+        this.label = label;
         this.listenPort = listenPort;
         this.sourcePort = sourcePort;
         this.resolvedSourcePort = sourcePort;
@@ -135,7 +137,7 @@ public class SipBackchannelRtpRelay {
             worker.start();
             workerThread = worker;
 
-            LOGGER.info("SIP backchannel RTP relay started on 127.0.0.1:{} with source port {}", listenPort,
+            LOGGER.info("SIP backchannel RTP relay '{}' started on 127.0.0.1:{} with source port {}", label, listenPort,
                     resolvedSourcePort);
         }
     }
@@ -180,8 +182,8 @@ public class SipBackchannelRtpRelay {
         }
 
         LOGGER.info(
-                "SIP backchannel RTP relay stopped (listenPort={}, sourcePort={}, received={}, forwarded={}, droppedNoTarget={}, droppedInvalid={})",
-                listenPort, getSourcePort(), receivedPackets, forwardedPackets, droppedNoTargetPackets,
+                "SIP backchannel RTP relay '{}' stopped (listenPort={}, sourcePort={}, received={}, forwarded={}, droppedNoTarget={}, droppedInvalid={})",
+                label, listenPort, getSourcePort(), receivedPackets, forwardedPackets, droppedNoTargetPackets,
                 droppedInvalidPackets);
     }
 
@@ -190,7 +192,7 @@ public class SipBackchannelRtpRelay {
             relayTarget = null;
             targetSetAtMillis = 0;
             lastNoInputWarningAtMillis = 0;
-            LOGGER.info("SIP backchannel relay target cleared (reason={})", reason);
+            LOGGER.info("SIP backchannel relay '{}' target cleared (reason={})", label, reason);
             return;
         }
 
@@ -200,8 +202,8 @@ public class SipBackchannelRtpRelay {
             if (!isSupportedTarget(codecName, clockRate)) {
                 relayTarget = null;
                 LOGGER.warn(
-                        "SIP backchannel relay target rejected (expected PCM/16000 or PCMA/PCMU 8000, got codec={} rate={}Hz, reason={})",
-                        codecName, clockRate, reason);
+                        "SIP backchannel relay '{}' target rejected (expected PCM/16000 or PCMA/PCMU 8000, got codec={} rate={}Hz, reason={})",
+                        label, codecName, clockRate, reason);
                 return;
             }
 
@@ -209,11 +211,11 @@ public class SipBackchannelRtpRelay {
             relayTarget = new RelayTarget(address, offer.getRemotePort(), offer.getPayloadType(), codecName, clockRate);
             targetSetAtMillis = System.currentTimeMillis();
             lastNoInputWarningAtMillis = 0;
-            LOGGER.info("SIP backchannel relay target set to {}:{} (pt={}, codec={}, reason={})", offer.getRemoteHost(),
-                    offer.getRemotePort(), offer.getPayloadType(), codecName, reason);
+            LOGGER.info("SIP backchannel relay '{}' target set to {}:{} (pt={}, codec={}, rate={}Hz, reason={})", label,
+                    offer.getRemoteHost(), offer.getRemotePort(), offer.getPayloadType(), codecName, clockRate, reason);
         } catch (IOException e) {
             relayTarget = null;
-            LOGGER.warn("Failed to resolve SIP backchannel relay target '{}': {}", offer.getRemoteHost(),
+            LOGGER.warn("Failed to resolve SIP backchannel relay '{}' target '{}': {}", label, offer.getRemoteHost(),
                     e.getMessage());
         }
     }
@@ -238,8 +240,8 @@ public class SipBackchannelRtpRelay {
                     if (now - targetSetAtMillis >= 2000 && now - lastIncomingPacketAtMillis >= 2000
                             && now - lastNoInputWarningAtMillis >= 2000) {
                         LOGGER.debug(
-                                "SIP backchannel relay has active target {}:{} but no incoming RTP on 127.0.0.1:{} for {} ms",
-                                target.remoteAddress.getHostAddress(), target.remotePort, listenPort,
+                                "SIP backchannel relay '{}' has active target {}:{} but no incoming RTP on 127.0.0.1:{} for {} ms",
+                                label, target.remoteAddress.getHostAddress(), target.remotePort, listenPort,
                                 now - lastIncomingPacketAtMillis);
                         lastNoInputWarningAtMillis = now;
                     }
@@ -247,12 +249,12 @@ public class SipBackchannelRtpRelay {
                 continue;
             } catch (SocketException e) {
                 if (running) {
-                    LOGGER.debug("SIP backchannel relay receive socket closed: {}", e.getMessage());
+                    LOGGER.debug("SIP backchannel relay '{}' receive socket closed: {}", label, e.getMessage());
                 }
                 continue;
             } catch (IOException e) {
                 if (running) {
-                    LOGGER.debug("SIP backchannel relay receive failed: {}", e.getMessage());
+                    LOGGER.debug("SIP backchannel relay '{}' receive failed: {}", label, e.getMessage());
                 }
                 continue;
             }
@@ -263,8 +265,9 @@ public class SipBackchannelRtpRelay {
             if (target == null) {
                 droppedNoTargetPackets++;
                 if (droppedNoTargetPackets == 1 || droppedNoTargetPackets % 100 == 0) {
-                    LOGGER.debug("SIP backchannel relay dropping RTP packet without target (count={}, listenPort={})",
-                            droppedNoTargetPackets, listenPort);
+                    LOGGER.debug(
+                            "SIP backchannel relay '{}' dropping RTP packet without target (count={}, listenPort={})",
+                            label, droppedNoTargetPackets, listenPort);
                 }
                 continue;
             }
@@ -273,7 +276,7 @@ public class SipBackchannelRtpRelay {
             if (forwardedPacket == null) {
                 droppedInvalidPackets++;
                 if (droppedInvalidPackets == 1 || droppedInvalidPackets % 100 == 0) {
-                    LOGGER.debug("SIP backchannel relay dropped invalid RTP packet (count={}, length={})",
+                    LOGGER.debug("SIP backchannel relay '{}' dropped invalid RTP packet (count={}, length={})", label,
                             droppedInvalidPackets, incoming.getLength());
                 }
                 continue;
@@ -285,12 +288,14 @@ public class SipBackchannelRtpRelay {
                 localSendSocket.send(forwarded);
                 forwardedPackets++;
                 if (forwardedPackets == 1 || forwardedPackets % 100 == 0) {
-                    LOGGER.debug("SIP backchannel relay forwarded RTP packet (count={}, bytes={}, target={}:{}, pt={})",
-                            forwardedPackets, forwardedPacket.length, target.remoteAddress.getHostAddress(),
-                            target.remotePort, target.payloadType);
+                    LOGGER.debug(
+                            "SIP backchannel relay '{}' forwarded RTP packet (count={}, bytes={}, listenPort={}, sourcePort={}, target={}:{}, pt={}, codec={}, rate={}Hz)",
+                            label, forwardedPackets, forwardedPacket.length, listenPort, getSourcePort(),
+                            target.remoteAddress.getHostAddress(), target.remotePort, target.payloadType,
+                            target.codecName, target.clockRate);
                 }
             } catch (IOException e) {
-                LOGGER.debug("SIP backchannel relay forward failed to {}:{}: {}", target.remoteAddress,
+                LOGGER.debug("SIP backchannel relay '{}' forward failed to {}:{}: {}", label, target.remoteAddress,
                         target.remotePort, e.getMessage());
             }
         }

--- a/bundles/org.openhab.binding.dahuadoor/src/main/java/org/openhab/binding/dahuadoor/internal/media/SipBackchannelRtpRelay.java
+++ b/bundles/org.openhab.binding.dahuadoor/src/main/java/org/openhab/binding/dahuadoor/internal/media/SipBackchannelRtpRelay.java
@@ -30,8 +30,8 @@ import org.slf4j.LoggerFactory;
  *
  * <p>
  * go2rtc currently uses ffmpeg to transcode browser backchannel audio to RTP PCM/16 kHz on a local
- * loopback port. This relay only forwards those RTP packets to the negotiated SIP target and rewrites
- * the payload type to the negotiated one.
+ * loopback port. This relay forwards those RTP packets to the negotiated SIP target, preferring
+ * PCM/16000 passthrough and falling back to G.711 PCMA/PCMU transcoding when needed.
  * </p>
  *
  * @author Sven Schad - Initial contribution
@@ -45,16 +45,28 @@ public class SipBackchannelRtpRelay {
     private static final int RTP_HEADER_MIN_LEN = 12;
     private static final int RTP_VERSION_MASK = 0xC0;
     private static final int RTP_VERSION_2 = 0x80;
+    private static final int RTP_TIMESTAMP_OFFSET = 4;
+    private static final String CODEC_PCM = "PCM";
+    private static final String CODEC_PCMA = "PCMA";
+    private static final String CODEC_PCMU = "PCMU";
+    private static final int PCM_CLOCK_RATE = 16000;
+    private static final int G711_CLOCK_RATE = 8000;
+    private static final int ULAW_CLIP = 32635;
+    private static final int[] SEGMENT_ENDS = { 0x1F, 0x3F, 0x7F, 0xFF, 0x1FF, 0x3FF, 0x7FF, 0xFFF };
 
     static final class RelayTarget {
         final InetAddress remoteAddress;
         final int remotePort;
         final int payloadType;
+        final String codecName;
+        final int clockRate;
 
-        RelayTarget(InetAddress remoteAddress, int remotePort, int payloadType) {
+        RelayTarget(InetAddress remoteAddress, int remotePort, int payloadType, String codecName, int clockRate) {
             this.remoteAddress = remoteAddress;
             this.remotePort = remotePort;
             this.payloadType = payloadType;
+            this.codecName = codecName;
+            this.clockRate = clockRate;
         }
     }
 
@@ -184,16 +196,17 @@ public class SipBackchannelRtpRelay {
 
         try {
             String codecName = offer.getCodecName();
-            if (!("PCM".equals(codecName) && offer.getClockRate() == 16000)) {
+            int clockRate = offer.getClockRate();
+            if (!isSupportedTarget(codecName, clockRate)) {
                 relayTarget = null;
                 LOGGER.warn(
-                        "SIP backchannel relay target rejected (expected PCM/16000, got codec={} rate={}Hz, reason={})",
-                        codecName, offer.getClockRate(), reason);
+                        "SIP backchannel relay target rejected (expected PCM/16000 or PCMA/PCMU 8000, got codec={} rate={}Hz, reason={})",
+                        codecName, clockRate, reason);
                 return;
             }
 
             InetAddress address = InetAddress.getByName(offer.getRemoteHost());
-            relayTarget = new RelayTarget(address, offer.getRemotePort(), offer.getPayloadType());
+            relayTarget = new RelayTarget(address, offer.getRemotePort(), offer.getPayloadType(), codecName, clockRate);
             targetSetAtMillis = System.currentTimeMillis();
             lastNoInputWarningAtMillis = 0;
             LOGGER.info("SIP backchannel relay target set to {}:{} (pt={}, codec={}, reason={})", offer.getRemoteHost(),
@@ -296,8 +309,114 @@ public class SipBackchannelRtpRelay {
             return null;
         }
 
-        rewriteRtpPayloadType(packet, target.payloadType);
-        return packet;
+        if (CODEC_PCM.equals(target.codecName) && target.clockRate == PCM_CLOCK_RATE) {
+            rewriteRtpPayloadType(packet, target.payloadType);
+            return packet;
+        }
+
+        if ((CODEC_PCMA.equals(target.codecName) || CODEC_PCMU.equals(target.codecName))
+                && target.clockRate == G711_CLOCK_RATE) {
+            return transcodePcm16LeToG711(packet, payloadOffset, length, target);
+        }
+
+        return null;
+    }
+
+    private static boolean isSupportedTarget(String codecName, int clockRate) {
+        return CODEC_PCM.equals(codecName) && clockRate == PCM_CLOCK_RATE
+                || (CODEC_PCMA.equals(codecName) || CODEC_PCMU.equals(codecName)) && clockRate == G711_CLOCK_RATE;
+    }
+
+    private static byte @Nullable [] transcodePcm16LeToG711(byte[] packet, int payloadOffset, int length,
+            RelayTarget target) {
+        int payloadLength = length - payloadOffset;
+        if (payloadLength < 4 || (payloadLength % 2) != 0) {
+            return null;
+        }
+
+        int sampleCount = payloadLength / 2;
+        int outputSamples = sampleCount / 2;
+        if (outputSamples <= 0) {
+            return null;
+        }
+
+        byte[] transcoded = new byte[payloadOffset + outputSamples];
+        System.arraycopy(packet, 0, transcoded, 0, payloadOffset);
+
+        for (int outputIndex = 0; outputIndex < outputSamples; outputIndex++) {
+            int inputIndex = payloadOffset + (outputIndex * 4);
+            short pcmSample = (short) ((packet[inputIndex] & 0xFF) | (packet[inputIndex + 1] << 8));
+            transcoded[payloadOffset + outputIndex] = CODEC_PCMA.equals(target.codecName) ? linearToALaw(pcmSample)
+                    : linearToMuLaw(pcmSample);
+        }
+
+        rewriteRtpPayloadType(transcoded, target.payloadType);
+        rewriteRtpTimestamp(transcoded, readRtpTimestamp(packet) / 2L);
+        return transcoded;
+    }
+
+    private static long readRtpTimestamp(byte[] packet) {
+        return ((packet[RTP_TIMESTAMP_OFFSET] & 0xFFL) << 24) | ((packet[RTP_TIMESTAMP_OFFSET + 1] & 0xFFL) << 16)
+                | ((packet[RTP_TIMESTAMP_OFFSET + 2] & 0xFFL) << 8) | (packet[RTP_TIMESTAMP_OFFSET + 3] & 0xFFL);
+    }
+
+    private static void rewriteRtpTimestamp(byte[] packet, long timestamp) {
+        packet[RTP_TIMESTAMP_OFFSET] = (byte) ((timestamp >>> 24) & 0xFF);
+        packet[RTP_TIMESTAMP_OFFSET + 1] = (byte) ((timestamp >>> 16) & 0xFF);
+        packet[RTP_TIMESTAMP_OFFSET + 2] = (byte) ((timestamp >>> 8) & 0xFF);
+        packet[RTP_TIMESTAMP_OFFSET + 3] = (byte) (timestamp & 0xFF);
+    }
+
+    private static byte linearToALaw(short sample) {
+        int pcmValue = sample;
+        int mask = 0xD5;
+        if (pcmValue < 0) {
+            mask = 0x55;
+            pcmValue = -pcmValue - 1;
+        }
+
+        int segment = searchSegment(pcmValue);
+        if (segment >= 8) {
+            return (byte) (0x7F ^ mask);
+        }
+
+        int alawValue = segment << 4;
+        if (segment < 2) {
+            alawValue |= (pcmValue >> 4) & 0x0F;
+        } else {
+            alawValue |= (pcmValue >> (segment + 3)) & 0x0F;
+        }
+        return (byte) (alawValue ^ mask);
+    }
+
+    private static byte linearToMuLaw(short sample) {
+        int pcmValue = sample;
+        int sign = (pcmValue >> 8) & 0x80;
+        if (sign != 0) {
+            pcmValue = -pcmValue;
+        }
+
+        if (pcmValue > ULAW_CLIP) {
+            pcmValue = ULAW_CLIP;
+        }
+
+        pcmValue += 0x84;
+        int exponent = 7;
+        for (int exponentMask = 0x4000; (pcmValue & exponentMask) == 0 && exponent > 0; exponentMask >>= 1) {
+            exponent--;
+        }
+
+        int mantissa = (pcmValue >> (exponent + 3)) & 0x0F;
+        return (byte) ~(sign | (exponent << 4) | mantissa);
+    }
+
+    private static int searchSegment(int pcmValue) {
+        for (int index = 0; index < SEGMENT_ENDS.length; index++) {
+            if (pcmValue <= SEGMENT_ENDS[index]) {
+                return index;
+            }
+        }
+        return SEGMENT_ENDS.length;
     }
 
     static void rewriteRtpPayloadType(byte[] packet, int payloadType) {

--- a/bundles/org.openhab.binding.dahuadoor/src/main/java/org/openhab/binding/dahuadoor/internal/media/SipCallControlServlet.java
+++ b/bundles/org.openhab.binding.dahuadoor/src/main/java/org/openhab/binding/dahuadoor/internal/media/SipCallControlServlet.java
@@ -88,15 +88,31 @@ public class SipCallControlServlet extends HttpServlet {
         String sessionId = req.getSession().getId();
 
         if ("assign-client".equals(action)) {
+            @Nullable
             String clientId = handler.assignClientForSession(sessionId);
+            if (clientId == null) {
+                resp.sendError(HttpServletResponse.SC_CONFLICT, "No free outgoing SIP client available");
+                return;
+            }
             String callState = handler.getSipCallStateForSession(sessionId);
+            @Nullable
+            String webRtcUrl = handler.getWebRtcUrlForClientId(clientId);
             writeJson(resp, HttpServletResponse.SC_OK,
-                    "{\"clientId\":\"" + escapeJson(clientId) + "\",\"callState\":\"" + escapeJson(callState) + "\"}");
+                    "{\"clientId\":\"" + escapeJson(clientId) + "\",\"callState\":\"" + escapeJson(callState)
+                            + "\",\"webrtcUrl\":\"" + escapeJson(webRtcUrl != null ? webRtcUrl : "") + "\"}");
             return;
         }
 
         if ("state".equals(action)) {
-            String clientId = handler.assignClientForSession(sessionId);
+            @Nullable
+            String clientId = handler.getAssignedClientForSession(sessionId);
+            if (clientId == null) {
+                clientId = handler.assignClientForSession(sessionId);
+            }
+            if (clientId == null) {
+                resp.sendError(HttpServletResponse.SC_CONFLICT, "No free outgoing SIP client available");
+                return;
+            }
             String callState = handler.getSipCallStateForSession(sessionId);
             @Nullable
             String caller = handler.getSipCallerForSession(sessionId);
@@ -142,9 +158,14 @@ public class SipCallControlServlet extends HttpServlet {
         }
 
         String sessionId = req.getSession().getId();
-        String clientId = handler.assignClientForSession(sessionId);
 
         if ("answer".equals(action)) {
+            @Nullable
+            String clientId = handler.assignClientForSession(sessionId);
+            if (clientId == null) {
+                resp.sendError(HttpServletResponse.SC_CONFLICT, "No free outgoing SIP client available");
+                return;
+            }
             boolean success = handler.answerSipCallForSession(sessionId);
             String callState = handler.getSipCallStateForSession(sessionId);
             writeJson(resp, success ? HttpServletResponse.SC_OK : HttpServletResponse.SC_CONFLICT,
@@ -154,11 +175,42 @@ public class SipCallControlServlet extends HttpServlet {
         }
 
         if ("hangup".equals(action)) {
+            @Nullable
+            String clientId = handler.assignClientForSession(sessionId);
+            if (clientId == null) {
+                resp.sendError(HttpServletResponse.SC_CONFLICT, "No free outgoing SIP client available");
+                return;
+            }
             boolean success = handler.hangupSipCallForSession(sessionId);
             String callState = handler.getSipCallStateForSession(sessionId);
             writeJson(resp, success ? HttpServletResponse.SC_OK : HttpServletResponse.SC_CONFLICT,
                     "{\"success\":" + success + ",\"clientId\":\"" + escapeJson(clientId) + "\",\"callState\":\""
                             + escapeJson(callState) + "\"}");
+            return;
+        }
+
+        if ("call".equals(action)) {
+            String target = req.getParameter("target");
+            if (target == null || target.isBlank()) {
+                resp.sendError(HttpServletResponse.SC_BAD_REQUEST, "Missing parameter: target");
+                return;
+            }
+            if (!target.matches("^[a-zA-Z0-9.#%_\\-]{1,64}$")) {
+                resp.sendError(HttpServletResponse.SC_BAD_REQUEST,
+                        "Invalid target format (allowed: [a-zA-Z0-9.#%_-]{1,64})");
+                return;
+            }
+
+            DahuaDoorBaseHandler.OutgoingCallResult result = handler.startOutgoingCallForSession(sessionId, target);
+            @Nullable
+            String resultClientId = result.clientId();
+            if (resultClientId == null) {
+                resp.sendError(HttpServletResponse.SC_CONFLICT, "No free outgoing SIP client available");
+                return;
+            }
+            writeJson(resp, result.success() ? HttpServletResponse.SC_OK : HttpServletResponse.SC_CONFLICT,
+                    "{\"success\":" + result.success() + ",\"clientId\":\"" + escapeJson(resultClientId)
+                            + "\",\"callState\":\"" + escapeJson(result.callState()) + "\"}");
             return;
         }
 

--- a/bundles/org.openhab.binding.dahuadoor/src/main/java/org/openhab/binding/dahuadoor/internal/media/SipSdpParser.java
+++ b/bundles/org.openhab.binding.dahuadoor/src/main/java/org/openhab/binding/dahuadoor/internal/media/SipSdpParser.java
@@ -35,6 +35,8 @@ public class SipSdpParser {
     private static final int DEFAULT_PTIME_MS = 20;
 
     private static final String CODEC_PCM = "PCM";
+    private static final String CODEC_PCMA = "PCMA";
+    private static final String CODEC_PCMU = "PCMU";
     private static final int DEFAULT_VIDEO_PAYLOAD_TYPE = 96;
     private static final int DEFAULT_VIDEO_PORT = 30000;
     private static final String DEFAULT_VIDEO_FRAMERATE = "25.000000";
@@ -223,16 +225,27 @@ public class SipSdpParser {
         if (mapped != null) {
             return mapped;
         }
-        return "";
+        return switch (payloadType) {
+            case 0 -> CODEC_PCMU;
+            case 8 -> CODEC_PCMA;
+            default -> "";
+        };
     }
 
     private static boolean isSupportedCodec(String codecName, int clockRate) {
-        return CODEC_PCM.equals(codecName) && clockRate == 16000;
+        return CODEC_PCM.equals(codecName) && clockRate == 16000
+                || (CODEC_PCMA.equals(codecName) || CODEC_PCMU.equals(codecName)) && clockRate == DEFAULT_CLOCK_RATE;
     }
 
     private static int codecPreference(String codecName, int clockRate) {
         if (CODEC_PCM.equals(codecName) && clockRate == 16000) {
             return 0;
+        }
+        if (CODEC_PCMA.equals(codecName) && clockRate == DEFAULT_CLOCK_RATE) {
+            return 1;
+        }
+        if (CODEC_PCMU.equals(codecName) && clockRate == DEFAULT_CLOCK_RATE) {
+            return 2;
         }
         return Integer.MAX_VALUE;
     }

--- a/bundles/org.openhab.binding.dahuadoor/src/main/java/org/openhab/binding/dahuadoor/internal/sip/SipClient.java
+++ b/bundles/org.openhab.binding.dahuadoor/src/main/java/org/openhab/binding/dahuadoor/internal/sip/SipClient.java
@@ -121,6 +121,7 @@ public class SipClient implements SipListener {
     // State
     private static final long TERMINATING_TIMEOUT_SECONDS = 5;
     private static final long ANSWERING_TIMEOUT_SECONDS = 15;
+    private static final long OUTGOING_RINGING_TIMEOUT_SECONDS = 60;
     private final ScheduledExecutorService callStateTimeoutScheduler = Executors.newSingleThreadScheduledExecutor(r -> {
         Thread thread = new Thread(r, BINDING_PREFIX + "-sip-answering-timeout");
         thread.setDaemon(true);
@@ -133,11 +134,14 @@ public class SipClient implements SipListener {
 
     private @Nullable ServerTransaction inviteServerTransaction;
     private @Nullable Request inviteRequest;
+    private @Nullable ClientTransaction inviteClientTransaction;
     private @Nullable String currentInviteSdp;
     private @Nullable Dialog activeDialog;
     private @Nullable String currentCallerId;
+    private @Nullable String outgoingCallId;
     private boolean pendingHangupAfterAck = false;
     private @Nullable ScheduledFuture<?> answeringTimeoutFuture;
+    private @Nullable ScheduledFuture<?> outgoingRingingTimeoutFuture;
     private SipCallState callState = SipCallState.IDLE;
 
     // Audio talkback
@@ -148,6 +152,7 @@ public class SipClient implements SipListener {
         IDLE,
         RINGING,
         ANSWERING,
+        OUTGOING_RINGING,
         ACTIVE,
         TERMINATING,
         HUNGUP
@@ -246,6 +251,18 @@ public class SipClient implements SipListener {
             registerCallId = callId;
         }
         return callId;
+    }
+
+    private String encodeUserPart(String userPart) {
+        return userPart.replace("#", "%23");
+    }
+
+    private SipURI createLocalUserUri(AddressFactory addrFactory, String host) throws ParseException {
+        return addrFactory.createSipURI(encodeUserPart(sipExtension), host);
+    }
+
+    private SipURI createLocalContactUri(AddressFactory addrFactory) throws ParseException {
+        return addrFactory.createSipURI(encodeUserPart(sipExtension), localIp);
     }
 
     /**
@@ -402,6 +419,7 @@ public class SipClient implements SipListener {
     public void dispose() {
         try {
             cancelAnsweringTimeout();
+            cancelOutgoingRingingTimeout();
             clearAudioPath("dispose");
             callStateTimeoutScheduler.shutdownNow();
             synchronized (this) {
@@ -492,10 +510,13 @@ public class SipClient implements SipListener {
 
         if (Request.REGISTER.equals(cseq.getMethod())) {
             handleRegisterResponse(response);
+        } else if (Request.INVITE.equals(cseq.getMethod())) {
+            handleOutgoingInviteResponse(response, responseEvent.getClientTransaction(), responseEvent.getDialog());
         } else if (Request.BYE.equals(cseq.getMethod()) && statusCode == Response.OK) {
             clearAudioPath("local-bye-ok");
             synchronized (this) {
                 cancelAnsweringTimeout();
+                cancelOutgoingRingingTimeout();
                 clearCallContextLocked(SipCallState.IDLE);
             }
             listener.onCallEnded();
@@ -676,6 +697,79 @@ public class SipClient implements SipListener {
         return currentInviteSdp;
     }
 
+    public synchronized boolean sendInvite(String target) {
+        if (callState != SipCallState.IDLE) {
+            logger.warn("Cannot send INVITE: state is {} (expected IDLE)", callState);
+            return false;
+        }
+
+        try {
+            AddressFactory addrFactory = addressFactory;
+            HeaderFactory hdrFactory = headerFactory;
+            MessageFactory msgFactory = messageFactory;
+            SipProvider provider = sipProvider;
+
+            if (addrFactory == null || hdrFactory == null || msgFactory == null || provider == null) {
+                logger.warn("Cannot send INVITE: SIP stack not initialized");
+                return false;
+            }
+
+            SipURI requestURI = addrFactory.createSipURI(target, vtoIp);
+            requestURI.setPort(5060);
+
+            SipURI fromURI = createLocalUserUri(addrFactory, vtoIp);
+            fromURI.setPort(5060);
+            FromHeader fromHeader = hdrFactory.createFromHeader(addrFactory.createAddress(fromURI),
+                    UUID.randomUUID().toString().substring(0, 8));
+
+            ToHeader toHeader = hdrFactory.createToHeader(addrFactory.createAddress(requestURI), null);
+            ViaHeader viaHeader = hdrFactory.createViaHeader(localIp, localSipPort, "udp", null);
+            String callId = provider.getNewCallId().getCallId();
+            CallIdHeader callIdHeader = hdrFactory.createCallIdHeader(callId);
+            CSeqHeader cSeqHeader = hdrFactory.createCSeqHeader(1L, Request.INVITE);
+            MaxForwardsHeader maxForwards = hdrFactory.createMaxForwardsHeader(70);
+            Request invite = msgFactory.createRequest(requestURI, Request.INVITE, callIdHeader, cSeqHeader, fromHeader,
+                    toHeader, List.of(viaHeader), maxForwards);
+
+            SipURI contactUri = createLocalContactUri(addrFactory);
+            contactUri.setPort(localSipPort);
+            invite.addHeader(hdrFactory.createContactHeader(addrFactory.createAddress(contactUri)));
+            invite.addHeader(hdrFactory.createContentTypeHeader("application", "sdp"));
+
+            byte[] sdpBytes = buildOutgoingOfferSdp().getBytes(StandardCharsets.UTF_8);
+            ContentTypeHeader contentTypeHeader = hdrFactory.createContentTypeHeader("application", "sdp");
+            invite.setContent(sdpBytes, contentTypeHeader);
+
+            callState = SipCallState.OUTGOING_RINGING;
+            currentCallerId = target;
+            currentInviteSdp = null;
+            currentAudioOffer = null;
+            outgoingCallId = callId;
+            ClientTransaction newInviteTransaction = provider.getNewClientTransaction(invite);
+            inviteClientTransaction = newInviteTransaction;
+            newInviteTransaction.sendRequest();
+            scheduleOutgoingRingingTimeout();
+
+            logger.info("Sent INVITE to {} from {}", target, sipExtension);
+            return true;
+        } catch (SipException | ParseException | InvalidArgumentException | RuntimeException e) {
+            logger.warn("Failed to send INVITE: {}", e.getMessage(), e);
+            cancelOutgoingRingingTimeout();
+            clearCallContextLocked(SipCallState.IDLE);
+            return false;
+        }
+    }
+
+    private String buildOutgoingOfferSdp() {
+        long sessionId = System.currentTimeMillis() / 1000L;
+        int audioPort = localAudioRtpPort > 0 ? localAudioRtpPort : 0;
+        return "v=0\r\n" + "o=- " + sessionId + " 1 IN IP4 " + localIp + "\r\n" + "s=openHAB DahuaDoor\r\n"
+                + "c=IN IP4 " + localIp + "\r\n" + "t=0 0\r\n" + "m=audio " + audioPort + " RTP/AVP 97 8 0 101\r\n"
+                + "a=rtpmap:97 PCM/16000\r\n" + "a=rtpmap:8 PCMA/8000\r\n" + "a=rtpmap:0 PCMU/8000\r\n"
+                + "a=rtpmap:101 telephone-event/8000\r\n" + "a=fmtp:101 0-15\r\n" + "a=ptime:20\r\n" + "a=sendrecv\r\n"
+                + "m=video 30000 RTP/AVP 96\r\n" + "a=rtpmap:96 H264/90000\r\n" + "a=recvonly\r\n";
+    }
+
     public synchronized boolean sendOkResponse() {
         try {
             MessageFactory msgFactory = messageFactory;
@@ -746,6 +840,10 @@ public class SipClient implements SipListener {
             if (callState == SipCallState.TERMINATING) {
                 logger.debug("Ignoring duplicate hangup request while call is TERMINATING (trigger={})", trigger);
                 return true;
+            }
+
+            if (callState == SipCallState.OUTGOING_RINGING) {
+                return cancelOutgoingInvite(trigger);
             }
 
             if (callState == SipCallState.RINGING) {
@@ -880,15 +978,123 @@ public class SipClient implements SipListener {
         boolean shouldNotifyEnded;
         synchronized (this) {
             shouldNotifyEnded = callState != SipCallState.IDLE || inviteRequest != null
-                    || inviteServerTransaction != null || activeDialog != null || currentCallerId != null;
+                    || inviteServerTransaction != null || inviteClientTransaction != null || activeDialog != null
+                    || currentCallerId != null || outgoingCallId != null;
             if (!shouldNotifyEnded) {
                 return;
             }
             cancelAnsweringTimeout();
+            cancelOutgoingRingingTimeout();
             clearAudioPath("dialog-terminated");
             clearCallContextLocked(SipCallState.IDLE);
         }
         listener.onCallEnded();
+    }
+
+    private void handleOutgoingInviteResponse(Response response, @Nullable ClientTransaction clientTransaction,
+            @Nullable Dialog dialog) {
+        int statusCode = response.getStatusCode();
+        if (statusCode == Response.TRYING || statusCode == 101) {
+            return;
+        }
+
+        if (statusCode == Response.RINGING || statusCode == Response.SESSION_PROGRESS) {
+            logger.debug("Remote ringing ({})", statusCode);
+            return;
+        }
+
+        if (statusCode == Response.OK) {
+            cancelOutgoingRingingTimeout();
+            try {
+                Dialog localDialog = dialog;
+                if (localDialog == null && clientTransaction != null) {
+                    localDialog = clientTransaction.getDialog();
+                }
+                CSeqHeader cSeqHeader = (CSeqHeader) response.getHeader(CSeqHeader.NAME);
+                if (localDialog != null && cSeqHeader != null) {
+                    Request ack = localDialog.createAck(cSeqHeader.getSeqNumber());
+                    localDialog.sendAck(ack);
+                }
+
+                byte[] rawContent = response.getRawContent();
+                String responseSdp = rawContent != null && rawContent.length > 0
+                        ? new String(rawContent, StandardCharsets.UTF_8)
+                        : null;
+                SipAudioOffer offer = sdpParser.parseAudioOffer(responseSdp).orElse(null);
+
+                synchronized (this) {
+                    activeDialog = localDialog;
+                    currentInviteSdp = responseSdp;
+                    currentAudioOffer = offer;
+                    callState = SipCallState.ACTIVE;
+                }
+
+                if (offer != null) {
+                    activateAudioPath(offer);
+                } else {
+                    logger.warn("Outgoing call 200 OK did not negotiate a supported audio offer");
+                }
+                listener.onCallActive();
+            } catch (InvalidArgumentException | SipException e) {
+                logger.warn("Failed to finalize outgoing INVITE: {}", e.getMessage(), e);
+                clearAudioPath("outgoing-ack-failed");
+                synchronized (this) {
+                    clearCallContextLocked(SipCallState.IDLE);
+                }
+                listener.onCallEnded();
+            }
+            return;
+        }
+
+        if (statusCode == Response.REQUEST_TERMINATED) {
+            cancelOutgoingRingingTimeout();
+            clearAudioPath("outgoing-487");
+            synchronized (this) {
+                clearCallContextLocked(SipCallState.IDLE);
+            }
+            listener.onCallEnded();
+            return;
+        }
+
+        if (statusCode >= Response.BAD_REQUEST) {
+            cancelOutgoingRingingTimeout();
+            logger.info("Outgoing call failed with {}", statusCode);
+            clearAudioPath("outgoing-error-" + statusCode);
+            synchronized (this) {
+                clearCallContextLocked(SipCallState.IDLE);
+            }
+            listener.onCallEnded();
+        }
+    }
+
+    private synchronized boolean cancelOutgoingInvite(String trigger) {
+        SipProvider provider = sipProvider;
+        ClientTransaction clientTransaction = inviteClientTransaction;
+        if (provider == null || clientTransaction == null) {
+            cancelOutgoingRingingTimeout();
+            clearAudioPath("outgoing-cancel-no-transaction");
+            clearCallContextLocked(SipCallState.IDLE);
+            listener.onCallEnded();
+            return true;
+        }
+
+        try {
+            Request cancelRequest = clientTransaction.createCancel();
+            ClientTransaction cancelTransaction = provider.getNewClientTransaction(cancelRequest);
+            cancelTransaction.sendRequest();
+            callState = SipCallState.TERMINATING;
+            scheduleAnsweringTimeout();
+            logger.debug("Sent CANCEL for outgoing INVITE (trigger={})", trigger);
+            listener.onCallTerminating();
+            return true;
+        } catch (SipException | RuntimeException e) {
+            logger.warn("Failed to cancel outgoing INVITE: {}", e.getMessage(), e);
+            cancelOutgoingRingingTimeout();
+            clearAudioPath("outgoing-cancel-failed");
+            clearCallContextLocked(SipCallState.IDLE);
+            listener.onCallEnded();
+            return false;
+        }
     }
 
     private synchronized void cancelAnsweringTimeout() {
@@ -896,6 +1102,14 @@ public class SipClient implements SipListener {
         if (timeoutFuture != null) {
             timeoutFuture.cancel(false);
             answeringTimeoutFuture = null;
+        }
+    }
+
+    private synchronized void cancelOutgoingRingingTimeout() {
+        ScheduledFuture<?> timeoutFuture = outgoingRingingTimeoutFuture;
+        if (timeoutFuture != null) {
+            timeoutFuture.cancel(false);
+            outgoingRingingTimeoutFuture = null;
         }
     }
 
@@ -925,6 +1139,31 @@ public class SipClient implements SipListener {
         }, timeoutSeconds, TimeUnit.SECONDS);
     }
 
+    private synchronized void scheduleOutgoingRingingTimeout() {
+        cancelOutgoingRingingTimeout();
+        if (callState != SipCallState.OUTGOING_RINGING) {
+            return;
+        }
+
+        outgoingRingingTimeoutFuture = callStateTimeoutScheduler.schedule(() -> {
+            boolean shouldNotifyEnded = false;
+            synchronized (SipClient.this) {
+                if (callState != SipCallState.OUTGOING_RINGING) {
+                    return;
+                }
+                logger.warn("Outgoing SIP call stuck in {} for {}s - forcing call end", SipCallState.OUTGOING_RINGING,
+                        OUTGOING_RINGING_TIMEOUT_SECONDS);
+                clearAudioPath("state-timeout-outgoing-ringing");
+                clearCallContextLocked(SipCallState.IDLE);
+                outgoingRingingTimeoutFuture = null;
+                shouldNotifyEnded = true;
+            }
+            if (shouldNotifyEnded) {
+                listener.onCallEnded();
+            }
+        }, OUTGOING_RINGING_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+    }
+
     private void activateAudioPath(SipAudioOffer offer) {
         SipBackchannelRtpRelay relay = backchannelRelay;
         if (relay != null) {
@@ -952,10 +1191,12 @@ public class SipClient implements SipListener {
         callState = nextState;
         inviteRequest = null;
         inviteServerTransaction = null;
+        inviteClientTransaction = null;
         currentInviteSdp = null;
         currentAudioOffer = null;
         activeDialog = null;
         currentCallerId = null;
+        outgoingCallId = null;
         pendingHangupAfterAck = false;
     }
 }

--- a/bundles/org.openhab.binding.dahuadoor/src/main/java/org/openhab/binding/dahuadoor/internal/sip/SipClient.java
+++ b/bundles/org.openhab.binding.dahuadoor/src/main/java/org/openhab/binding/dahuadoor/internal/sip/SipClient.java
@@ -122,6 +122,7 @@ public class SipClient implements SipListener {
     private static final long TERMINATING_TIMEOUT_SECONDS = 5;
     private static final long ANSWERING_TIMEOUT_SECONDS = 15;
     private static final long OUTGOING_RINGING_TIMEOUT_SECONDS = 60;
+    private static final long ACK_FALLBACK_TIMEOUT_MILLIS = 300;
     private final ScheduledExecutorService callStateTimeoutScheduler = Executors.newSingleThreadScheduledExecutor(r -> {
         Thread thread = new Thread(r, BINDING_PREFIX + "-sip-answering-timeout");
         thread.setDaemon(true);
@@ -141,6 +142,7 @@ public class SipClient implements SipListener {
     private @Nullable String outgoingCallId;
     private boolean pendingHangupAfterAck = false;
     private @Nullable ScheduledFuture<?> answeringTimeoutFuture;
+    private @Nullable ScheduledFuture<?> ackFallbackFuture;
     private @Nullable ScheduledFuture<?> outgoingRingingTimeoutFuture;
     private SipCallState callState = SipCallState.IDLE;
 
@@ -236,7 +238,7 @@ public class SipClient implements SipListener {
             listeningPoint = localListeningPoint;
             sipProvider = localSipProvider;
 
-            logger.info("SIP stack initialized for {} on {}:{}", sipExtension, localIp, localSipPort);
+            logger.debug("SIP stack initialized for {} on {}:{}", sipExtension, localIp, localSipPort);
         } catch (PeerUnavailableException | TransportNotSupportedException | InvalidArgumentException
                 | ObjectInUseException | TooManyListenersException | RuntimeException e) {
             cleanupFailedInitialization(localSipStack, localSipProvider, localListeningPoint);
@@ -463,6 +465,57 @@ public class SipClient implements SipListener {
         }
     }
 
+    private void sendUnregister() {
+        try {
+            AddressFactory addrFactory = addressFactory;
+            HeaderFactory hdrFactory = headerFactory;
+            MessageFactory msgFactory = messageFactory;
+            SipProvider provider = sipProvider;
+
+            if (addrFactory == null || hdrFactory == null || msgFactory == null || provider == null) {
+                return;
+            }
+
+            SipURI requestURI = addrFactory.createSipURI(null, vtoIp);
+            requestURI.setPort(5060);
+
+            String encodedExtension = sipExtension.replace("#", "%23");
+            SipURI fromURI = addrFactory.createSipURI(encodedExtension, vtoIp);
+            fromURI.setPort(5060);
+            Address fromAddress = addrFactory.createAddress(fromURI);
+            FromHeader fromHeader = hdrFactory.createFromHeader(fromAddress, ensureRegisterFromTag());
+            ToHeader toHeader = hdrFactory.createToHeader(fromAddress, null);
+
+            ViaHeader viaHeader = hdrFactory.createViaHeader(localIp, localSipPort, "udp", null);
+            List<ViaHeader> viaHeaders = new ArrayList<>();
+            viaHeaders.add(viaHeader);
+
+            CallIdHeader callIdHeader = hdrFactory.createCallIdHeader(ensureRegisterCallId(provider));
+            CSeqHeader cSeqHeader = hdrFactory.createCSeqHeader(nextRegisterCSeq(), Request.REGISTER);
+            MaxForwardsHeader maxForwards = hdrFactory.createMaxForwardsHeader(70);
+
+            Request request = msgFactory.createRequest(requestURI, Request.REGISTER, callIdHeader, cSeqHeader,
+                    fromHeader, toHeader, viaHeaders, maxForwards);
+
+            // Contact: * with Expires: 0 to unregister all bindings
+            ContactHeader contactHeader = hdrFactory.createContactHeader();
+            contactHeader.setWildCard();
+            request.addHeader(contactHeader);
+
+            ExpiresHeader expiresHeader = hdrFactory.createExpiresHeader(0);
+            request.addHeader(expiresHeader);
+
+            UserAgentHeader userAgentHeader = hdrFactory.createUserAgentHeader(Arrays.asList("openHAB/5.2.0"));
+            request.addHeader(userAgentHeader);
+
+            ClientTransaction tx = provider.getNewClientTransaction(request);
+            tx.sendRequest();
+            logger.debug("Sent REGISTER Expires:0 (unregister) for {}", sipExtension);
+        } catch (SipException | ParseException | InvalidArgumentException | RuntimeException e) {
+            logger.debug("Failed to send unregister for {}: {}", sipExtension, e.getMessage());
+        }
+    }
+
     /**
      * Dispose SIP client and clean up resources.
      * Must be called before creating a new instance to prevent "Provider already attached" error.
@@ -476,6 +529,9 @@ public class SipClient implements SipListener {
             synchronized (this) {
                 clearCallContextLocked(SipCallState.IDLE);
             }
+
+            // Send unregister before tearing down the stack so the VTO clears the binding immediately
+            sendUnregister();
 
             SipProvider provider = sipProvider;
             SipStack stack = sipStack;
@@ -647,13 +703,52 @@ public class SipClient implements SipListener {
         Response ok = msgFactory.createResponse(Response.OK, request);
         serverTransaction.sendResponse(ok);
 
-        logger.info("Call cancelled by VTO");
-        clearAudioPath("cancel");
+        boolean shouldCancelCall;
+        boolean shouldActivateAudio;
         synchronized (this) {
-            cancelAnsweringTimeout();
-            clearCallContextLocked(SipCallState.IDLE);
+            if (callState == SipCallState.RINGING || callState == SipCallState.IDLE) {
+                // RFC 3261 §9.2: CANCEL is only effective if no final response has been sent yet
+                logger.info("Call cancelled by VTO (state={})", callState);
+                clearAudioPath("cancel");
+                cancelAnsweringTimeout();
+                clearCallContextLocked(SipCallState.IDLE);
+                shouldCancelCall = true;
+                shouldActivateAudio = false;
+            } else if (callState == SipCallState.ANSWERING) {
+                // Dahua VTO firmware quirk: VTO sends CANCEL immediately after our 200 OK and never
+                // sends ACK. Treat CANCEL-in-ANSWERING as implicit ACK to activate the audio path.
+                logger.info("CANCEL received in ANSWERING state - Dahua VTO workaround: activating audio path");
+                cancelAnsweringTimeout();
+                ServerTransaction localInviteServerTransaction = inviteServerTransaction;
+                if (activeDialog == null && localInviteServerTransaction != null) {
+                    activeDialog = localInviteServerTransaction.getDialog();
+                }
+                callState = SipCallState.ACTIVE;
+                shouldCancelCall = false;
+                shouldActivateAudio = true;
+            } else {
+                // A final response (200 OK) was already sent - CANCEL must not affect dialog state
+                logger.info("CANCEL received in state {} - ignoring per RFC 3261 §9.2 (final response already sent)",
+                        callState);
+                shouldCancelCall = false;
+                shouldActivateAudio = false;
+            }
         }
-        listener.onCallCancelled();
+        if (shouldActivateAudio) {
+            SipAudioOffer offer;
+            synchronized (this) {
+                offer = currentAudioOffer;
+            }
+            if (offer != null) {
+                activateAudioPath(offer);
+            } else {
+                logger.warn("CANCEL-in-ANSWERING workaround: no audio offer available");
+            }
+            listener.onCallActive();
+        }
+        if (shouldCancelCall) {
+            listener.onCallCancelled();
+        }
     }
 
     private void handleAck(Request request) {
@@ -664,7 +759,9 @@ public class SipClient implements SipListener {
                 logger.debug("Ignoring ACK in state {}", callState);
                 return;
             }
+            logger.debug("ACK received by {} - activating call", sipExtension);
             cancelAnsweringTimeout();
+            cancelAckFallbackTimeout();
             ServerTransaction localInviteServerTransaction = inviteServerTransaction;
             if (activeDialog == null && localInviteServerTransaction != null) {
                 activeDialog = localInviteServerTransaction.getDialog();
@@ -860,6 +957,7 @@ public class SipClient implements SipListener {
             activeDialog = localInviteServerTransaction.getDialog();
             callState = SipCallState.ANSWERING;
             scheduleAnsweringTimeout();
+            scheduleAckFallbackTimeout();
             logger.debug("Sent 200 OK for incoming INVITE");
             return true;
         } catch (SipException | ParseException | InvalidArgumentException | RuntimeException e) {
@@ -1149,6 +1247,14 @@ public class SipClient implements SipListener {
         }
     }
 
+    private synchronized void cancelAckFallbackTimeout() {
+        ScheduledFuture<?> timeoutFuture = ackFallbackFuture;
+        if (timeoutFuture != null) {
+            timeoutFuture.cancel(false);
+            ackFallbackFuture = null;
+        }
+    }
+
     private synchronized void cancelOutgoingRingingTimeout() {
         ScheduledFuture<?> timeoutFuture = outgoingRingingTimeoutFuture;
         if (timeoutFuture != null) {
@@ -1208,6 +1314,52 @@ public class SipClient implements SipListener {
         }, OUTGOING_RINGING_TIMEOUT_SECONDS, TimeUnit.SECONDS);
     }
 
+    private synchronized void scheduleAckFallbackTimeout() {
+        cancelAckFallbackTimeout();
+        if (callState != SipCallState.ANSWERING) {
+            return;
+        }
+
+        ackFallbackFuture = callStateTimeoutScheduler.schedule(() -> {
+            SipAudioOffer offer;
+            boolean shouldSendDeferredBye;
+
+            synchronized (SipClient.this) {
+                if (callState != SipCallState.ANSWERING) {
+                    ackFallbackFuture = null;
+                    return;
+                }
+
+                cancelAnsweringTimeout();
+                ServerTransaction localInviteServerTransaction = inviteServerTransaction;
+                if (activeDialog == null && localInviteServerTransaction != null) {
+                    activeDialog = localInviteServerTransaction.getDialog();
+                }
+
+                offer = currentAudioOffer;
+                callState = SipCallState.ACTIVE;
+                shouldSendDeferredBye = pendingHangupAfterAck;
+                pendingHangupAfterAck = false;
+                ackFallbackFuture = null;
+            }
+
+            if (offer != null) {
+                logger.info("No ACK received after 200 OK within {} ms - activating audio path via fallback",
+                        ACK_FALLBACK_TIMEOUT_MILLIS);
+                activateAudioPath(offer);
+            } else {
+                logger.warn("ACK fallback triggered but no audio offer available - skipping audio path activation");
+            }
+
+            listener.onCallActive();
+
+            if (shouldSendDeferredBye) {
+                logger.debug("ACK fallback active, executing deferred hangup");
+                sendBye("deferred-after-ack-timeout");
+            }
+        }, ACK_FALLBACK_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
+    }
+
     private void activateAudioPath(SipAudioOffer offer) {
         SipBackchannelRtpRelay relay = backchannelRelay;
         if (relay != null) {
@@ -1233,6 +1385,7 @@ public class SipClient implements SipListener {
 
     private void clearCallContextLocked(SipCallState nextState) {
         callState = nextState;
+        cancelAckFallbackTimeout();
         inviteRequest = null;
         inviteServerTransaction = null;
         inviteClientTransaction = null;

--- a/bundles/org.openhab.binding.dahuadoor/src/main/java/org/openhab/binding/dahuadoor/internal/sip/SipClient.java
+++ b/bundles/org.openhab.binding.dahuadoor/src/main/java/org/openhab/binding/dahuadoor/internal/sip/SipClient.java
@@ -96,6 +96,7 @@ public class SipClient implements SipListener {
 
     private final Logger logger = LoggerFactory.getLogger(SipClient.class);
     private static final String BINDING_PREFIX = "dahuadoor";
+    private static final String USER_AGENT = "openHAB";
 
     // Configuration
     private final String vtoIp;
@@ -382,7 +383,7 @@ public class SipClient implements SipListener {
             request.addHeader(expiresHeader);
 
             // User-Agent
-            UserAgentHeader userAgentHeader = hdrFactory.createUserAgentHeader(Arrays.asList("openHAB/5.2.0"));
+            UserAgentHeader userAgentHeader = hdrFactory.createUserAgentHeader(Arrays.asList(USER_AGENT));
             request.addHeader(userAgentHeader);
 
             // Send
@@ -439,7 +440,7 @@ public class SipClient implements SipListener {
             ExpiresHeader expiresHeader = hdrFactory.createExpiresHeader(60);
             request.addHeader(expiresHeader);
 
-            UserAgentHeader userAgentHeader = hdrFactory.createUserAgentHeader(Arrays.asList("openHAB/5.2.0"));
+            UserAgentHeader userAgentHeader = hdrFactory.createUserAgentHeader(Arrays.asList(USER_AGENT));
             request.addHeader(userAgentHeader);
 
             // Add Authorization header with Digest
@@ -505,7 +506,7 @@ public class SipClient implements SipListener {
             ExpiresHeader expiresHeader = hdrFactory.createExpiresHeader(0);
             request.addHeader(expiresHeader);
 
-            UserAgentHeader userAgentHeader = hdrFactory.createUserAgentHeader(Arrays.asList("openHAB/5.2.0"));
+            UserAgentHeader userAgentHeader = hdrFactory.createUserAgentHeader(Arrays.asList(USER_AGENT));
             request.addHeader(userAgentHeader);
 
             ClientTransaction tx = provider.getNewClientTransaction(request);
@@ -855,7 +856,8 @@ public class SipClient implements SipListener {
                 return false;
             }
 
-            SipURI requestURI = addrFactory.createSipURI(target, vtoIp);
+            String encodedTarget = encodeUserPart(target);
+            SipURI requestURI = addrFactory.createSipURI(encodedTarget, vtoIp);
             requestURI.setPort(5060);
 
             SipURI fromURI = createLocalUserUri(addrFactory, vtoIp);
@@ -875,7 +877,6 @@ public class SipClient implements SipListener {
             SipURI contactUri = createLocalContactUri(addrFactory);
             contactUri.setPort(localSipPort);
             invite.addHeader(hdrFactory.createContactHeader(addrFactory.createAddress(contactUri)));
-            invite.addHeader(hdrFactory.createContentTypeHeader("application", "sdp"));
 
             byte[] sdpBytes = buildOutgoingOfferSdp().getBytes(StandardCharsets.UTF_8);
             ContentTypeHeader contentTypeHeader = hdrFactory.createContentTypeHeader("application", "sdp");

--- a/bundles/org.openhab.binding.dahuadoor/src/main/java/org/openhab/binding/dahuadoor/internal/sip/SipClient.java
+++ b/bundles/org.openhab.binding.dahuadoor/src/main/java/org/openhab/binding/dahuadoor/internal/sip/SipClient.java
@@ -199,31 +199,86 @@ public class SipClient implements SipListener {
 
     public void initializeSipStack() throws PeerUnavailableException, TransportNotSupportedException,
             InvalidArgumentException, ObjectInUseException, TooManyListenersException {
-        SipFactory sipFactory = SipFactory.getInstance();
-        sipFactory.setPathName("gov.nist");
+        SipStack localSipStack = null;
+        ListeningPoint localListeningPoint = null;
+        SipProvider localSipProvider = null;
+        String initStep = "create SIP stack";
+        try {
+            SipFactory sipFactory = SipFactory.getInstance();
+            sipFactory.setPathName("gov.nist");
 
-        Properties properties = new Properties();
-        properties.setProperty("javax.sip.STACK_NAME", buildSipStackName());
-        properties.setProperty("javax.sip.IP_ADDRESS", localIp);
-        properties.setProperty("gov.nist.javax.sip.TRACE_LEVEL", "0"); // No JAIN-SIP logging
+            Properties properties = new Properties();
+            String stackName = buildSipStackName();
+            properties.setProperty("javax.sip.STACK_NAME", stackName);
+            properties.setProperty("gov.nist.javax.sip.TRACE_LEVEL", "0"); // No JAIN-SIP logging
+            // Do not set javax.sip.IP_ADDRESS here. JAIN-SIP reuses stacks by IP address, which
+            // prevents multiple SipClient instances on the same host from attaching their own listeners.
 
-        SipStack localSipStack = sipFactory.createSipStack(properties);
-        HeaderFactory localHeaderFactory = sipFactory.createHeaderFactory();
-        AddressFactory localAddressFactory = sipFactory.createAddressFactory();
-        MessageFactory localMessageFactory = sipFactory.createMessageFactory();
+            localSipStack = sipFactory.createSipStack(properties);
+            initStep = "create SIP factories";
+            HeaderFactory localHeaderFactory = sipFactory.createHeaderFactory();
+            AddressFactory localAddressFactory = sipFactory.createAddressFactory();
+            MessageFactory localMessageFactory = sipFactory.createMessageFactory();
 
-        ListeningPoint localListeningPoint = localSipStack.createListeningPoint(localIp, localSipPort, "udp");
-        SipProvider localSipProvider = localSipStack.createSipProvider(localListeningPoint);
-        localSipProvider.addSipListener(this);
+            initStep = "create listening point";
+            localListeningPoint = localSipStack.createListeningPoint(localIp, localSipPort, "udp");
 
-        sipStack = localSipStack;
-        headerFactory = localHeaderFactory;
-        addressFactory = localAddressFactory;
-        messageFactory = localMessageFactory;
-        listeningPoint = localListeningPoint;
-        sipProvider = localSipProvider;
+            initStep = "create SIP provider";
+            localSipProvider = localSipStack.createSipProvider(localListeningPoint);
 
-        logger.info("SIP stack initialized on {}:{}", localIp, localSipPort);
+            initStep = "attach SIP listener";
+            localSipProvider.addSipListener(this);
+
+            sipStack = localSipStack;
+            headerFactory = localHeaderFactory;
+            addressFactory = localAddressFactory;
+            messageFactory = localMessageFactory;
+            listeningPoint = localListeningPoint;
+            sipProvider = localSipProvider;
+
+            logger.info("SIP stack initialized for {} on {}:{}", sipExtension, localIp, localSipPort);
+        } catch (PeerUnavailableException | TransportNotSupportedException | InvalidArgumentException
+                | ObjectInUseException | TooManyListenersException | RuntimeException e) {
+            cleanupFailedInitialization(localSipStack, localSipProvider, localListeningPoint);
+            logger.warn("Failed to initialize SIP stack for {} on {}:{} during {} ({}): {}", sipExtension, localIp,
+                    localSipPort, initStep, e.getClass().getSimpleName(), e.getMessage(), e);
+            throw e;
+        }
+    }
+
+    private void cleanupFailedInitialization(@Nullable SipStack stack, @Nullable SipProvider provider,
+            @Nullable ListeningPoint lp) {
+        try {
+            if (provider != null) {
+                provider.removeSipListener(this);
+                if (lp != null) {
+                    provider.removeListeningPoint(lp);
+                }
+            }
+        } catch (ObjectInUseException | RuntimeException e) {
+            logger.debug("Ignoring SIP provider cleanup error for {}: {}", sipExtension, e.getMessage(), e);
+        }
+        try {
+            if (stack != null && provider != null) {
+                stack.deleteSipProvider(provider);
+            }
+        } catch (ObjectInUseException | RuntimeException e) {
+            logger.debug("Ignoring SIP provider deletion error for {}: {}", sipExtension, e.getMessage(), e);
+        }
+        try {
+            if (stack != null && lp != null) {
+                stack.deleteListeningPoint(lp);
+            }
+        } catch (ObjectInUseException | RuntimeException e) {
+            logger.debug("Ignoring SIP listening point cleanup error for {}: {}", sipExtension, e.getMessage(), e);
+        }
+        try {
+            if (stack != null) {
+                stack.stop();
+            }
+        } catch (RuntimeException e) {
+            logger.debug("Ignoring SIP stack stop error for {}: {}", sipExtension, e.getMessage(), e);
+        }
     }
 
     private String buildSipStackName() {
@@ -277,7 +332,7 @@ public class SipClient implements SipListener {
             SipProvider provider = sipProvider;
 
             if (addrFactory == null || hdrFactory == null || msgFactory == null || provider == null) {
-                logger.error("SIP stack not initialized");
+                logger.error("SIP stack not initialized for extension {}", sipExtension);
                 return;
             }
 
@@ -331,8 +386,6 @@ public class SipClient implements SipListener {
             // Send
             ClientTransaction localRegisterTransaction = provider.getNewClientTransaction(request);
             localRegisterTransaction.sendRequest();
-
-            logger.debug("Sent REGISTER (unauthenticated)");
 
         } catch (SipException | ParseException | InvalidArgumentException | RuntimeException e) {
             logger.warn("Failed to send REGISTER: {}", e.getMessage(), e);
@@ -403,8 +456,6 @@ public class SipClient implements SipListener {
             // Send
             ClientTransaction localRegisterTransaction = provider.getNewClientTransaction(request);
             localRegisterTransaction.sendRequest();
-
-            logger.debug("Sent REGISTER (with Digest auth)");
 
         } catch (SipException | ParseException | InvalidArgumentException | RuntimeException e) {
             logger.warn("Failed to send authenticated REGISTER: {}", e.getMessage(), e);
@@ -504,9 +555,6 @@ public class SipClient implements SipListener {
             logger.debug("Received response without CSeq header: {}", statusCode);
             return;
         }
-
-        logger.debug("Received SIP response: {} {} (CSeq: {} {})", statusCode, response.getReasonPhrase(),
-                cseq.getSeqNumber(), cseq.getMethod());
 
         if (Request.REGISTER.equals(cseq.getMethod())) {
             handleRegisterResponse(response);
@@ -666,16 +714,12 @@ public class SipClient implements SipListener {
         int statusCode = response.getStatusCode();
 
         if (statusCode == Response.UNAUTHORIZED) {
-            logger.debug("Received 401 Unauthorized - extracting nonce");
-
             WWWAuthenticateHeader authHeader = (WWWAuthenticateHeader) response.getHeader(WWWAuthenticateHeader.NAME);
             if (authHeader != null) {
                 String nonce = authHeader.getNonce();
-                logger.debug("Nonce: {}", nonce);
                 sendAuthenticatedRegister(nonce);
             }
         } else if (statusCode == Response.OK) {
-            logger.debug("SIP registration successful");
             listener.onRegistrationSuccess();
         } else {
             String reasonPhrase = response.getReasonPhrase();

--- a/bundles/org.openhab.binding.dahuadoor/src/main/resources/OH-INF/i18n/dahuadoor.properties
+++ b/bundles/org.openhab.binding.dahuadoor/src/main/resources/OH-INF/i18n/dahuadoor.properties
@@ -47,7 +47,7 @@ thing-type.config.dahuadoor.vto2202.rtspChannel.description = RTSP channel index
 thing-type.config.dahuadoor.vto2202.rtspSubtype.label = RTSP Sub-type
 thing-type.config.dahuadoor.vto2202.rtspSubtype.description = RTSP sub-type index: 0 = main stream, 1 = sub stream (default 0).
 thing-type.config.dahuadoor.vto2202.sipExtension.label = SIP Extension
-thing-type.config.dahuadoor.vto2202.sipExtension.description = SIP extension to register as (e.g., 9901#2). Also used as SIP username for authentication. Only used when Enable SIP Client is on.
+thing-type.config.dahuadoor.vto2202.sipExtension.description = Comma-separated list of SIP extensions to register as, e.g. "9901#2,9901#3". Each extension is used as its own SIP username and may handle one browser/SIP session in parallel. A single value is also allowed. Only used when Enable SIP Client is on.
 thing-type.config.dahuadoor.vto2202.sipPassword.label = SIP Password
 thing-type.config.dahuadoor.vto2202.sipPassword.description = Password for SIP authentication (may differ from API password). Only used when Enable SIP Client is on.
 thing-type.config.dahuadoor.vto2202.sipRealm.label = SIP Realm
@@ -81,7 +81,7 @@ thing-type.config.dahuadoor.vto3211.rtspChannel.description = RTSP channel index
 thing-type.config.dahuadoor.vto3211.rtspSubtype.label = RTSP Sub-type
 thing-type.config.dahuadoor.vto3211.rtspSubtype.description = RTSP sub-type index: 0 = main stream, 1 = sub stream (default 0).
 thing-type.config.dahuadoor.vto3211.sipExtension.label = SIP Extension
-thing-type.config.dahuadoor.vto3211.sipExtension.description = SIP extension to register as (e.g., 9901#2). Also used as SIP username for authentication. Only used when Enable SIP Client is on.
+thing-type.config.dahuadoor.vto3211.sipExtension.description = Comma-separated list of SIP extensions to register as, e.g. "9901#2,9901#3". Each extension is used as its own SIP username and may handle one browser/SIP session in parallel. A single value is also allowed. Only used when Enable SIP Client is on.
 thing-type.config.dahuadoor.vto3211.sipPassword.label = SIP Password
 thing-type.config.dahuadoor.vto3211.sipPassword.description = Password for SIP authentication (may differ from API password). Only used when Enable SIP Client is on.
 thing-type.config.dahuadoor.vto3211.sipRealm.label = SIP Realm

--- a/bundles/org.openhab.binding.dahuadoor/src/main/resources/OH-INF/thing/vto2202.xml
+++ b/bundles/org.openhab.binding.dahuadoor/src/main/resources/OH-INF/thing/vto2202.xml
@@ -103,7 +103,10 @@
 			</parameter>
 			<parameter name="sipExtension" type="text">
 				<label>SIP Extension</label>
-				<description>SIP extension to register as (e.g., 9901#2). Also used as SIP username for authentication. Only used
+				<description>Comma-separated list of SIP extensions to register as, e.g. "9901#2,9901#3". Each
+					extension is used as
+					its own SIP username and may handle one browser/SIP session in parallel.
+					A single value is also allowed. Only used
 					when Enable SIP Client is on.</description>
 				<default></default>
 			</parameter>

--- a/bundles/org.openhab.binding.dahuadoor/src/main/resources/OH-INF/thing/vto3211.xml
+++ b/bundles/org.openhab.binding.dahuadoor/src/main/resources/OH-INF/thing/vto3211.xml
@@ -117,7 +117,10 @@
 			</parameter>
 			<parameter name="sipExtension" type="text">
 				<label>SIP Extension</label>
-				<description>SIP extension to register as (e.g., 9901#2). Also used as SIP username for authentication. Only used
+				<description>Comma-separated list of SIP extensions to register as, e.g. "9901#2,9901#3". Each
+					extension is used as
+					its own SIP username and may handle one browser/SIP session in parallel.
+					A single value is also allowed. Only used
 					when Enable SIP Client is on.</description>
 				<default></default>
 			</parameter>

--- a/bundles/org.openhab.binding.dahuadoor/src/main/resources/OH-INF/update/instructions.xml
+++ b/bundles/org.openhab.binding.dahuadoor/src/main/resources/OH-INF/update/instructions.xml
@@ -9,12 +9,28 @@
 				<type>dahuadoor:webrtc-url</type>
 			</add-channel>
 		</instruction-set>
+		<instruction-set targetVersion="2">
+			<add-channel id="sip-registered">
+				<type>dahuadoor:sip-registered</type>
+			</add-channel>
+			<add-channel id="sip-call-state">
+				<type>dahuadoor:sip-call-state</type>
+			</add-channel>
+		</instruction-set>
 	</thing-type>
 
 	<thing-type uid="dahuadoor:vto3211">
 		<instruction-set targetVersion="1">
 			<add-channel id="webrtc-url">
 				<type>dahuadoor:webrtc-url</type>
+			</add-channel>
+		</instruction-set>
+		<instruction-set targetVersion="2">
+			<add-channel id="sip-registered">
+				<type>dahuadoor:sip-registered</type>
+			</add-channel>
+			<add-channel id="sip-call-state">
+				<type>dahuadoor:sip-call-state</type>
 			</add-channel>
 		</instruction-set>
 	</thing-type>

--- a/bundles/org.openhab.binding.dahuadoor/src/test/java/org/openhab/binding/dahuadoor/internal/media/SipBackchannelRtpRelayTest.java
+++ b/bundles/org.openhab.binding.dahuadoor/src/test/java/org/openhab/binding/dahuadoor/internal/media/SipBackchannelRtpRelayTest.java
@@ -40,7 +40,7 @@ class SipBackchannelRtpRelayTest {
 
         DatagramPacket incoming = new DatagramPacket(packet, packet.length);
         SipBackchannelRtpRelay.RelayTarget target = new SipBackchannelRtpRelay.RelayTarget(
-                InetAddress.getLoopbackAddress(), 5004, 97);
+                InetAddress.getLoopbackAddress(), 5004, 97, "PCM", 16000);
 
         byte[] forwarded = SipBackchannelRtpRelay.buildForwardPacket(incoming, target);
         assertNotNull(forwarded);
@@ -56,7 +56,7 @@ class SipBackchannelRtpRelayTest {
 
         DatagramPacket incoming = new DatagramPacket(packet, packet.length);
         SipBackchannelRtpRelay.RelayTarget target = new SipBackchannelRtpRelay.RelayTarget(
-                InetAddress.getLoopbackAddress(), 5004, 97);
+                InetAddress.getLoopbackAddress(), 5004, 97, "PCM", 16000);
 
         assertNull(SipBackchannelRtpRelay.buildForwardPacket(incoming, target));
     }
@@ -68,8 +68,75 @@ class SipBackchannelRtpRelayTest {
 
         DatagramPacket incoming = new DatagramPacket(packet, packet.length);
         SipBackchannelRtpRelay.RelayTarget target = new SipBackchannelRtpRelay.RelayTarget(
-                InetAddress.getLoopbackAddress(), 5004, 97);
+                InetAddress.getLoopbackAddress(), 5004, 97, "PCM", 16000);
 
         assertNull(SipBackchannelRtpRelay.buildForwardPacket(incoming, target));
+    }
+
+    @Test
+    void buildForwardPacketTranscodesPcm16LeToPcma() {
+        byte[] packet = new byte[20];
+        packet[0] = (byte) 0x80;
+        packet[1] = (byte) 0x80;
+        packet[6] = 0x01;
+        packet[7] = 0x40; // RTP timestamp 320
+
+        // Four 16-bit little-endian PCM samples, all zero.
+        packet[12] = 0x00;
+        packet[13] = 0x00;
+        packet[14] = 0x00;
+        packet[15] = 0x00;
+        packet[16] = 0x00;
+        packet[17] = 0x00;
+        packet[18] = 0x00;
+        packet[19] = 0x00;
+
+        DatagramPacket incoming = new DatagramPacket(packet, packet.length);
+        SipBackchannelRtpRelay.RelayTarget target = new SipBackchannelRtpRelay.RelayTarget(
+                InetAddress.getLoopbackAddress(), 5004, 8, "PCMA", 8000);
+
+        byte[] forwarded = SipBackchannelRtpRelay.buildForwardPacket(incoming, target);
+        assertNotNull(forwarded);
+        assertEquals(14, forwarded.length);
+        assertEquals(8, forwarded[1] & 0x7F);
+        assertEquals(0x00, forwarded[4] & 0xFF);
+        assertEquals(0x00, forwarded[5] & 0xFF);
+        assertEquals(0x00, forwarded[6] & 0xFF);
+        assertEquals(0xA0, forwarded[7] & 0xFF);
+        assertEquals(0xD5, forwarded[12] & 0xFF);
+        assertEquals(0xD5, forwarded[13] & 0xFF);
+    }
+
+    @Test
+    void buildForwardPacketTranscodesPcm16LeToPcmu() {
+        byte[] packet = new byte[20];
+        packet[0] = (byte) 0x80;
+        packet[1] = 0x00;
+        packet[6] = 0x01;
+        packet[7] = 0x40; // RTP timestamp 320
+
+        packet[12] = 0x00;
+        packet[13] = 0x00;
+        packet[14] = 0x00;
+        packet[15] = 0x00;
+        packet[16] = 0x00;
+        packet[17] = 0x00;
+        packet[18] = 0x00;
+        packet[19] = 0x00;
+
+        DatagramPacket incoming = new DatagramPacket(packet, packet.length);
+        SipBackchannelRtpRelay.RelayTarget target = new SipBackchannelRtpRelay.RelayTarget(
+                InetAddress.getLoopbackAddress(), 5004, 0, "PCMU", 8000);
+
+        byte[] forwarded = SipBackchannelRtpRelay.buildForwardPacket(incoming, target);
+        assertNotNull(forwarded);
+        assertEquals(14, forwarded.length);
+        assertEquals(0, forwarded[1] & 0x7F);
+        assertEquals(0x00, forwarded[4] & 0xFF);
+        assertEquals(0x00, forwarded[5] & 0xFF);
+        assertEquals(0x00, forwarded[6] & 0xFF);
+        assertEquals(0xA0, forwarded[7] & 0xFF);
+        assertEquals(0xFF, forwarded[12] & 0xFF);
+        assertEquals(0xFF, forwarded[13] & 0xFF);
     }
 }

--- a/bundles/org.openhab.binding.dahuadoor/src/test/java/org/openhab/binding/dahuadoor/internal/media/SipSdpParserTest.java
+++ b/bundles/org.openhab.binding.dahuadoor/src/test/java/org/openhab/binding/dahuadoor/internal/media/SipSdpParserTest.java
@@ -70,7 +70,21 @@ class SipSdpParserTest {
                 + "t=0 0\r\n" + "m=audio 6000 RTP/AVP 101\r\n" + "a=rtpmap:101 PCMA/8000\r\n" + "a=ptime:30\r\n";
 
         Optional<SipAudioOffer> parsed = parser.parseAudioOffer(sdp);
-        assertTrue(parsed.isEmpty());
+        assertTrue(parsed.isPresent());
+        assertEquals("PCMA", parsed.get().getCodecName());
+        assertEquals(8000, parsed.get().getClockRate());
+    }
+
+    @Test
+    void parseAudioOfferFallsBackToPcmuWhenPcmIsMissing() {
+        String sdp = "v=0\r\n" + "o=- 1 1 IN IP4 203.0.113.31\r\n" + "s=-\r\n" + "c=IN IP4 203.0.113.31\r\n"
+                + "t=0 0\r\n" + "m=audio 7000 RTP/AVP 0 101\r\n" + "a=ptime:20\r\n";
+
+        Optional<SipAudioOffer> parsed = parser.parseAudioOffer(sdp);
+        assertTrue(parsed.isPresent());
+        assertEquals(0, parsed.get().getPayloadType());
+        assertEquals("PCMU", parsed.get().getCodecName());
+        assertEquals(8000, parsed.get().getClockRate());
     }
 
     @Test
@@ -125,5 +139,18 @@ class SipSdpParserTest {
         String answerText = answer.get();
         assertTrue(answerText.contains("m=audio 20000 RTP/AVP 97\r\n"));
         assertTrue(answerText.contains("a=rtpmap:97 PCM/16000\r\n"));
+    }
+
+    @Test
+    void buildAnswerSdpFallsBackToPcmaWhenOnlyPcmaIsOffered() {
+        String sdp = "v=0\r\n" + "o=- 1 1 IN IP4 198.51.100.61\r\n" + "s=Dahua VT 1.5\r\n"
+                + "c=IN IP4 198.51.100.61\r\n" + "t=0 0\r\n" + "m=audio 20000 RTP/AVP 8 101\r\n" + "a=ptime:20\r\n";
+
+        Optional<String> answer = parser.buildAnswerSdp(sdp, "192.0.2.62", 20000);
+        assertTrue(answer.isPresent());
+
+        String answerText = answer.get();
+        assertTrue(answerText.contains("m=audio 20000 RTP/AVP 8\r\n"));
+        assertTrue(answerText.contains("a=rtpmap:8 PCMA/8000\r\n"));
     }
 }


### PR DESCRIPTION
## Summary
This PR improves multi-client behavior for the DahuaDoor binding by letting multiple SIP clients register and handle calls concurrently, while keeping call state and routing consistent per client. It also routes WebRTC sessions by HTTP session and adds a duplicate-offer gate to prevent concurrent setup conflicts, with a soft-accept path for the /webrtc/session endpoint to avoid hard 409 rejections.

SIP stack initialization and cleanup are made more robust to avoid listener conflicts and partial init failures. SIP address/URI handling is tightened (escaping of “#”, consistent local/contact URI creation), and register/unregister logic is improved. The SIP backchannel parsing/relay path is expanded with better diagnostics and test coverage, and related thing definitions/i18n/readme notes are updated accordingly.
