### PR TITLE
[checkstyle] Suppress license header checks for src/3rdparty Java files

### DIFF
--- a/tools/static-code-analysis/checkstyle/suppressions.xml
+++ b/tools/static-code-analysis/checkstyle/suppressions.xml
@@ -24,6 +24,8 @@
     <suppress files=".+org.openhab.binding.yeelight.+" checks="OutsideOfLibExternalLibrariesCheck" />
     <!-- suppress header checks for imported and patched apache commons-io files in logreader binding -->
     <suppress files=".+org.openhab.binding.logreader.internal.thirdparty.commonsio.+" checks="ParameterizedRegexpHeaderCheck|AuthorTagCheck" />
+    <!-- suppress license header and author tag checks for all 3rd-party code stored under src/3rdparty -->
+    <suppress files=".+[\\/]src[\\/]3rdparty[\\/].+\.java" checks="ParameterizedRegexpHeaderCheck|AuthorTagCheck" />
     <!-- Mail: Do not check org.apache.commons.mail usage -->
     <suppress files=".+[\\/]mail[\\/].+[\\/]MailBuilder\.java" checks="ForbiddenPackageUsageCheck"/>
     <suppress files=".+[\\/]mail[\\/].+[\\/]MailBuilderTest\.java" checks="ForbiddenPackageUsageCheck"/>


### PR DESCRIPTION
## Summary

Extends the existing checkstyle `ParameterizedRegexpHeaderCheck` and `AuthorTagCheck` suppressions to cover all Java files stored under `src/3rdparty/` in any binding.

This is a prerequisite for [#18628](https://github.com/openhab/openhab-addons/pull/18628) (Jellyfin binding), which stores OpenAPI-generated code under `src/3rdparty/java/` — files that intentionally carry the upstream OpenAPI Generator header rather than the openHAB license header.

## Change

```xml
<!-- suppress license header and author tag checks for all 3rd-party code stored under src/3rdparty -->
<suppress files=".+[\\/]src[\\/]3rdparty[\\/].+\.java" checks="ParameterizedRegexpHeaderCheck|AuthorTagCheck" />
```

This is a more general form of the existing logreader-specific suppression, following the same pattern already used by the project.
