### PR TITLE
[timescaledb] Fix TimescaleDB JDBC URL validation

### DIFF
--- a/bundles/org.openhab.persistence.timescaledb/README.md
+++ b/bundles/org.openhab.persistence.timescaledb/README.md
@@ -49,7 +49,7 @@ Configure via `$OPENHAB_CONF/services/timescaledb.cfg` or in the UI under `Setti
 
 | Property               | Default   | Required | Description                                               |
 |------------------------|-----------|:--------:|-----------------------------------------------------------|
-| `url`                  |           | Yes      | JDBC URL, e.g. `jdbc:postgresql://localhost:5432/openhab` |
+| `url`                  |           | Yes      | Database URL, e.g. `jdbc:postgresql://localhost:5432/openhab` or `postgresql://localhost:5432/openhab` (`jdbc:` is added automatically if missing) |
 | `user`                 | `openhab` | No       | Database user                                             |
 | `password`             |           | Yes      | Database password                                         |
 | `chunkInterval`        | `7 days`  | No       | TimescaleDB chunk interval for the hypertable             |

--- a/bundles/org.openhab.persistence.timescaledb/src/main/java/org/openhab/persistence/timescaledb/internal/TimescaleDBPersistenceService.java
+++ b/bundles/org.openhab.persistence.timescaledb/src/main/java/org/openhab/persistence/timescaledb/internal/TimescaleDBPersistenceService.java
@@ -114,7 +114,7 @@ public class TimescaleDBPersistenceService implements ModifiablePersistenceServi
 
     @Activate
     public void activate(final Map<String, Object> config) {
-        String url = (String) config.getOrDefault("url", "");
+        String url = normalizeJdbcUrl((String) config.getOrDefault("url", ""));
         if (url.isBlank()) {
             LOGGER.warn("TimescaleDB persistence not configured: missing 'url'. "
                     + "Configure org.openhab.timescaledb:url.");
@@ -445,6 +445,14 @@ public class TimescaleDBPersistenceService implements ModifiablePersistenceServi
         cfg.setConnectionTimeout(connectTimeoutMs);
         cfg.setPoolName("timescaledb-persistence");
         return new HikariDataSource(cfg);
+    }
+
+    static String normalizeJdbcUrl(String url) {
+        String trimmed = url.trim();
+        if (trimmed.regionMatches(true, 0, "postgresql://", 0, "postgresql://".length())) {
+            return "jdbc:postgresql://" + trimmed.substring("postgresql://".length());
+        }
+        return trimmed;
     }
 
     static int parseIntConfig(Map<String, Object> config, String key, int defaultValue) {

--- a/bundles/org.openhab.persistence.timescaledb/src/main/resources/OH-INF/config/timescaledb.xml
+++ b/bundles/org.openhab.persistence.timescaledb/src/main/resources/OH-INF/config/timescaledb.xml
@@ -17,7 +17,6 @@
 		</parameter-group>
 
 		<parameter name="url" type="text" required="true" groupName="connection">
-			<context>url</context>
 			<label>JDBC URL</label>
 			<description>JDBC connection URL, e.g. jdbc:postgresql://localhost:5432/openhab</description>
 		</parameter>

--- a/bundles/org.openhab.persistence.timescaledb/src/main/resources/OH-INF/config/timescaledb.xml
+++ b/bundles/org.openhab.persistence.timescaledb/src/main/resources/OH-INF/config/timescaledb.xml
@@ -18,7 +18,7 @@
 
 		<parameter name="url" type="text" required="true" groupName="connection">
 			<label>JDBC URL</label>
-			<description>JDBC connection URL, e.g. jdbc:postgresql://localhost:5432/openhab</description>
+			<description>Database URL, e.g. [jdbc]:postgresql://localhost:5432/openhab</description>
 		</parameter>
 
 		<parameter name="user" type="text" required="false" groupName="connection">

--- a/bundles/org.openhab.persistence.timescaledb/src/test/java/org/openhab/persistence/timescaledb/internal/BundleManifestTest.java
+++ b/bundles/org.openhab.persistence.timescaledb/src/test/java/org/openhab/persistence/timescaledb/internal/BundleManifestTest.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assumptions.*;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -25,9 +24,14 @@ import java.util.List;
 import java.util.Set;
 import java.util.jar.Manifest;
 
+import javax.xml.parsers.DocumentBuilderFactory;
+
 import org.eclipse.jdt.annotation.DefaultLocation;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
 
 /**
  * Verifies structural requirements of the OSGi bundle to ensure it deploys and integrates
@@ -105,15 +109,34 @@ class BundleManifestTest {
     }
 
     @Test
-    void jdbcUrlParameterDoesNotUseUrlContext() throws IOException {
+    void jdbcUrlParameterDoesNotUseUrlContext() throws Exception {
         Path configPath = Path.of("src/main/resources/OH-INF/config/timescaledb.xml");
         assertTrue(Files.exists(configPath), "OH-INF/config/timescaledb.xml is missing.");
 
-        String xml = Files.readString(configPath, StandardCharsets.UTF_8);
-        assertTrue(xml.contains("<parameter name=\"url\" type=\"text\""),
-                "timescaledb.xml must define a text parameter named 'url'.");
-        assertFalse(xml.contains("<context>url</context>"), "The JDBC URL parameter must not use context 'url': "
-                + "MainUI enforces http/https URL semantics and rejects jdbc:postgresql://... values.");
+        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+        dbf.setNamespaceAware(true);
+        Document doc = dbf.newDocumentBuilder().parse(configPath.toFile());
+
+        Element urlParameter = null;
+        NodeList parameters = doc.getElementsByTagName("parameter");
+        for (int i = 0; i < parameters.getLength(); i++) {
+            Element parameter = (Element) parameters.item(i);
+            if ("url".equals(parameter.getAttribute("name"))) {
+                urlParameter = parameter;
+                break;
+            }
+        }
+
+        assertNotNull(urlParameter, "timescaledb.xml must define a parameter named 'url'.");
+        assertEquals("text", urlParameter.getAttribute("type"),
+                "The 'url' parameter must remain a text field for JDBC URLs.");
+
+        NodeList contexts = urlParameter.getElementsByTagName("context");
+        for (int i = 0; i < contexts.getLength(); i++) {
+            String context = contexts.item(i).getTextContent().trim();
+            assertNotEquals("url", context, "The JDBC URL parameter must not use context 'url': "
+                    + "MainUI enforces http/https URL semantics and rejects jdbc:postgresql://... values.");
+        }
     }
 
     /**

--- a/bundles/org.openhab.persistence.timescaledb/src/test/java/org/openhab/persistence/timescaledb/internal/BundleManifestTest.java
+++ b/bundles/org.openhab.persistence.timescaledb/src/test/java/org/openhab/persistence/timescaledb/internal/BundleManifestTest.java
@@ -17,6 +17,7 @@ import static org.junit.jupiter.api.Assumptions.*;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -101,6 +102,18 @@ class BundleManifestTest {
         assertTrue(Files.exists(Path.of("src/main/resources/OH-INF/addon/addon.xml")),
                 "OH-INF/addon/addon.xml is missing — the addon will not appear in the openHAB UI. "
                         + "Create src/main/resources/OH-INF/addon/addon.xml.");
+    }
+
+    @Test
+    void jdbcUrlParameterDoesNotUseUrlContext() throws IOException {
+        Path configPath = Path.of("src/main/resources/OH-INF/config/timescaledb.xml");
+        assertTrue(Files.exists(configPath), "OH-INF/config/timescaledb.xml is missing.");
+
+        String xml = Files.readString(configPath, StandardCharsets.UTF_8);
+        assertTrue(xml.contains("<parameter name=\"url\" type=\"text\""),
+                "timescaledb.xml must define a text parameter named 'url'.");
+        assertFalse(xml.contains("<context>url</context>"), "The JDBC URL parameter must not use context 'url': "
+                + "MainUI enforces http/https URL semantics and rejects jdbc:postgresql://... values.");
     }
 
     /**

--- a/bundles/org.openhab.persistence.timescaledb/src/test/java/org/openhab/persistence/timescaledb/internal/TimescaleDBContainerTest.java
+++ b/bundles/org.openhab.persistence.timescaledb/src/test/java/org/openhab/persistence/timescaledb/internal/TimescaleDBContainerTest.java
@@ -719,6 +719,25 @@ class TimescaleDBContainerTest {
     }
 
     @Test
+    @Order(70)
+    void serviceActivateAcceptsPostgresqlUrlWithoutJdbcPrefix() throws Exception {
+        MetadataRegistry mr = mock(MetadataRegistry.class);
+        when(mr.getAll()).thenReturn(Collections.emptyList());
+        TimescaleDBPersistenceService service = new TimescaleDBPersistenceService(mock(ItemRegistry.class), mr,
+                new TimescaleDBMetadataService(mr));
+
+        String urlWithoutJdbc = DB.getJdbcUrl().replaceFirst("^jdbc:", "");
+        service.activate(Map.of("url", urlWithoutJdbc, "user", DB.getUsername(), "password", DB.getPassword()));
+
+        var dsField = TimescaleDBPersistenceService.class.getDeclaredField("dataSource");
+        dsField.setAccessible(true);
+        assertNotNull(dsField.get(service), "DataSource must be initialized for postgresql:// URL");
+
+        service.deactivate();
+        assertNull(dsField.get(service), "DataSource must be null after deactivate()");
+    }
+
+    @Test
     @Order(71)
     void serviceStoreandqueryViaserviceinterface() throws Exception {
         MetadataRegistry mr = mock(MetadataRegistry.class);

--- a/bundles/org.openhab.persistence.timescaledb/src/test/java/org/openhab/persistence/timescaledb/internal/TimescaleDBPersistenceServiceTest.java
+++ b/bundles/org.openhab.persistence.timescaledb/src/test/java/org/openhab/persistence/timescaledb/internal/TimescaleDBPersistenceServiceTest.java
@@ -386,6 +386,21 @@ class TimescaleDBPersistenceServiceTest {
     }
 
     @Test
+    void activatePostgresqlUrlWithoutJdbcPrefixIsAcceptedAndNormalized() throws Exception {
+        var realService = new TimescaleDBPersistenceService(mock(ItemRegistry.class), mock(MetadataRegistry.class),
+                new TimescaleDBMetadataService(mock(MetadataRegistry.class)));
+        // Same as invalid URL test, but without jdbc: prefix to verify normalization path.
+        realService.activate(
+                Map.of("url", "postgresql://localhost:19999/invalid", "password", "x", "connectTimeout", "500"));
+
+        var dsField = TimescaleDBPersistenceService.class.getDeclaredField("dataSource");
+        dsField.setAccessible(true);
+        assertTrue(null == dsField.get(realService),
+                "dataSource must be null when connection fails after URL normalization");
+        realService.deactivate();
+    }
+
+    @Test
     @SuppressWarnings("unchecked")
     void deactivateWithscheduledjobCancelsjob() throws Exception {
         ScheduledFuture<Object> mockJob = mock(ScheduledFuture.class);
@@ -444,6 +459,24 @@ class TimescaleDBPersistenceServiceTest {
     @Test
     void parseIntConfigInvalidvalueReturnsdefault() {
         assertEquals(3, TimescaleDBPersistenceService.parseIntConfig(Map.of("k", "notanumber"), "k", 3));
+    }
+
+    @Test
+    void normalizeJdbcUrlAddsJdbcPrefixForPostgresqlUrls() {
+        assertEquals("jdbc:postgresql://localhost:5432/openhab",
+                TimescaleDBPersistenceService.normalizeJdbcUrl("postgresql://localhost:5432/openhab"));
+        assertEquals("jdbc:postgresql://localhost:5432/openhab",
+                TimescaleDBPersistenceService.normalizeJdbcUrl("PostgreSQL://localhost:5432/openhab"));
+    }
+
+    @Test
+    void normalizeJdbcUrlLeavesAlreadyJdbcAndOtherUrlsUnchanged() {
+        assertEquals("jdbc:postgresql://localhost:5432/openhab",
+                TimescaleDBPersistenceService.normalizeJdbcUrl("jdbc:postgresql://localhost:5432/openhab"));
+        assertEquals("jdbc:mysql://localhost:3306/openhab",
+                TimescaleDBPersistenceService.normalizeJdbcUrl("jdbc:mysql://localhost:3306/openhab"));
+        assertEquals("jdbc:postgresql://localhost:5432/openhab",
+                TimescaleDBPersistenceService.normalizeJdbcUrl("  jdbc:postgresql://localhost:5432/openhab  "));
     }
 
     // ------------------------------------------------------------------


### PR DESCRIPTION
### Fix TimescaleDB JDBC URL validation for MainUI and backend handling

This PR fixes #20676 by removing the overly strict URL UI context and by making backend URL handling more robust.

#### What changed
- Removed the URL context from the TimescaleDB URL config parameter so MainUI no longer enforces http/https URL validation for this JDBC field.
- Added backend normalization so both variants are accepted:
  - jdbc:postgresql://host:port/db
  - postgresql://host:port/db
- If the JDBC prefix is missing for PostgreSQL URLs, it is added automatically before datasource initialization.
- Reworked the bundle config regression test to use structural XML parsing instead of brittle string matching.
- Updated TimescaleDB documentation to clarify accepted URL formats.

#### Tests
- Ran:
  - mvn -pl bundles/org.openhab.persistence.timescaledb -Dtest=BundleManifestTest,TimescaleDBPersistenceServiceTest,TimescaleDBContainerTest test -DskipITs
- Result:
  - BUILD SUCCESS
  - Tests run: 82
  - Failures: 0
  - Errors: 0
  - Skipped: 0
- Includes end-to-end Testcontainers coverage for both URL variants (with and without JDBC prefix).