### PR TITLE
[bluelink] Various fixes related to refreshing data

### DIFF
--- a/bundles/org.openhab.binding.bluelink/src/main/java/org/openhab/binding/bluelink/internal/handler/BluelinkVehicleHandler.java
+++ b/bundles/org.openhab.binding.bluelink/src/main/java/org/openhab/binding/bluelink/internal/handler/BluelinkVehicleHandler.java
@@ -180,7 +180,11 @@ public class BluelinkVehicleHandler extends BaseThingHandler implements VehicleS
             final BluelinkVehicleConfiguration config = getConfigAs(BluelinkVehicleConfiguration.class);
             final String vin = config.vin;
             if (vin != null && !vin.isBlank()) {
-                scheduler.execute(() -> loadVehicle(vin));
+                ScheduledFuture<?> job = initTask;
+                if (job != null) {
+                    job.cancel(true);
+                }
+                initTask = scheduler.schedule(() -> loadVehicle(vin), 0, TimeUnit.MILLISECONDS);
             }
         }
     }

--- a/bundles/org.openhab.binding.bluelink/src/main/java/org/openhab/binding/bluelink/internal/handler/BluelinkVehicleHandler.java
+++ b/bundles/org.openhab.binding.bluelink/src/main/java/org/openhab/binding/bluelink/internal/handler/BluelinkVehicleHandler.java
@@ -559,10 +559,13 @@ public class BluelinkVehicleHandler extends BaseThingHandler implements VehicleS
         }
         final Set<ChannelUID> currentChannels = getThing().getChannelsOfGroup(group).stream().map(Channel::getUID)
                 .collect(toUnmodifiableSet());
-        final ThingBuilder thingBuilder = editThing();
-        newChannels.stream().map(ChannelBuilder::build).filter(c -> !currentChannels.contains(c.getUID()))
-                .forEach(thingBuilder::withChannel);
-        updateThing(thingBuilder.build());
+        final List<Channel> channelsToAdd = newChannels.stream().map(ChannelBuilder::build)
+                .filter(c -> !currentChannels.contains(c.getUID())).toList();
+        if (!channelsToAdd.isEmpty()) {
+            final ThingBuilder thingBuilder = editThing();
+            channelsToAdd.forEach(thingBuilder::withChannel);
+            updateThing(thingBuilder.build());
+        }
     }
 
     private ChannelBuilder buildChannel(final String group, final String channelId, final String itemType,

--- a/bundles/org.openhab.binding.bluelink/src/main/java/org/openhab/binding/bluelink/internal/handler/BluelinkVehicleHandler.java
+++ b/bundles/org.openhab.binding.bluelink/src/main/java/org/openhab/binding/bluelink/internal/handler/BluelinkVehicleHandler.java
@@ -48,6 +48,7 @@ import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.Thing;
 import org.openhab.core.thing.ThingStatus;
 import org.openhab.core.thing.ThingStatusDetail;
+import org.openhab.core.thing.ThingStatusInfo;
 import org.openhab.core.thing.binding.BaseThingHandler;
 import org.openhab.core.thing.binding.ThingHandlerService;
 import org.openhab.core.thing.binding.builder.ChannelBuilder;
@@ -167,6 +168,17 @@ public class BluelinkVehicleHandler extends BaseThingHandler implements VehicleS
         }
 
         vehicle = null;
+    }
+
+    @Override
+    public void bridgeStatusChanged(ThingStatusInfo bridgeStatusInfo) {
+        if (bridgeStatusInfo.getStatus() == ThingStatus.ONLINE && vehicle == null) {
+            final BluelinkVehicleConfiguration config = getConfigAs(BluelinkVehicleConfiguration.class);
+            final String vin = config.vin;
+            if (vin != null && !vin.isBlank()) {
+                scheduler.execute(() -> loadVehicle(vin));
+            }
+        }
     }
 
     @Override

--- a/bundles/org.openhab.binding.bluelink/src/main/java/org/openhab/binding/bluelink/internal/handler/BluelinkVehicleHandler.java
+++ b/bundles/org.openhab.binding.bluelink/src/main/java/org/openhab/binding/bluelink/internal/handler/BluelinkVehicleHandler.java
@@ -586,7 +586,7 @@ public class BluelinkVehicleHandler extends BaseThingHandler implements VehicleS
     /**
      * Reschedule the forced refresh so the first execution starts in 10 seconds.
      */
-    private void scheduleForceRefresh() {
+    private synchronized void scheduleForceRefresh() {
         final ScheduledFuture<?> job = forceRefreshJob;
         if (job != null) {
             job.cancel(false);

--- a/bundles/org.openhab.binding.bluelink/src/main/java/org/openhab/binding/bluelink/internal/handler/BluelinkVehicleHandler.java
+++ b/bundles/org.openhab.binding.bluelink/src/main/java/org/openhab/binding/bluelink/internal/handler/BluelinkVehicleHandler.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReentrantLock;
 
 import javax.measure.quantity.Length;
 import javax.measure.quantity.Temperature;
@@ -72,6 +73,9 @@ public class BluelinkVehicleHandler extends BaseThingHandler implements VehicleS
     private static final Duration DEFAULT_FORCE_REFRESH_INTERVAL = Duration.ofMinutes(240);
 
     private final Logger logger = LoggerFactory.getLogger(BluelinkVehicleHandler.class);
+
+    private final ReentrantLock refreshLock = new ReentrantLock();
+    private final ReentrantLock forceRefreshLock = new ReentrantLock();
 
     private volatile @Nullable ScheduledFuture<?> refreshJob;
     private volatile @Nullable ScheduledFuture<?> forceRefreshJob;
@@ -345,14 +349,22 @@ public class BluelinkVehicleHandler extends BaseThingHandler implements VehicleS
             return;
         }
 
+        final ReentrantLock lock = forceRefresh ? forceRefreshLock : refreshLock;
+        if (!lock.tryLock()) {
+            logger.debug("{} status refresh already in progress, skipping", forceRefresh ? "Forced" : "Vehicle");
+            return;
+        }
+
         try {
-            logger.debug("refreshing vehicle status");
+            logger.debug("Refreshing {}vehicle status", forceRefresh ? "forced " : "");
             if (bridgeHnd.getVehicleStatus(vehicle, forceRefresh, this)) {
                 updateStatus(ThingStatus.ONLINE);
             }
         } catch (final BluelinkApiException e) {
-            logger.debug("Failed to refresh vehicle status: {}", e.getMessage());
+            logger.debug("Failed to refresh {}vehicle status: {}", forceRefresh ? "forced " : "", e.getMessage());
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, e.getMessage());
+        } finally {
+            lock.unlock();
         }
     }
 


### PR DESCRIPTION
- Re-attempt failed vehicle init when bridge comes online.
- Only update Thing if dynamic channels have actually changed.
- Synchronize `scheduleForceRefresh()` invocations as `scheduleForceRefresh()` re-assigns/modifies the global timer forceRefreshJob.
- Synchronize (force) refresh execution to ensure only one refresh request is sent at a time.