### PR TITLE
[googletts] Fix `NullPointerException` when API returns error response

### DIFF
--- a/bundles/org.openhab.voice.googletts/src/main/java/org/openhab/voice/googletts/internal/GoogleCloudAPI.java
+++ b/bundles/org.openhab.voice.googletts/src/main/java/org/openhab/voice/googletts/internal/GoogleCloudAPI.java
@@ -368,17 +368,25 @@ class GoogleCloudAPI {
                 .withContent(gson.toJson(request), MimeTypes.Type.APPLICATION_JSON.name());
 
         try {
-            SynthesizeSpeechResponse synthesizeSpeechResponse = gson.fromJson(builder.getContentAsString(),
+            String responseBody = builder.getContentAsString();
+            SynthesizeSpeechResponse synthesizeSpeechResponse = gson.fromJson(responseBody,
                     SynthesizeSpeechResponse.class);
 
             if (synthesizeSpeechResponse == null) {
+                logger.warn("Google Cloud TTS returned null response");
                 return null;
             }
 
-            byte[] encodedBytes = synthesizeSpeechResponse.getAudioContent().getBytes(StandardCharsets.UTF_8);
+            String audioContent = synthesizeSpeechResponse.getAudioContent();
+            if (audioContent == null || audioContent.isEmpty()) {
+                logger.warn("Google Cloud TTS returned empty audio content. Response: {}", responseBody);
+                return null;
+            }
+
+            byte[] encodedBytes = audioContent.getBytes(StandardCharsets.UTF_8);
             return Base64.getDecoder().decode(encodedBytes);
         } catch (JsonSyntaxException e) {
-            // do nothing
+            logger.warn("Google Cloud TTS returned invalid JSON: {}", e.getMessage());
         } catch (IOException e) {
             throw new CommunicationException(String.format("An unexpected IOException occurred: %s", e.getMessage()));
         }


### PR DESCRIPTION
Fixes #20700

## Summary

Adds null check for `audioContent` in `GoogleCloudAPI.synthesizeSpeechByGoogle()` to prevent `NullPointerException` when the Google Cloud TTS API returns an error response.

## Changes

- Check `audioContent` for null/empty before calling `getBytes()`
- Log the actual API response body when audio content is missing (aids debugging)
- Replace silent `JsonSyntaxException` catch with a warning log

## Root Cause

When Google returns an error response (e.g., expired OAuth token, invalid voice/format), the JSON is parsed as `SynthesizeSpeechResponse` with null `audioContent`. The existing null check only verifies the response object itself, not the `audioContent` field.

## Testing

Tested on openHAB 5.1.4 with:
- Expired OAuth token scenario (401 response)
- Invalid voice/format combination (empty response)
- Normal operation (no regression)

Signed-off-by: Gabor Bicskei <gbicskei@gmail.com>