### PR TITLE
[paradoxalarm] Fix binding not polling data correctly after restart

### DIFF
--- a/bundles/org.openhab.binding.paradoxalarm/src/main/java/org/openhab/binding/paradoxalarm/internal/communication/CommunicationState.java
+++ b/bundles/org.openhab.binding.paradoxalarm/src/main/java/org/openhab/binding/paradoxalarm/internal/communication/CommunicationState.java
@@ -314,9 +314,11 @@ public enum CommunicationState implements IResponseReceiver {
         @Override
         protected void runPhase(IParadoxInitialLoginCommunicator communicator, Object... args) {
             if (communicator instanceof IParadoxCommunicator comm) {
+                // initializeData() only queues requests — responses arrive asynchronously.
+                // Transition to ONLINE is deferred until the first complete RAM read cycle
+                // completes (see EvoCommunicator.receiveRamResponse).
                 comm.initializeData();
             }
-            nextState().runPhase(communicator);
         }
     },
     ONLINE {

--- a/bundles/org.openhab.binding.paradoxalarm/src/main/java/org/openhab/binding/paradoxalarm/internal/communication/CommunicationState.java
+++ b/bundles/org.openhab.binding.paradoxalarm/src/main/java/org/openhab/binding/paradoxalarm/internal/communication/CommunicationState.java
@@ -318,6 +318,8 @@ public enum CommunicationState implements IResponseReceiver {
                 // Transition to ONLINE is deferred until the first complete RAM read cycle
                 // completes (see EvoCommunicator.receiveRamResponse).
                 comm.initializeData();
+            } else {
+                nextState().runPhase(communicator);
             }
         }
     },

--- a/bundles/org.openhab.binding.paradoxalarm/src/main/java/org/openhab/binding/paradoxalarm/internal/communication/EvoCommunicator.java
+++ b/bundles/org.openhab.binding.paradoxalarm/src/main/java/org/openhab/binding/paradoxalarm/internal/communication/EvoCommunicator.java
@@ -94,6 +94,11 @@ public class EvoCommunicator extends GenericCommunicator implements IParadoxComm
 
             // Trigger listeners update when last memory page update is received
             if (ramBlockNumber == panelType.getRamPagesNumber()) {
+                // Transition to ONLINE on the first completed RAM read cycle so that
+                // the bridge handler is not marked online before real data is available.
+                if (!isOnline()) {
+                    CommunicationState.ONLINE.runPhase(this);
+                }
                 updateListeners();
             }
         } else {
@@ -277,7 +282,10 @@ public class EvoCommunicator extends GenericCommunicator implements IParadoxComm
             logger.debug("Attempt to refresh memory map was made, but communicator is not online. Skipping update.");
             return;
         }
+        submitRamRequests();
+    }
 
+    private void submitRamRequests() {
         SyncQueue queue = SyncQueue.getInstance();
         synchronized (queue) {
             for (int i = 1; i <= panelType.getRamPagesNumber(); i++) {
@@ -346,7 +354,7 @@ public class EvoCommunicator extends GenericCommunicator implements IParadoxComm
     public void initializeData() {
         synchronized (SyncQueue.getInstance()) {
             initializeEpromData();
-            refreshMemoryMap();
+            submitRamRequests();
         }
     }
 


### PR DESCRIPTION
## Backport of #20678 to 5.1.x

Cherry-picks both commits from #20678 onto the `5.1.x` branch.

## Problem

After an openHAB restart, the Paradox alarm binding would appear to connect successfully (bridge shows Online) but all channel states — zone states, partition states, panel timestamp and voltages — would remain stale and never update.

The only workaround was to manually send a `LOGOUT` command followed by `RESET` to the bridge, sometimes requiring multiple attempts.

## Root Cause

Two-part initialization bug in the startup sequence:

1. **`initializeData()` requests were silently dropped** — `refreshMemoryMap()` has an `isOnline()` guard that skipped requests if the communicator was not yet online, which it never is at that point in the login sequence.

2. **ONLINE transition fired immediately with an empty memory map** — `INITIALIZE_DATA` called `nextState().runPhase()` immediately, transitioning to ONLINE before any RAM responses had been received.

## Fix

1. **Extract `submitRamRequests()`** — submits RAM read requests directly to the `SyncQueue`, bypassing the `isOnline()` guard during initialization.
2. **Defer ONLINE transition** — `receiveRamResponse()` now triggers `CommunicationState.ONLINE.runPhase()` when the last RAM page of the first complete read cycle is received.

## Testing

Verified on a live openHAB 5.1.4 instance with an EVO192 panel via IP150 across multiple Docker container restarts.