### PR TITLE
[powermax] Improve scheduled job handling

### DIFF
--- a/bundles/org.openhab.binding.powermax/src/main/java/org/openhab/binding/powermax/internal/handler/PowermaxBridgeHandler.java
+++ b/bundles/org.openhab.binding.powermax/src/main/java/org/openhab/binding/powermax/internal/handler/PowermaxBridgeHandler.java
@@ -142,26 +142,33 @@ public class PowermaxBridgeHandler extends BaseBridgeHandler implements Powermax
             errorMsg = initializeBridgeIp(getConfigAs(PowermaxIpConfiguration.class), threadName);
         }
 
+        // Normally globalJob should always be null when initialize() is called
+        // because job is cancelled and globalJob is set to null in dispose().
+        // By security, cancel the job in case it is not null.
+        ScheduledFuture<?> job = globalJob;
+        if (job != null) {
+            logger.warn("initialize(): encountering not null globalJob");
+            job.cancel(true);
+            globalJob = null;
+        }
+
         if (errorMsg == null) {
-            ScheduledFuture<?> job = globalJob;
-            if (job == null || job.isCancelled()) {
-                // Delay the startup in case the handler is restarted immediately
-                globalJob = scheduler.scheduleWithFixedDelay(() -> {
-                    try {
-                        logger.trace("Powermax job...");
-                        updateMotionSensorState();
-                        updateRingingState();
-                        if (isConnected()) {
-                            checkKeepAlive();
-                            retryDownloadSetup();
-                        } else {
-                            tryReconnect();
-                        }
-                    } catch (Exception e) {
-                        logger.warn("Exception in scheduled job: {}", e.getMessage(), e);
+            // Delay the startup in case the handler is restarted immediately
+            globalJob = scheduler.scheduleWithFixedDelay(() -> {
+                try {
+                    logger.trace("Powermax job...");
+                    updateMotionSensorState();
+                    updateRingingState();
+                    if (isConnected()) {
+                        checkKeepAlive();
+                        retryDownloadSetup();
+                    } else {
+                        tryReconnect();
                     }
-                }, 10, JOB_REPEAT, TimeUnit.SECONDS);
-            }
+                } catch (Exception e) {
+                    logger.warn("Exception in scheduled job: {}", e.getMessage(), e);
+                }
+            }, 10, JOB_REPEAT, TimeUnit.SECONDS);
         } else {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, errorMsg);
         }
@@ -225,7 +232,7 @@ public class PowermaxBridgeHandler extends BaseBridgeHandler implements Powermax
     public void dispose() {
         logger.debug("Handler disposed for thing {}", getThing().getUID());
         ScheduledFuture<?> job = globalJob;
-        if (job != null && !job.isCancelled()) {
+        if (job != null) {
             job.cancel(true);
             globalJob = null;
         }

--- a/bundles/org.openhab.binding.powermax/src/main/java/org/openhab/binding/powermax/internal/handler/PowermaxBridgeHandler.java
+++ b/bundles/org.openhab.binding.powermax/src/main/java/org/openhab/binding/powermax/internal/handler/PowermaxBridgeHandler.java
@@ -147,7 +147,7 @@ public class PowermaxBridgeHandler extends BaseBridgeHandler implements Powermax
         // By security, cancel the job in case it is not null.
         ScheduledFuture<?> job = globalJob;
         if (job != null) {
-            logger.warn("initialize(): encountering not null globalJob");
+            logger.warn("initialize() for {}: encountering not null globalJob", getThing().getUID());
             job.cancel(true);
             globalJob = null;
         }


### PR DESCRIPTION
At first openHAB startup (when binding is first installed from the big kar file) and when I have already my things defined in a YAML file, I frequently get repeated logs telling me that the handler is already disposed when checking if a channel is linked. My things never went ONLINE. The problem is resolved by restarting openHAB.

Making an attempt to fix that bug with that PR.
