### PR TITLE
[shelly] Minor tweak to Shelly v1 handler californium adaption

### DIFF
--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api1/Shelly1CoapHandler.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api1/Shelly1CoapHandler.java
@@ -34,6 +34,7 @@ import org.eclipse.californium.core.coap.OptionNumberRegistry;
 import org.eclipse.californium.core.coap.Request;
 import org.eclipse.californium.core.coap.Response;
 import org.eclipse.californium.core.coap.option.IntegerOption;
+import org.eclipse.californium.core.coap.option.OpaqueOption;
 import org.eclipse.californium.core.coap.option.StringOption;
 import org.eclipse.californium.core.network.Endpoint;
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -290,7 +291,7 @@ public class Shelly1CoapHandler implements Shelly1CoapListener {
                     break;
                 default:
                     logger.debug("{} ({}): CoAP option {} with value {} skipped", thingName, devId, opt.getNumber(),
-                            opt.toValueString());
+                            opt instanceof OpaqueOption opOpt ? opOpt.getValue() : opt);
             }
         }
 


### PR DESCRIPTION
After #20727 and [this post](https://community.openhab.org/t/issue-with-californium-and-shelly-binding-using-oh-5-2-0-snapshot-5369/169281), there was some doubt as to the correctness of #20704. I now believe that this was wrong, #20704 seems to be mostly correct.

I did this very minor tweak to make the code closer in behavior to what it originally was, and made a build that has been successfully tested by two different users that have such Shelly devices.

I therefore submit this PR to make the code 100% in line with the version they have tested, but I'm confident that the binding works also without this tweak, but the log might be slightly worse.