### PR TITLE
[roborock] Add local protocol support and refresh controls

### DIFF
--- a/bundles/org.openhab.binding.roborock/README.md
+++ b/bundles/org.openhab.binding.roborock/README.md
@@ -33,7 +33,32 @@ Once received, update the twofa field and hit save.
 | Thing Parameter | Default Value | Required | Advanced | Description                                                                          |
 |-----------------|---------------|----------|----------|--------------------------------------------------------------------------------------|
 | duid            | N/A           | Yes      | No       | duid (Device UID) of the robot from the Roborock api                                 |
-| refresh         | 5             | No       | Yes      | The frequency with which to refresh information from Roborock specified in minutes   |
+| communication   | cloud         | No       | No       | Command transport mode: `cloud` (default) or `direct`                                |
+| localHost       | N/A           | No       | Yes      | Optional local IP/hostname override, used only in `direct` mode                      |
+| localPort       | 58867         | No       | Yes      | Local port used in `direct` mode communication                                        |
+| cloudMapRefresh | on            | No       | Yes      | Cloud-only map refresh policy in `direct` mode: `on` or `off`                        |
+| cloudMetadataRefresh | on       | No       | Yes      | Cloud-only metadata refresh policy in `direct` mode: `on` or `off`                    |
+| refresh         | 5             | No       | Yes      | Legacy compatibility refresh interval in minutes (existing Thing configs continue to use this) |
+| fastRefreshInterval | 15        | No       | Yes      | Direct-mode status refresh interval in seconds while `status#vacuum` is `ON`         |
+| mapRefreshCloudCleaningInterval | 30 | No | Yes | Map refresh interval in seconds while cleaning when `communication=cloud` (minimum 30) |
+| mapRefreshDirectCleaningInterval | 15 | No | Yes | Map refresh interval in seconds while cleaning when `communication=direct` (minimum 15) |
+| cloudRefreshInterval | refresh interval | No | Yes      | Cloud-only refresh interval in seconds for map/metadata tasks in `direct` mode (falls back to `refresh`, enforced minimum 60s) |
+
+### Communication Modes
+
+- `cloud` (default): uses Roborock cloud transport for command routing and data retrieval.
+- `direct`: uses local direct transport for supported vacuum communication. `localHost` can be set to override the detected local endpoint; `localPort` defaults to `58867`.
+
+Map retrieval/refresh remains cloud-only at this stage, regardless of selected communication mode.
+
+During cleaning, map refresh uses a mode-specific interval:
+
+- `communication=cloud`: `mapRefreshCloudCleaningInterval` (default 30s, minimum 30s)
+- `communication=direct`: `mapRefreshDirectCleaningInterval` (default 15s, minimum 15s)
+- If `communication=direct` and `cloudMapRefresh=off`, channel `cleaning#map` is explicitly set to `UNDEF` and map refresh is skipped.
+- If `communication=direct` and `cloudMetadataRefresh=off`, cloud metadata refresh tasks are skipped and metadata channels (for example routines and room mapping when present) are explicitly set to `UNDEF`.
+
+When `communication=direct` is selected and a capability is cloud-only (for example map retrieval/refresh), it is still routed through cloud transport. If cloud access is not available, those cloud-only capabilities will not refresh/update, while direct-mode supported operations continue to use local direct transport.
 
 ### Channels
 
@@ -102,7 +127,7 @@ In case your vacuum does not support one of these commands, it will show "unsupp
 
 ```java
 Bridge roborock:account:account [ email="xxxx", twofa="xxxx" ] {
-    roborock:vacuum:QrevoS [ refresh=5 ]
+    roborock:vacuum:QrevoS [ refresh=5, cloudRefreshInterval=300 ]
 }
 ```
 
@@ -149,5 +174,5 @@ Number:Area          lastArea         "Last Cleaned Area [%1.0fm²]"   <zoom>   
 Number:Time          lastTime         "Last Clean Time [%1.0f']"      <clock>        (gVacLast)      {channel="roborock:vacuum:034F0E45:cleaning#last-clean-duration"}
 Number               lastError        "Error [%s]"                    <error>        (gVacLast)      {channel="roborock:vacuum:034F0E45:cleaning#last-clean-error" }
 Switch               lastCompleted    "Last Cleaning Completed"                      (gVacLast)      {channel="roborock:vacuum:034F0E45:cleaning#last-clean-finish" }
-Image                cleaningMap      "Cleaning Map"                                                 {channel="roborock:vacuum:034F0E45:cleaning#map"}
+Image                cleaningMap      "Cleaning Map"                                 (gVacStat)      {channel="roborock:vacuum:034F0E45:cleaning#map"}
 ```

--- a/bundles/org.openhab.binding.roborock/src/main/java/org/openhab/binding/roborock/internal/CloudRefreshPolicy.java
+++ b/bundles/org.openhab.binding.roborock/src/main/java/org/openhab/binding/roborock/internal/CloudRefreshPolicy.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.roborock.internal;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * Helper methods for cloud-only refresh behavior in direct communication mode.
+ *
+ * @author reyhard - Initial contribution
+ */
+@NonNullByDefault
+public final class CloudRefreshPolicy {
+
+    private CloudRefreshPolicy() {
+    }
+
+    public static boolean isCloudMapRefreshAllowed(RoborockCommunicationMode communicationMode,
+            RoborockVacuumConfiguration config) {
+        return communicationMode != RoborockCommunicationMode.DIRECT || config.isCloudMapRefreshEnabled();
+    }
+
+    public static boolean isCloudMetadataRefreshAllowed(RoborockCommunicationMode communicationMode,
+            RoborockVacuumConfiguration config) {
+        return communicationMode != RoborockCommunicationMode.DIRECT || config.isCloudMetadataRefreshEnabled();
+    }
+
+    public static boolean isCloudOnlyRefreshDue(long now, long lastCloudOnlyPollTimestamp,
+            int cloudRefreshIntervalSeconds) {
+        long secondsSinceLastCloudPoll = (now - lastCloudOnlyPollTimestamp) / 1000;
+        return lastCloudOnlyPollTimestamp == 0 || secondsSinceLastCloudPoll >= cloudRefreshIntervalSeconds;
+    }
+}

--- a/bundles/org.openhab.binding.roborock/src/main/java/org/openhab/binding/roborock/internal/MapUpdateDeduplicator.java
+++ b/bundles/org.openhab.binding.roborock/src/main/java/org/openhab/binding/roborock/internal/MapUpdateDeduplicator.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.roborock.internal;
+
+import java.util.Arrays;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * Tracks the last published rendered map image and suppresses duplicate updates.
+ *
+ * @author reyhard - Initial contribution
+ */
+@NonNullByDefault
+final class MapUpdateDeduplicator {
+
+    private byte[] lastPublishedMapPng = new byte[0];
+
+    synchronized boolean shouldPublish(byte[] renderedMapPng) {
+        if (Arrays.equals(lastPublishedMapPng, renderedMapPng)) {
+            return false;
+        }
+        lastPublishedMapPng = Arrays.copyOf(renderedMapPng, renderedMapPng.length);
+        return true;
+    }
+
+    synchronized void reset() {
+        lastPublishedMapPng = new byte[0];
+    }
+}

--- a/bundles/org.openhab.binding.roborock/src/main/java/org/openhab/binding/roborock/internal/MqttInboundLivenessWatchdog.java
+++ b/bundles/org.openhab.binding.roborock/src/main/java/org/openhab/binding/roborock/internal/MqttInboundLivenessWatchdog.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.roborock.internal;
+
+import java.time.Duration;
+import java.time.Instant;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
+/**
+ * Tracks cloud MQTT inbound/outbound activity and determines whether the MQTT client should be recycled.
+ * This exists because the Roborock cloud session may appear connected while inbound MQTT delivery silently stalls;
+ * recycling the client is used as a recovery mitigation when outbound traffic is active but inbound stays silent.
+ *
+ * @author reyhard - Initial contribution
+ */
+@NonNullByDefault
+final class MqttInboundLivenessWatchdog {
+
+    enum Decision {
+        NOT_CONNECTED,
+        IDLE,
+        HEALTHY,
+        COOLDOWN,
+        STALE
+    }
+
+    private final Duration activeUsageWindow;
+    private final Duration inboundSilenceThreshold;
+    private final Duration recycleCooldown;
+
+    private volatile @Nullable Instant lastInboundMessageAt;
+    private volatile @Nullable Instant lastOutboundPublishAt;
+    private volatile @Nullable Instant lastRecycleAttemptAt;
+
+    MqttInboundLivenessWatchdog(Duration activeUsageWindow, Duration inboundSilenceThreshold,
+            Duration recycleCooldown) {
+        this.activeUsageWindow = activeUsageWindow;
+        this.inboundSilenceThreshold = inboundSilenceThreshold;
+        this.recycleCooldown = recycleCooldown;
+    }
+
+    void reset(Instant now) {
+        lastInboundMessageAt = now;
+        lastOutboundPublishAt = null;
+        lastRecycleAttemptAt = null;
+    }
+
+    void noteInboundMessage(Instant now) {
+        lastInboundMessageAt = now;
+    }
+
+    void noteOutboundPublish(Instant now) {
+        lastOutboundPublishAt = now;
+    }
+
+    void noteRecycleAttempt(Instant now) {
+        lastRecycleAttemptAt = now;
+    }
+
+    @Nullable
+    Instant getLastInboundMessageAt() {
+        return lastInboundMessageAt;
+    }
+
+    Decision evaluate(Instant now, boolean mqttConnected) {
+        if (!mqttConnected) {
+            return Decision.NOT_CONNECTED;
+        }
+
+        Instant outboundAt = lastOutboundPublishAt;
+        if (outboundAt == null || Duration.between(outboundAt, now).compareTo(activeUsageWindow) > 0) {
+            return Decision.IDLE;
+        }
+
+        Instant recycleAt = lastRecycleAttemptAt;
+        if (recycleAt != null && Duration.between(recycleAt, now).compareTo(recycleCooldown) <= 0) {
+            return Decision.COOLDOWN;
+        }
+
+        Instant inboundAt = lastInboundMessageAt;
+        if (inboundAt == null || Duration.between(inboundAt, now).compareTo(inboundSilenceThreshold) > 0) {
+            return Decision.STALE;
+        }
+
+        return Decision.HEALTHY;
+    }
+}

--- a/bundles/org.openhab.binding.roborock/src/main/java/org/openhab/binding/roborock/internal/RoborockAccountHandler.java
+++ b/bundles/org.openhab.binding.roborock/src/main/java/org/openhab/binding/roborock/internal/RoborockAccountHandler.java
@@ -76,13 +76,20 @@ import com.google.gson.JsonParser;
 @NonNullByDefault
 public class RoborockAccountHandler extends BaseBridgeHandler implements MqttCallbackExtended {
 
+    static final Duration MQTT_INBOUND_SILENCE_THRESHOLD = Duration.ofMinutes(3);
+    static final Duration MQTT_ACTIVITY_USAGE_WINDOW = Duration.ofMinutes(2);
+    static final Duration MQTT_WATCHDOG_RECYCLE_COOLDOWN = Duration.ofMinutes(1);
+    static final long MQTT_WATCHDOG_INTERVAL_SECONDS = 30;
+
     private final Logger logger = LoggerFactory.getLogger(RoborockAccountHandler.class);
 
     private final Storage<String> sessionStorage;
     private @Nullable RoborockAccountConfiguration config;
     private final SchedulerTask initTask;
     private final SchedulerTask mqttConnectTask;
+    private final SchedulerTask mqttWatchdogTask;
     private final RoborockWebTargets webTargets;
+    private final MqttInboundLivenessWatchdog mqttWatchdog;
     private @Nullable MqttClient mqttClient;
     private volatile boolean disposed = false;
     private String country = "";
@@ -100,11 +107,19 @@ public class RoborockAccountHandler extends BaseBridgeHandler implements MqttCal
     private final Gson gson = new Gson();
 
     public RoborockAccountHandler(Bridge bridge, Storage<String> stateStorage, HttpClient httpClient) {
+        this(bridge, stateStorage, httpClient, new MqttInboundLivenessWatchdog(MQTT_ACTIVITY_USAGE_WINDOW,
+                MQTT_INBOUND_SILENCE_THRESHOLD, MQTT_WATCHDOG_RECYCLE_COOLDOWN));
+    }
+
+    RoborockAccountHandler(Bridge bridge, Storage<String> stateStorage, HttpClient httpClient,
+            MqttInboundLivenessWatchdog mqttWatchdog) {
         super(bridge);
         webTargets = new RoborockWebTargets(httpClient);
         sessionStorage = stateStorage;
+        this.mqttWatchdog = mqttWatchdog;
         initTask = new SchedulerTask(scheduler, logger, "API Init", this::initAPI);
         mqttConnectTask = new SchedulerTask(scheduler, logger, "MQTT Connection", this::establishMQTTConnection);
+        mqttWatchdogTask = new SchedulerTask(scheduler, logger, "MQTT Watchdog", this::checkMqttInboundLiveness);
     }
 
     public String getToken() {
@@ -190,7 +205,9 @@ public class RoborockAccountHandler extends BaseBridgeHandler implements MqttCal
         updateStatus(ThingStatus.UNKNOWN);
         initTask.setNamePrefix(getThing().getUID().getId());
         mqttConnectTask.setNamePrefix(getThing().getUID().getId());
+        mqttWatchdogTask.setNamePrefix(getThing().getUID().getId());
         initTask.submit();
+        mqttWatchdogTask.scheduleRecurring(MQTT_WATCHDOG_INTERVAL_SECONDS);
     }
 
     @Override
@@ -277,7 +294,7 @@ public class RoborockAccountHandler extends BaseBridgeHandler implements MqttCal
             logger.debug("No available token or rriot values from sessionStorage, logging in");
             try {
                 if (localConfig.twofa.isBlank()) {
-                    if (country != null && !country.isBlank()) {
+                    if (!country.isBlank()) {
                         webTargets.requestCodeV4(baseUri, localConfig.email);
                     } else {
                         webTargets.requestCode(baseUri, localConfig.email);
@@ -286,7 +303,7 @@ public class RoborockAccountHandler extends BaseBridgeHandler implements MqttCal
                     return;
                 } else {
                     String response = "";
-                    if (country != null && !country.isBlank()) {
+                    if (!country.isBlank()) {
                         response = webTargets.doLoginV4(baseUri, country, countryCode, localConfig.email,
                                 localConfig.twofa);
                     } else {
@@ -332,6 +349,7 @@ public class RoborockAccountHandler extends BaseBridgeHandler implements MqttCal
         disposed = true;
         initTask.cancel();
         mqttConnectTask.cancel();
+        mqttWatchdogTask.cancel();
         disconnectMqttClient();
     }
 
@@ -380,9 +398,10 @@ public class RoborockAccountHandler extends BaseBridgeHandler implements MqttCal
             connOpts.setPassword(mqttPassword.toCharArray());
             connOpts.setAutomaticReconnect(true);
             connOpts.setConnectionTimeout(60);
-            connOpts.setKeepAliveInterval(0);
+            connOpts.setKeepAliveInterval(30);
 
             localMqttClient.connect(connOpts);
+            mqttWatchdog.reset(Instant.now());
         } catch (URISyntaxException e) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
                     "@text/offline.comm-error.mqtt-url-bad");
@@ -400,7 +419,11 @@ public class RoborockAccountHandler extends BaseBridgeHandler implements MqttCal
             logger.debug("Handler disposed, ignoring MQTT connectComplete");
             return;
         }
-        logger.debug("MQTT connection established. Reconnect: {}, Server URI: {}", reconnect, serverURI);
+        if (reconnect) {
+            logger.info("MQTT reconnection completed for server URI: {}", serverURI);
+        } else {
+            logger.debug("MQTT connection established. Server URI: {}", serverURI);
+        }
 
         // Subscribe to topics after a successful connection
         try {
@@ -423,7 +446,8 @@ public class RoborockAccountHandler extends BaseBridgeHandler implements MqttCal
             logger.debug("Handler disposed, ignoring MQTT connectionLost");
             return;
         }
-        // Additional logic can be placed here if specific actions are needed on disconnect
+        String causeMessage = cause != null ? cause.getMessage() : "unknown";
+        logger.warn("MQTT connection lost: {}. Attempting automatic reconnection...", causeMessage);
     }
 
     @Override
@@ -443,6 +467,7 @@ public class RoborockAccountHandler extends BaseBridgeHandler implements MqttCal
         }
 
         String destination = localTopic.substring(localTopic.lastIndexOf('/') + 1);
+        mqttWatchdog.noteInboundMessage(Instant.now());
         logger.debug("Received MQTT message for device {}", destination);
 
         // Check list of child handlers and send message to the right one
@@ -513,6 +538,7 @@ public class RoborockAccountHandler extends BaseBridgeHandler implements MqttCal
                 message.setQos(1);
                 message.setRetained(false);
                 localMqttClient.publish(topic, message);
+                mqttWatchdog.noteOutboundPublish(Instant.now());
                 return id;
             } catch (MqttException e) {
                 logger.error("MQTT publish failed", e);
@@ -570,6 +596,44 @@ public class RoborockAccountHandler extends BaseBridgeHandler implements MqttCal
         }
         logger.debug("Device connection failed, reconnecting", error);
         mqttConnectTask.schedule(60);
+    }
+
+    void checkMqttInboundLiveness() {
+        if (disposed) {
+            return;
+        }
+
+        MqttClient localMqttClient = mqttClient;
+        boolean connected = localMqttClient != null && localMqttClient.isConnected();
+        Instant now = Instant.now();
+        MqttInboundLivenessWatchdog.Decision decision = mqttWatchdog.evaluate(now, connected);
+
+        if (decision == MqttInboundLivenessWatchdog.Decision.STALE) {
+            @Nullable
+            Instant lastInbound = mqttWatchdog.getLastInboundMessageAt();
+            String lastInboundAge = lastInbound == null ? "never"
+                    : Duration.between(lastInbound, now).toSeconds() + "s";
+            logger.debug(
+                    "MQTT inbound watchdog detected possible silent cloud downlink stall (connection may appear alive but no inbound traffic; last inbound: {}). Recycling MQTT client as recovery.",
+                    lastInboundAge);
+            mqttWatchdog.noteRecycleAttempt(now);
+            recycleMqttClient();
+        } else if (decision != MqttInboundLivenessWatchdog.Decision.HEALTHY) {
+            logger.debug("MQTT inbound watchdog check skipped: {}", decision);
+        }
+    }
+
+    void recycleMqttClient() {
+        disconnectMqttClient();
+        try {
+            connectMqttClient();
+            logger.debug("MQTT client recycled after inbound liveness watchdog trigger");
+            updateStatus(ThingStatus.ONLINE);
+        } catch (MqttException e) {
+            logger.warn("MQTT recycle attempt failed", e);
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
+                    "@text/offline.comm-error.no-mqtt");
+        }
     }
 
     @Override

--- a/bundles/org.openhab.binding.roborock/src/main/java/org/openhab/binding/roborock/internal/RoborockBindingConstants.java
+++ b/bundles/org.openhab.binding.roborock/src/main/java/org/openhab/binding/roborock/internal/RoborockBindingConstants.java
@@ -195,6 +195,13 @@ public class RoborockBindingConstants {
     public static final String COMMAND_GET_MAP = "get_map_v1";
 
     public static final String THING_CONFIG_DUID = "duid";
+    public static final String THING_CONFIG_COMMUNICATION = "communication";
+    public static final String THING_CONFIG_LOCAL_HOST = "localHost";
+    public static final String THING_CONFIG_LOCAL_PORT = "localPort";
+    public static final String THING_CONFIG_CLOUD_MAP_REFRESH = "cloudMapRefresh";
+    public static final String THING_CONFIG_CLOUD_METADATA_REFRESH = "cloudMetadataRefresh";
+    public static final String THING_CONFIG_CLOUD_REFRESH_INTERVAL = "cloudRefreshInterval";
+    public static final String THING_CONFIG_FAST_REFRESH_INTERVAL = "fastRefreshInterval";
     public static final String THING_PROPERTY_SN = "sn";
 
     public static final Set<ThingTypeUID> BRIDGE_THING_TYPES_UIDS = Set.of(ROBOROCK_ACCOUNT);

--- a/bundles/org.openhab.binding.roborock/src/main/java/org/openhab/binding/roborock/internal/RoborockCommunicationMode.java
+++ b/bundles/org.openhab.binding.roborock/src/main/java/org/openhab/binding/roborock/internal/RoborockCommunicationMode.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.roborock.internal;
+
+import java.util.Locale;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * Supported vacuum communication modes.
+ *
+ * @author Paul Smedley - Initial contribution
+ * @author Maciej Pham - direct/cloud mode routing support
+ */
+@NonNullByDefault
+public enum RoborockCommunicationMode {
+    CLOUD,
+    DIRECT;
+
+    public static RoborockCommunicationMode fromConfigValue(String configuredValue) {
+        return "direct".equals(configuredValue.trim().toLowerCase(Locale.ROOT)) ? DIRECT : CLOUD;
+    }
+
+    public String toConfigValue() {
+        return name().toLowerCase(Locale.ROOT);
+    }
+}

--- a/bundles/org.openhab.binding.roborock/src/main/java/org/openhab/binding/roborock/internal/RoborockTransportRouting.java
+++ b/bundles/org.openhab.binding.roborock/src/main/java/org/openhab/binding/roborock/internal/RoborockTransportRouting.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.roborock.internal;
+
+import static org.openhab.binding.roborock.internal.RoborockBindingConstants.COMMAND_GET_MAP;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * Transport routing helpers for command handling.
+ *
+ * @author Maciej Pham - Initial contribution
+ */
+@NonNullByDefault
+public final class RoborockTransportRouting {
+
+    private RoborockTransportRouting() {
+    }
+
+    public static boolean isCloudOnlyMethod(String method) {
+        return COMMAND_GET_MAP.equals(method);
+    }
+
+    public static RoborockCommunicationMode selectTransportMode(RoborockCommunicationMode configuredMode,
+            String method) {
+        if (isCloudOnlyMethod(method)) {
+            return RoborockCommunicationMode.CLOUD;
+        }
+        return configuredMode;
+    }
+}

--- a/bundles/org.openhab.binding.roborock/src/main/java/org/openhab/binding/roborock/internal/RoborockVacuumConfiguration.java
+++ b/bundles/org.openhab.binding.roborock/src/main/java/org/openhab/binding/roborock/internal/RoborockVacuumConfiguration.java
@@ -13,6 +13,7 @@
 package org.openhab.binding.roborock.internal;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 
 /**
  * The {@link RoborockVacuumConfiguration} class contains fields mapping thing configuration parameters.
@@ -22,9 +23,73 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 @NonNullByDefault
 public class RoborockVacuumConfiguration {
 
+    public static final String REFRESH_ON = "on";
+    public static final String REFRESH_OFF = "off";
+    public static final int MAP_REFRESH_CLOUD_CLEANING_DEFAULT_SECONDS = 30;
+    public static final int MAP_REFRESH_DIRECT_CLEANING_DEFAULT_SECONDS = 15;
+    public static final int MAP_REFRESH_CLOUD_CLEANING_MIN_SECONDS = 30;
+    public static final int MAP_REFRESH_DIRECT_CLEANING_MIN_SECONDS = 15;
+    public static final int LEGACY_REFRESH_DEFAULT_MINUTES = 5;
+    public static final int CLOUD_REFRESH_MIN_SECONDS = 60;
+
     /**
      * Vacuum configuration parameters.
      */
     public String duid = "";
-    public int refresh = 5; // in minutes
+    public int refresh = LEGACY_REFRESH_DEFAULT_MINUTES; // legacy input in minutes
+    public int fastRefreshInterval = 15; // in seconds, used while vacuum channel is ON
+    public int cloudRefreshInterval = 0; // in seconds, fallback to legacy refresh when <= 0
+    public String communication = RoborockCommunicationMode.CLOUD.toConfigValue();
+    public String localHost = "";
+    public int localPort = 58867;
+    public String cloudMapRefresh = REFRESH_ON;
+    public String cloudMetadataRefresh = REFRESH_ON;
+    public int mapRefreshCloudCleaningInterval = MAP_REFRESH_CLOUD_CLEANING_DEFAULT_SECONDS;
+    public int mapRefreshDirectCleaningInterval = MAP_REFRESH_DIRECT_CLEANING_DEFAULT_SECONDS;
+
+    public int getRefreshIntervalSeconds() {
+        return VacuumRefreshPolicy.normalizeLegacyRefreshMinutesToSeconds(refresh, LEGACY_REFRESH_DEFAULT_MINUTES,
+                CLOUD_REFRESH_MIN_SECONDS);
+    }
+
+    public int getCloudRefreshIntervalSeconds() {
+        return VacuumRefreshPolicy.normalizeIntervalSeconds(cloudRefreshInterval, getRefreshIntervalSeconds(),
+                CLOUD_REFRESH_MIN_SECONDS);
+    }
+
+    public int getFastRefreshIntervalSeconds() {
+        return fastRefreshInterval > 0 ? fastRefreshInterval : 15;
+    }
+
+    public int getMapRefreshCloudCleaningIntervalSeconds() {
+        return VacuumRefreshPolicy.normalizeIntervalSeconds(mapRefreshCloudCleaningInterval,
+                MAP_REFRESH_CLOUD_CLEANING_DEFAULT_SECONDS, MAP_REFRESH_CLOUD_CLEANING_MIN_SECONDS);
+    }
+
+    public int getMapRefreshDirectCleaningIntervalSeconds() {
+        return VacuumRefreshPolicy.normalizeIntervalSeconds(mapRefreshDirectCleaningInterval,
+                MAP_REFRESH_DIRECT_CLEANING_DEFAULT_SECONDS, MAP_REFRESH_DIRECT_CLEANING_MIN_SECONDS);
+    }
+
+    public int getMapRefreshDuringCleaningIntervalSeconds(RoborockCommunicationMode mode) {
+        return mode == RoborockCommunicationMode.DIRECT ? getMapRefreshDirectCleaningIntervalSeconds()
+                : getMapRefreshCloudCleaningIntervalSeconds();
+    }
+
+    public RoborockCommunicationMode getCommunicationMode() {
+        return RoborockCommunicationMode.fromConfigValue(communication);
+    }
+
+    public @Nullable String getLocalHostOrNull() {
+        String value = localHost.trim();
+        return value.isEmpty() ? null : value;
+    }
+
+    public boolean isCloudMapRefreshEnabled() {
+        return !REFRESH_OFF.equalsIgnoreCase(cloudMapRefresh);
+    }
+
+    public boolean isCloudMetadataRefreshEnabled() {
+        return !REFRESH_OFF.equalsIgnoreCase(cloudMetadataRefresh);
+    }
 }

--- a/bundles/org.openhab.binding.roborock/src/main/java/org/openhab/binding/roborock/internal/RoborockVacuumHandler.java
+++ b/bundles/org.openhab.binding.roborock/src/main/java/org/openhab/binding/roborock/internal/RoborockVacuumHandler.java
@@ -14,24 +14,36 @@ package org.openhab.binding.roborock.internal;
 
 import static org.openhab.binding.roborock.internal.RoborockBindingConstants.*;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.math.BigInteger;
+import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
 import java.security.SecureRandom;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
+import java.util.concurrent.TimeoutException;
+import java.util.zip.GZIPOutputStream;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.roborock.internal.action.RoborockVacuumActions;
 import org.openhab.binding.roborock.internal.api.GetCleanRecord;
 import org.openhab.binding.roborock.internal.api.GetConsumables;
 import org.openhab.binding.roborock.internal.api.GetDndTimer;
@@ -49,6 +61,9 @@ import org.openhab.binding.roborock.internal.api.enums.VacuumErrorType;
 import org.openhab.binding.roborock.internal.map.RRMapData;
 import org.openhab.binding.roborock.internal.map.RRMapParser;
 import org.openhab.binding.roborock.internal.map.RRMapRenderer;
+import org.openhab.binding.roborock.internal.transport.CloudMqttTransport;
+import org.openhab.binding.roborock.internal.transport.LocalDirectTransport;
+import org.openhab.binding.roborock.internal.transport.RoborockCommandTransport;
 import org.openhab.binding.roborock.internal.util.ProtocolUtils;
 import org.openhab.binding.roborock.internal.util.RequestCorrelationTracker;
 import org.openhab.binding.roborock.internal.util.SchedulerTask;
@@ -68,6 +83,7 @@ import org.openhab.core.thing.ThingStatus;
 import org.openhab.core.thing.ThingStatusDetail;
 import org.openhab.core.thing.ThingStatusInfo;
 import org.openhab.core.thing.binding.BaseThingHandler;
+import org.openhab.core.thing.binding.ThingHandlerService;
 import org.openhab.core.thing.binding.builder.ChannelBuilder;
 import org.openhab.core.thing.binding.builder.ThingBuilder;
 import org.openhab.core.thing.type.ChannelType;
@@ -97,12 +113,16 @@ import com.google.gson.JsonSyntaxException;
 @NonNullByDefault
 public class RoborockVacuumHandler extends BaseThingHandler {
 
+    private static final int REQUEST_ID_SYNC_DIRECT_COMPLETED = -2;
+    private static final String MAP_DOWNLOAD_REQUEST_METHOD = "downloadRrMap";
+    private static final long MAP_DOWNLOAD_TIMEOUT_MS = 30_000L;
+
     private final Logger logger = LoggerFactory.getLogger(RoborockVacuumHandler.class);
 
-    @Nullable
-    RoborockAccountHandler bridgeHandler;
+    private @Nullable RoborockAccountHandler bridgeHandler;
     private final SchedulerTask initTask;
     private final SchedulerTask pollTask;
+    private final SchedulerTask statusPollTask;
     private final RoborockStateDescriptionOptionProvider stateDescriptionProvider;
     private String token = "";
     private Rooms[] homeRooms = new Rooms[0];
@@ -112,10 +132,19 @@ public class RoborockVacuumHandler extends BaseThingHandler {
     private String endpointPrefix = "";
     private final byte[] nonce = new byte[16];
     private boolean hasChannelStructure;
+    private RoborockCommunicationMode communicationMode = RoborockCommunicationMode.CLOUD;
+    private @Nullable RoborockCommandTransport cloudTransport;
+    private @Nullable RoborockCommandTransport directTransport;
     private ConcurrentHashMap<RobotCapabilities, Boolean> deviceCapabilities = new ConcurrentHashMap<>();
     private ChannelTypeRegistry channelTypeRegistry;
     private long lastSuccessfulPollTimestamp;
+    private long lastCloudOnlyPollTimestamp;
+    private long lastMapPollTimestamp;
     private boolean supportsRoutines = true;
+    private boolean cloudMapRefreshDisabledLogged;
+    private boolean cloudMetadataRefreshDisabledLogged;
+    private volatile boolean vacuumChannelOn;
+    private @Nullable Integer lastKnownStateId;
     private final Gson gson = new Gson();
     private final SecureRandom secureRandom = new SecureRandom();
     protected RoborockVacuumConfiguration config = new RoborockVacuumConfiguration();
@@ -125,14 +154,16 @@ public class RoborockVacuumHandler extends BaseThingHandler {
     private final RequestCorrelationTracker requestCorrelationTracker = new RequestCorrelationTracker();
     private final RRMapParser rrMapParser = new RRMapParser();
     private final RRMapRenderer rrMapRenderer = new RRMapRenderer();
+    private final MapUpdateDeduplicator mapUpdateDeduplicator = new MapUpdateDeduplicator();
+    private final Map<Integer, CompletableFuture<byte[]>> pendingRrMapDownloads = new ConcurrentHashMap<>();
 
     private static final Set<RobotCapabilities> FEATURES_CHANNELS = Collections.unmodifiableSet(
-            Stream.of(RobotCapabilities.SEGMENT_STATUS, RobotCapabilities.MAP_STATUS, RobotCapabilities.LED_STATUS,
+            EnumSet.of(RobotCapabilities.SEGMENT_STATUS, RobotCapabilities.MAP_STATUS, RobotCapabilities.LED_STATUS,
                     RobotCapabilities.CARPET_MODE, RobotCapabilities.FW_FEATURES, RobotCapabilities.ROOM_MAPPING,
                     RobotCapabilities.MULTI_MAP_LIST, RobotCapabilities.CUSTOMIZE_CLEAN_MODE,
                     RobotCapabilities.COLLECT_DUST, RobotCapabilities.CLEAN_MOP_START, RobotCapabilities.CLEAN_MOP_STOP,
                     RobotCapabilities.MOP_DRYING, RobotCapabilities.MOP_DRYING_REMAINING_TIME,
-                    RobotCapabilities.DOCK_STATE_ID, RobotCapabilities.CLEAN_PERCENT).collect(Collectors.toSet()));
+                    RobotCapabilities.DOCK_STATE_ID, RobotCapabilities.CLEAN_PERCENT));
 
     public RoborockVacuumHandler(Thing thing, ChannelTypeRegistry channelTypeRegistry,
             RoborockStateDescriptionOptionProvider stateDescriptionProvider) {
@@ -141,7 +172,8 @@ public class RoborockVacuumHandler extends BaseThingHandler {
         this.stateDescriptionProvider = stateDescriptionProvider;
         initTask = new SchedulerTask(scheduler, logger, "Init", this::initDevice);
         pollTask = new SchedulerTask(scheduler, logger, "Poll", this::pollData);
-        new java.security.SecureRandom().nextBytes(nonce);
+        statusPollTask = new SchedulerTask(scheduler, logger, "StatusPoll", this::pollStatusOnly);
+        secureRandom.nextBytes(nonce);
     }
 
     protected String getTokenFromBridge() {
@@ -164,6 +196,11 @@ public class RoborockVacuumHandler extends BaseThingHandler {
             return "";
         }
         return localBridge.setRoutine(routine);
+    }
+
+    @Override
+    public Collection<Class<? extends ThingHandlerService>> getServices() {
+        return Set.of(RoborockVacuumActions.class);
     }
 
     @Override
@@ -276,6 +313,14 @@ public class RoborockVacuumHandler extends BaseThingHandler {
     @Override
     public void initialize() {
         config = getConfigAs(RoborockVacuumConfiguration.class);
+        communicationMode = config.getCommunicationMode();
+        lastCloudOnlyPollTimestamp = 0;
+        lastMapPollTimestamp = 0;
+        vacuumChannelOn = false;
+        lastKnownStateId = null;
+        cloudMapRefreshDisabledLogged = false;
+        cloudMetadataRefreshDisabledLogged = false;
+        mapUpdateDeduplicator.reset();
 
         if (!(getBridge() instanceof Bridge bridge
                 && bridge.getHandler() instanceof RoborockAccountHandler accountHandler)) {
@@ -283,10 +328,17 @@ public class RoborockVacuumHandler extends BaseThingHandler {
             return;
         }
         bridgeHandler = accountHandler;
+        cloudTransport = new CloudMqttTransport(accountHandler, config.duid, nonce);
+        LocalDirectTransport localDirectTransport = new LocalDirectTransport();
+        localDirectTransport.setMessageConsumer(this::handleMessage);
+        directTransport = localDirectTransport;
+        refreshTransportContext();
         hasChannelStructure = false;
+        applyCloudOnlyCapabilityPolicies();
 
         initTask.setNamePrefix(getThing().getUID().getId());
         pollTask.setNamePrefix(getThing().getUID().getId());
+        statusPollTask.setNamePrefix(getThing().getUID().getId());
         updateStatus(ThingStatus.UNKNOWN);
         initTask.schedule(5);
     }
@@ -294,17 +346,24 @@ public class RoborockVacuumHandler extends BaseThingHandler {
     private synchronized void scheduleNextPoll(long initialDelaySeconds) {
         final long delayUntilNextPoll;
         if (initialDelaySeconds < 0) {
-            long intervalSeconds = config.refresh * 60;
+            long intervalSeconds = config.getRefreshIntervalSeconds();
             long secondsSinceLastPoll = (System.currentTimeMillis() - lastSuccessfulPollTimestamp) / 1000;
             long deltaRemaining = intervalSeconds - secondsSinceLastPoll;
             delayUntilNextPoll = Math.max(0, deltaRemaining);
         } else {
             delayUntilNextPoll = initialDelaySeconds;
         }
-        logger.debug("{}: Scheduling next poll in {}s, refresh interval {}min", config.duid, delayUntilNextPoll,
-                config.refresh);
+        logger.debug("{}: Scheduling next poll in {}s, refresh interval {}s", config.duid, delayUntilNextPoll,
+                config.getRefreshIntervalSeconds());
         pollTask.cancel();
         pollTask.schedule(delayUntilNextPoll);
+    }
+
+    private synchronized void scheduleNextStatusPoll(long delaySeconds) {
+        logger.debug("{}: Scheduling status-only poll in {}s, fast refresh interval {}s", config.duid, delaySeconds,
+                config.getFastRefreshIntervalSeconds());
+        statusPollTask.cancel();
+        statusPollTask.schedule(delaySeconds);
     }
 
     private void initDevice() {
@@ -336,7 +395,9 @@ public class RoborockVacuumHandler extends BaseThingHandler {
 
     private synchronized void teardown(boolean scheduleReconnection) {
         pollTask.cancel();
+        statusPollTask.cancel();
         initTask.cancel();
+        requestCorrelationTracker.cleanupExpired(0);
 
         if (scheduleReconnection) {
             initTask.schedule(30);
@@ -345,8 +406,12 @@ public class RoborockVacuumHandler extends BaseThingHandler {
 
     @Override
     public void dispose() {
-        super.dispose();
+        RoborockCommandTransport localDirectTransport = directTransport;
+        if (localDirectTransport != null) {
+            localDirectTransport.dispose();
+        }
         teardown(false);
+        super.dispose();
     }
 
     @Override
@@ -364,16 +429,8 @@ public class RoborockVacuumHandler extends BaseThingHandler {
             if (config.duid.equals(devices[i].duid)) {
                 if (localKey.isEmpty()) {
                     localKey = devices[i].localKey;
+                    refreshTransportContext();
                 }
-                updateState(CHANNEL_ERROR_ID, new DecimalType(devices[i].deviceStatus.errorCode));
-                updateState(CHANNEL_STATE_ID, new DecimalType(devices[i].deviceStatus.vacuumState));
-                updateState(CHANNEL_BATTERY, new DecimalType(devices[i].deviceStatus.battery));
-                updateState(CHANNEL_FAN_POWER, new DecimalType(devices[i].deviceStatus.fanPower));
-                updateState(CHANNEL_MOP_DRYING, new DecimalType(devices[i].deviceStatus.dryingStatus));
-                updateState(CHANNEL_CONSUMABLE_MAIN_PERC, new DecimalType(devices[i].deviceStatus.mainBrushWorkTime));
-                updateState(CHANNEL_CONSUMABLE_SIDE_PERC, new DecimalType(devices[i].deviceStatus.sideBrushWorkTime));
-                updateState(CHANNEL_CONSUMABLE_FILTER_PERC, new DecimalType(devices[i].deviceStatus.filterWorkTime));
-
                 if (devices[i].online) {
                     sendAllMqttCommands();
                 } else {
@@ -387,6 +444,8 @@ public class RoborockVacuumHandler extends BaseThingHandler {
     private void pollData() {
         RoborockAccountHandler localBridgeHandler = bridgeHandler;
         if (localBridgeHandler != null) {
+            applyCloudOnlyCapabilityPolicies();
+            boolean cloudOnlyRefreshDue = isCloudOnlyRefreshDue();
             HomeData homeData = localBridgeHandler.getHomeData();
             if (homeData != null && homeData.result != null) {
                 homeRooms = homeData.result.rooms;
@@ -396,17 +455,16 @@ public class RoborockVacuumHandler extends BaseThingHandler {
                 updateDevice(receivedDevices);
             }
 
-            if (supportsRoutines) {
+            if (supportsRoutines && isCloudMetadataRefreshAllowed() && cloudOnlyRefreshDue) {
                 String routinesResponse = localBridgeHandler.getRoutines(config.duid);
                 List<StateOption> options = new ArrayList<>();
-                if (routinesResponse != null && !routinesResponse.isEmpty()
-                        && JsonParser.parseString(routinesResponse).getAsJsonObject().get("result").isJsonArray()
-                        && JsonParser.parseString(routinesResponse).getAsJsonObject().get("result").getAsJsonArray()
-                                .size() > 0
-                        && JsonParser.parseString(routinesResponse).getAsJsonObject().get("result").getAsJsonArray()
-                                .get(0).isJsonObject()) {
-                    JsonArray routinesArray = JsonParser.parseString(routinesResponse).getAsJsonObject().get("result")
-                            .getAsJsonArray();
+                JsonObject parsedRoutines = routinesResponse != null && !routinesResponse.isEmpty()
+                        ? JsonParser.parseString(routinesResponse).getAsJsonObject()
+                        : null;
+                if (parsedRoutines != null && parsedRoutines.get("result").isJsonArray()
+                        && parsedRoutines.get("result").getAsJsonArray().size() > 0
+                        && parsedRoutines.get("result").getAsJsonArray().get(0).isJsonObject()) {
+                    JsonArray routinesArray = parsedRoutines.get("result").getAsJsonArray();
                     Map<String, Object> routines = new HashMap<>();
                     for (int i = 0; i < routinesArray.size(); ++i) {
                         JsonObject routinesJsonObject = routinesArray.get(i).getAsJsonObject();
@@ -422,6 +480,12 @@ public class RoborockVacuumHandler extends BaseThingHandler {
                     logger.debug("Routines not supported for device {}", config.duid);
                     supportsRoutines = false;
                 }
+            } else if (supportsRoutines && !isCloudMetadataRefreshAllowed()) {
+                disableRoutinesState("cloudMetadataRefresh=off in direct communication mode");
+            }
+
+            if (cloudOnlyRefreshDue) {
+                lastCloudOnlyPollTimestamp = System.currentTimeMillis();
             }
 
             lastSuccessfulPollTimestamp = System.currentTimeMillis();
@@ -434,14 +498,37 @@ public class RoborockVacuumHandler extends BaseThingHandler {
         }
     }
 
+    private void pollStatusOnly() {
+        @Nullable
+        Integer nextStatusPollDelaySeconds = VacuumRefreshPolicy.getStatusPollDelaySeconds(communicationMode,
+                vacuumChannelOn, config.getFastRefreshIntervalSeconds());
+        if (nextStatusPollDelaySeconds == null) {
+            statusPollTask.cancel();
+            return;
+        }
+        requestImmediateStatusUpdate("vacuum channel is ON");
+        try {
+            requestMapRefreshIfDue(false, "vacuum channel is ON");
+        } catch (UnsupportedEncodingException e) {
+            logger.warn("Failed to request map update during status-only poll: {}", e.getMessage());
+        }
+        scheduleNextStatusPoll(nextStatusPollDelaySeconds.intValue());
+    }
+
     private void sendAllMqttCommands() {
         try {
+            requestCorrelationTracker.cleanupExpired(MAP_REQUEST_CORRELATION_TIMEOUT_MS);
+            boolean cloudOnlyRefreshDue = isCloudOnlyRefreshDue();
             registerRequest("getStatus", sendRPCCommand(COMMAND_GET_STATUS));
             registerRequest("getConsumable", sendRPCCommand(COMMAND_GET_CONSUMABLE));
             registerRequest("getNetworkInfo", sendRPCCommand(COMMAND_GET_NETWORK_INFO));
             registerRequest("getCleanSummary", sendRPCCommand(COMMAND_GET_CLEAN_SUMMARY));
             registerRequest("getDndTimer", sendRPCCommand(COMMAND_GET_DND_TIMER));
-            registerRequest("getRoomMapping", sendRPCCommand(COMMAND_GET_ROOM_MAPPING));
+            if (isCloudMetadataRefreshAllowed() && cloudOnlyRefreshDue) {
+                registerRequest("getRoomMapping", sendRPCCommand(COMMAND_GET_ROOM_MAPPING));
+            } else if (!isCloudMetadataRefreshAllowed()) {
+                disableRoomMappingState("cloudMetadataRefresh=off in direct communication mode");
+            }
             registerRequest("getSegmentStatus", sendRPCCommand(COMMAND_GET_SEGMENT_STATUS));
             registerRequest("getMapStatus", sendRPCCommand(COMMAND_GET_MAP_STATUS));
             registerRequest("getLedStatus", sendRPCCommand(COMMAND_GET_LED_STATUS));
@@ -449,7 +536,7 @@ public class RoborockVacuumHandler extends BaseThingHandler {
             registerRequest("getFwFeatures", sendRPCCommand(COMMAND_GET_FW_FEATURES));
             registerRequest("getMultiMapsList", sendRPCCommand(COMMAND_GET_MULTI_MAP_LIST));
             registerRequest("getCustomizeCleanMode", sendRPCCommand(COMMAND_GET_CUSTOMIZE_CLEAN_MODE));
-            registerRequest("getMap", sendRPCCommand(COMMAND_GET_MAP));
+            requestMapRefreshIfDue(cloudOnlyRefreshDue, "periodic poll cycle");
         } catch (UnsupportedEncodingException e) {
             logger.warn("Failed to send MQTT commands due to unsupported encoding: {}", e.getMessage());
         }
@@ -458,8 +545,17 @@ public class RoborockVacuumHandler extends BaseThingHandler {
     public void handleMessage(byte[] payload) {
         requestCorrelationTracker.cleanupExpired(MAP_REQUEST_CORRELATION_TIMEOUT_MS);
         try {
+            int connectNonce = -1;
+            int ackNonce = -1;
+            @Nullable
+            RoborockCommandTransport currentDirectTransport = directTransport;
+            if (currentDirectTransport instanceof LocalDirectTransport localDirect) {
+                connectNonce = localDirect.getConnectNonce();
+                ackNonce = localDirect.getAckNonce();
+            }
+
             ProtocolUtils.DecodedMessage decodedMessage = ProtocolUtils.decodeMessage(payload, localKey, nonce,
-                    endpointPrefix);
+                    endpointPrefix, connectNonce, ackNonce);
             if (decodedMessage instanceof ProtocolUtils.IgnoredResponse) {
                 return;
             }
@@ -471,11 +567,14 @@ public class RoborockVacuumHandler extends BaseThingHandler {
 
             String response = ((ProtocolUtils.JsonPayloadResponse) decodedMessage).payload();
 
-            if (JsonParser.parseString(response).isJsonObject()
-                    && JsonParser.parseString(response).getAsJsonObject().get("dps").isJsonObject()
-                    && JsonParser.parseString(response).getAsJsonObject().get("dps").getAsJsonObject().has("102")) {
-                String jsonString = JsonParser.parseString(response).getAsJsonObject().get("dps").getAsJsonObject()
-                        .get("102").getAsString();
+            JsonElement parsedResponse = JsonParser.parseString(response);
+            if (!parsedResponse.isJsonObject()) {
+                return;
+            }
+            JsonObject responseJson = parsedResponse.getAsJsonObject();
+            JsonElement rpcPayload = extractRpcPayload(responseJson);
+            if (rpcPayload != null && rpcPayload.isJsonPrimitive()) {
+                String jsonString = rpcPayload.getAsString();
                 if (!jsonString.endsWith("\"result\":[\"ok\"]}") && !jsonString.endsWith("\"result\":[]}")
                         && JsonParser.parseString(jsonString).getAsJsonObject().has("id")
                         && JsonParser.parseString(jsonString).getAsJsonObject().has("result")) {
@@ -490,45 +589,59 @@ public class RoborockVacuumHandler extends BaseThingHandler {
 
                     switch (methodName) {
                         case "getStatus":
+                        case COMMAND_GET_STATUS:
                             handleGetStatus(jsonString);
                             break;
                         case "getConsumable":
+                        case COMMAND_GET_CONSUMABLE:
                             handleGetConsumables(jsonString);
                             break;
                         case "getRoomMapping":
+                        case COMMAND_GET_ROOM_MAPPING:
                             handleGetRoomMapping(jsonString);
                             break;
                         case "getNetworkInfo":
+                        case COMMAND_GET_NETWORK_INFO:
                             handleGetNetworkInfo(jsonString);
                             break;
                         case "getCleanRecord":
+                        case COMMAND_GET_CLEAN_RECORD:
                             handleGetCleanRecord(jsonString);
                             break;
                         case "getCleanSummary":
+                        case COMMAND_GET_CLEAN_SUMMARY:
                             handleGetCleanSummary(jsonString);
                             break;
                         case "getDndTimer":
+                        case COMMAND_GET_DND_TIMER:
                             handleGetDndTimer(jsonString);
                             break;
                         case "getSegmentStatus":
+                        case COMMAND_GET_SEGMENT_STATUS:
                             handleGetSegmentStatus(jsonString);
                             break;
                         case "getMapStatus":
+                        case COMMAND_GET_MAP_STATUS:
                             handleGetMapStatus(jsonString);
                             break;
                         case "getLedStatus":
+                        case COMMAND_GET_LED_STATUS:
                             handleGetLedStatus(jsonString);
                             break;
                         case "getCarpetMode":
+                        case COMMAND_GET_CARPET_MODE:
                             handleGetCarpetMode(jsonString);
                             break;
                         case "getFwFeatures":
+                        case COMMAND_GET_FW_FEATURES:
                             handleGetFwFeatures(jsonString);
                             break;
                         case "getMultiMapsList":
+                        case COMMAND_GET_MULTI_MAP_LIST:
                             handleGetMultiMapsList(jsonString);
                             break;
                         case "getCustomizeCleanMode":
+                        case COMMAND_GET_CUSTOMIZE_CLEAN_MODE:
                             handleGetCustomizeCleanMode(jsonString);
                             break;
                         default:
@@ -540,13 +653,12 @@ public class RoborockVacuumHandler extends BaseThingHandler {
             } else {
                 // handle live updates ie any one (or more of values of dps)
                 // "dps":{"121":8,"122":100,"123":104,"124":203,"125":75,"126":63,"127":50,"128":0,"133":1,"134":0}
-                if (JsonParser.parseString(response).isJsonObject()
-                        && JsonParser.parseString(response).getAsJsonObject().get("dps").isJsonObject()) {
-                    JsonObject dpsJsonObject = JsonParser.parseString(response).getAsJsonObject().get("dps")
-                            .getAsJsonObject();
+                JsonElement dpsElement = responseJson.get("dps");
+                if (dpsElement != null && dpsElement.isJsonObject()) {
+                    JsonObject dpsJsonObject = dpsElement.getAsJsonObject();
                     if (dpsJsonObject.has("121")) {
                         int stateInt = dpsJsonObject.get("121").getAsInt();
-                        updateState(CHANNEL_STATE_ID, new DecimalType(stateInt));
+                        updateStateIdAndRequestStatusIfChanged(stateInt, true);
                     } else if (dpsJsonObject.has("122")) {
                         int battery = dpsJsonObject.get("122").getAsInt();
                         updateState(CHANNEL_BATTERY, new DecimalType(battery));
@@ -583,9 +695,9 @@ public class RoborockVacuumHandler extends BaseThingHandler {
             updateState(CHANNEL_ERROR_ID, new DecimalType(getStatus.result[0].errorCode));
             updateState(CHANNEL_IN_CLEANING, OnOffType.from(1 == getStatus.result[0].inCleaning));
             updateState(CHANNEL_MAP_PRESENT, OnOffType.from(1 == getStatus.result[0].mapPresent));
-            updateState(CHANNEL_STATE_ID, new DecimalType(getStatus.result[0].state));
+            updateStateIdAndRequestStatusIfChanged(getStatus.result[0].state, false);
 
-            State vacuum = OnOffType.OFF;
+            OnOffType vacuum = OnOffType.OFF;
             StatusType state = StatusType.getType(getStatus.result[0].state);
             String control;
             switch (state) {
@@ -620,7 +732,7 @@ public class RoborockVacuumHandler extends BaseThingHandler {
             } else {
                 updateState(CHANNEL_CONTROL, new StringType(control));
             }
-            updateState(CHANNEL_VACUUM, vacuum);
+            updateVacuumChannelState(vacuum);
 
             if (this.deviceCapabilities.containsKey(RobotCapabilities.DOCK_STATE_ID)) {
                 updateState(CHANNEL_DOCK_STATE_ID, new DecimalType(getStatus.result[0].dockErrorStatus));
@@ -734,6 +846,7 @@ public class RoborockVacuumHandler extends BaseThingHandler {
             updateState(CHANNEL_RSSI, new DecimalType(getNetworkInfo.result.rssi));
             if (localIP.isEmpty()) {
                 localIP = getNetworkInfo.result.ip;
+                refreshTransportContext();
             }
         }
     }
@@ -850,7 +963,7 @@ public class RoborockVacuumHandler extends BaseThingHandler {
             updateState(CHANNEL_HISTORY_TOTALAREA,
                     new QuantityType<>(cleanSummary.get("clean_area").getAsDouble() / 1000000D, SIUnits.SQUARE_METRE));
             updateState(CHANNEL_HISTORY_COUNT, new DecimalType(cleanSummary.get("clean_count").getAsLong()));
-            if (cleanSummary.has("records") & cleanSummary.get("records").isJsonArray()) {
+            if (cleanSummary.has("records") && cleanSummary.get("records").isJsonArray()) {
                 JsonArray cleanSummaryRecords = cleanSummary.get("records").getAsJsonArray();
                 if (!cleanSummaryRecords.isEmpty()) {
                     String lastClean = cleanSummaryRecords.get(0).getAsString();
@@ -920,7 +1033,7 @@ public class RoborockVacuumHandler extends BaseThingHandler {
                 }
             } catch (ClassCastException | IllegalStateException e) {
                 logger.debug("Could not update numeric channel {} with '{}': {}",
-                        RobotCapabilities.MAP_STATUS.getChannel(), response, e.getMessage());
+                        RobotCapabilities.LED_STATUS.getChannel(), response, e.getMessage());
             }
         }
     }
@@ -931,8 +1044,8 @@ public class RoborockVacuumHandler extends BaseThingHandler {
             updateState(RobotCapabilities.CARPET_MODE.getChannel(),
                     new StringType(getCarpetMode.get(0).getAsJsonObject().toString()));
         } catch (ClassCastException | IllegalStateException e) {
-            logger.debug("Could not update numeric channel {} with '{}': {}", RobotCapabilities.MAP_STATUS.getChannel(),
-                    response, e.getMessage());
+            logger.debug("Could not update numeric channel {} with '{}': {}",
+                    RobotCapabilities.CARPET_MODE.getChannel(), response, e.getMessage());
         }
     }
 
@@ -960,7 +1073,12 @@ public class RoborockVacuumHandler extends BaseThingHandler {
 
     private void handleGetMap(int requestId, byte[] mapPayload) {
         String methodName = requestCorrelationTracker.findMethodByRequestId(requestId);
-        if (!"getMap".equals(methodName)) {
+        CompletableFuture<byte[]> pendingDownload = pendingRrMapDownloads.remove(Integer.valueOf(requestId));
+        if (pendingDownload != null) {
+            pendingDownload.complete(mapPayload);
+        }
+        if (!"getMap".equals(methodName) && !COMMAND_GET_MAP.equals(methodName)
+                && !MAP_DOWNLOAD_REQUEST_METHOD.equals(methodName) && pendingDownload == null) {
             logger.debug("Ignoring map response for request id {} with unknown method mapping", requestId);
             return;
         }
@@ -968,7 +1086,11 @@ public class RoborockVacuumHandler extends BaseThingHandler {
         try {
             RRMapData mapData = rrMapParser.parse(mapPayload);
             byte[] pngBytes = rrMapRenderer.renderAsPng(mapData);
-            updateState(CHANNEL_VACUUM_MAP, new RawType(pngBytes, "image/png"));
+            if (mapUpdateDeduplicator.shouldPublish(pngBytes)) {
+                updateState(CHANNEL_VACUUM_MAP, new RawType(pngBytes, "image/png"));
+            } else {
+                logger.trace("Suppressing duplicate map image update for request id {}", requestId);
+            }
         } catch (RoborockException e) {
             logger.debug("Failed to parse map payload for request id {}: {}", requestId, e.getMessage());
         } finally {
@@ -976,7 +1098,158 @@ public class RoborockVacuumHandler extends BaseThingHandler {
         }
     }
 
+    public @Nullable String downloadRrMap(@Nullable String requestedDirectory) {
+        int requestId = 0;
+        try {
+            requestCorrelationTracker.cleanupExpired(MAP_REQUEST_CORRELATION_TIMEOUT_MS);
+            RoborockCommunicationMode selectedMode = RoborockTransportRouting.selectTransportMode(communicationMode,
+                    COMMAND_GET_MAP);
+            RoborockCommandTransport selectedTransport = selectedMode == RoborockCommunicationMode.DIRECT
+                    ? directTransport
+                    : cloudTransport;
+            if (selectedTransport == null) {
+                logger.debug("Cannot download RR map because transport {} is not available.", selectedMode);
+                return null;
+            }
+
+            do {
+                requestId = secureRandom.nextInt(22767 + 1) + 10000;
+            } while (requestCorrelationTracker.isRequestIdInUse(requestId));
+
+            CompletableFuture<byte[]> rrMapFuture = new CompletableFuture<>();
+            pendingRrMapDownloads.put(Integer.valueOf(requestId), rrMapFuture);
+            registerRequest(MAP_DOWNLOAD_REQUEST_METHOD, requestId);
+            int sentRequestId = selectedTransport.sendCommand(COMMAND_GET_MAP, "[]", requestId);
+            if (sentRequestId <= 0) {
+                logger.debug("Cannot download RR map because request id {} could not be sent.", sentRequestId);
+                return null;
+            }
+
+            byte[] mapPayload = rrMapFuture.get(MAP_DOWNLOAD_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+            byte[] gzipPayload = gzip(mapPayload);
+            String fileName = "roborock-" + getThing().getUID().getId() + "-" + requestId + ".rrmap";
+            Path mapFile = storeRrMapFile(gzipPayload, fileName, requestedDirectory);
+            return mapFile.toAbsolutePath().toString();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            logger.debug("Interrupted while waiting for RR map download: {}", e.getMessage());
+        } catch (ExecutionException | TimeoutException e) {
+            logger.debug("Timed out while waiting for RR map payload: {}", e.getMessage());
+        } catch (UnsupportedEncodingException e) {
+            logger.debug("Failed to request RR map payload: {}", e.getMessage());
+        } catch (IOException e) {
+            logger.debug("Failed to store RR map payload: {}", e.getMessage());
+        } finally {
+            if (requestId > 0) {
+                pendingRrMapDownloads.remove(Integer.valueOf(requestId));
+                requestCorrelationTracker.removeByRequestId(requestId);
+            }
+        }
+        return null;
+    }
+
+    static Path getDefaultRrMapDownloadDirectory() {
+        String userHome = System.getProperty("user.home", ".");
+        return Paths.get(userHome);
+    }
+
+    static Path resolveRrMapDownloadDirectory(@Nullable String requestedDirectory, Path defaultDirectory) {
+        if (requestedDirectory == null || requestedDirectory.isBlank()) {
+            return defaultDirectory;
+        }
+        if (requestedDirectory.indexOf('\u0000') >= 0) {
+            return defaultDirectory;
+        }
+        try {
+            Path candidate = Paths.get(requestedDirectory.trim()).normalize();
+            if (Files.exists(candidate) && !Files.isDirectory(candidate)) {
+                return defaultDirectory;
+            }
+            return candidate;
+        } catch (InvalidPathException | SecurityException e) {
+            return defaultDirectory;
+        }
+    }
+
+    private Path storeRrMapFile(byte[] gzipPayload, String fileName, @Nullable String requestedDirectory)
+            throws IOException {
+        Path defaultDirectory = getDefaultRrMapDownloadDirectory();
+        Path targetDirectory = resolveRrMapDownloadDirectory(requestedDirectory, defaultDirectory);
+        if (requestedDirectory != null && !requestedDirectory.isBlank() && targetDirectory.equals(defaultDirectory)
+                && !isRequestedDefaultDirectory(requestedDirectory, defaultDirectory)) {
+            logger.warn("Invalid or unusable RR map download directory '{}'. Falling back to '{}'.", requestedDirectory,
+                    defaultDirectory.toAbsolutePath());
+        }
+
+        try {
+            return writeRrMapFile(gzipPayload, targetDirectory, fileName);
+        } catch (IOException e) {
+            if (requestedDirectory != null && !requestedDirectory.isBlank()
+                    && !targetDirectory.equals(defaultDirectory)) {
+                logger.warn("Failed to store RR map in '{}': {}. Falling back to '{}'.", targetDirectory,
+                        e.getMessage(), defaultDirectory.toAbsolutePath());
+                return writeRrMapFile(gzipPayload, defaultDirectory, fileName);
+            }
+            throw e;
+        }
+    }
+
+    private static boolean isRequestedDefaultDirectory(String requestedDirectory, Path defaultDirectory) {
+        try {
+            return Paths.get(requestedDirectory.trim()).equals(defaultDirectory);
+        } catch (InvalidPathException | SecurityException e) {
+            return false;
+        }
+    }
+
+    private static Path writeRrMapFile(byte[] gzipPayload, Path directory, String fileName) throws IOException {
+        Files.createDirectories(directory);
+        Path mapFile = directory.resolve(fileName);
+        Files.write(mapFile, gzipPayload, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING,
+                StandardOpenOption.WRITE);
+        return mapFile;
+    }
+
+    private static byte[] gzip(byte[] input) throws IOException {
+        try (ByteArrayOutputStream output = new ByteArrayOutputStream();
+                GZIPOutputStream gzipOutputStream = new GZIPOutputStream(output)) {
+            gzipOutputStream.write(input);
+            gzipOutputStream.finish();
+            return output.toByteArray();
+        }
+    }
+
     private void registerRequest(String methodName, int requestId) {
+        if (requestId == REQUEST_ID_SYNC_DIRECT_COMPLETED) {
+            if (logger.isTraceEnabled()) {
+                logger.trace(
+                        "Skipping request registration for method '{}' because direct response handling already completed synchronously.",
+                        methodName);
+            }
+            return;
+        }
+        if (requestId == -1) {
+            if (logger.isTraceEnabled()) {
+                logger.trace(
+                        "Skipping request registration for method '{}' because transport returned timeout sentinel request id -1.",
+                        methodName);
+            }
+            if ("getMap".equals(methodName)) {
+                setMapStateUndefinedAndResetDeduplicator();
+            }
+            return;
+        }
+        if (requestId <= 0) {
+            logger.debug("Skipping request registration for method '{}' due to invalid request id {}", methodName,
+                    requestId);
+            if ("getMap".equals(methodName)) {
+                setMapStateUndefinedAndResetDeduplicator();
+            }
+            return;
+        }
+        if (requestCorrelationTracker.isRequestIdInUse(requestId)) {
+            return;
+        }
         requestCorrelationTracker.register(methodName, requestId);
         if ("getMap".equals(methodName)) {
             logger.debug("Registered getMap request correlation id {}", requestId);
@@ -1036,11 +1309,11 @@ public class RoborockVacuumHandler extends BaseThingHandler {
     }
 
     private int sendRPCCommand(String method, String params) throws UnsupportedEncodingException {
-        RoborockAccountHandler localBridge = bridgeHandler;
-        if (localBridge == null) {
+        if (bridgeHandler == null) {
             return 0;
         }
         try {
+            requestCorrelationTracker.cleanupExpired(MAP_REQUEST_CORRELATION_TIMEOUT_MS);
             @Nullable
             String methodName = null;
             int id;
@@ -1048,10 +1321,215 @@ public class RoborockVacuumHandler extends BaseThingHandler {
                 id = secureRandom.nextInt(22767 + 1) + 10000;
                 methodName = requestCorrelationTracker.isRequestIdInUse(id) ? "inUse" : null;
             } while (methodName != null);
-            return localBridge.sendRPCCommand(method, params, config.duid, localKey, nonce, id);
+            RoborockCommunicationMode selectedMode = RoborockTransportRouting.selectTransportMode(communicationMode,
+                    method);
+            RoborockCommandTransport selectedTransport = selectedMode == RoborockCommunicationMode.DIRECT
+                    ? directTransport
+                    : cloudTransport;
+            if (selectedTransport == null) {
+                logger.debug("No available transport for mode {} and method {}", selectedMode, method);
+                return -1;
+            }
+            if (communicationMode == RoborockCommunicationMode.DIRECT && selectedMode == RoborockCommunicationMode.CLOUD
+                    && RoborockTransportRouting.isCloudOnlyMethod(method)) {
+                logger.debug(
+                        "Direct communication mode selected for {}, but method '{}' remains cloud-only and is routed via cloud transport.",
+                        config.duid, method);
+            }
+            // Pre-register for direct mode responses (sync handling) or cloud-routed map requests
+            // to avoid race condition where response arrives before correlation is registered
+            boolean preRegisterForDirect = selectedMode == RoborockCommunicationMode.DIRECT
+                    && shouldPreRegisterForDirectResponseHandling(method);
+            boolean preRegisterForCloudMap = selectedMode == RoborockCommunicationMode.CLOUD
+                    && COMMAND_GET_MAP.equals(method);
+            boolean preRegisterRequest = preRegisterForDirect || preRegisterForCloudMap;
+            if (preRegisterRequest) {
+                requestCorrelationTracker.register(method, id);
+                if (preRegisterForCloudMap) {
+                    logger.debug("Pre-registered cloud map correlation for request id {}", id);
+                }
+            }
+            int requestId = selectedTransport.sendCommand(method, params, id);
+            if (requestId <= 0 && preRegisterRequest) {
+                requestCorrelationTracker.removeByRequestId(id);
+                return requestId;
+            }
+            if (preRegisterRequest && !requestCorrelationTracker.isRequestIdInUse(id)) {
+                return REQUEST_ID_SYNC_DIRECT_COMPLETED;
+            }
+            return requestId;
         } catch (IllegalStateException e) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE, e.getMessage());
             return 0;
+        }
+    }
+
+    private @Nullable JsonElement extractRpcPayload(JsonObject responseJson) {
+        JsonElement dpsElement = responseJson.get("dps");
+        if (dpsElement == null || !dpsElement.isJsonObject()) {
+            return null;
+        }
+        JsonObject dpsJson = dpsElement.getAsJsonObject();
+        if (dpsJson.has("102")) {
+            return dpsJson.get("102");
+        }
+        if (dpsJson.has("101")) {
+            return dpsJson.get("101");
+        }
+        return null;
+    }
+
+    private boolean shouldPreRegisterForDirectResponseHandling(String method) {
+        return switch (method) {
+            case COMMAND_GET_STATUS, COMMAND_GET_CONSUMABLE, COMMAND_GET_NETWORK_INFO, COMMAND_GET_CLEAN_SUMMARY,
+                    COMMAND_GET_DND_TIMER, COMMAND_GET_ROOM_MAPPING, COMMAND_GET_SEGMENT_STATUS, COMMAND_GET_MAP_STATUS,
+                    COMMAND_GET_LED_STATUS, COMMAND_GET_CARPET_MODE, COMMAND_GET_FW_FEATURES,
+                    COMMAND_GET_MULTI_MAP_LIST, COMMAND_GET_CUSTOMIZE_CLEAN_MODE, COMMAND_GET_CLEAN_RECORD,
+                    COMMAND_GET_MAP ->
+                true;
+            default -> false;
+        };
+    }
+
+    private void updateStateIdAndRequestStatusIfChanged(int stateId, boolean triggerImmediateStatusQuery) {
+        @Nullable
+        Integer previousStateId = lastKnownStateId;
+        updateState(CHANNEL_STATE_ID, new DecimalType(stateId));
+        lastKnownStateId = stateId;
+        if (triggerImmediateStatusQuery && VacuumRefreshPolicy.shouldRequestImmediateStatus(previousStateId, stateId)) {
+            requestImmediateStatusUpdate("state-id changed from " + previousStateId + " to " + stateId);
+        }
+    }
+
+    private void requestImmediateStatusUpdate(String reason) {
+        try {
+            logger.debug("{}: Triggering immediate '{}' request because {}", config.duid, COMMAND_GET_STATUS, reason);
+            registerRequest("getStatus", sendRPCCommand(COMMAND_GET_STATUS));
+        } catch (UnsupportedEncodingException e) {
+            logger.debug("UnsupportedEncodingException while requesting immediate status, {}", e.getMessage());
+        }
+    }
+
+    private void updateVacuumChannelState(OnOffType vacuumState) {
+        boolean wasVacuumOn = vacuumChannelOn;
+        vacuumChannelOn = OnOffType.ON.equals(vacuumState);
+        updateState(CHANNEL_VACUUM, vacuumState);
+        if (vacuumChannelOn != wasVacuumOn) {
+            @Nullable
+            Integer nextStatusPollDelaySeconds = VacuumRefreshPolicy.getStatusPollDelaySeconds(communicationMode,
+                    vacuumChannelOn, config.getFastRefreshIntervalSeconds());
+            if (nextStatusPollDelaySeconds != null) {
+                scheduleNextStatusPoll(nextStatusPollDelaySeconds.intValue());
+            } else {
+                statusPollTask.cancel();
+            }
+        }
+    }
+
+    private boolean isCloudMapRefreshAllowed() {
+        return CloudRefreshPolicy.isCloudMapRefreshAllowed(communicationMode, config);
+    }
+
+    private boolean isCloudMetadataRefreshAllowed() {
+        return CloudRefreshPolicy.isCloudMetadataRefreshAllowed(communicationMode, config);
+    }
+
+    private boolean isCloudOnlyRefreshDue() {
+        return CloudRefreshPolicy.isCloudOnlyRefreshDue(System.currentTimeMillis(), lastCloudOnlyPollTimestamp,
+                config.getCloudRefreshIntervalSeconds());
+    }
+
+    private int getMapRefreshDuringCleaningIntervalSeconds() {
+        return config.getMapRefreshDuringCleaningIntervalSeconds(communicationMode);
+    }
+
+    private boolean isCleaningMapRefreshDue(long now) {
+        return VacuumRefreshPolicy.isRefreshDue(now, lastMapPollTimestamp,
+                getMapRefreshDuringCleaningIntervalSeconds());
+    }
+
+    private void requestMapRefreshIfDue(boolean cloudOnlyRefreshDue, String reason)
+            throws UnsupportedEncodingException {
+        if (!isCloudMapRefreshAllowed()) {
+            disableMapState("cloudMapRefresh=off in direct communication mode");
+            return;
+        }
+
+        long now = System.currentTimeMillis();
+        boolean mapRefreshDue = vacuumChannelOn ? isCleaningMapRefreshDue(now) : cloudOnlyRefreshDue;
+        if (!mapRefreshDue) {
+            return;
+        }
+
+        registerRequest("getMap", sendRPCCommand(COMMAND_GET_MAP));
+        lastMapPollTimestamp = now;
+        logger.debug("{}: Requested map refresh because {} (vacuumOn={}, interval={}s)", config.duid, reason,
+                vacuumChannelOn, getMapRefreshDuringCleaningIntervalSeconds());
+    }
+
+    private void applyCloudOnlyCapabilityPolicies() {
+        if (!isCloudMapRefreshAllowed()) {
+            disableMapState("cloudMapRefresh=off in direct communication mode");
+        }
+        if (!isCloudMetadataRefreshAllowed()) {
+            disableRoutinesState("cloudMetadataRefresh=off in direct communication mode");
+            disableRoomMappingState("cloudMetadataRefresh=off in direct communication mode");
+        }
+    }
+
+    private void disableMapState(String reason) {
+        if (thing.getChannel(CHANNEL_VACUUM_MAP) != null) {
+            setMapStateUndefinedAndResetDeduplicator();
+        }
+        if (!cloudMapRefreshDisabledLogged) {
+            logger.info("Cloud map refresh disabled for {}: {}. Channel '{}' is set to UNDEF.", config.duid, reason,
+                    CHANNEL_VACUUM_MAP);
+            cloudMapRefreshDisabledLogged = true;
+        }
+    }
+
+    private void disableRoutinesState(String reason) {
+        updateChannelStateIfExists(CHANNEL_ROUTINES, UnDefType.UNDEF);
+        if (!cloudMetadataRefreshDisabledLogged) {
+            logger.info(
+                    "Cloud metadata refresh disabled for {}: {}. Channels '{}' and '{}' are set to UNDEF when available.",
+                    config.duid, reason, CHANNEL_ROUTINES, RobotCapabilities.ROOM_MAPPING.getChannel());
+            cloudMetadataRefreshDisabledLogged = true;
+        }
+    }
+
+    private void disableRoomMappingState(String reason) {
+        updateChannelStateIfExists(RobotCapabilities.ROOM_MAPPING.getChannel(), UnDefType.UNDEF);
+        if (!cloudMetadataRefreshDisabledLogged) {
+            logger.info(
+                    "Cloud metadata refresh disabled for {}: {}. Channels '{}' and '{}' are set to UNDEF when available.",
+                    config.duid, reason, CHANNEL_ROUTINES, RobotCapabilities.ROOM_MAPPING.getChannel());
+            cloudMetadataRefreshDisabledLogged = true;
+        }
+    }
+
+    private void updateChannelStateIfExists(String channelId, State state) {
+        if (thing.getChannel(channelId) != null) {
+            updateState(channelId, state);
+        }
+    }
+
+    private void setMapStateUndefinedAndResetDeduplicator() {
+        updateState(CHANNEL_VACUUM_MAP, UnDefType.UNDEF);
+        mapUpdateDeduplicator.reset();
+    }
+
+    private void refreshTransportContext() {
+        @Nullable
+        String configuredLocalHost = config.getLocalHostOrNull();
+        String effectiveLocalHost = configuredLocalHost != null ? configuredLocalHost : localIP;
+        RoborockCommandTransport localCloudTransport = cloudTransport;
+        if (localCloudTransport != null) {
+            localCloudTransport.updateContext(localKey, effectiveLocalHost, config.localPort, endpointPrefix);
+        }
+        RoborockCommandTransport localDirectTransport = directTransport;
+        if (localDirectTransport != null) {
+            localDirectTransport.updateContext(localKey, effectiveLocalHost, config.localPort, endpointPrefix);
         }
     }
 }

--- a/bundles/org.openhab.binding.roborock/src/main/java/org/openhab/binding/roborock/internal/VacuumRefreshPolicy.java
+++ b/bundles/org.openhab.binding.roborock/src/main/java/org/openhab/binding/roborock/internal/VacuumRefreshPolicy.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.roborock.internal;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
+/**
+ * Helper methods for adaptive polling and status refresh triggers.
+ */
+@NonNullByDefault
+public final class VacuumRefreshPolicy {
+
+    private VacuumRefreshPolicy() {
+    }
+
+    public static boolean shouldRequestImmediateStatus(@Nullable Integer previousStateId, int newStateId) {
+        return previousStateId != null && previousStateId.intValue() != newStateId;
+    }
+
+    public static @Nullable Integer getStatusPollDelaySeconds(RoborockCommunicationMode communicationMode,
+            boolean vacuumOn, int fastRefreshIntervalSeconds) {
+        return communicationMode == RoborockCommunicationMode.DIRECT && vacuumOn ? fastRefreshIntervalSeconds : null;
+    }
+
+    public static int normalizeLegacyRefreshMinutesToSeconds(int configuredMinutes, int defaultMinutes,
+            int minimumSeconds) {
+        int effectiveMinutes = configuredMinutes > 0 ? configuredMinutes : defaultMinutes;
+        int effectiveSeconds = effectiveMinutes * 60;
+        return Math.max(effectiveSeconds, minimumSeconds);
+    }
+
+    public static int normalizeIntervalSeconds(int configuredSeconds, int defaultSeconds, int minimumSeconds) {
+        int effectiveInterval = configuredSeconds > 0 ? configuredSeconds : defaultSeconds;
+        return Math.max(effectiveInterval, minimumSeconds);
+    }
+
+    public static boolean isRefreshDue(long now, long lastPollTimestamp, int refreshIntervalSeconds) {
+        long secondsSinceLastPoll = (now - lastPollTimestamp) / 1000;
+        return lastPollTimestamp == 0 || secondsSinceLastPoll >= refreshIntervalSeconds;
+    }
+}

--- a/bundles/org.openhab.binding.roborock/src/main/java/org/openhab/binding/roborock/internal/action/RoborockVacuumActions.java
+++ b/bundles/org.openhab.binding.roborock/src/main/java/org/openhab/binding/roborock/internal/action/RoborockVacuumActions.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.roborock.internal.action;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.roborock.internal.RoborockVacuumHandler;
+import org.openhab.core.automation.annotation.ActionInput;
+import org.openhab.core.automation.annotation.ActionOutput;
+import org.openhab.core.automation.annotation.ActionOutputs;
+import org.openhab.core.automation.annotation.RuleAction;
+import org.openhab.core.thing.binding.ThingActions;
+import org.openhab.core.thing.binding.ThingActionsScope;
+import org.openhab.core.thing.binding.ThingHandler;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ServiceScope;
+
+/**
+ * Exposes Roborock vacuum actions to automation rules.
+ *
+ * @author reyhard - Initial contribution
+ */
+@Component(scope = ServiceScope.PROTOTYPE, service = RoborockVacuumActions.class)
+@ThingActionsScope(name = "roborock")
+@NonNullByDefault
+public class RoborockVacuumActions implements ThingActions {
+    private @Nullable RoborockVacuumHandler handler;
+
+    @Override
+    public void setThingHandler(@Nullable ThingHandler handler) {
+        if (handler instanceof RoborockVacuumHandler roborockVacuumHandler) {
+            this.handler = roborockVacuumHandler;
+        }
+    }
+
+    @Override
+    public @Nullable ThingHandler getThingHandler() {
+        return handler;
+    }
+
+    @RuleAction(label = "@text/action.download-rrmap.label", description = "@text/action.download-rrmap.description")
+    public @Nullable @ActionOutputs({
+            @ActionOutput(name = "result", label = "@text/action.download-rrmap.result", type = "java.lang.String") }) String downloadRrMap(
+                    @ActionInput(name = "directory", label = "@text/action.download-rrmap.directory.label", description = "@text/action.download-rrmap.directory.description", type = "java.lang.String") @Nullable String directory) {
+        RoborockVacuumHandler handler = this.handler;
+        return handler != null ? handler.downloadRrMap(directory) : null;
+    }
+
+    public static @Nullable String downloadRrMap(@Nullable ThingActions actions) {
+        return downloadRrMap(actions, null);
+    }
+
+    public static @Nullable String downloadRrMap(@Nullable ThingActions actions, @Nullable String directory) {
+        if (actions instanceof RoborockVacuumActions roborockActions) {
+            return roborockActions.downloadRrMap(directory);
+        }
+        return null;
+    }
+}

--- a/bundles/org.openhab.binding.roborock/src/main/java/org/openhab/binding/roborock/internal/map/RRMapParser.java
+++ b/bundles/org.openhab.binding.roborock/src/main/java/org/openhab/binding/roborock/internal/map/RRMapParser.java
@@ -305,16 +305,11 @@ public final class RRMapParser {
     }
 
     private int readUInt16LE(byte[] bytes, int pos) {
-        int value = bytes[pos] & 0xFF;
-        value |= (bytes[pos + 1] << 8) & 0xFFFF;
-        return value;
+        return (bytes[pos] & 0xFF) | ((bytes[pos + 1] & 0xFF) << 8);
     }
 
     private int readUInt32LE(byte[] bytes, int pos) {
-        int value = bytes[pos] & 0xFF;
-        value |= (bytes[pos + 1] << 8) & 0xFFFF;
-        value |= (bytes[pos + 2] << 16) & 0xFFFFFF;
-        value |= (bytes[pos + 3] << 24) & 0xFFFFFFFF;
-        return value;
+        return (bytes[pos] & 0xFF) | ((bytes[pos + 1] & 0xFF) << 8) | ((bytes[pos + 2] & 0xFF) << 16)
+                | ((bytes[pos + 3] & 0xFF) << 24);
     }
 }

--- a/bundles/org.openhab.binding.roborock/src/main/java/org/openhab/binding/roborock/internal/transport/CloudMqttTransport.java
+++ b/bundles/org.openhab.binding.roborock/src/main/java/org/openhab/binding/roborock/internal/transport/CloudMqttTransport.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.roborock.internal.transport;
+
+import java.io.UnsupportedEncodingException;
+import java.util.Arrays;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.roborock.internal.RoborockAccountHandler;
+
+/**
+ * Cloud-backed command transport using existing MQTT bridge behavior.
+ *
+ * @author Maciej Pham - Initial contribution
+ */
+@NonNullByDefault
+public class CloudMqttTransport implements RoborockCommandTransport {
+
+    private final RoborockAccountHandler accountHandler;
+    private final String duid;
+    private final byte[] nonce;
+    private String localKey = "";
+
+    public CloudMqttTransport(RoborockAccountHandler accountHandler, String duid, byte[] nonce) {
+        this.accountHandler = accountHandler;
+        this.duid = duid;
+        this.nonce = Arrays.copyOf(nonce, nonce.length);
+    }
+
+    @Override
+    public int sendCommand(String method, String params, int requestId) throws UnsupportedEncodingException {
+        return accountHandler.sendRPCCommand(method, params, duid, localKey, nonce, requestId);
+    }
+
+    @Override
+    public void updateContext(@Nullable String localKey, @Nullable String localHost, int localPort,
+            @Nullable String endpointPrefix) {
+        this.localKey = localKey == null ? "" : localKey;
+    }
+}

--- a/bundles/org.openhab.binding.roborock/src/main/java/org/openhab/binding/roborock/internal/transport/LocalDirectProtocolSession.java
+++ b/bundles/org.openhab.binding.roborock/src/main/java/org/openhab/binding/roborock/internal/transport/LocalDirectProtocolSession.java
@@ -1,0 +1,241 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.roborock.internal.transport;
+
+import static org.openhab.binding.roborock.internal.RoborockBindingConstants.*;
+
+import java.nio.charset.StandardCharsets;
+import java.security.SecureRandom;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.zip.CRC32;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.binding.roborock.internal.RoborockException;
+import org.openhab.binding.roborock.internal.util.ProtocolUtils;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
+
+/**
+ * Foundation implementation for direct-session message framing.
+ *
+ * This class builds local direct protocol frames and tracks minimal handshake state required
+ * for request/response command exchange.
+ *
+ * @author Maciej Pham - Initial contribution
+ */
+@NonNullByDefault
+final class LocalDirectProtocolSession {
+
+    private static final int PROTOCOL_HELLO_REQUEST = 0;
+    private static final int PROTOCOL_HELLO_RESPONSE = 1;
+    private static final int PROTOCOL_PING_REQUEST = 2;
+    private static final int PROTOCOL_PING_RESPONSE = 3;
+    private static final int PROTOCOL_GENERAL_REQUEST = 4;
+    private static final byte[] VERSION_V1 = new byte[] { '1', '.', '0' };
+    private static final byte[] VERSION_L01 = new byte[] { 'L', '0', '1' };
+
+    enum LocalProtocolVersion {
+        V1,
+        L01
+    }
+
+    private final Gson gson = new Gson();
+    private final SecureRandom secureRandom = new SecureRandom();
+    private final AtomicInteger sequenceCounter;
+    private final int connectNonce;
+    private int ackNonce = -1;
+    private boolean handshakeContextAvailable;
+    private LocalProtocolVersion negotiatedProtocol = LocalProtocolVersion.V1;
+
+    LocalDirectProtocolSession() {
+        this.sequenceCounter = new AtomicInteger(1);
+        this.connectNonce = secureRandom.nextInt(22767 + 1) + 10000;
+    }
+
+    int getConnectNonce() {
+        return connectNonce;
+    }
+
+    int getAckNonce() {
+        return ackNonce;
+    }
+
+    boolean hasHandshakeContext() {
+        return handshakeContextAvailable;
+    }
+
+    LocalProtocolVersion getNegotiatedProtocol() {
+        return negotiatedProtocol;
+    }
+
+    byte[] buildHelloRequestFrame() {
+        return buildHelloRequestFrame(false, true);
+    }
+
+    byte[] buildHelloRequestFrame(boolean l01Version) {
+        return buildHelloRequestFrame(l01Version, true);
+    }
+
+    byte[] buildHelloRequestFrame(boolean l01Version, boolean prefixed) {
+        int timestamp = (int) (System.currentTimeMillis() / 1000L);
+        int seq = 1;
+
+        byte[] message = new byte[17];
+        byte[] version = l01Version ? VERSION_L01 : VERSION_V1;
+        System.arraycopy(version, 0, message, 0, 3);
+        ProtocolUtils.writeInt32BE(message, seq, SEQ_OFFSET);
+        ProtocolUtils.writeInt32BE(message, connectNonce, RANDOM_OFFSET);
+        ProtocolUtils.writeInt32BE(message, timestamp, TIMESTAMP_OFFSET);
+        ProtocolUtils.writeInt16BE(message, PROTOCOL_HELLO_REQUEST, PROTOCOL_OFFSET);
+
+        CRC32 crc32 = new CRC32();
+        crc32.update(message, 0, message.length);
+
+        byte[] helloFrame = new byte[message.length + CRC_LENGTH];
+        System.arraycopy(message, 0, helloFrame, 0, message.length);
+        ProtocolUtils.writeInt32BE(helloFrame, (int) crc32.getValue(), message.length);
+
+        return prefixed ? withPrefix(helloFrame) : helloFrame;
+    }
+
+    boolean applyHelloResponse(byte[] responseFrame) {
+        if (responseFrame.length < 17) {
+            return false;
+        }
+        byte[] versionBytes = Arrays.copyOfRange(responseFrame, 0, 3);
+        LocalProtocolVersion detectedVersion;
+        if (Arrays.equals(VERSION_V1, versionBytes)) {
+            detectedVersion = LocalProtocolVersion.V1;
+        } else if (Arrays.equals(VERSION_L01, versionBytes)) {
+            detectedVersion = LocalProtocolVersion.L01;
+        } else {
+            return false;
+        }
+        int protocol = ProtocolUtils.readInt16BE(responseFrame, PROTOCOL_OFFSET);
+        if (protocol != PROTOCOL_HELLO_RESPONSE) {
+            return false;
+        }
+        ackNonce = ProtocolUtils.readInt32BE(responseFrame, RANDOM_OFFSET);
+        handshakeContextAvailable = true;
+        negotiatedProtocol = detectedVersion;
+        return true;
+    }
+
+    byte[] buildCommandFrame(String method, String params, int requestId, String localKey) throws RoborockException {
+        int timestamp = (int) (System.currentTimeMillis() / 1000L);
+        int protocol = PROTOCOL_GENERAL_REQUEST;
+
+        JsonElement paramsElement = JsonParser.parseString(params);
+        Map<String, Object> inner = new HashMap<>();
+        inner.put("id", requestId);
+        inner.put("method", method);
+        inner.put("params", paramsElement);
+
+        Map<String, Object> dps = new HashMap<>();
+        dps.put("101", gson.toJson(inner));
+
+        Map<String, Object> payloadMap = new HashMap<>();
+        payloadMap.put("t", timestamp);
+        payloadMap.put("dps", dps);
+
+        String payload = gson.toJson(payloadMap);
+        return withPrefix(buildFrame(localKey, protocol, timestamp, payload.getBytes(StandardCharsets.UTF_8),
+                negotiatedProtocol));
+    }
+
+    byte[] buildPingRequestFrame() {
+        int timestamp = (int) (System.currentTimeMillis() / 1000L);
+        int seq = nextSequence();
+        int randomInt = secureRandom.nextInt(90000) + 10000;
+
+        byte[] message = new byte[17];
+        byte[] version = negotiatedProtocol == LocalProtocolVersion.L01 ? VERSION_L01 : VERSION_V1;
+        System.arraycopy(version, 0, message, 0, 3);
+        ProtocolUtils.writeInt32BE(message, seq, SEQ_OFFSET);
+        ProtocolUtils.writeInt32BE(message, randomInt, RANDOM_OFFSET);
+        ProtocolUtils.writeInt32BE(message, timestamp, TIMESTAMP_OFFSET);
+        ProtocolUtils.writeInt16BE(message, PROTOCOL_PING_REQUEST, PROTOCOL_OFFSET);
+
+        CRC32 crc32 = new CRC32();
+        crc32.update(message, 0, message.length);
+
+        byte[] pingFrame = new byte[message.length + CRC_LENGTH];
+        System.arraycopy(message, 0, pingFrame, 0, message.length);
+        ProtocolUtils.writeInt32BE(pingFrame, (int) crc32.getValue(), message.length);
+        return withPrefix(pingFrame);
+    }
+
+    boolean isPingResponseFrame(byte[] responseFrame) {
+        if (responseFrame.length < 17) {
+            return false;
+        }
+        byte[] versionBytes = Arrays.copyOfRange(responseFrame, 0, 3);
+        if (!Arrays.equals(VERSION_V1, versionBytes) && !Arrays.equals(VERSION_L01, versionBytes)) {
+            return false;
+        }
+        int protocol = ProtocolUtils.readInt16BE(responseFrame, PROTOCOL_OFFSET);
+        return protocol == PROTOCOL_PING_RESPONSE;
+    }
+
+    private byte[] buildFrame(String localKey, int protocol, int timestamp, byte[] payload,
+            LocalProtocolVersion protocolVersion) throws RoborockException {
+        int randomInt = secureRandom.nextInt(90000) + 10000;
+        int seq = nextSequence();
+
+        byte[] encryptedPayload;
+        if (protocolVersion == LocalProtocolVersion.L01) {
+            encryptedPayload = ProtocolUtils.encryptL01(payload, localKey, timestamp, seq, randomInt, connectNonce,
+                    ackNonce);
+        } else {
+            String key = ProtocolUtils.encodeTimestamp(timestamp) + localKey + SALT;
+            encryptedPayload = ProtocolUtils.encrypt(payload, key);
+        }
+
+        int totalLength = HEADER_LENGTH_WITHOUT_CRC + encryptedPayload.length + CRC_LENGTH;
+        byte[] message = new byte[totalLength];
+
+        byte[] versionBytes = protocolVersion == LocalProtocolVersion.L01 ? VERSION_L01 : VERSION_V1;
+        message[0] = versionBytes[0];
+        message[1] = versionBytes[1];
+        message[2] = versionBytes[2];
+
+        ProtocolUtils.writeInt32BE(message, seq, SEQ_OFFSET);
+        ProtocolUtils.writeInt32BE(message, randomInt, RANDOM_OFFSET);
+        ProtocolUtils.writeInt32BE(message, timestamp, TIMESTAMP_OFFSET);
+        ProtocolUtils.writeInt16BE(message, protocol, PROTOCOL_OFFSET);
+        ProtocolUtils.writeInt16BE(message, encryptedPayload.length, PAYLOAD_OFFSET);
+
+        System.arraycopy(encryptedPayload, 0, message, HEADER_LENGTH_WITHOUT_CRC, encryptedPayload.length);
+
+        CRC32 crc32 = new CRC32();
+        crc32.update(message, 0, message.length - CRC_LENGTH);
+        ProtocolUtils.writeInt32BE(message, (int) crc32.getValue(), message.length - CRC_LENGTH);
+        return message;
+    }
+
+    private int nextSequence() {
+        return sequenceCounter.updateAndGet(current -> current >= Integer.MAX_VALUE ? 2 : current + 1);
+    }
+
+    private byte[] withPrefix(byte[] frameWithoutPrefix) {
+        byte[] prefixed = new byte[4 + frameWithoutPrefix.length];
+        ProtocolUtils.writeInt32BE(prefixed, frameWithoutPrefix.length, 0);
+        System.arraycopy(frameWithoutPrefix, 0, prefixed, 4, frameWithoutPrefix.length);
+        return prefixed;
+    }
+}

--- a/bundles/org.openhab.binding.roborock/src/main/java/org/openhab/binding/roborock/internal/transport/LocalDirectTransport.java
+++ b/bundles/org.openhab.binding.roborock/src/main/java/org/openhab/binding/roborock/internal/transport/LocalDirectTransport.java
@@ -321,7 +321,7 @@ public class LocalDirectTransport implements RoborockCommandTransport {
             if (cause != null) {
                 logger.debug("{} Cause: {}", reason, cause.getMessage());
             } else if (logger.isTraceEnabled()) {
-                logger.trace(reason);
+                logger.trace("{}", reason);
             }
 
             if (socket == null) {

--- a/bundles/org.openhab.binding.roborock/src/main/java/org/openhab/binding/roborock/internal/transport/LocalDirectTransport.java
+++ b/bundles/org.openhab.binding.roborock/src/main/java/org/openhab/binding/roborock/internal/transport/LocalDirectTransport.java
@@ -1,0 +1,860 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.roborock.internal.transport;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.UnsupportedEncodingException;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.net.SocketTimeoutException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Consumer;
+import java.util.function.LongSupplier;
+import java.util.function.Supplier;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.roborock.internal.RoborockException;
+import org.openhab.binding.roborock.internal.util.ProtocolUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.google.gson.JsonSyntaxException;
+
+/**
+ * Direct/local transport foundation for Roborock communication.
+ *
+ * This class performs local direct handshaking and command exchange over a short-lived socket.
+ *
+ * @author Maciej Pham - Initial contribution
+ */
+@NonNullByDefault
+public class LocalDirectTransport implements RoborockCommandTransport {
+
+    private static final int CRC_LENGTH = 4;
+    private static final int HELLO_FRAME_LENGTH_WITHOUT_CRC = 17;
+    private static final int HELLO_FRAME_LENGTH = HELLO_FRAME_LENGTH_WITHOUT_CRC + CRC_LENGTH;
+    private static final int COMMON_HEADER_LENGTH_WITHOUT_CRC = 19;
+    private static final int SOCKET_CONNECT_TIMEOUT_MS = 3000;
+    private static final int SOCKET_BASE_READ_TIMEOUT_MS = 600;
+    private static final int COMMAND_RESPONSE_TIMEOUT_MS = 600;
+    private static final int FRAME_READ_SLICE_TIMEOUT_MS = 200;
+    private static final int KEEPALIVE_INTERVAL_SECONDS = 15;
+    private static final int KEEPALIVE_RESPONSE_TIMEOUT_MS = 1500;
+    private static final int DIRECT_INTER_COMMAND_GAP_MS = 20;
+    private static final int READ_TIMEOUT_SENTINEL = -1;
+    private static final int READ_EOF_SENTINEL = -2;
+    private static final int MAX_PREFIXED_FRAME_LENGTH = 1024 * 1024;
+    private static final int MAX_NON_PREFIXED_PAYLOAD_LENGTH = 0xFFFF;
+    private static final byte[] EMPTY_NONCE = new byte[16];
+
+    private final Logger logger = LoggerFactory.getLogger(LocalDirectTransport.class);
+    private LocalDirectProtocolSession protocolSession = new LocalDirectProtocolSession();
+    private final Object commandLock = new Object();
+    private final ScheduledExecutorService keepaliveScheduler;
+    private final boolean ownsKeepaliveScheduler;
+    private final long interCommandGapMillis;
+    private final LongSupplier nanoTimeSupplier;
+    private final Sleeper sleeper;
+    private final Supplier<Socket> socketSupplier;
+    private @Nullable ScheduledFuture<?> keepaliveFuture;
+    private long lastDirectCommandFinishedNanos;
+
+    private String localKey = "";
+    private String localHost = "";
+    private int localPort = 58867;
+    private String endpointPrefix = "";
+    private @Nullable Consumer<byte[]> messageConsumer;
+    private @Nullable Socket sessionSocket;
+    private boolean preferredHelloL01;
+    private boolean preferredHelloPrefixed = true;
+    private final AtomicLong readSliceTimeoutCount = new AtomicLong();
+    private final AtomicLong readSliceEofCount = new AtomicLong();
+
+    @FunctionalInterface
+    interface Sleeper {
+        void sleep(long millis) throws InterruptedException;
+    }
+
+    public LocalDirectTransport() {
+        this(createKeepaliveScheduler(), true, DIRECT_INTER_COMMAND_GAP_MS, System::nanoTime, Thread::sleep,
+                Socket::new);
+    }
+
+    LocalDirectTransport(ScheduledExecutorService keepaliveScheduler, long interCommandGapMillis,
+            LongSupplier nanoTimeSupplier, Sleeper sleeper) {
+        this(keepaliveScheduler, false, interCommandGapMillis, nanoTimeSupplier, sleeper, Socket::new);
+    }
+
+    LocalDirectTransport(ScheduledExecutorService keepaliveScheduler, long interCommandGapMillis,
+            LongSupplier nanoTimeSupplier, Sleeper sleeper, Supplier<Socket> socketSupplier) {
+        this(keepaliveScheduler, false, interCommandGapMillis, nanoTimeSupplier, sleeper, socketSupplier);
+    }
+
+    private LocalDirectTransport(ScheduledExecutorService keepaliveScheduler, boolean ownsKeepaliveScheduler,
+            long interCommandGapMillis, LongSupplier nanoTimeSupplier, Sleeper sleeper,
+            Supplier<Socket> socketSupplier) {
+        this.keepaliveScheduler = keepaliveScheduler;
+        this.ownsKeepaliveScheduler = ownsKeepaliveScheduler;
+        this.interCommandGapMillis = Math.max(0, interCommandGapMillis);
+        this.nanoTimeSupplier = nanoTimeSupplier;
+        this.sleeper = sleeper;
+        this.socketSupplier = socketSupplier;
+    }
+
+    private @Nullable Socket getSocketFromSupplier() {
+        return socketSupplier.get();
+    }
+
+    @Override
+    public int sendCommand(String method, String params, int requestId) throws UnsupportedEncodingException {
+        long waitStartedNanos = System.nanoTime();
+        synchronized (commandLock) {
+            long queueWaitMillis = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - waitStartedNanos);
+            if (queueWaitMillis > 0 && logger.isTraceEnabled()) {
+                logger.trace("Queued direct command '{}' for {} ms while another command was in-flight (requestId={}).",
+                        method, queueWaitMillis, requestId);
+            }
+            return sendCommandSerialized(method, params, requestId);
+        }
+    }
+
+    private int sendCommandSerialized(String method, String params, int requestId) {
+        if (localHost.isBlank()) {
+            logger.debug("Direct mode requested, but local host is not available. Skipping method {}", method);
+            return -1;
+        }
+        if (localKey.isBlank()) {
+            logger.debug("Direct mode requested, but local key is not available. Skipping method {}", method);
+            return -1;
+        }
+
+        enforceInterCommandGap(method, requestId);
+
+        try {
+            return sendCommandWithReconnect(method, params, requestId);
+        } catch (RoborockException | IOException e) {
+            logger.debug("Direct command send failed for method '{}' (requestId={}): {}", method, requestId,
+                    e.getMessage());
+            return -1;
+        } finally {
+            lastDirectCommandFinishedNanos = nanoTimeSupplier.getAsLong();
+        }
+    }
+
+    @Override
+    public void updateContext(@Nullable String localKey, @Nullable String localHost, int localPort,
+            @Nullable String endpointPrefix) {
+        boolean contextChanged;
+        synchronized (commandLock) {
+            String updatedLocalKey = localKey == null ? "" : localKey;
+            String updatedLocalHost = localHost == null ? "" : localHost;
+            String updatedEndpointPrefix = endpointPrefix == null ? "" : endpointPrefix;
+
+            contextChanged = !this.localKey.equals(updatedLocalKey) || !this.localHost.equals(updatedLocalHost)
+                    || this.localPort != localPort || !this.endpointPrefix.equals(updatedEndpointPrefix);
+
+            this.localKey = updatedLocalKey;
+            this.localHost = updatedLocalHost;
+            this.localPort = localPort;
+            this.endpointPrefix = updatedEndpointPrefix;
+        }
+        if (contextChanged) {
+            invalidateSession("Direct transport context changed. Reconnect required.");
+        }
+    }
+
+    @Override
+    public void setMessageConsumer(@Nullable Consumer<byte[]> messageConsumer) {
+        this.messageConsumer = messageConsumer;
+    }
+
+    @Override
+    public void dispose() {
+        invalidateSession("Disposing direct transport session.");
+        if (ownsKeepaliveScheduler) {
+            keepaliveScheduler.shutdownNow();
+        }
+    }
+
+    public int getConnectNonce() {
+        return protocolSession.getConnectNonce();
+    }
+
+    public int getAckNonce() {
+        return protocolSession.getAckNonce();
+    }
+
+    private int sendCommandWithReconnect(String method, String params, int requestId)
+            throws RoborockException, IOException {
+        try {
+            return sendCommandOnSession(method, params, requestId, false);
+        } catch (IOException firstFailure) {
+            invalidateSession("Direct session failure detected. Reconnecting and retrying command.", firstFailure);
+            return sendCommandOnSession(method, params, requestId, true);
+        }
+    }
+
+    private int sendCommandOnSession(String method, String params, int requestId, boolean reconnectAttempt)
+            throws RoborockException, IOException {
+        Socket socket = ensureConnectedSession(method, requestId, reconnectAttempt);
+        OutputStream outputStream = socket.getOutputStream();
+
+        byte[] frame = protocolSession.buildCommandFrame(method, params, requestId, localKey);
+        outputStream.write(frame);
+        outputStream.flush();
+
+        byte[] response = readMatchingResponseFrame(socket, requestId, method, COMMAND_RESPONSE_TIMEOUT_MS);
+        if (response.length > 0) {
+            @Nullable
+            Consumer<byte[]> consumer = messageConsumer;
+            if (consumer != null) {
+                consumer.accept(response);
+            }
+            logger.debug(
+                    "Direct transport sent method '{}' and received matching response ({} bytes) from {}:{} (requestId={}).",
+                    method, response.length, localHost, localPort, requestId);
+        } else {
+            logger.debug(
+                    "Direct transport sent method '{}' to {}:{} (requestId={}) but received no matching response before timeout.",
+                    method, localHost, localPort, requestId);
+            // A full no-match timeout is treated as session failure immediately so we reconnect and retry once.
+            invalidateSession("No matching direct response frame received before timeout.");
+            if (logger.isTraceEnabled()) {
+                logger.trace("Direct no-match timeout counters: timeoutSlices={}, eofEvents={}",
+                        readSliceTimeoutCount.get(), readSliceEofCount.get());
+            }
+            throw new SocketTimeoutException("Direct command did not receive matching response before timeout.");
+        }
+        return requestId;
+    }
+
+    private Socket ensureConnectedSession(String method, int requestId, boolean reconnectAttempt) throws IOException {
+        @Nullable
+        Socket currentSocket = sessionSocket;
+        if (currentSocket != null && isSessionHealthy(currentSocket)) {
+            return currentSocket;
+        }
+        if (currentSocket != null && logger.isTraceEnabled()) {
+            logger.trace(
+                    "Direct session socket is not reusable (connected={}, closed={}, inputShutdown={}, outputShutdown={}). Opening replacement session.",
+                    currentSocket.isConnected(), currentSocket.isClosed(), currentSocket.isInputShutdown(),
+                    currentSocket.isOutputShutdown());
+        }
+
+        if (logger.isTraceEnabled()) {
+            logger.trace("Opening {} direct session for {}:{} before method '{}' (requestId={}).",
+                    reconnectAttempt ? "replacement" : "new", localHost, localPort, method, requestId);
+        }
+
+        @Nullable
+        Socket socket = getSocketFromSupplier();
+        if (socket == null) {
+            throw new IOException("Direct socket supplier returned null socket instance.");
+        }
+        try {
+            socket.connect(new InetSocketAddress(localHost, localPort), SOCKET_CONNECT_TIMEOUT_MS);
+            socket.setSoTimeout(SOCKET_BASE_READ_TIMEOUT_MS);
+
+            protocolSession = new LocalDirectProtocolSession();
+            OutputStream outputStream = socket.getOutputStream();
+            if (!performHelloHandshake(socket, outputStream, method, requestId)) {
+                throw new IOException("Direct local handshake failed while establishing reusable session.");
+            }
+
+            sessionSocket = socket;
+            scheduleKeepalive();
+            if (logger.isTraceEnabled()) {
+                logger.trace("Direct session established for {}:{} (requestId={}); keepalive active every {}s.",
+                        localHost, localPort, requestId, KEEPALIVE_INTERVAL_SECONDS);
+            }
+            return socket;
+        } catch (IOException e) {
+            try {
+                socket.close();
+            } catch (IOException closeException) {
+                logger.trace("Failed to close partially initialized direct socket cleanly: {}",
+                        closeException.getMessage());
+            }
+            throw e;
+        }
+    }
+
+    private boolean isSessionHealthy(@Nullable Socket socket) {
+        return socket != null && socket.isConnected() && !socket.isClosed() && !socket.isInputShutdown()
+                && !socket.isOutputShutdown();
+    }
+
+    private void invalidateSession(String reason) {
+        invalidateSession(reason, null);
+    }
+
+    private void invalidateSession(String reason, @Nullable Throwable cause) {
+        synchronized (commandLock) {
+            cancelKeepalive();
+
+            @Nullable
+            Socket socket = sessionSocket;
+            sessionSocket = null;
+
+            if (cause != null) {
+                logger.debug("{} Cause: {}", reason, cause.getMessage());
+            } else if (logger.isTraceEnabled()) {
+                logger.trace(reason);
+            }
+
+            if (socket == null) {
+                return;
+            }
+
+            try {
+                socket.close();
+            } catch (IOException closeException) {
+                logger.trace("Failed to close direct session socket cleanly: {}", closeException.getMessage());
+            }
+        }
+    }
+
+    private void enforceInterCommandGap(String method, int requestId) {
+        if (interCommandGapMillis <= 0) {
+            return;
+        }
+        long lastFinishedNanos = lastDirectCommandFinishedNanos;
+        if (lastFinishedNanos <= 0) {
+            return;
+        }
+        long elapsedMillis = TimeUnit.NANOSECONDS.toMillis(nanoTimeSupplier.getAsLong() - lastFinishedNanos);
+        long remainingMillis = interCommandGapMillis - elapsedMillis;
+        if (remainingMillis <= 0) {
+            return;
+        }
+        try {
+            sleeper.sleep(remainingMillis);
+            if (logger.isTraceEnabled()) {
+                logger.trace("Applied direct inter-command pacing gap of {} ms before method '{}' (requestId={}).",
+                        remainingMillis, method, requestId);
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            logger.trace("Interrupted while applying direct inter-command pacing gap before '{}' (requestId={}).",
+                    method, requestId);
+        }
+    }
+
+    private void scheduleKeepalive() {
+        @Nullable
+        ScheduledFuture<?> currentKeepaliveFuture = keepaliveFuture;
+        if (currentKeepaliveFuture != null && !currentKeepaliveFuture.isDone()) {
+            if (logger.isTraceEnabled()) {
+                logger.trace("Direct keepalive scheduler already active for {}:{}.", localHost, localPort);
+            }
+            return;
+        }
+        keepaliveFuture = keepaliveScheduler.scheduleWithFixedDelay(this::runKeepalive, KEEPALIVE_INTERVAL_SECONDS,
+                KEEPALIVE_INTERVAL_SECONDS, TimeUnit.SECONDS);
+        if (logger.isTraceEnabled()) {
+            logger.trace("Started direct keepalive scheduler for {}:{} with interval={}s.", localHost, localPort,
+                    KEEPALIVE_INTERVAL_SECONDS);
+        }
+    }
+
+    private void cancelKeepalive() {
+        @Nullable
+        ScheduledFuture<?> task = keepaliveFuture;
+        keepaliveFuture = null;
+        if (task != null) {
+            task.cancel(true);
+            if (logger.isTraceEnabled()) {
+                logger.trace("Cancelled direct keepalive scheduler for {}:{}.", localHost, localPort);
+            }
+        }
+    }
+
+    private void runKeepalive() {
+        synchronized (commandLock) {
+            @Nullable
+            Socket socket = sessionSocket;
+            if (socket == null || !isSessionHealthy(socket)) {
+                return;
+            }
+            try {
+                if (logger.isTraceEnabled()) {
+                    logger.trace("Running direct keepalive ping for {}:{}.", localHost, localPort);
+                }
+                OutputStream outputStream = socket.getOutputStream();
+                byte[] pingFrame = protocolSession.buildPingRequestFrame();
+                outputStream.write(pingFrame);
+                outputStream.flush();
+
+                if (!readPingResponseFrame(socket, KEEPALIVE_RESPONSE_TIMEOUT_MS)) {
+                    throw new IOException("Direct keepalive ping timed out waiting for ping response.");
+                }
+                if (logger.isTraceEnabled()) {
+                    logger.trace("Direct keepalive ping succeeded for {}:{}.", localHost, localPort);
+                }
+            } catch (IOException e) {
+                invalidateSession("Direct keepalive ping failed. Marking session invalid.", e);
+            }
+        }
+    }
+
+    private boolean readPingResponseFrame(Socket socket, int timeoutMs) throws IOException {
+        long deadlineNanos = nanoTimeSupplier.getAsLong() + TimeUnit.MILLISECONDS.toNanos(timeoutMs);
+        while (nanoTimeSupplier.getAsLong() < deadlineNanos) {
+            long remainingMillis = Math.max(1,
+                    TimeUnit.NANOSECONDS.toMillis(deadlineNanos - nanoTimeSupplier.getAsLong()));
+            socket.setSoTimeout((int) Math.min(remainingMillis, FRAME_READ_SLICE_TIMEOUT_MS));
+
+            byte[] candidate = normalizeFrame(readSingleFrame(socket));
+            if (candidate.length == 0) {
+                continue;
+            }
+            if (protocolSession.isPingResponseFrame(candidate)) {
+                return true;
+            }
+            if (!isControlOrAckFrame(candidate)) {
+                @Nullable
+                Consumer<byte[]> consumer = messageConsumer;
+                if (consumer != null) {
+                    try {
+                        consumer.accept(candidate);
+                    } catch (RuntimeException e) {
+                        logger.debug(
+                                "Failed to dispatch background direct frame while waiting for keepalive response: {}",
+                                e.getMessage());
+                    }
+                }
+            }
+        }
+        return false;
+    }
+
+    private static ScheduledExecutorService createKeepaliveScheduler() {
+        ThreadFactory threadFactory = runnable -> {
+            Thread thread = new Thread(runnable, "roborock-direct-keepalive");
+            thread.setDaemon(true);
+            return thread;
+        };
+        return Executors.newSingleThreadScheduledExecutor(threadFactory);
+    }
+
+    private byte[] readMatchingResponseFrame(Socket socket, int requestId, String method, int timeoutMs)
+            throws IOException {
+        long timeoutCountAtStart = readSliceTimeoutCount.get();
+        long eofCountAtStart = readSliceEofCount.get();
+        long deadlineNanos = nanoTimeSupplier.getAsLong() + TimeUnit.MILLISECONDS.toNanos(timeoutMs);
+        while (nanoTimeSupplier.getAsLong() < deadlineNanos) {
+            long remainingMillis = Math.max(1,
+                    TimeUnit.NANOSECONDS.toMillis(deadlineNanos - nanoTimeSupplier.getAsLong()));
+            socket.setSoTimeout((int) Math.min(remainingMillis, FRAME_READ_SLICE_TIMEOUT_MS));
+
+            byte[] candidate = normalizeFrame(readSingleFrame(socket));
+            if (candidate.length == 0) {
+                continue;
+            }
+
+            int candidateProtocol = readFrameProtocol(candidate);
+            int candidatePayloadLength = readFramePayloadLength(candidate);
+
+            if (isControlOrAckFrame(candidate)) {
+                if (logger.isTraceEnabled()) {
+                    logger.trace(
+                            "Ignoring direct non-payload frame ({} bytes, protocol={}, payloadLen={}) while waiting for method '{}' (requestId={}).",
+                            candidate.length, candidateProtocol, candidatePayloadLength, method, requestId);
+                }
+                continue;
+            }
+
+            @Nullable
+            Integer candidateRequestId = extractResponseRequestId(candidate);
+            if (candidateRequestId == null) {
+                if (logger.isTraceEnabled()) {
+                    logger.trace(
+                            "Ignoring direct payload frame without correlatable request id while waiting for method '{}' requestId {} (protocol={}, payloadLen={}, firstBytes={}).",
+                            method, requestId, candidateProtocol, candidatePayloadLength, toHexPreview(candidate, 18));
+                }
+                continue;
+            }
+
+            if (candidateRequestId.intValue() != requestId) {
+                dispatchOutOfOrderFrame(candidate, candidateRequestId.intValue(), requestId, method, candidateProtocol,
+                        candidatePayloadLength);
+                if (logger.isTraceEnabled()) {
+                    logger.trace(
+                            "Ignoring direct payload frame for different requestId {} while waiting for method '{}' requestId {} (protocol={}, payloadLen={}).",
+                            candidateRequestId, method, requestId, candidateProtocol, candidatePayloadLength);
+                }
+                continue;
+            }
+            return candidate;
+        }
+        if (logger.isTraceEnabled()) {
+            long timeoutDelta = readSliceTimeoutCount.get() - timeoutCountAtStart;
+            long eofDelta = readSliceEofCount.get() - eofCountAtStart;
+            logger.trace(
+                    "Direct response wait timed out for method '{}' (requestId={}) after {}ms with sliceTimeouts={} and eofEvents={}",
+                    method, requestId, timeoutMs, timeoutDelta, eofDelta);
+        }
+        return new byte[0];
+    }
+
+    private void dispatchOutOfOrderFrame(byte[] frame, int candidateRequestId, int awaitedRequestId,
+            String awaitedMethod, int candidateProtocol, int candidatePayloadLength) {
+        @Nullable
+        Consumer<byte[]> consumer = messageConsumer;
+        if (consumer == null) {
+            return;
+        }
+        try {
+            consumer.accept(frame);
+            if (logger.isTraceEnabled()) {
+                logger.trace(
+                        "Dispatched out-of-order direct payload for requestId {} while awaiting method '{}' requestId {} (protocol={}, payloadLen={}).",
+                        candidateRequestId, awaitedMethod, awaitedRequestId, candidateProtocol, candidatePayloadLength);
+            }
+        } catch (RuntimeException e) {
+            logger.debug(
+                    "Failed to dispatch out-of-order direct payload for requestId {} while awaiting method '{}' requestId {}: {}",
+                    candidateRequestId, awaitedMethod, awaitedRequestId, e.getMessage());
+        }
+    }
+
+    private boolean isControlOrAckFrame(byte[] frame) {
+        if (frame.length <= HELLO_FRAME_LENGTH_WITHOUT_CRC) {
+            return true;
+        }
+
+        if (frame.length > HELLO_FRAME_LENGTH_WITHOUT_CRC) {
+            int protocol = ProtocolUtils.readInt16BE(frame, 15);
+            if (protocol >= 0 && protocol <= 3) {
+                return true;
+            }
+        }
+
+        if (frame.length >= COMMON_HEADER_LENGTH_WITHOUT_CRC) {
+            int payloadLength = ProtocolUtils.readInt16BE(frame, 17);
+            return payloadLength <= 0;
+        }
+
+        return false;
+    }
+
+    private @Nullable Integer extractResponseRequestId(byte[] responseFrame) {
+        try {
+            ProtocolUtils.DecodedMessage decodedMessage = ProtocolUtils.decodeMessage(responseFrame, localKey,
+                    EMPTY_NONCE, endpointPrefix, protocolSession.getConnectNonce(), protocolSession.getAckNonce(),
+                    protocolSession.hasHandshakeContext());
+            if (decodedMessage instanceof ProtocolUtils.MapPayloadResponse mapPayloadResponse) {
+                if (logger.isTraceEnabled()) {
+                    logger.trace("Correlated direct map payload to requestId={} (protocol={}).",
+                            mapPayloadResponse.requestId(), readFrameProtocol(responseFrame));
+                }
+                return Integer.valueOf(mapPayloadResponse.requestId());
+            }
+
+            if (decodedMessage instanceof ProtocolUtils.JsonPayloadResponse jsonPayloadResponse) {
+                @Nullable
+                Integer requestId = extractRequestIdFromJsonPayload(jsonPayloadResponse.payload());
+                if (logger.isTraceEnabled()) {
+                    logger.trace("Decoded direct JSON payload correlation result requestId={} (protocol={}).",
+                            requestId, readFrameProtocol(responseFrame));
+                }
+                return requestId;
+            }
+
+            if (logger.isTraceEnabled()) {
+                logger.trace("Decoded direct frame did not produce correlatable payload (protocol={}).",
+                        readFrameProtocol(responseFrame));
+            }
+            return null;
+        } catch (RuntimeException e) {
+            if (logger.isTraceEnabled()) {
+                logger.trace("Failed to decode direct frame for request correlation (protocol={}): {}",
+                        readFrameProtocol(responseFrame), e.getMessage());
+            }
+            return null;
+        }
+    }
+
+    private @Nullable Integer extractRequestIdFromJsonPayload(String decodedPayload) {
+        try {
+            JsonElement parsedPayload = JsonParser.parseString(decodedPayload);
+            if (!parsedPayload.isJsonObject()) {
+                return null;
+            }
+
+            JsonObject decodedPayloadJson = parsedPayload.getAsJsonObject();
+            if (decodedPayloadJson.has("id") && decodedPayloadJson.get("id").isJsonPrimitive()) {
+                return Integer.valueOf(decodedPayloadJson.get("id").getAsInt());
+            }
+
+            @Nullable
+            JsonElement rpcPayload = extractRpcPayload(decodedPayloadJson);
+            if (rpcPayload == null) {
+                return null;
+            }
+
+            if (rpcPayload.isJsonPrimitive()) {
+                JsonElement rpcPayloadJson = JsonParser.parseString(rpcPayload.getAsString());
+                if (rpcPayloadJson.isJsonObject() && rpcPayloadJson.getAsJsonObject().has("id")) {
+                    return Integer.valueOf(rpcPayloadJson.getAsJsonObject().get("id").getAsInt());
+                }
+            } else if (rpcPayload.isJsonObject() && rpcPayload.getAsJsonObject().has("id")) {
+                return Integer.valueOf(rpcPayload.getAsJsonObject().get("id").getAsInt());
+            }
+
+            return null;
+        } catch (JsonSyntaxException | NumberFormatException | IllegalStateException e) {
+            return null;
+        }
+    }
+
+    private @Nullable JsonElement extractRpcPayload(JsonObject responseJson) {
+        JsonElement dpsElement = responseJson.get("dps");
+        if (dpsElement == null || !dpsElement.isJsonObject()) {
+            return null;
+        }
+        JsonObject dpsJson = dpsElement.getAsJsonObject();
+        if (dpsJson.has("102")) {
+            return dpsJson.get("102");
+        }
+        if (dpsJson.has("101")) {
+            return dpsJson.get("101");
+        }
+        return null;
+    }
+
+    private byte[] readSingleFrame(Socket socket) throws IOException {
+        InputStream inputStream = socket.getInputStream();
+        int first = readByte(inputStream);
+        if (first == READ_TIMEOUT_SENTINEL) {
+            return new byte[0];
+        }
+        if (first == READ_EOF_SENTINEL) {
+            if (logger.isTraceEnabled() && shouldLogReadCounter(readSliceEofCount.get())) {
+                logger.trace(
+                        "Direct frame read reached stream EOF while awaiting next frame byte (timeoutCount={}, eofCount={}).",
+                        readSliceTimeoutCount.get(), readSliceEofCount.get());
+            }
+            throw new IOException("Direct transport stream reached EOF while reading frame.");
+        }
+
+        if ((byte) first != '1' && (byte) first != 'L') {
+            byte[] prefix = new byte[4];
+            prefix[0] = (byte) first;
+            readFully(inputStream, prefix, 1, 3);
+            int frameLength = ProtocolUtils.readInt32BE(prefix, 0);
+            validatePrefixedFrameLength(frameLength);
+            byte[] frame = new byte[frameLength];
+            readFully(inputStream, frame, 0, frameLength);
+            byte[] combined = new byte[prefix.length + frame.length];
+            System.arraycopy(prefix, 0, combined, 0, prefix.length);
+            System.arraycopy(frame, 0, combined, prefix.length, frame.length);
+            return combined;
+        }
+
+        byte[] firstPart = new byte[HELLO_FRAME_LENGTH_WITHOUT_CRC];
+        firstPart[0] = (byte) first;
+        readFully(inputStream, firstPart, 1, HELLO_FRAME_LENGTH_WITHOUT_CRC - 1);
+        int protocol = ProtocolUtils.readInt16BE(firstPart, 15);
+        if (protocol <= 3) {
+            byte[] helloFrame = new byte[HELLO_FRAME_LENGTH];
+            System.arraycopy(firstPart, 0, helloFrame, 0, HELLO_FRAME_LENGTH_WITHOUT_CRC);
+            readFully(inputStream, helloFrame, HELLO_FRAME_LENGTH_WITHOUT_CRC, CRC_LENGTH);
+            return helloFrame;
+        }
+
+        byte[] headerAndPayload = new byte[COMMON_HEADER_LENGTH_WITHOUT_CRC];
+        System.arraycopy(firstPart, 0, headerAndPayload, 0, firstPart.length);
+        readFully(inputStream, headerAndPayload, HELLO_FRAME_LENGTH_WITHOUT_CRC,
+                COMMON_HEADER_LENGTH_WITHOUT_CRC - HELLO_FRAME_LENGTH_WITHOUT_CRC);
+        int payloadLength = ProtocolUtils.readInt16BE(headerAndPayload, 17);
+        validatePayloadLength(payloadLength);
+        byte[] remaining = new byte[payloadLength + CRC_LENGTH];
+        readFully(inputStream, remaining, 0, remaining.length);
+
+        ByteArrayOutputStream output = new ByteArrayOutputStream(headerAndPayload.length + remaining.length);
+        output.write(headerAndPayload);
+        output.write(remaining);
+        return output.toByteArray();
+    }
+
+    private void validatePrefixedFrameLength(int frameLength) throws IOException {
+        if (frameLength <= 0) {
+            logger.warn("Rejecting direct frame with invalid prefixed length {} (must be > 0).", frameLength);
+            throw new IOException("Invalid direct frame prefix length: " + frameLength);
+        }
+        if (frameLength > MAX_PREFIXED_FRAME_LENGTH) {
+            logger.warn("Rejecting direct frame with implausible prefixed length {} (max {}).", frameLength,
+                    MAX_PREFIXED_FRAME_LENGTH);
+            throw new IOException("Direct frame prefix length exceeds maximum: " + frameLength);
+        }
+    }
+
+    private void validatePayloadLength(int payloadLength) throws IOException {
+        if (payloadLength <= 0) {
+            logger.warn("Rejecting direct frame with invalid payload length {} (must be > 0).", payloadLength);
+            throw new IOException("Invalid direct frame payload length: " + payloadLength);
+        }
+        if (payloadLength > MAX_NON_PREFIXED_PAYLOAD_LENGTH) {
+            logger.warn("Rejecting direct frame with implausible payload length {} (max {}).", payloadLength,
+                    MAX_NON_PREFIXED_PAYLOAD_LENGTH);
+            throw new IOException("Direct frame payload length exceeds maximum: " + payloadLength);
+        }
+    }
+
+    private int readByte(InputStream inputStream) throws IOException {
+        try {
+            int value = inputStream.read();
+            if (value < 0) {
+                readSliceEofCount.incrementAndGet();
+                return READ_EOF_SENTINEL;
+            }
+            return value;
+        } catch (SocketTimeoutException e) {
+            readSliceTimeoutCount.incrementAndGet();
+            return READ_TIMEOUT_SENTINEL;
+        }
+    }
+
+    private boolean shouldLogReadCounter(long counter) {
+        return counter <= 3 || counter % 100 == 0;
+    }
+
+    private void readFully(InputStream inputStream, byte[] buffer, int offset, int length) throws IOException {
+        int total = 0;
+        while (total < length) {
+            int read = inputStream.read(buffer, offset + total, length - total);
+            if (read < 0) {
+                throw new IOException("Socket closed while reading direct transport frame.");
+            }
+            total += read;
+        }
+    }
+
+    private byte[] normalizeFrame(byte[] wireFrame) {
+        if (wireFrame.length >= 7 && wireFrame[4] == '1' && wireFrame[5] == '.' && wireFrame[6] == '0') {
+            int prefixedLength = ProtocolUtils.readInt32BE(wireFrame, 0);
+            if (prefixedLength > 0 && wireFrame.length >= 4 + prefixedLength) {
+                byte[] stripped = new byte[prefixedLength];
+                System.arraycopy(wireFrame, 4, stripped, 0, prefixedLength);
+                return stripped;
+            }
+        }
+        if (wireFrame.length >= 7 && wireFrame[4] == 'L' && wireFrame[5] == '0' && wireFrame[6] == '1') {
+            int prefixedLength = ProtocolUtils.readInt32BE(wireFrame, 0);
+            if (prefixedLength > 0 && wireFrame.length >= 4 + prefixedLength) {
+                byte[] stripped = new byte[prefixedLength];
+                System.arraycopy(wireFrame, 4, stripped, 0, prefixedLength);
+                return stripped;
+            }
+        }
+        return wireFrame;
+    }
+
+    private int readFrameProtocol(byte[] frame) {
+        if (frame.length >= HELLO_FRAME_LENGTH_WITHOUT_CRC) {
+            return ProtocolUtils.readInt16BE(frame, 15);
+        }
+        return -1;
+    }
+
+    private int readFramePayloadLength(byte[] frame) {
+        if (frame.length >= COMMON_HEADER_LENGTH_WITHOUT_CRC) {
+            return ProtocolUtils.readInt16BE(frame, 17);
+        }
+        return -1;
+    }
+
+    private boolean performHelloHandshake(Socket socket, OutputStream outputStream, String method, int requestId)
+            throws IOException {
+        if (logger.isTraceEnabled()) {
+            logger.trace("Starting direct HELLO negotiation for {}:{} before method '{}' (requestId={})", localHost,
+                    localPort, method, requestId);
+        }
+        boolean[] l01Modes = preferredHelloL01 ? new boolean[] { true, false } : new boolean[] { false, true };
+        boolean[] prefixedModes = preferredHelloPrefixed ? new boolean[] { true, false }
+                : new boolean[] { false, true };
+        for (boolean prefixedMode : prefixedModes) {
+            for (boolean l01Mode : l01Modes) {
+                byte[] helloRequest = protocolSession.buildHelloRequestFrame(l01Mode, prefixedMode);
+                if (logger.isTraceEnabled()) {
+                    logger.trace("Direct HELLO send using {} (prefixed={}) bytes={} firstBytes={}",
+                            l01Mode ? "L01" : "1.0", prefixedMode, helloRequest.length, toHexPreview(helloRequest, 24));
+                }
+                outputStream.write(helloRequest);
+                outputStream.flush();
+
+                byte[] helloResponse = normalizeFrame(readSingleFrame(socket));
+                if (logger.isTraceEnabled()) {
+                    logger.trace("Direct HELLO recv using {} (prefixed={}) bytes={} firstBytes={}",
+                            l01Mode ? "L01" : "1.0", prefixedMode, helloResponse.length,
+                            toHexPreview(helloResponse, 24));
+                }
+                if (protocolSession.applyHelloResponse(helloResponse)) {
+                    rememberHelloPreference(l01Mode, prefixedMode);
+                    logger.debug(
+                            "Direct local handshake succeeded for {}:{} using {} (prefixed={}) with connectNonce={} and ackNonce={} before method '{}' (requestId={}).",
+                            localHost, localPort, l01Mode ? "L01" : "1.0", prefixedMode,
+                            protocolSession.getConnectNonce(), protocolSession.getAckNonce(), method, requestId);
+                    return true;
+                }
+
+                logger.debug(
+                        "Direct local handshake attempt using {} (prefixed={}) produced no valid HELLO response for {}:{} before method '{}' (requestId={}). responseBytes={}",
+                        l01Mode ? "L01" : "1.0", prefixedMode, localHost, localPort, method, requestId,
+                        helloResponse.length);
+            }
+        }
+        return false;
+    }
+
+    private void rememberHelloPreference(boolean l01Mode, boolean prefixedMode) {
+        boolean changed = preferredHelloL01 != l01Mode || preferredHelloPrefixed != prefixedMode;
+        preferredHelloL01 = l01Mode;
+        preferredHelloPrefixed = prefixedMode;
+        if (changed && logger.isTraceEnabled()) {
+            logger.trace("Updated direct HELLO preference to {} (prefixed={}) for subsequent sessions.",
+                    l01Mode ? "L01" : "1.0", prefixedMode);
+        }
+    }
+
+    private String toHexPreview(byte[] bytes, int maxLen) {
+        int length = Math.min(bytes.length, maxLen);
+        if (length == 0) {
+            return "<empty>";
+        }
+        StringBuilder sb = new StringBuilder(length * 3 + 8);
+        for (int i = 0; i < length; i++) {
+            sb.append(String.format("%02x", bytes[i] & 0xFF));
+            if (i + 1 < length) {
+                sb.append(' ');
+            }
+        }
+        if (bytes.length > maxLen) {
+            sb.append(" ...");
+        }
+        return sb.toString();
+    }
+}

--- a/bundles/org.openhab.binding.roborock/src/main/java/org/openhab/binding/roborock/internal/transport/RoborockCommandTransport.java
+++ b/bundles/org.openhab.binding.roborock/src/main/java/org/openhab/binding/roborock/internal/transport/RoborockCommandTransport.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.roborock.internal.transport;
+
+import java.io.UnsupportedEncodingException;
+import java.util.function.Consumer;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
+/**
+ * Strategy interface for command transport selection.
+ *
+ * @author Maciej Pham - Initial contribution
+ */
+@NonNullByDefault
+public interface RoborockCommandTransport {
+
+    int sendCommand(String method, String params, int requestId) throws UnsupportedEncodingException;
+
+    default void updateContext(@Nullable String localKey, @Nullable String localHost, int localPort,
+            @Nullable String endpointPrefix) {
+    }
+
+    default void setMessageConsumer(@Nullable Consumer<byte[]> messageConsumer) {
+    }
+
+    default void dispose() {
+    }
+}

--- a/bundles/org.openhab.binding.roborock/src/main/java/org/openhab/binding/roborock/internal/util/ProtocolUtils.java
+++ b/bundles/org.openhab.binding.roborock/src/main/java/org/openhab/binding/roborock/internal/util/ProtocolUtils.java
@@ -33,6 +33,7 @@ import javax.crypto.BadPaddingException;
 import javax.crypto.Cipher;
 import javax.crypto.IllegalBlockSizeException;
 import javax.crypto.NoSuchPaddingException;
+import javax.crypto.spec.GCMParameterSpec;
 import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
 
@@ -48,6 +49,12 @@ import org.slf4j.LoggerFactory;
 @NonNullByDefault
 public final class ProtocolUtils {
     private static final Logger LOGGER = LoggerFactory.getLogger(ProtocolUtils.class);
+    private static final String SHA_256_ALGORITHM = "SHA-256";
+    private static final String AES_GCM_NO_PADDING = "AES/GCM/NoPadding";
+    private static final int GCM_TAG_LENGTH_BITS = 128;
+    private static final int PROTOCOL_GENERAL_REQUEST = 4;
+    private static final int PROTOCOL_GENERAL_RESPONSE = 5;
+    private static final String VERSION_L01 = "L01";
     private static final int MAX_GZIP_DECOMPRESSED_SIZE_BYTES = 10 * 1024 * 1024;
     private static final int GZIP_DECOMPRESSION_BUFFER_SIZE_BYTES = 8192;
 
@@ -101,6 +108,75 @@ public final class ProtocolUtils {
                 | BadPaddingException e) {
             throw new RoborockException("Failed to encrypt data using AES/ECB/PKCS5Padding.", e);
         }
+    }
+
+    public static byte[] encryptL01(byte[] payload, String localKey, int timestamp, int sequence, int nonce,
+            int connectNonce, int ackNonce) throws RoborockException {
+        try {
+            byte[] key = deriveL01Key(localKey, timestamp);
+            byte[] iv = deriveL01Iv(timestamp, nonce, sequence);
+            byte[] aad = deriveL01Aad(timestamp, nonce, sequence, connectNonce, ackNonce);
+
+            Cipher cipher = Cipher.getInstance(AES_GCM_NO_PADDING);
+            SecretKeySpec keySpec = new SecretKeySpec(key, "AES");
+            GCMParameterSpec gcmSpec = new GCMParameterSpec(GCM_TAG_LENGTH_BITS, iv);
+            cipher.init(Cipher.ENCRYPT_MODE, keySpec, gcmSpec);
+            cipher.updateAAD(aad);
+            return cipher.doFinal(payload);
+        } catch (GeneralSecurityException e) {
+            throw new RoborockException("Failed to encrypt data using AES/GCM/NoPadding (L01).", e);
+        }
+    }
+
+    public static byte[] decryptL01(byte[] payload, String localKey, int timestamp, int sequence, int nonce,
+            int connectNonce, int ackNonce) throws RoborockException {
+        try {
+            byte[] key = deriveL01Key(localKey, timestamp);
+            byte[] iv = deriveL01Iv(timestamp, nonce, sequence);
+            byte[] aad = deriveL01Aad(timestamp, nonce, sequence, connectNonce, ackNonce);
+
+            Cipher cipher = Cipher.getInstance(AES_GCM_NO_PADDING);
+            SecretKeySpec keySpec = new SecretKeySpec(key, "AES");
+            GCMParameterSpec gcmSpec = new GCMParameterSpec(GCM_TAG_LENGTH_BITS, iv);
+            cipher.init(Cipher.DECRYPT_MODE, keySpec, gcmSpec);
+            cipher.updateAAD(aad);
+            return cipher.doFinal(payload);
+        } catch (GeneralSecurityException e) {
+            throw new RoborockException("Failed to decrypt data using AES/GCM/NoPadding (L01).", e);
+        }
+    }
+
+    private static byte[] deriveL01Key(String localKey, int timestamp) throws RoborockException {
+        String encodedTimestamp = encodeTimestamp(timestamp);
+        byte[] hashInput = (encodedTimestamp + localKey + SALT).getBytes(StandardCharsets.UTF_8);
+        try {
+            return MessageDigest.getInstance(SHA_256_ALGORITHM).digest(hashInput);
+        } catch (NoSuchAlgorithmException e) {
+            throw new RoborockException("SHA-256 algorithm not available for L01 key derivation.", e);
+        }
+    }
+
+    private static byte[] deriveL01Iv(int timestamp, int nonce, int sequence) throws RoborockException {
+        byte[] digestInput = new byte[12];
+        writeInt32BE(digestInput, sequence, 0);
+        writeInt32BE(digestInput, nonce, 4);
+        writeInt32BE(digestInput, timestamp, 8);
+        try {
+            byte[] digest = MessageDigest.getInstance(SHA_256_ALGORITHM).digest(digestInput);
+            return Arrays.copyOf(digest, 12);
+        } catch (NoSuchAlgorithmException e) {
+            throw new RoborockException("SHA-256 algorithm not available for L01 IV derivation.", e);
+        }
+    }
+
+    private static byte[] deriveL01Aad(int timestamp, int nonce, int sequence, int connectNonce, int ackNonce) {
+        byte[] aad = new byte[20];
+        writeInt32BE(aad, sequence, 0);
+        writeInt32BE(aad, connectNonce, 4);
+        writeInt32BE(aad, ackNonce, 8);
+        writeInt32BE(aad, nonce, 12);
+        writeInt32BE(aad, timestamp, 16);
+        return aad;
     }
 
     private static String bytesToString(byte[] data, int start, int length) {
@@ -278,7 +354,8 @@ public final class ProtocolUtils {
      * @param localKey The local key for decryption.
      * @return The decrypted payload as a string, or an empty string on decryption failure.
      */
-    private static String handleDataProtocol(byte[] message, MessageHeader header, String localKey) {
+    private static String handleDataProtocol(byte[] message, MessageHeader header, String localKey, int connectNonce,
+            int ackNonce, boolean handshakeContextAvailable) {
         int payloadStart = HEADER_LENGTH_WITHOUT_CRC;
         int payloadEnd = payloadStart + header.payloadLen;
 
@@ -288,9 +365,21 @@ public final class ProtocolUtils {
 
         byte[] payload = Arrays.copyOfRange(message, payloadStart, payloadEnd);
 
-        String encryptionKey = encodeTimestamp(header.timestamp) + localKey + SALT;
         try {
-            byte[] decryptedResult = decrypt(payload, encryptionKey);
+            byte[] decryptedResult;
+            if (VERSION_L01.equals(header.version)) {
+                if (!handshakeContextAvailable) {
+                    LOGGER.debug(
+                            "Received L01 frame but local handshake context is unavailable (connectNonce={}, ackNonce={}).",
+                            connectNonce, ackNonce);
+                    return "";
+                }
+                decryptedResult = decryptL01(payload, localKey, header.timestamp, header.sequence, header.random,
+                        connectNonce, ackNonce);
+            } else {
+                String encryptionKey = encodeTimestamp(header.timestamp) + localKey + SALT;
+                decryptedResult = decrypt(payload, encryptionKey);
+            }
             return new String(decryptedResult, StandardCharsets.UTF_8);
         } catch (RoborockException e) {
             LOGGER.debug("Exception decrypting payload for protocol 102: {}", e.getMessage(), e);
@@ -317,13 +406,25 @@ public final class ProtocolUtils {
     }
 
     public static DecodedMessage decodeMessage(byte[] message, String localKey, byte[] nonce, String endpointPrefix) {
+        return decodeMessage(message, localKey, nonce, endpointPrefix, -1, -1, false);
+    }
+
+    public static DecodedMessage decodeMessage(byte[] message, String localKey, byte[] nonce, String endpointPrefix,
+            int connectNonce, int ackNonce) {
+        boolean handshakeContextAvailable = !(connectNonce == -1 && ackNonce == -1);
+        return decodeMessage(message, localKey, nonce, endpointPrefix, connectNonce, ackNonce,
+                handshakeContextAvailable);
+    }
+
+    public static DecodedMessage decodeMessage(byte[] message, String localKey, byte[] nonce, String endpointPrefix,
+            int connectNonce, int ackNonce, boolean handshakeContextAvailable) {
         if (message.length < HEADER_LENGTH_WITHOUT_CRC + CRC_LENGTH) {
             return new IgnoredResponse();
         }
 
         MessageHeader header = parseMessageHeader(message);
-        if (!VERSION_1_0.equals(header.version)) {
-            LOGGER.debug("Received message version is not 1.0: {}", header.version);
+        if (!VERSION_1_0.equals(header.version) && !VERSION_L01.equals(header.version)) {
+            LOGGER.debug("Received unsupported message version: {}", header.version);
             return new IgnoredResponse();
         }
 
@@ -336,8 +437,9 @@ public final class ProtocolUtils {
         switch (header.protocol) {
             case PROTOCOL_MAP:
                 return handleImageProtocol(message, header, localKey, nonce, endpointPrefix);
-            case PROTOCOL_JSON:
-                String payload = handleDataProtocol(message, header, localKey);
+            case PROTOCOL_JSON, PROTOCOL_GENERAL_RESPONSE, PROTOCOL_GENERAL_REQUEST:
+                String payload = handleDataProtocol(message, header, localKey, connectNonce, ackNonce,
+                        handshakeContextAvailable);
                 if (!payload.isEmpty()) {
                     return new JsonPayloadResponse(payload);
                 }

--- a/bundles/org.openhab.binding.roborock/src/main/java/org/openhab/binding/roborock/internal/util/RequestCorrelationTracker.java
+++ b/bundles/org.openhab.binding.roborock/src/main/java/org/openhab/binding/roborock/internal/util/RequestCorrelationTracker.java
@@ -18,6 +18,8 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Tracks outgoing request ids and correlates them with method names.
@@ -26,6 +28,7 @@ import org.eclipse.jdt.annotation.Nullable;
  */
 @NonNullByDefault
 public class RequestCorrelationTracker {
+    private final Logger logger = LoggerFactory.getLogger(RequestCorrelationTracker.class);
     private final Map<String, Set<Integer>> requestIdsByMethod = new ConcurrentHashMap<>();
     private final Map<Integer, String> methodsByRequestId = new ConcurrentHashMap<>();
     private final Map<Integer, Long> requestTimestampsById = new ConcurrentHashMap<>();
@@ -37,7 +40,11 @@ public class RequestCorrelationTracker {
 
         methodsByRequestId.put(requestId, methodName);
         requestTimestampsById.put(requestId, System.currentTimeMillis());
-        requestIdsByMethod.computeIfAbsent(methodName, ignored -> ConcurrentHashMap.newKeySet()).add(requestId);
+        Set<Integer> requestIds = requestIdsByMethod.computeIfAbsent(methodName,
+                ignored -> ConcurrentHashMap.newKeySet());
+        if (requestIds != null) {
+            requestIds.add(requestId);
+        }
     }
 
     public @Nullable String findMethodByRequestId(int requestId) {
@@ -72,6 +79,11 @@ public class RequestCorrelationTracker {
         }
     }
 
+    /**
+     * Removes expired entries, logging map-related expiries at DEBUG level with age information.
+     *
+     * @param timeoutMs timeout in milliseconds; if <= 0, all entries are removed
+     */
     public void cleanupExpired(long timeoutMs) {
         if (timeoutMs <= 0) {
             methodsByRequestId.keySet().forEach(this::removeByRequestId);
@@ -81,8 +93,27 @@ public class RequestCorrelationTracker {
         long now = System.currentTimeMillis();
         requestTimestampsById.forEach((requestId, timestamp) -> {
             if (now - timestamp.longValue() >= timeoutMs) {
+                String methodName = methodsByRequestId.get(requestId);
+                if (isMapRelatedMethod(methodName)) {
+                    long ageMs = now - timestamp.longValue();
+                    logger.debug("Map correlation expired for request id {}, method '{}', age {}ms", requestId,
+                            methodName, ageMs);
+                }
                 removeByRequestId(requestId.intValue());
             }
         });
+    }
+
+    /**
+     * Returns true if the method name is related to map requests, for diagnostic logging purposes.
+     *
+     * @param methodName the method name to check (may be null)
+     * @return true if map-related
+     */
+    public static boolean isMapRelatedMethod(@Nullable String methodName) {
+        if (methodName == null) {
+            return false;
+        }
+        return "getMap".equals(methodName) || "get_map_v1".equals(methodName) || "mapDownload".equals(methodName);
     }
 }

--- a/bundles/org.openhab.binding.roborock/src/main/resources/OH-INF/i18n/roborock.properties
+++ b/bundles/org.openhab.binding.roborock/src/main/resources/OH-INF/i18n/roborock.properties
@@ -18,8 +18,32 @@ thing-type.config.roborock.account.twofa.label = 2FA
 thing-type.config.roborock.account.twofa.description = 2FA code from email. Leave blank until code is received via email
 thing-type.config.roborock.vacuum.duid.label = Device ID
 thing-type.config.roborock.vacuum.duid.description = Specifies the vacuum's Device UID.
+thing-type.config.roborock.vacuum.communication.label = Communication Mode
+thing-type.config.roborock.vacuum.communication.description = Select cloud or direct communication transport for command routing.
+thing-type.config.roborock.vacuum.communication.option.cloud = Cloud
+thing-type.config.roborock.vacuum.communication.option.direct = Direct
+thing-type.config.roborock.vacuum.localHost.label = Local Host Override
+thing-type.config.roborock.vacuum.localHost.description = Optional local IP/hostname override used in direct mode.
+thing-type.config.roborock.vacuum.localPort.label = Local Port
+thing-type.config.roborock.vacuum.localPort.description = Local port used for direct mode communication.
+thing-type.config.roborock.vacuum.cloudMapRefresh.label = Cloud Map Refresh
+thing-type.config.roborock.vacuum.cloudMapRefresh.description = Controls cloud map retrieval while communication mode is direct.
+thing-type.config.roborock.vacuum.cloudMapRefresh.option.on = On
+thing-type.config.roborock.vacuum.cloudMapRefresh.option.off = Off
+thing-type.config.roborock.vacuum.cloudMetadataRefresh.label = Cloud Metadata Refresh
+thing-type.config.roborock.vacuum.cloudMetadataRefresh.description = Controls cloud metadata refresh (routines and cloud-only metadata) while communication mode is direct.
+thing-type.config.roborock.vacuum.cloudMetadataRefresh.option.on = On
+thing-type.config.roborock.vacuum.cloudMetadataRefresh.option.off = Off
 thing-type.config.roborock.vacuum.refresh.label = Refresh Interval
-thing-type.config.roborock.vacuum.refresh.description = Specifies the refresh interval in minutes.
+thing-type.config.roborock.vacuum.refresh.description = Legacy compatibility refresh interval in minutes. Existing Thing configurations continue to use this setting.
+thing-type.config.roborock.vacuum.fastRefreshInterval.label = Fast Refresh Interval
+thing-type.config.roborock.vacuum.fastRefreshInterval.description = Specifies direct-mode status refresh interval in seconds while Vacuum channel is ON.
+thing-type.config.roborock.vacuum.mapRefreshCloudCleaningInterval.label = Map Refresh While Cleaning (Cloud Mode)
+thing-type.config.roborock.vacuum.mapRefreshCloudCleaningInterval.description = Specifies map refresh interval in seconds while cleaning when communication mode is cloud. Minimum value is 30 seconds.
+thing-type.config.roborock.vacuum.mapRefreshDirectCleaningInterval.label = Map Refresh While Cleaning (Direct Mode)
+thing-type.config.roborock.vacuum.mapRefreshDirectCleaningInterval.description = Specifies map refresh interval in seconds while cleaning when communication mode is direct. Minimum value is 15 seconds.
+thing-type.config.roborock.vacuum.cloudRefreshInterval.label = Cloud Refresh Interval
+thing-type.config.roborock.vacuum.cloudRefreshInterval.description = Specifies the refresh interval in seconds for cloud-only refresh tasks in direct mode. Falls back to Refresh Interval when unset; enforced minimum is 60 seconds.
 
 # channel group types
 
@@ -230,3 +254,11 @@ channel-type.roborock.water-box-mode.state.option.202 = Medium
 channel-type.roborock.water-box-mode.state.option.203 = High
 channel-type.roborock.water-box-mode.state.option.204 = Customised
 channel-type.roborock.water-box-status.label = Water Box State
+
+# actions
+
+action.download-rrmap.label = Download RR map
+action.download-rrmap.description = Downloads the current raw RR map payload and stores it in the configured directory, defaulting to the user home directory.
+action.download-rrmap.directory.label = Download directory (optional)
+action.download-rrmap.directory.description = Optional target directory for the saved RR map file. If empty, invalid, or unusable, the user home directory is used.
+action.download-rrmap.result = Saved RR map file path

--- a/bundles/org.openhab.binding.roborock/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.roborock/src/main/resources/OH-INF/thing/thing-types.xml
@@ -48,12 +48,83 @@
 				<label>Device ID</label>
 				<description>Specifies the vacuum's Device UID.</description>
 			</parameter>
+			<parameter name="communication" type="text" required="false">
+				<label>Communication Mode</label>
+				<description>Select cloud or direct communication transport for command routing.</description>
+				<default>cloud</default>
+				<options>
+					<option value="cloud">Cloud</option>
+					<option value="direct">Direct</option>
+				</options>
+			</parameter>
+			<parameter name="localHost" type="text" required="false">
+				<label>Local Host Override</label>
+				<advanced>true</advanced>
+				<description>Optional local IP/hostname override used in direct mode.</description>
+			</parameter>
+			<parameter name="localPort" type="integer" min="1" max="65535" required="false">
+				<label>Local Port</label>
+				<advanced>true</advanced>
+				<description>Local port used for direct mode communication.</description>
+				<default>58867</default>
+			</parameter>
+			<parameter name="cloudMapRefresh" type="text" required="false">
+				<label>Cloud Map Refresh</label>
+				<advanced>true</advanced>
+				<description>Controls cloud map retrieval while communication mode is direct.</description>
+				<default>on</default>
+				<options>
+					<option value="on">On</option>
+					<option value="off">Off</option>
+				</options>
+			</parameter>
+			<parameter name="cloudMetadataRefresh" type="text" required="false">
+				<label>Cloud Metadata Refresh</label>
+				<advanced>true</advanced>
+				<description>Controls cloud metadata refresh (routines and cloud-only metadata) while communication mode is direct.</description>
+				<default>on</default>
+				<options>
+					<option value="on">On</option>
+					<option value="off">Off</option>
+				</options>
+			</parameter>
 			<parameter name="refresh" type="integer" unit="min" min="1" required="false">
 				<label>Refresh Interval</label>
 				<advanced>true</advanced>
-				<description>Specifies the refresh interval in minutes.</description>
+				<description>Legacy compatibility refresh interval in minutes. Existing Thing configurations continue to use this
+					setting.</description>
 				<unitLabel>Minutes</unitLabel>
 				<default>5</default>
+			</parameter>
+			<parameter name="fastRefreshInterval" type="integer" unit="s" min="1" required="false">
+				<label>Fast Refresh Interval</label>
+				<advanced>true</advanced>
+				<description>Specifies direct-mode status refresh interval in seconds while Vacuum channel is ON.</description>
+				<unitLabel>Seconds</unitLabel>
+				<default>15</default>
+			</parameter>
+			<parameter name="mapRefreshCloudCleaningInterval" type="integer" unit="s" min="30" required="false">
+				<label>Map Refresh While Cleaning (Cloud Mode)</label>
+				<advanced>true</advanced>
+				<description>Specifies map refresh interval in seconds while cleaning when communication mode is cloud. Minimum
+					value is 30 seconds.</description>
+				<unitLabel>Seconds</unitLabel>
+				<default>30</default>
+			</parameter>
+			<parameter name="mapRefreshDirectCleaningInterval" type="integer" unit="s" min="15" required="false">
+				<label>Map Refresh While Cleaning (Direct Mode)</label>
+				<advanced>true</advanced>
+				<description>Specifies map refresh interval in seconds while cleaning when communication mode is direct. Minimum
+					value is 15 seconds.</description>
+				<unitLabel>Seconds</unitLabel>
+				<default>15</default>
+			</parameter>
+			<parameter name="cloudRefreshInterval" type="integer" unit="s" min="1" required="false">
+				<label>Cloud Refresh Interval</label>
+				<advanced>true</advanced>
+				<description>Specifies the refresh interval in seconds for cloud-only refresh tasks in direct mode. Falls back to
+					Refresh Interval when unset; enforced minimum is 60 seconds.</description>
+				<unitLabel>Seconds</unitLabel>
 			</parameter>
 		</config-description>
 	</thing-type>

--- a/bundles/org.openhab.binding.roborock/src/test/java/org/openhab/binding/roborock/internal/CloudRefreshPolicyTest.java
+++ b/bundles/org.openhab.binding.roborock/src/test/java/org/openhab/binding/roborock/internal/CloudRefreshPolicyTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.roborock.internal;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class CloudRefreshPolicyTest {
+
+    @Test
+    void directModeRespectsCloudMapAndMetadataRefreshFlags() {
+        RoborockVacuumConfiguration config = new RoborockVacuumConfiguration();
+        config.cloudMapRefresh = RoborockVacuumConfiguration.REFRESH_OFF;
+        config.cloudMetadataRefresh = RoborockVacuumConfiguration.REFRESH_OFF;
+
+        assertFalse(CloudRefreshPolicy.isCloudMapRefreshAllowed(RoborockCommunicationMode.DIRECT, config));
+        assertFalse(CloudRefreshPolicy.isCloudMetadataRefreshAllowed(RoborockCommunicationMode.DIRECT, config));
+    }
+
+    @Test
+    void cloudModeAlwaysAllowsCloudMapAndMetadataRefresh() {
+        RoborockVacuumConfiguration config = new RoborockVacuumConfiguration();
+        config.cloudMapRefresh = RoborockVacuumConfiguration.REFRESH_OFF;
+        config.cloudMetadataRefresh = RoborockVacuumConfiguration.REFRESH_OFF;
+
+        assertTrue(CloudRefreshPolicy.isCloudMapRefreshAllowed(RoborockCommunicationMode.CLOUD, config));
+        assertTrue(CloudRefreshPolicy.isCloudMetadataRefreshAllowed(RoborockCommunicationMode.CLOUD, config));
+    }
+
+    @Test
+    void cloudOnlyRefreshDueUsesConfiguredSecondsInterval() {
+        assertTrue(CloudRefreshPolicy.isCloudOnlyRefreshDue(1_000L, 0L, 120));
+        assertFalse(CloudRefreshPolicy.isCloudOnlyRefreshDue(61_000L, 1_000L, 120));
+        assertTrue(CloudRefreshPolicy.isCloudOnlyRefreshDue(121_000L, 1_000L, 120));
+    }
+}

--- a/bundles/org.openhab.binding.roborock/src/test/java/org/openhab/binding/roborock/internal/CloudRefreshPolicyTest.java
+++ b/bundles/org.openhab.binding.roborock/src/test/java/org/openhab/binding/roborock/internal/CloudRefreshPolicyTest.java
@@ -15,8 +15,10 @@ package org.openhab.binding.roborock.internal;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.junit.jupiter.api.Test;
 
+@NonNullByDefault({})
 class CloudRefreshPolicyTest {
 
     @Test

--- a/bundles/org.openhab.binding.roborock/src/test/java/org/openhab/binding/roborock/internal/MapUpdateDeduplicatorTest.java
+++ b/bundles/org.openhab.binding.roborock/src/test/java/org/openhab/binding/roborock/internal/MapUpdateDeduplicatorTest.java
@@ -15,8 +15,10 @@ package org.openhab.binding.roborock.internal;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.junit.jupiter.api.Test;
 
+@NonNullByDefault({})
 class MapUpdateDeduplicatorTest {
 
     @Test

--- a/bundles/org.openhab.binding.roborock/src/test/java/org/openhab/binding/roborock/internal/MapUpdateDeduplicatorTest.java
+++ b/bundles/org.openhab.binding.roborock/src/test/java/org/openhab/binding/roborock/internal/MapUpdateDeduplicatorTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.roborock.internal;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class MapUpdateDeduplicatorTest {
+
+    @Test
+    void shouldPublishReturnsFalseForUnchangedMapImageBytes() {
+        MapUpdateDeduplicator deduplicator = new MapUpdateDeduplicator();
+        byte[] firstMap = new byte[] { 1, 2, 3, 4 };
+        byte[] sameMapContent = new byte[] { 1, 2, 3, 4 };
+
+        assertTrue(deduplicator.shouldPublish(firstMap));
+        assertFalse(deduplicator.shouldPublish(sameMapContent));
+    }
+
+    @Test
+    void shouldPublishReturnsTrueWhenMapImageBytesChange() {
+        MapUpdateDeduplicator deduplicator = new MapUpdateDeduplicator();
+        byte[] firstMap = new byte[] { 1, 2, 3, 4 };
+        byte[] changedMap = new byte[] { 1, 2, 3, 5 };
+
+        assertTrue(deduplicator.shouldPublish(firstMap));
+        assertTrue(deduplicator.shouldPublish(changedMap));
+    }
+
+    @Test
+    void resetAllowsRepublishingSameMapAfterUndefinedTransition() {
+        MapUpdateDeduplicator deduplicator = new MapUpdateDeduplicator();
+        byte[] mapImage = new byte[] { 9, 8, 7, 6 };
+
+        assertTrue(deduplicator.shouldPublish(mapImage));
+        assertFalse(deduplicator.shouldPublish(mapImage));
+
+        deduplicator.reset();
+
+        assertTrue(deduplicator.shouldPublish(mapImage));
+    }
+}

--- a/bundles/org.openhab.binding.roborock/src/test/java/org/openhab/binding/roborock/internal/MqttInboundLivenessWatchdogTest.java
+++ b/bundles/org.openhab.binding.roborock/src/test/java/org/openhab/binding/roborock/internal/MqttInboundLivenessWatchdogTest.java
@@ -18,9 +18,11 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import java.time.Duration;
 import java.time.Instant;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.junit.jupiter.api.Test;
 import org.openhab.binding.roborock.internal.MqttInboundLivenessWatchdog.Decision;
 
+@NonNullByDefault({})
 class MqttInboundLivenessWatchdogTest {
 
     @Test

--- a/bundles/org.openhab.binding.roborock/src/test/java/org/openhab/binding/roborock/internal/MqttInboundLivenessWatchdogTest.java
+++ b/bundles/org.openhab.binding.roborock/src/test/java/org/openhab/binding/roborock/internal/MqttInboundLivenessWatchdogTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.roborock.internal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.time.Duration;
+import java.time.Instant;
+
+import org.junit.jupiter.api.Test;
+import org.openhab.binding.roborock.internal.MqttInboundLivenessWatchdog.Decision;
+
+class MqttInboundLivenessWatchdogTest {
+
+    @Test
+    void noteInboundMessageUpdatesInboundTimestamp() {
+        MqttInboundLivenessWatchdog watchdog = new MqttInboundLivenessWatchdog(Duration.ofMinutes(2),
+                Duration.ofMinutes(3), Duration.ofMinutes(1));
+        Instant t0 = Instant.parse("2026-01-01T00:00:00Z");
+        Instant t1 = t0.plusSeconds(42);
+
+        assertNull(watchdog.getLastInboundMessageAt());
+        watchdog.noteInboundMessage(t1);
+
+        assertEquals(t1, watchdog.getLastInboundMessageAt());
+    }
+
+    @Test
+    void evaluateReturnsIdleWhenConnectedButNoRecentOutboundUsage() {
+        MqttInboundLivenessWatchdog watchdog = new MqttInboundLivenessWatchdog(Duration.ofMinutes(2),
+                Duration.ofMinutes(3), Duration.ofMinutes(1));
+        Instant t0 = Instant.parse("2026-01-01T00:00:00Z");
+
+        watchdog.reset(t0);
+
+        assertEquals(Decision.IDLE, watchdog.evaluate(t0.plusSeconds(30), true));
+        assertEquals(Decision.NOT_CONNECTED, watchdog.evaluate(t0.plusSeconds(30), false));
+    }
+
+    @Test
+    void evaluateReturnsStaleForInboundSilenceDuringActiveUsageAndCooldownAfterRecycleAttempt() {
+        MqttInboundLivenessWatchdog watchdog = new MqttInboundLivenessWatchdog(Duration.ofMinutes(10),
+                Duration.ofMinutes(2), Duration.ofMinutes(1));
+        Instant t0 = Instant.parse("2026-01-01T00:00:00Z");
+
+        watchdog.reset(t0);
+        watchdog.noteOutboundPublish(t0.plusSeconds(30));
+
+        Instant staleCheck = t0.plusSeconds(181);
+        assertEquals(Decision.STALE, watchdog.evaluate(staleCheck, true));
+
+        watchdog.noteRecycleAttempt(staleCheck);
+        assertEquals(Decision.COOLDOWN, watchdog.evaluate(staleCheck.plusSeconds(30), true));
+    }
+}

--- a/bundles/org.openhab.binding.roborock/src/test/java/org/openhab/binding/roborock/internal/RoborockAccountHandlerRoutingTest.java
+++ b/bundles/org.openhab.binding.roborock/src/test/java/org/openhab/binding/roborock/internal/RoborockAccountHandlerRoutingTest.java
@@ -14,8 +14,10 @@ package org.openhab.binding.roborock.internal;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.junit.jupiter.api.Test;
 
+@NonNullByDefault({})
 class RoborockAccountHandlerRoutingTest {
 
     @Test

--- a/bundles/org.openhab.binding.roborock/src/test/java/org/openhab/binding/roborock/internal/RoborockCommunicationModeTest.java
+++ b/bundles/org.openhab.binding.roborock/src/test/java/org/openhab/binding/roborock/internal/RoborockCommunicationModeTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.roborock.internal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class RoborockCommunicationModeTest {
+
+    @Test
+    void parsesDirectModeCaseInsensitive() {
+        assertEquals(RoborockCommunicationMode.DIRECT, RoborockCommunicationMode.fromConfigValue("direct"));
+        assertEquals(RoborockCommunicationMode.DIRECT, RoborockCommunicationMode.fromConfigValue("DiReCt"));
+    }
+
+    @Test
+    void defaultsToCloudForUnknownOrEmptyValue() {
+        assertEquals(RoborockCommunicationMode.CLOUD, RoborockCommunicationMode.fromConfigValue(""));
+        assertEquals(RoborockCommunicationMode.CLOUD, RoborockCommunicationMode.fromConfigValue("cloud"));
+        assertEquals(RoborockCommunicationMode.CLOUD, RoborockCommunicationMode.fromConfigValue("unsupported"));
+    }
+}

--- a/bundles/org.openhab.binding.roborock/src/test/java/org/openhab/binding/roborock/internal/RoborockCommunicationModeTest.java
+++ b/bundles/org.openhab.binding.roborock/src/test/java/org/openhab/binding/roborock/internal/RoborockCommunicationModeTest.java
@@ -14,8 +14,10 @@ package org.openhab.binding.roborock.internal;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.junit.jupiter.api.Test;
 
+@NonNullByDefault({})
 class RoborockCommunicationModeTest {
 
     @Test

--- a/bundles/org.openhab.binding.roborock/src/test/java/org/openhab/binding/roborock/internal/RoborockTransportRoutingTest.java
+++ b/bundles/org.openhab.binding.roborock/src/test/java/org/openhab/binding/roborock/internal/RoborockTransportRoutingTest.java
@@ -17,8 +17,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.openhab.binding.roborock.internal.RoborockBindingConstants.COMMAND_APP_START;
 import static org.openhab.binding.roborock.internal.RoborockBindingConstants.COMMAND_GET_MAP;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.junit.jupiter.api.Test;
 
+@NonNullByDefault({})
 class RoborockTransportRoutingTest {
 
     @Test

--- a/bundles/org.openhab.binding.roborock/src/test/java/org/openhab/binding/roborock/internal/RoborockTransportRoutingTest.java
+++ b/bundles/org.openhab.binding.roborock/src/test/java/org/openhab/binding/roborock/internal/RoborockTransportRoutingTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.roborock.internal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.openhab.binding.roborock.internal.RoborockBindingConstants.COMMAND_APP_START;
+import static org.openhab.binding.roborock.internal.RoborockBindingConstants.COMMAND_GET_MAP;
+
+import org.junit.jupiter.api.Test;
+
+class RoborockTransportRoutingTest {
+
+    @Test
+    void cloudOnlyMethodIsRecognized() {
+        assertTrue(RoborockTransportRouting.isCloudOnlyMethod(COMMAND_GET_MAP));
+    }
+
+    @Test
+    void directModeRoutesMapToCloud() {
+        assertEquals(RoborockCommunicationMode.CLOUD,
+                RoborockTransportRouting.selectTransportMode(RoborockCommunicationMode.DIRECT, COMMAND_GET_MAP));
+    }
+
+    @Test
+    void directModeKeepsDirectForRegularCommands() {
+        assertEquals(RoborockCommunicationMode.DIRECT,
+                RoborockTransportRouting.selectTransportMode(RoborockCommunicationMode.DIRECT, COMMAND_APP_START));
+    }
+}

--- a/bundles/org.openhab.binding.roborock/src/test/java/org/openhab/binding/roborock/internal/RoborockVacuumConfigurationTest.java
+++ b/bundles/org.openhab.binding.roborock/src/test/java/org/openhab/binding/roborock/internal/RoborockVacuumConfigurationTest.java
@@ -16,8 +16,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.junit.jupiter.api.Test;
 
+@NonNullByDefault({})
 class RoborockVacuumConfigurationTest {
 
     @Test

--- a/bundles/org.openhab.binding.roborock/src/test/java/org/openhab/binding/roborock/internal/RoborockVacuumConfigurationTest.java
+++ b/bundles/org.openhab.binding.roborock/src/test/java/org/openhab/binding/roborock/internal/RoborockVacuumConfigurationTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.roborock.internal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class RoborockVacuumConfigurationTest {
+
+    @Test
+    void refreshDefaultsAreLegacyMinutesConvertedToSeconds() {
+        RoborockVacuumConfiguration config = new RoborockVacuumConfiguration();
+
+        assertEquals(300, config.getRefreshIntervalSeconds());
+        assertEquals(15, config.getFastRefreshIntervalSeconds());
+        assertEquals(300, config.getCloudRefreshIntervalSeconds());
+        assertEquals(30, config.getMapRefreshCloudCleaningIntervalSeconds());
+        assertEquals(15, config.getMapRefreshDirectCleaningIntervalSeconds());
+    }
+
+    @Test
+    void legacyRefreshInputIsInterpretedAsMinutes() {
+        RoborockVacuumConfiguration config = new RoborockVacuumConfiguration();
+
+        config.refresh = 1;
+        assertEquals(60, config.getRefreshIntervalSeconds());
+
+        config.refresh = 2;
+        assertEquals(120, config.getRefreshIntervalSeconds());
+
+        config.refresh = 0;
+        assertEquals(300, config.getRefreshIntervalSeconds());
+
+        config.refresh = -10;
+        assertEquals(300, config.getRefreshIntervalSeconds());
+    }
+
+    @Test
+    void fastRefreshIntervalUsesConfiguredValueAndFallsBackToDefault() {
+        RoborockVacuumConfiguration config = new RoborockVacuumConfiguration();
+
+        config.fastRefreshInterval = 20;
+        assertEquals(20, config.getFastRefreshIntervalSeconds());
+
+        config.fastRefreshInterval = 0;
+        assertEquals(15, config.getFastRefreshIntervalSeconds());
+
+        config.fastRefreshInterval = -10;
+        assertEquals(15, config.getFastRefreshIntervalSeconds());
+    }
+
+    @Test
+    void cloudRefreshIntervalUsesConfiguredValueAndFallsBackToRefreshInterval() {
+        RoborockVacuumConfiguration config = new RoborockVacuumConfiguration();
+        config.refresh = 2;
+
+        assertEquals(120, config.getCloudRefreshIntervalSeconds());
+
+        config.cloudRefreshInterval = 30;
+        assertEquals(60, config.getCloudRefreshIntervalSeconds());
+
+        config.cloudRefreshInterval = 90;
+        assertEquals(90, config.getCloudRefreshIntervalSeconds());
+
+        config.cloudRefreshInterval = 0;
+        assertEquals(120, config.getCloudRefreshIntervalSeconds());
+
+        config.cloudRefreshInterval = -10;
+        assertEquals(120, config.getCloudRefreshIntervalSeconds());
+    }
+
+    @Test
+    void cloudOnlyRefreshDefaultsToEnabled() {
+        RoborockVacuumConfiguration config = new RoborockVacuumConfiguration();
+
+        assertTrue(config.isCloudMapRefreshEnabled());
+        assertTrue(config.isCloudMetadataRefreshEnabled());
+    }
+
+    @Test
+    void cloudOnlyRefreshCanBeDisabledWithOffValue() {
+        RoborockVacuumConfiguration config = new RoborockVacuumConfiguration();
+        config.cloudMapRefresh = RoborockVacuumConfiguration.REFRESH_OFF;
+        config.cloudMetadataRefresh = RoborockVacuumConfiguration.REFRESH_OFF;
+
+        assertFalse(config.isCloudMapRefreshEnabled());
+        assertFalse(config.isCloudMetadataRefreshEnabled());
+    }
+
+    @Test
+    void cloudOnlyRefreshTreatsUnknownValuesAsEnabled() {
+        RoborockVacuumConfiguration config = new RoborockVacuumConfiguration();
+        config.cloudMapRefresh = "invalid";
+        config.cloudMetadataRefresh = "enabled";
+
+        assertTrue(config.isCloudMapRefreshEnabled());
+        assertTrue(config.isCloudMetadataRefreshEnabled());
+    }
+
+    @Test
+    void mapRefreshCleaningIntervalsAreClampedToSafeMinimums() {
+        RoborockVacuumConfiguration config = new RoborockVacuumConfiguration();
+
+        config.mapRefreshCloudCleaningInterval = 10;
+        assertEquals(30, config.getMapRefreshCloudCleaningIntervalSeconds());
+
+        config.mapRefreshDirectCleaningInterval = 10;
+        assertEquals(15, config.getMapRefreshDirectCleaningIntervalSeconds());
+    }
+
+    @Test
+    void mapRefreshDuringCleaningUsesCommunicationModeSpecificInterval() {
+        RoborockVacuumConfiguration config = new RoborockVacuumConfiguration();
+        config.mapRefreshCloudCleaningInterval = 40;
+        config.mapRefreshDirectCleaningInterval = 20;
+
+        assertEquals(40, config.getMapRefreshDuringCleaningIntervalSeconds(RoborockCommunicationMode.CLOUD));
+        assertEquals(20, config.getMapRefreshDuringCleaningIntervalSeconds(RoborockCommunicationMode.DIRECT));
+    }
+}

--- a/bundles/org.openhab.binding.roborock/src/test/java/org/openhab/binding/roborock/internal/RoborockVacuumHandlerConsumableWriterTest.java
+++ b/bundles/org.openhab.binding.roborock/src/test/java/org/openhab/binding/roborock/internal/RoborockVacuumHandlerConsumableWriterTest.java
@@ -19,8 +19,10 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.junit.jupiter.api.Test;
 
+@NonNullByDefault({})
 class RoborockVacuumHandlerConsumableWriterTest {
 
     private static final Path HANDLER_PATH = Path

--- a/bundles/org.openhab.binding.roborock/src/test/java/org/openhab/binding/roborock/internal/RoborockVacuumHandlerConsumableWriterTest.java
+++ b/bundles/org.openhab.binding.roborock/src/test/java/org/openhab/binding/roborock/internal/RoborockVacuumHandlerConsumableWriterTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.roborock.internal;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+
+class RoborockVacuumHandlerConsumableWriterTest {
+
+    private static final Path HANDLER_PATH = Path
+            .of("src/main/java/org/openhab/binding/roborock/internal/RoborockVacuumHandler.java");
+
+    @Test
+    void updateDeviceDoesNotWriteConsumablePercentChannelsFromRawWorkTime() throws IOException {
+        String source = Files.readString(HANDLER_PATH);
+        String updateDeviceBody = extractMethodBody(source, "private void updateDevice(Devices devices\\[])");
+
+        assertFalse(updateDeviceBody.contains("CHANNEL_CONSUMABLE_MAIN_PERC"),
+                "updateDevice must not write main consumable percent channel");
+        assertFalse(updateDeviceBody.contains("CHANNEL_CONSUMABLE_SIDE_PERC"),
+                "updateDevice must not write side consumable percent channel");
+        assertFalse(updateDeviceBody.contains("CHANNEL_CONSUMABLE_FILTER_PERC"),
+                "updateDevice must not write filter consumable percent channel");
+    }
+
+    @Test
+    void updateDeviceDoesNotWriteBatteryChannelFromSnapshot() throws IOException {
+        String source = Files.readString(HANDLER_PATH);
+        String updateDeviceBody = extractMethodBody(source, "private void updateDevice(Devices devices\\[])");
+
+        assertFalse(updateDeviceBody.contains("CHANNEL_BATTERY"),
+                "updateDevice must not write battery channel; live status/DPS handlers are authoritative");
+    }
+
+    @Test
+    void updateDeviceDoesNotWriteStateOrFanPowerFromSnapshot() throws IOException {
+        String source = Files.readString(HANDLER_PATH);
+        String updateDeviceBody = extractMethodBody(source, "private void updateDevice(Devices devices\\[])");
+
+        assertFalse(updateDeviceBody.contains("CHANNEL_STATE_ID"),
+                "updateDevice must not write state-id; live status/DPS handlers are authoritative");
+        assertFalse(updateDeviceBody.contains("CHANNEL_FAN_POWER"),
+                "updateDevice must not write fan-power; live status handlers are authoritative");
+    }
+
+    @Test
+    void handleGetConsumablesRemainsAuthoritativeWriterForConsumablePercentChannels() throws IOException {
+        String source = Files.readString(HANDLER_PATH);
+        String consumablesBody = extractMethodBody(source, "private void handleGetConsumables\\(String response\\)");
+
+        assertTrue(consumablesBody.contains("CHANNEL_CONSUMABLE_MAIN_PERC"),
+                "handleGetConsumables should write main consumable percent channel");
+        assertTrue(consumablesBody.contains("CHANNEL_CONSUMABLE_SIDE_PERC"),
+                "handleGetConsumables should write side consumable percent channel");
+        assertTrue(consumablesBody.contains("CHANNEL_CONSUMABLE_FILTER_PERC"),
+                "handleGetConsumables should write filter consumable percent channel");
+    }
+
+    @Test
+    void liveStatusAndDpsHandlersRemainAuthoritativeWritersForBatteryChannel() throws IOException {
+        String source = Files.readString(HANDLER_PATH);
+        String handleGetStatusBody = extractMethodBody(source, "private void handleGetStatus\\(String response\\)");
+
+        assertTrue(handleGetStatusBody.contains("CHANNEL_BATTERY"),
+                "handleGetStatus should continue writing battery channel from live status data");
+        assertTrue(
+                source.contains("dpsJsonObject.has(\"122\")")
+                        && source.contains("updateState(CHANNEL_BATTERY, new DecimalType(battery));"),
+                "handleMessage should continue writing battery channel from live DPS updates");
+    }
+
+    private static String extractMethodBody(String source, String methodSignatureRegex) {
+        int signatureStart = source.indexOf(methodSignatureRegex.replace("\\", ""));
+        assertTrue(signatureStart >= 0, "Method signature not found: " + methodSignatureRegex);
+
+        int bodyStart = source.indexOf('{', signatureStart);
+        assertTrue(bodyStart >= 0, "Method body start not found: " + methodSignatureRegex);
+
+        int depth = 1;
+        int index = bodyStart + 1;
+        while (index < source.length() && depth > 0) {
+            char current = source.charAt(index);
+            if (current == '{') {
+                depth++;
+            } else if (current == '}') {
+                depth--;
+            }
+            index++;
+        }
+
+        assertTrue(depth == 0, "Method body end not found: " + methodSignatureRegex);
+        return source.substring(bodyStart + 1, index - 1);
+    }
+}

--- a/bundles/org.openhab.binding.roborock/src/test/java/org/openhab/binding/roborock/internal/RoborockVacuumHandlerPathResolutionTest.java
+++ b/bundles/org.openhab.binding.roborock/src/test/java/org/openhab/binding/roborock/internal/RoborockVacuumHandlerPathResolutionTest.java
@@ -19,9 +19,11 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+@NonNullByDefault({})
 class RoborockVacuumHandlerPathResolutionTest {
 
     @Test

--- a/bundles/org.openhab.binding.roborock/src/test/java/org/openhab/binding/roborock/internal/RoborockVacuumHandlerPathResolutionTest.java
+++ b/bundles/org.openhab.binding.roborock/src/test/java/org/openhab/binding/roborock/internal/RoborockVacuumHandlerPathResolutionTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.roborock.internal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class RoborockVacuumHandlerPathResolutionTest {
+
+    @Test
+    void resolveRrMapDownloadDirectoryUsesDefaultWhenInputIsNull() {
+        Path defaultDirectory = Paths.get("default-home");
+
+        Path resolved = RoborockVacuumHandler.resolveRrMapDownloadDirectory(null, defaultDirectory);
+
+        assertEquals(defaultDirectory, resolved);
+    }
+
+    @Test
+    void resolveRrMapDownloadDirectoryUsesDefaultWhenInputIsBlank() {
+        Path defaultDirectory = Paths.get("default-home");
+
+        Path resolved = RoborockVacuumHandler.resolveRrMapDownloadDirectory("   ", defaultDirectory);
+
+        assertEquals(defaultDirectory, resolved);
+    }
+
+    @Test
+    void resolveRrMapDownloadDirectoryUsesProvidedDirectoryWhenValid() {
+        Path defaultDirectory = Paths.get("default-home");
+
+        Path resolved = RoborockVacuumHandler.resolveRrMapDownloadDirectory("custom/maps", defaultDirectory);
+
+        assertEquals(Paths.get("custom/maps"), resolved);
+    }
+
+    @Test
+    void resolveRrMapDownloadDirectoryUsesDefaultWhenInputIsInvalid() {
+        Path defaultDirectory = Paths.get("default-home");
+
+        String invalidPathInput = "\u0000invalid";
+        Path resolved = RoborockVacuumHandler.resolveRrMapDownloadDirectory(invalidPathInput, defaultDirectory);
+
+        assertEquals(defaultDirectory, resolved);
+    }
+
+    @Test
+    void resolveRrMapDownloadDirectoryUsesDefaultWhenPathPointsToFile(@TempDir Path tempDir) throws IOException {
+        Path defaultDirectory = Paths.get("default-home");
+        Path existingFile = Files.createFile(tempDir.resolve("map.rrmap"));
+
+        Path resolved = RoborockVacuumHandler.resolveRrMapDownloadDirectory(existingFile.toString(), defaultDirectory);
+
+        assertEquals(defaultDirectory, resolved);
+    }
+}

--- a/bundles/org.openhab.binding.roborock/src/test/java/org/openhab/binding/roborock/internal/VacuumRefreshPolicyTest.java
+++ b/bundles/org.openhab.binding.roborock/src/test/java/org/openhab/binding/roborock/internal/VacuumRefreshPolicyTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.roborock.internal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class VacuumRefreshPolicyTest {
+
+    @Test
+    void stateIdChangeRequestsImmediateStatusOnlyWhenKnownAndChanged() {
+        assertFalse(VacuumRefreshPolicy.shouldRequestImmediateStatus(null, 5));
+        assertFalse(VacuumRefreshPolicy.shouldRequestImmediateStatus(Integer.valueOf(5), 5));
+        assertTrue(VacuumRefreshPolicy.shouldRequestImmediateStatus(Integer.valueOf(5), 6));
+    }
+
+    @Test
+    void statusPollDelayUsesFastIntervalWhenVacuumIsOn() {
+        assertEquals(Integer.valueOf(15),
+                VacuumRefreshPolicy.getStatusPollDelaySeconds(RoborockCommunicationMode.DIRECT, true, 15));
+    }
+
+    @Test
+    void statusPollDelayDisabledWhenVacuumIsOff() {
+        assertNull(VacuumRefreshPolicy.getStatusPollDelaySeconds(RoborockCommunicationMode.DIRECT, false, 15));
+    }
+
+    @Test
+    void statusPollDelayDisabledInCloudMode() {
+        assertNull(VacuumRefreshPolicy.getStatusPollDelaySeconds(RoborockCommunicationMode.CLOUD, true, 15));
+    }
+
+    @Test
+    void normalizeLegacyRefreshMinutesToSecondsUsesDefaultAndMinimum() {
+        assertEquals(300, VacuumRefreshPolicy.normalizeLegacyRefreshMinutesToSeconds(0, 5, 60));
+        assertEquals(60, VacuumRefreshPolicy.normalizeLegacyRefreshMinutesToSeconds(1, 5, 60));
+        assertEquals(180, VacuumRefreshPolicy.normalizeLegacyRefreshMinutesToSeconds(3, 5, 60));
+    }
+
+    @Test
+    void normalizeIntervalSecondsUsesDefaultAndMinimum() {
+        assertEquals(30, VacuumRefreshPolicy.normalizeIntervalSeconds(0, 30, 30));
+        assertEquals(30, VacuumRefreshPolicy.normalizeIntervalSeconds(10, 30, 30));
+        assertEquals(45, VacuumRefreshPolicy.normalizeIntervalSeconds(45, 30, 30));
+    }
+
+    @Test
+    void isRefreshDueChecksTimestampAndInterval() {
+        assertTrue(VacuumRefreshPolicy.isRefreshDue(10_000L, 0L, 30));
+        assertFalse(VacuumRefreshPolicy.isRefreshDue(20_000L, 10_000L, 30));
+        assertTrue(VacuumRefreshPolicy.isRefreshDue(40_000L, 10_000L, 30));
+    }
+}

--- a/bundles/org.openhab.binding.roborock/src/test/java/org/openhab/binding/roborock/internal/VacuumRefreshPolicyTest.java
+++ b/bundles/org.openhab.binding.roborock/src/test/java/org/openhab/binding/roborock/internal/VacuumRefreshPolicyTest.java
@@ -17,8 +17,10 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.junit.jupiter.api.Test;
 
+@NonNullByDefault({})
 class VacuumRefreshPolicyTest {
 
     @Test

--- a/bundles/org.openhab.binding.roborock/src/test/java/org/openhab/binding/roborock/internal/map/RRMapParserTest.java
+++ b/bundles/org.openhab.binding.roborock/src/test/java/org/openhab/binding/roborock/internal/map/RRMapParserTest.java
@@ -18,9 +18,11 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.ByteArrayOutputStream;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.junit.jupiter.api.Test;
 import org.openhab.binding.roborock.internal.RoborockException;
 
+@NonNullByDefault({})
 class RRMapParserTest {
 
     @Test

--- a/bundles/org.openhab.binding.roborock/src/test/java/org/openhab/binding/roborock/internal/map/RRMapRendererTest.java
+++ b/bundles/org.openhab.binding.roborock/src/test/java/org/openhab/binding/roborock/internal/map/RRMapRendererTest.java
@@ -24,8 +24,10 @@ import java.util.function.Predicate;
 
 import javax.imageio.ImageIO;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.junit.jupiter.api.Test;
 
+@NonNullByDefault({})
 class RRMapRendererTest {
 
     private static final int UPSCALE_TARGET_MAX_DIMENSION = 1024;

--- a/bundles/org.openhab.binding.roborock/src/test/java/org/openhab/binding/roborock/internal/transport/LocalDirectTransportTest.java
+++ b/bundles/org.openhab.binding.roborock/src/test/java/org/openhab/binding/roborock/internal/transport/LocalDirectTransportTest.java
@@ -37,10 +37,12 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Supplier;
 import java.util.zip.CRC32;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.junit.jupiter.api.Test;
 import org.openhab.binding.roborock.internal.RoborockException;
 import org.openhab.binding.roborock.internal.util.ProtocolUtils;
 
+@NonNullByDefault({})
 class LocalDirectTransportTest {
 
     @Test
@@ -173,7 +175,7 @@ class LocalDirectTransportTest {
                     dispatchedRequestId.set(requestId.intValue());
                 }
             } catch (Exception e) {
-                throw new RuntimeException(e);
+                throw new AssertionError(e);
             }
         });
 

--- a/bundles/org.openhab.binding.roborock/src/test/java/org/openhab/binding/roborock/internal/transport/LocalDirectTransportTest.java
+++ b/bundles/org.openhab.binding.roborock/src/test/java/org/openhab/binding/roborock/internal/transport/LocalDirectTransportTest.java
@@ -1,0 +1,1011 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.roborock.internal.transport;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.net.InetAddress;
+import java.net.Socket;
+import java.net.SocketTimeoutException;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Supplier;
+import java.util.zip.CRC32;
+
+import org.junit.jupiter.api.Test;
+import org.openhab.binding.roborock.internal.RoborockException;
+import org.openhab.binding.roborock.internal.util.ProtocolUtils;
+
+class LocalDirectTransportTest {
+
+    @Test
+    void normalizeFrameStripsLengthPrefixForV10AndL01() throws Exception {
+        LocalDirectTransport transport = new LocalDirectTransport();
+        Method normalize = LocalDirectTransport.class.getDeclaredMethod("normalizeFrame", byte[].class);
+        normalize.setAccessible(true);
+
+        byte[] v10 = buildRawFrame("1.0", 5, "{}".getBytes(StandardCharsets.UTF_8));
+        byte[] prefixedV10 = withPrefix(v10);
+        Object normalizedV10Object = normalize.invoke(transport, prefixedV10);
+        assertNotNull(normalizedV10Object);
+        byte[] normalizedV10 = (byte[]) normalizedV10Object;
+        assertEquals(v10.length, normalizedV10.length);
+        assertEquals('1', normalizedV10[0]);
+
+        byte[] l01 = buildRawFrame("L01", 5, "{}".getBytes(StandardCharsets.UTF_8));
+        byte[] prefixedL01 = withPrefix(l01);
+        Object normalizedL01Object = normalize.invoke(transport, prefixedL01);
+        assertNotNull(normalizedL01Object);
+        byte[] normalizedL01 = (byte[]) normalizedL01Object;
+        assertEquals(l01.length, normalizedL01.length);
+        assertEquals('L', normalizedL01[0]);
+    }
+
+    @Test
+    void isControlOrAckFrameRecognizesShortHelloAndZeroPayload() throws Exception {
+        LocalDirectTransport transport = new LocalDirectTransport();
+        Method isControl = LocalDirectTransport.class.getDeclaredMethod("isControlOrAckFrame", byte[].class);
+        isControl.setAccessible(true);
+
+        byte[] shortHello = new byte[17];
+        shortHello[0] = '1';
+        shortHello[1] = '.';
+        shortHello[2] = '0';
+        ProtocolUtils.writeInt16BE(shortHello, 1, 15);
+        assertTrue(Boolean.TRUE.equals(isControl.invoke(transport, shortHello)));
+
+        byte[] zeroPayload = buildRawFrame("1.0", 5, new byte[0]);
+        assertTrue(Boolean.TRUE.equals(isControl.invoke(transport, zeroPayload)));
+    }
+
+    @Test
+    void extractResponseRequestIdReadsJsonIdFromRpcPayload() throws Exception {
+        LocalDirectTransport transport = new LocalDirectTransport();
+        String localKey = "local-key";
+        transport.updateContext(localKey, "127.0.0.1", 58867, "ABCDEF==");
+
+        String rpc = "{\"id\":43210,\"result\":[{\"enabled\":1}]}";
+        String payloadText = "{\"dps\":{\"102\":" + quoteJsonString(rpc) + "}}";
+        byte[] frame = buildEncryptedV10Frame(localKey, payloadText.getBytes(StandardCharsets.UTF_8));
+
+        Method extract = LocalDirectTransport.class.getDeclaredMethod("extractResponseRequestId", byte[].class);
+        extract.setAccessible(true);
+
+        Integer requestId = (Integer) extract.invoke(transport, frame);
+        assertNotNull(requestId);
+        assertEquals(43210, requestId.intValue());
+    }
+
+    @Test
+    void extractResponseRequestIdSupportsDndAndCleanSummaryPayloadShapes() throws Exception {
+        LocalDirectTransport transport = new LocalDirectTransport();
+        String localKey = "local-key";
+        transport.updateContext(localKey, "127.0.0.1", 58867, "ABCDEF==");
+
+        Method extract = LocalDirectTransport.class.getDeclaredMethod("extractResponseRequestId", byte[].class);
+        extract.setAccessible(true);
+
+        String dndRpc = "{\"id\":51001,\"result\":[{\"start_hour\":22,\"start_minute\":0,\"end_hour\":8,\"end_minute\":0,\"enabled\":1}]}";
+        String dndPayload = "{\"dps\":{\"102\":" + quoteJsonString(dndRpc) + "}}";
+        byte[] dndFrame = buildEncryptedV10Frame(localKey, dndPayload.getBytes(StandardCharsets.UTF_8));
+        Integer dndId = (Integer) extract.invoke(transport, dndFrame);
+        assertNotNull(dndId);
+        assertEquals(51001, dndId.intValue());
+
+        String summaryRpc = "{\"id\":51002,\"result\":[12345,6789000,9,[\"record-1\"]]}";
+        String summaryPayload = "{\"dps\":{\"102\":" + quoteJsonString(summaryRpc) + "}}";
+        byte[] summaryFrame = buildEncryptedV10Frame(localKey, summaryPayload.getBytes(StandardCharsets.UTF_8));
+        Integer summaryId = (Integer) extract.invoke(transport, summaryFrame);
+        assertNotNull(summaryId);
+        assertEquals(51002, summaryId.intValue());
+    }
+
+    @Test
+    void readMatchingResponseFrameSkipsAckAndMismatchedFrames() throws Exception {
+        LocalDirectTransport transport = new LocalDirectTransport();
+        String localKey = "local-key";
+        transport.updateContext(localKey, "127.0.0.1", 58867, "ABCDEF==");
+
+        Method readMatching = LocalDirectTransport.class.getDeclaredMethod("readMatchingResponseFrame", Socket.class,
+                int.class, String.class, int.class);
+        readMatching.setAccessible(true);
+
+        byte[] ackFrame = buildRawFrame("1.0", 5, new byte[0]);
+
+        String wrongRpc = "{\"id\":62002,\"result\":[{\"enabled\":0}]}";
+        String wrongPayload = "{\"dps\":{\"102\":" + quoteJsonString(wrongRpc) + "}}";
+        byte[] wrongFrame = buildEncryptedV10Frame(localKey, wrongPayload.getBytes(StandardCharsets.UTF_8));
+
+        String matchRpc = "{\"id\":62001,\"result\":[{\"enabled\":1}]}";
+        String matchPayload = "{\"dps\":{\"102\":" + quoteJsonString(matchRpc) + "}}";
+        byte[] matchingFrame = buildEncryptedV10Frame(localKey, matchPayload.getBytes(StandardCharsets.UTF_8));
+
+        byte[] wireBytes = concat(withPrefix(ackFrame), withPrefix(wrongFrame), withPrefix(matchingFrame));
+        FakeSocket fakeSocket = new FakeSocket(wireBytes);
+
+        Object selectedObject = readMatching.invoke(transport, fakeSocket, 62001, "get_dnd_timer", 200);
+        assertNotNull(selectedObject);
+        byte[] selected = (byte[]) selectedObject;
+        assertEquals(matchingFrame.length, selected.length);
+        assertEquals(matchingFrame[0], selected[0]);
+        assertEquals(matchingFrame[1], selected[1]);
+        assertEquals(matchingFrame[2], selected[2]);
+    }
+
+    @Test
+    void readMatchingResponseFrameDispatchesOutOfOrderFrameToConsumer() throws Exception {
+        LocalDirectTransport transport = new LocalDirectTransport();
+        String localKey = "local-key";
+        transport.updateContext(localKey, "127.0.0.1", 58867, "ABCDEF==");
+
+        AtomicInteger dispatchedRequestId = new AtomicInteger(-1);
+        transport.setMessageConsumer(frame -> {
+            try {
+                Method extract = LocalDirectTransport.class.getDeclaredMethod("extractResponseRequestId", byte[].class);
+                extract.setAccessible(true);
+                Integer requestId = (Integer) extract.invoke(transport, frame);
+                if (requestId != null) {
+                    dispatchedRequestId.set(requestId.intValue());
+                }
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
+
+        Method readMatching = LocalDirectTransport.class.getDeclaredMethod("readMatchingResponseFrame", Socket.class,
+                int.class, String.class, int.class);
+        readMatching.setAccessible(true);
+
+        String wrongRpc = "{\"id\":62002,\"result\":[{\"enabled\":0}]}";
+        String wrongPayload = "{\"dps\":{\"102\":" + quoteJsonString(wrongRpc) + "}}";
+        byte[] wrongFrame = buildEncryptedV10Frame(localKey, wrongPayload.getBytes(StandardCharsets.UTF_8));
+
+        String matchRpc = "{\"id\":62001,\"result\":[{\"enabled\":1}]}";
+        String matchPayload = "{\"dps\":{\"102\":" + quoteJsonString(matchRpc) + "}}";
+        byte[] matchingFrame = buildEncryptedV10Frame(localKey, matchPayload.getBytes(StandardCharsets.UTF_8));
+
+        byte[] wireBytes = concat(withPrefix(wrongFrame), withPrefix(matchingFrame));
+        FakeSocket fakeSocket = new FakeSocket(wireBytes);
+
+        Object selectedObject = readMatching.invoke(transport, fakeSocket, 62001, "get_dnd_timer", 200);
+        assertNotNull(selectedObject);
+        byte[] selected = (byte[]) selectedObject;
+        assertEquals(62002, dispatchedRequestId.get());
+        assertEquals(matchingFrame.length, selected.length);
+    }
+
+    @Test
+    void readSingleFrameRejectsOversizedPrefixedLength() throws Exception {
+        LocalDirectTransport transport = new LocalDirectTransport();
+        Method readSingleFrame = LocalDirectTransport.class.getDeclaredMethod("readSingleFrame", Socket.class);
+        readSingleFrame.setAccessible(true);
+
+        byte[] oversizedPrefix = new byte[] { 0x7F, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF };
+        FakeSocket fakeSocket = new FakeSocket(oversizedPrefix);
+
+        InvocationTargetException exception = assertThrows(InvocationTargetException.class,
+                () -> readSingleFrame.invoke(transport, fakeSocket));
+        Throwable cause = exception.getCause();
+        assertNotNull(cause);
+        assertTrue(cause instanceof java.io.IOException);
+        String causeMessage = cause.getMessage();
+        assertNotNull(causeMessage);
+        assertTrue(causeMessage.contains("prefix length"));
+    }
+
+    @Test
+    void readSingleFrameRejectsNonPositivePayloadLength() throws Exception {
+        LocalDirectTransport transport = new LocalDirectTransport();
+        Method readSingleFrame = LocalDirectTransport.class.getDeclaredMethod("readSingleFrame", Socket.class);
+        readSingleFrame.setAccessible(true);
+
+        byte[] malformedNonPrefixedHeader = new byte[19];
+        malformedNonPrefixedHeader[0] = '1';
+        malformedNonPrefixedHeader[1] = '.';
+        malformedNonPrefixedHeader[2] = '0';
+        ProtocolUtils.writeInt16BE(malformedNonPrefixedHeader, 5, 15);
+        ProtocolUtils.writeInt16BE(malformedNonPrefixedHeader, 0, 17);
+        FakeSocket fakeSocket = new FakeSocket(malformedNonPrefixedHeader);
+
+        InvocationTargetException exception = assertThrows(InvocationTargetException.class,
+                () -> readSingleFrame.invoke(transport, fakeSocket));
+        Throwable cause = exception.getCause();
+        assertNotNull(cause);
+        assertTrue(cause instanceof java.io.IOException);
+        String causeMessage = cause.getMessage();
+        assertNotNull(causeMessage);
+        assertTrue(causeMessage.contains("payload length"));
+    }
+
+    @Test
+    void readSingleFrameRejectsMalformedPrefixLengthWithoutAllocatingPayloadBuffer() throws Exception {
+        LocalDirectTransport transport = new LocalDirectTransport();
+        Method readSingleFrame = LocalDirectTransport.class.getDeclaredMethod("readSingleFrame", Socket.class);
+        readSingleFrame.setAccessible(true);
+
+        byte[] zeroLengthPrefix = new byte[] { 0x00, 0x00, 0x00, 0x00 };
+        FakeSocket fakeSocket = new FakeSocket(zeroLengthPrefix);
+
+        InvocationTargetException exception = assertThrows(InvocationTargetException.class,
+                () -> readSingleFrame.invoke(transport, fakeSocket));
+        Throwable cause = exception.getCause();
+        assertNotNull(cause);
+        assertTrue(cause instanceof java.io.IOException);
+        String causeMessage = cause.getMessage();
+        assertNotNull(causeMessage);
+        assertTrue(causeMessage.contains("prefix length"));
+    }
+
+    @Test
+    void updateContextInvalidatesExistingSession() throws Exception {
+        LocalDirectTransport transport = new LocalDirectTransport();
+
+        Field sessionSocketField = LocalDirectTransport.class.getDeclaredField("sessionSocket");
+        sessionSocketField.setAccessible(true);
+        sessionSocketField.set(transport, new Socket());
+
+        transport.updateContext("local-key", "127.0.0.1", 58867, "ABCDEF==");
+        transport.updateContext("local-key", "192.168.1.10", 58867, "ABCDEF==");
+
+        Object sessionSocket = sessionSocketField.get(transport);
+        assertEquals(null, sessionSocket);
+    }
+
+    @Test
+    void ensureConnectedSessionReusesHealthySocket() throws Exception {
+        LocalDirectTransport transport = new LocalDirectTransport();
+
+        Field sessionSocketField = LocalDirectTransport.class.getDeclaredField("sessionSocket");
+        sessionSocketField.setAccessible(true);
+
+        ReusableFakeSocket fakeSocket = new ReusableFakeSocket();
+        sessionSocketField.set(transport, fakeSocket);
+
+        Method ensureConnected = LocalDirectTransport.class.getDeclaredMethod("ensureConnectedSession", String.class,
+                int.class, boolean.class);
+        ensureConnected.setAccessible(true);
+
+        Object result = ensureConnected.invoke(transport, "get_status", 70001, false);
+        assertEquals(fakeSocket, result);
+    }
+
+    @Test
+    void sendCommandOnSessionInvalidatesOnFirstNoMatchTimeout() throws Exception {
+        LocalDirectTransport transport = new LocalDirectTransport();
+        transport.updateContext("local-key", "127.0.0.1", 58867, "ABCDEF==");
+
+        Field sessionSocketField = LocalDirectTransport.class.getDeclaredField("sessionSocket");
+        sessionSocketField.setAccessible(true);
+        TimeoutOnlySocket timeoutSocket = new TimeoutOnlySocket();
+        sessionSocketField.set(transport, timeoutSocket);
+
+        Method sendOnSession = LocalDirectTransport.class.getDeclaredMethod("sendCommandOnSession", String.class,
+                String.class, int.class, boolean.class);
+        sendOnSession.setAccessible(true);
+
+        int requestId = 62011;
+        InvocationTargetException exception = assertThrows(InvocationTargetException.class,
+                () -> sendOnSession.invoke(transport, "get_status", "[]", requestId, false));
+        assertTrue(exception.getCause() instanceof SocketTimeoutException);
+        assertEquals(null, sessionSocketField.get(transport));
+        assertTrue(timeoutSocket.wasClosed());
+    }
+
+    @Test
+    void sendCommandOnSessionInvalidatesOnNoMatchTimeoutWithoutThresholdState() throws Exception {
+        LocalDirectTransport transport = new LocalDirectTransport();
+        transport.updateContext("local-key", "127.0.0.1", 58867, "ABCDEF==");
+
+        Field sessionSocketField = LocalDirectTransport.class.getDeclaredField("sessionSocket");
+        sessionSocketField.setAccessible(true);
+        TimeoutOnlySocket timeoutSocket = new TimeoutOnlySocket();
+        sessionSocketField.set(transport, timeoutSocket);
+
+        Method sendOnSession = LocalDirectTransport.class.getDeclaredMethod("sendCommandOnSession", String.class,
+                String.class, int.class, boolean.class);
+        sendOnSession.setAccessible(true);
+
+        int requestId = 62012;
+        InvocationTargetException exception = assertThrows(InvocationTargetException.class,
+                () -> sendOnSession.invoke(transport, "get_status", "[]", requestId, false));
+        assertTrue(exception.getCause() instanceof SocketTimeoutException);
+        assertEquals(null, sessionSocketField.get(transport));
+        assertTrue(timeoutSocket.wasClosed());
+    }
+
+    @Test
+    void sendCommandRetriesOnceAfterNoMatchTimeout() throws Exception {
+        ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
+        try {
+            byte[] helloResponse = withPrefix(buildHelloResponseFrame("1.0", 0x12345678));
+
+            ScriptedSocket firstSocket = new ScriptedSocket(new HelloThenTimeoutInputStream(helloResponse));
+
+            String localKey = "local-key";
+            String rpcPayload = "{\"id\":62021,\"result\":[{\"state\":8}]}";
+            String payload = "{\"dps\":{\"102\":" + quoteJsonString(rpcPayload) + "}}";
+            byte[] matchingResponse = withPrefix(
+                    buildEncryptedV10Frame(localKey, payload.getBytes(StandardCharsets.UTF_8)));
+            ScriptedSocket secondSocket = new ScriptedSocket(
+                    new ByteArrayInputStream(concat(helloResponse, matchingResponse)));
+
+            AtomicInteger supplierCalls = new AtomicInteger();
+            Supplier<Socket> socketSupplier = () -> supplierCalls.getAndIncrement() == 0 ? firstSocket : secondSocket;
+
+            LocalDirectTransport transport = new LocalDirectTransport(scheduler, 0, System::nanoTime, millis -> {
+            }, socketSupplier);
+            transport.updateContext(localKey, "127.0.0.1", 58867, "ABCDEF==");
+
+            int result = transport.sendCommand("get_status", "[]", 62021);
+            assertEquals(62021, result);
+            assertEquals(2, supplierCalls.get());
+            assertTrue(firstSocket.wasClosed());
+
+            Field sessionSocketField = LocalDirectTransport.class.getDeclaredField("sessionSocket");
+            sessionSocketField.setAccessible(true);
+            assertEquals(secondSocket, sessionSocketField.get(transport));
+        } finally {
+            scheduler.shutdownNow();
+        }
+    }
+
+    @Test
+    void sendCommandNoMatchTimeoutFailsAfterSingleRetry() throws Exception {
+        ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
+        try {
+            byte[] helloResponse = withPrefix(buildHelloResponseFrame("1.0", 0x12345678));
+            ScriptedSocket firstSocket = new ScriptedSocket(new HelloThenTimeoutInputStream(helloResponse));
+            ScriptedSocket secondSocket = new ScriptedSocket(new HelloThenTimeoutInputStream(helloResponse));
+
+            AtomicInteger supplierCalls = new AtomicInteger();
+            Supplier<Socket> socketSupplier = () -> supplierCalls.getAndIncrement() == 0 ? firstSocket : secondSocket;
+
+            LocalDirectTransport transport = new LocalDirectTransport(scheduler, 0, System::nanoTime, millis -> {
+            }, socketSupplier);
+            transport.updateContext("local-key", "127.0.0.1", 58867, "ABCDEF==");
+
+            int result = transport.sendCommand("get_status", "[]", 62022);
+            assertEquals(-1, result);
+            assertEquals(2, supplierCalls.get());
+            assertTrue(firstSocket.wasClosed());
+            assertTrue(secondSocket.wasClosed());
+        } finally {
+            scheduler.shutdownNow();
+        }
+    }
+
+    @Test
+    void getConnectAndAckNonceReflectProtocolSession() throws Exception {
+        LocalDirectTransport transport = new LocalDirectTransport();
+
+        Field protocolSessionField = LocalDirectTransport.class.getDeclaredField("protocolSession");
+        protocolSessionField.setAccessible(true);
+        Object protocolSession = protocolSessionField.get(transport);
+        assertNotNull(protocolSession);
+
+        Field connectNonceField = protocolSession.getClass().getDeclaredField("connectNonce");
+        connectNonceField.setAccessible(true);
+        int connectNonce = connectNonceField.getInt(protocolSession);
+
+        Field ackNonceField = protocolSession.getClass().getDeclaredField("ackNonce");
+        ackNonceField.setAccessible(true);
+        ackNonceField.setInt(protocolSession, 12345);
+
+        assertEquals(connectNonce, transport.getConnectNonce());
+        assertEquals(12345, transport.getAckNonce());
+    }
+
+    @Test
+    void l01JsonFrameNeedsHandshakeContextForDecode() throws Exception {
+        String localKey = "abcdef1234567890";
+        int connectNonce = 23456;
+        int ackNonce = 65432;
+        byte[] frame = buildL01Frame(localKey, connectNonce, ackNonce,
+                "{\"id\":50001,\"result\":[{\"start_hour\":22,\"enabled\":1}]}");
+
+        ProtocolUtils.DecodedMessage missingContext = ProtocolUtils.decodeMessage(frame, localKey, new byte[16],
+                "ABCDEF==");
+        assertTrue(missingContext instanceof ProtocolUtils.IgnoredResponse);
+
+        ProtocolUtils.DecodedMessage withContext = ProtocolUtils.decodeMessage(frame, localKey, new byte[16],
+                "ABCDEF==", connectNonce, ackNonce);
+        assertTrue(withContext instanceof ProtocolUtils.JsonPayloadResponse);
+    }
+
+    @Test
+    void extractResponseRequestIdDecodesL01WithNegativeAckNonce() throws Exception {
+        LocalDirectTransport transport = new LocalDirectTransport();
+        String localKey = "abcdef1234567890";
+        transport.updateContext(localKey, "127.0.0.1", 58867, "ABCDEF==");
+
+        Field protocolSessionField = LocalDirectTransport.class.getDeclaredField("protocolSession");
+        protocolSessionField.setAccessible(true);
+        Object protocolSession = protocolSessionField.get(transport);
+        assertNotNull(protocolSession);
+
+        Field connectNonceField = protocolSession.getClass().getDeclaredField("connectNonce");
+        connectNonceField.setAccessible(true);
+        int connectNonce = connectNonceField.getInt(protocolSession);
+
+        int ackNonce = 0x9ABCDEFF;
+        Field ackNonceField = protocolSession.getClass().getDeclaredField("ackNonce");
+        ackNonceField.setAccessible(true);
+        ackNonceField.setInt(protocolSession, ackNonce);
+
+        Field handshakeContextField = protocolSession.getClass().getDeclaredField("handshakeContextAvailable");
+        handshakeContextField.setAccessible(true);
+        handshakeContextField.setBoolean(protocolSession, true);
+
+        byte[] frame = buildL01Frame(localKey, connectNonce, ackNonce, "{\"id\":62055,\"result\":[1]}");
+
+        Method extract = LocalDirectTransport.class.getDeclaredMethod("extractResponseRequestId", byte[].class);
+        extract.setAccessible(true);
+
+        Integer requestId = (Integer) extract.invoke(transport, frame);
+        assertNotNull(requestId);
+        assertEquals(62055, requestId.intValue());
+    }
+
+    @Test
+    void helloNegotiationRemembersLastGoodVariantAndFallsBack() throws Exception {
+        LocalDirectTransport transport = new LocalDirectTransport();
+        Method performHello = LocalDirectTransport.class.getDeclaredMethod("performHelloHandshake", Socket.class,
+                java.io.OutputStream.class, String.class, int.class);
+        performHello.setAccessible(true);
+
+        ByteArrayOutputStream firstHelloWrites = new ByteArrayOutputStream();
+        Socket firstSocket = new HandshakeSocket(
+                new TimeoutThenBytesInputStream(buildHelloResponseFrame("L01", 0x91ABCDEF)));
+        Object firstSucceeded = performHello.invoke(transport, firstSocket, firstHelloWrites, "get_status", 91001);
+        assertTrue(Boolean.TRUE.equals(firstSucceeded));
+        assertEquals("1.0", extractHelloRequestVersion(firstHelloWrites.toByteArray(), 0));
+        assertEquals("L01", extractHelloRequestVersion(firstHelloWrites.toByteArray(), 1));
+
+        Field protocolSessionField = LocalDirectTransport.class.getDeclaredField("protocolSession");
+        protocolSessionField.setAccessible(true);
+        protocolSessionField.set(transport, new LocalDirectProtocolSession());
+
+        ByteArrayOutputStream secondHelloWrites = new ByteArrayOutputStream();
+        Socket secondSocket = new HandshakeSocket(
+                new TimeoutThenBytesInputStream(buildHelloResponseFrame("1.0", 0x12345678)));
+        Object secondSucceeded = performHello.invoke(transport, secondSocket, secondHelloWrites, "get_consumable",
+                91002);
+        assertTrue(Boolean.TRUE.equals(secondSucceeded));
+        assertEquals("L01", extractHelloRequestVersion(secondHelloWrites.toByteArray(), 0));
+        assertEquals("1.0", extractHelloRequestVersion(secondHelloWrites.toByteArray(), 1));
+    }
+
+    @Test
+    void keepaliveSchedulingAndCancelLifecycle() throws Exception {
+        ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
+        try {
+            LocalDirectTransport transport = new LocalDirectTransport(scheduler, 0, System::nanoTime, millis -> {
+            });
+
+            Method scheduleKeepalive = LocalDirectTransport.class.getDeclaredMethod("scheduleKeepalive");
+            scheduleKeepalive.setAccessible(true);
+            scheduleKeepalive.invoke(transport);
+
+            Field keepaliveFutureField = LocalDirectTransport.class.getDeclaredField("keepaliveFuture");
+            keepaliveFutureField.setAccessible(true);
+            ScheduledFuture<?> future = (ScheduledFuture<?>) keepaliveFutureField.get(transport);
+            assertNotNull(future);
+
+            Method invalidateSession = LocalDirectTransport.class.getDeclaredMethod("invalidateSession", String.class);
+            invalidateSession.setAccessible(true);
+            invalidateSession.invoke(transport, "test");
+
+            ScheduledFuture<?> cancelledFuture = (ScheduledFuture<?>) keepaliveFutureField.get(transport);
+            assertEquals(null, cancelledFuture);
+            assertTrue(future.isCancelled());
+        } finally {
+            scheduler.shutdownNow();
+        }
+    }
+
+    @Test
+    void keepaliveFailureInvalidatesSession() throws Exception {
+        ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
+        try {
+            LocalDirectTransport transport = new LocalDirectTransport(scheduler, 0, System::nanoTime, millis -> {
+            });
+
+            Field sessionSocketField = LocalDirectTransport.class.getDeclaredField("sessionSocket");
+            sessionSocketField.setAccessible(true);
+            PingFailureSocket pingFailureSocket = new PingFailureSocket();
+            sessionSocketField.set(transport, pingFailureSocket);
+
+            Method runKeepalive = LocalDirectTransport.class.getDeclaredMethod("runKeepalive");
+            runKeepalive.setAccessible(true);
+            runKeepalive.invoke(transport);
+
+            assertEquals(null, sessionSocketField.get(transport));
+            assertTrue(pingFailureSocket.wasClosed());
+        } finally {
+            scheduler.shutdownNow();
+        }
+    }
+
+    @Test
+    void directInterCommandPacingSleepsForRemainingGap() throws Exception {
+        AtomicLong nowNanos = new AtomicLong(TimeUnit.MILLISECONDS.toNanos(200));
+        AtomicLong sleptMillis = new AtomicLong(-1);
+        ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
+        try {
+            LocalDirectTransport transport = new LocalDirectTransport(scheduler, 40, nowNanos::get,
+                    millis -> sleptMillis.set(millis));
+
+            Field lastFinishedField = LocalDirectTransport.class.getDeclaredField("lastDirectCommandFinishedNanos");
+            lastFinishedField.setAccessible(true);
+            lastFinishedField.setLong(transport, TimeUnit.MILLISECONDS.toNanos(170));
+
+            Method enforceGap = LocalDirectTransport.class.getDeclaredMethod("enforceInterCommandGap", String.class,
+                    int.class);
+            enforceGap.setAccessible(true);
+            enforceGap.invoke(transport, "get_status", 99001);
+
+            assertEquals(10L, sleptMillis.get());
+        } finally {
+            scheduler.shutdownNow();
+        }
+    }
+
+    private static byte[] buildRawFrame(String version, int protocol, byte[] payload) {
+        byte[] frame = new byte[19 + payload.length + 4];
+        frame[0] = (byte) version.charAt(0);
+        frame[1] = (byte) version.charAt(1);
+        frame[2] = (byte) version.charAt(2);
+        ProtocolUtils.writeInt32BE(frame, 555555, 3);
+        ProtocolUtils.writeInt32BE(frame, 77777, 7);
+        ProtocolUtils.writeInt32BE(frame, (int) (System.currentTimeMillis() / 1000L), 11);
+        ProtocolUtils.writeInt16BE(frame, protocol, 15);
+        ProtocolUtils.writeInt16BE(frame, payload.length, 17);
+        System.arraycopy(payload, 0, frame, 19, payload.length);
+
+        java.util.zip.CRC32 crc32 = new java.util.zip.CRC32();
+        crc32.update(frame, 0, frame.length - 4);
+        ProtocolUtils.writeInt32BE(frame, (int) crc32.getValue(), frame.length - 4);
+        return frame;
+    }
+
+    private static byte[] withPrefix(byte[] frame) {
+        byte[] prefixed = new byte[frame.length + 4];
+        ProtocolUtils.writeInt32BE(prefixed, frame.length, 0);
+        System.arraycopy(frame, 0, prefixed, 4, frame.length);
+        return prefixed;
+    }
+
+    private static byte[] buildL01Frame(String localKey, int connectNonce, int ackNonce, String rpcPayload)
+            throws RoborockException {
+        int timestamp = (int) (System.currentTimeMillis() / 1000L);
+        int sequence = 600001;
+        int random = 70001;
+        String payloadJson = "{\"dps\":{\"102\":" + quoteJsonString(rpcPayload) + "}}";
+        byte[] encrypted = ProtocolUtils.encryptL01(payloadJson.getBytes(StandardCharsets.UTF_8), localKey, timestamp,
+                sequence, random, connectNonce, ackNonce);
+
+        byte[] frame = new byte[19 + encrypted.length + 4];
+        frame[0] = 'L';
+        frame[1] = '0';
+        frame[2] = '1';
+        ProtocolUtils.writeInt32BE(frame, sequence, 3);
+        ProtocolUtils.writeInt32BE(frame, random, 7);
+        ProtocolUtils.writeInt32BE(frame, timestamp, 11);
+        ProtocolUtils.writeInt16BE(frame, 5, 15);
+        ProtocolUtils.writeInt16BE(frame, encrypted.length, 17);
+        System.arraycopy(encrypted, 0, frame, 19, encrypted.length);
+
+        CRC32 crc32 = new CRC32();
+        crc32.update(frame, 0, frame.length - 4);
+        ProtocolUtils.writeInt32BE(frame, (int) crc32.getValue(), frame.length - 4);
+        return frame;
+    }
+
+    private static byte[] buildEncryptedV10Frame(String localKey, byte[] plaintextPayload) {
+        try {
+            int timestamp = (int) (System.currentTimeMillis() / 1000L);
+            byte[] encryptedPayload = ProtocolUtils.encrypt(plaintextPayload, ProtocolUtils.encodeTimestamp(timestamp)
+                    + localKey + org.openhab.binding.roborock.internal.RoborockBindingConstants.SALT);
+            byte[] frame = new byte[19 + encryptedPayload.length + 4];
+            frame[0] = '1';
+            frame[1] = '.';
+            frame[2] = '0';
+            ProtocolUtils.writeInt32BE(frame, 555555, 3);
+            ProtocolUtils.writeInt32BE(frame, 77777, 7);
+            ProtocolUtils.writeInt32BE(frame, timestamp, 11);
+            ProtocolUtils.writeInt16BE(frame, 5, 15);
+            ProtocolUtils.writeInt16BE(frame, encryptedPayload.length, 17);
+            System.arraycopy(encryptedPayload, 0, frame, 19, encryptedPayload.length);
+
+            CRC32 crc32 = new CRC32();
+            crc32.update(frame, 0, frame.length - 4);
+            ProtocolUtils.writeInt32BE(frame, (int) crc32.getValue(), frame.length - 4);
+            return frame;
+        } catch (RoborockException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private static byte[] concat(byte[]... chunks) {
+        int total = 0;
+        for (byte[] chunk : chunks) {
+            total += chunk.length;
+        }
+        byte[] result = new byte[total];
+        int offset = 0;
+        for (byte[] chunk : chunks) {
+            System.arraycopy(chunk, 0, result, offset, chunk.length);
+            offset += chunk.length;
+        }
+        return result;
+    }
+
+    private static String quoteJsonString(String value) {
+        StringBuilder sb = new StringBuilder(value.length() + 8);
+        sb.append('"');
+        for (int i = 0; i < value.length(); i++) {
+            char ch = value.charAt(i);
+            switch (ch) {
+                case '\\':
+                    sb.append("\\\\");
+                    break;
+                case '"':
+                    sb.append("\\\"");
+                    break;
+                case '\n':
+                    sb.append("\\n");
+                    break;
+                case '\r':
+                    sb.append("\\r");
+                    break;
+                case '\t':
+                    sb.append("\\t");
+                    break;
+                default:
+                    if (ch < 0x20) {
+                        sb.append(String.format("\\u%04x", (int) ch));
+                    } else {
+                        sb.append(ch);
+                    }
+                    break;
+            }
+        }
+        sb.append('"');
+        return sb.toString();
+    }
+
+    private static byte[] buildHelloResponseFrame(String version, int ackNonce) {
+        byte[] frame = new byte[21];
+        frame[0] = (byte) version.charAt(0);
+        frame[1] = (byte) version.charAt(1);
+        frame[2] = (byte) version.charAt(2);
+        ProtocolUtils.writeInt32BE(frame, 1, 3);
+        ProtocolUtils.writeInt32BE(frame, ackNonce, 7);
+        ProtocolUtils.writeInt32BE(frame, (int) (System.currentTimeMillis() / 1000L), 11);
+        ProtocolUtils.writeInt16BE(frame, 1, 15);
+
+        CRC32 crc32 = new CRC32();
+        crc32.update(frame, 0, 17);
+        ProtocolUtils.writeInt32BE(frame, (int) crc32.getValue(), 17);
+        return frame;
+    }
+
+    private static String extractHelloRequestVersion(byte[] writes, int requestIndex) {
+        int requestLength = 25;
+        int base = requestIndex * requestLength;
+        return new String(new byte[] { writes[base + 4], writes[base + 5], writes[base + 6] }, StandardCharsets.UTF_8);
+    }
+
+    private static final class FakeSocket extends Socket {
+        private final InputStream inputStream;
+
+        FakeSocket(byte[] bytes) {
+            this.inputStream = new ByteArrayInputStream(bytes);
+        }
+
+        @Override
+        public InputStream getInputStream() {
+            return inputStream;
+        }
+
+        @Override
+        public void setSoTimeout(int timeout) {
+            // no-op for deterministic in-memory stream
+        }
+    }
+
+    private static final class HandshakeSocket extends Socket {
+        private final InputStream inputStream;
+
+        HandshakeSocket(InputStream inputStream) {
+            this.inputStream = inputStream;
+        }
+
+        @Override
+        public InputStream getInputStream() {
+            return inputStream;
+        }
+
+        @Override
+        public void setSoTimeout(int timeout) {
+            // no-op for deterministic in-memory stream
+        }
+    }
+
+    private static final class TimeoutThenBytesInputStream extends InputStream {
+        private final ByteArrayInputStream delegate;
+        private boolean timedOut;
+
+        TimeoutThenBytesInputStream(byte[] bytes) {
+            this.delegate = new ByteArrayInputStream(bytes);
+        }
+
+        @Override
+        public int read() throws java.io.IOException {
+            if (!timedOut) {
+                timedOut = true;
+                throw new SocketTimeoutException("simulated handshake timeout");
+            }
+            return delegate.read();
+        }
+
+        @Override
+        public int read(byte[] b, int off, int len) throws java.io.IOException {
+            if (!timedOut) {
+                timedOut = true;
+                throw new SocketTimeoutException("simulated handshake timeout");
+            }
+            return delegate.read(b, off, len);
+        }
+    }
+
+    private static final class ReusableFakeSocket extends Socket {
+        @Override
+        public boolean isConnected() {
+            return true;
+        }
+
+        @Override
+        public boolean isClosed() {
+            return false;
+        }
+
+        @Override
+        public boolean isInputShutdown() {
+            return false;
+        }
+
+        @Override
+        public boolean isOutputShutdown() {
+            return false;
+        }
+
+        @Override
+        public InetAddress getInetAddress() {
+            return null;
+        }
+    }
+
+    private static final class TimeoutOnlySocket extends Socket {
+        private final InputStream inputStream = new TimeoutOnlyInputStream();
+        private final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        private boolean closed;
+
+        @Override
+        public InputStream getInputStream() {
+            return inputStream;
+        }
+
+        @Override
+        public java.io.OutputStream getOutputStream() {
+            return outputStream;
+        }
+
+        @Override
+        public void setSoTimeout(int timeout) {
+            // no-op for deterministic timeout stream
+        }
+
+        @Override
+        public boolean isConnected() {
+            return true;
+        }
+
+        @Override
+        public boolean isClosed() {
+            return closed;
+        }
+
+        @Override
+        public boolean isInputShutdown() {
+            return false;
+        }
+
+        @Override
+        public boolean isOutputShutdown() {
+            return false;
+        }
+
+        @Override
+        public void close() {
+            closed = true;
+        }
+
+        boolean wasClosed() {
+            return closed;
+        }
+    }
+
+    private static final class TimeoutOnlyInputStream extends InputStream {
+        @Override
+        public int read() throws java.io.IOException {
+            throw new SocketTimeoutException("simulated frame timeout");
+        }
+
+        @Override
+        public int read(byte[] b, int off, int len) throws java.io.IOException {
+            throw new SocketTimeoutException("simulated frame timeout");
+        }
+    }
+
+    private static final class HelloThenTimeoutInputStream extends InputStream {
+        private final ByteArrayInputStream helloBytes;
+
+        HelloThenTimeoutInputStream(byte[] helloBytes) {
+            this.helloBytes = new ByteArrayInputStream(helloBytes);
+        }
+
+        @Override
+        public int read() throws java.io.IOException {
+            int value = helloBytes.read();
+            if (value >= 0) {
+                return value;
+            }
+            throw new SocketTimeoutException("simulated command response timeout");
+        }
+
+        @Override
+        public int read(byte[] b, int off, int len) throws java.io.IOException {
+            int read = helloBytes.read(b, off, len);
+            if (read >= 0) {
+                return read;
+            }
+            throw new SocketTimeoutException("simulated command response timeout");
+        }
+    }
+
+    private static final class ScriptedSocket extends Socket {
+        private final InputStream inputStream;
+        private final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        private boolean closed;
+        private boolean connected;
+
+        ScriptedSocket(InputStream inputStream) {
+            this.inputStream = inputStream;
+        }
+
+        @Override
+        public void connect(java.net.SocketAddress endpoint, int timeout) {
+            connected = true;
+        }
+
+        @Override
+        public InputStream getInputStream() {
+            return inputStream;
+        }
+
+        @Override
+        public OutputStream getOutputStream() {
+            return outputStream;
+        }
+
+        @Override
+        public void setSoTimeout(int timeout) {
+            // no-op
+        }
+
+        @Override
+        public boolean isConnected() {
+            return connected;
+        }
+
+        @Override
+        public boolean isClosed() {
+            return closed;
+        }
+
+        @Override
+        public boolean isInputShutdown() {
+            return false;
+        }
+
+        @Override
+        public boolean isOutputShutdown() {
+            return false;
+        }
+
+        @Override
+        public void close() {
+            closed = true;
+        }
+
+        boolean wasClosed() {
+            return closed;
+        }
+    }
+
+    private static final class PingFailureSocket extends Socket {
+        private final InputStream inputStream = new TimeoutOnlyInputStream();
+        private final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        private boolean closed;
+
+        @Override
+        public InputStream getInputStream() {
+            return inputStream;
+        }
+
+        @Override
+        public java.io.OutputStream getOutputStream() {
+            return outputStream;
+        }
+
+        @Override
+        public void setSoTimeout(int timeout) {
+            // no-op
+        }
+
+        @Override
+        public boolean isConnected() {
+            return true;
+        }
+
+        @Override
+        public boolean isClosed() {
+            return closed;
+        }
+
+        @Override
+        public boolean isInputShutdown() {
+            return false;
+        }
+
+        @Override
+        public boolean isOutputShutdown() {
+            return false;
+        }
+
+        @Override
+        public void close() {
+            closed = true;
+        }
+
+        boolean wasClosed() {
+            return closed;
+        }
+    }
+}

--- a/bundles/org.openhab.binding.roborock/src/test/java/org/openhab/binding/roborock/internal/util/ProtocolUtilsDirectJsonDecodeTest.java
+++ b/bundles/org.openhab.binding.roborock/src/test/java/org/openhab/binding/roborock/internal/util/ProtocolUtilsDirectJsonDecodeTest.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.roborock.internal.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.openhab.binding.roborock.internal.RoborockBindingConstants.*;
+
+import java.nio.charset.StandardCharsets;
+import java.util.zip.CRC32;
+
+import org.junit.jupiter.api.Test;
+import org.openhab.binding.roborock.internal.RoborockException;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+class ProtocolUtilsDirectJsonDecodeTest {
+
+    @Test
+    void decodeMessageHandlesProtocol4AsJsonPayload() {
+        String localKey = "local-key";
+        int timestamp = 1_762_101_111;
+        String rpc = "{\"id\":73001,\"result\":[{\"enabled\":1}]}";
+        String payload = "{\"dps\":{\"102\":" + quoteJsonString(rpc) + "}}";
+
+        byte[] frame = buildEncryptedV10Frame(4, timestamp, localKey, payload.getBytes(StandardCharsets.UTF_8));
+        ProtocolUtils.DecodedMessage decoded = ProtocolUtils.decodeMessage(frame, localKey, new byte[16], "ABCDEF==");
+
+        ProtocolUtils.JsonPayloadResponse json = assertInstanceOf(ProtocolUtils.JsonPayloadResponse.class, decoded);
+        assertRpcId(json.payload(), 73001);
+    }
+
+    @Test
+    void decodeMessageHandlesProtocol5AsJsonPayload() {
+        String localKey = "local-key";
+        int timestamp = 1_762_101_112;
+        String rpc = "{\"id\":73002,\"result\":[{\"enabled\":0}]}";
+        String payload = "{\"dps\":{\"102\":" + quoteJsonString(rpc) + "}}";
+
+        byte[] frame = buildEncryptedV10Frame(5, timestamp, localKey, payload.getBytes(StandardCharsets.UTF_8));
+        ProtocolUtils.DecodedMessage decoded = ProtocolUtils.decodeMessage(frame, localKey, new byte[16], "ABCDEF==");
+
+        ProtocolUtils.JsonPayloadResponse json = assertInstanceOf(ProtocolUtils.JsonPayloadResponse.class, decoded);
+        assertRpcId(json.payload(), 73002);
+    }
+
+    @Test
+    void decodeMessageKeepsUnknownProtocolIgnored() {
+        String localKey = "local-key";
+        int timestamp = 1_762_101_113;
+        byte[] frame = buildEncryptedV10Frame(9, timestamp, localKey,
+                "{\"dps\":{\"102\":\"{}\"}}".getBytes(StandardCharsets.UTF_8));
+
+        ProtocolUtils.DecodedMessage decoded = ProtocolUtils.decodeMessage(frame, localKey, new byte[16], "ABCDEF==");
+        assertEquals(ProtocolUtils.IgnoredResponse.class, decoded.getClass());
+    }
+
+    @Test
+    void decodeL01NeedsHandshakeContext() throws Exception {
+        String localKey = "abcdef1234567890";
+        int connectNonce = 23456;
+        int ackNonce = 65432;
+        byte[] frame = buildL01Frame(localKey, connectNonce, ackNonce,
+                "{\"id\":74001,\"result\":[{\"start_hour\":22,\"enabled\":1}]}");
+
+        ProtocolUtils.DecodedMessage withoutHandshake = ProtocolUtils.decodeMessage(frame, localKey, new byte[16],
+                "ABCDEF==");
+        assertEquals(ProtocolUtils.IgnoredResponse.class, withoutHandshake.getClass());
+
+        ProtocolUtils.DecodedMessage withHandshake = ProtocolUtils.decodeMessage(frame, localKey, new byte[16],
+                "ABCDEF==", connectNonce, ackNonce);
+        ProtocolUtils.JsonPayloadResponse json = assertInstanceOf(ProtocolUtils.JsonPayloadResponse.class,
+                withHandshake);
+        assertRpcId(json.payload(), 74001);
+    }
+
+    @Test
+    void decodeL01AcceptsNegativeAckNonceWhenHandshakeContextIsAvailable() throws Exception {
+        String localKey = "abcdef1234567890";
+        int connectNonce = 24567;
+        int ackNonce = 0x9ABCDEFF;
+        byte[] frame = buildL01Frame(localKey, connectNonce, ackNonce, "{\"id\":74002,\"result\":[{\"enabled\":1}]}");
+
+        ProtocolUtils.DecodedMessage decoded = ProtocolUtils.decodeMessage(frame, localKey, new byte[16], "ABCDEF==",
+                connectNonce, ackNonce, true);
+        ProtocolUtils.JsonPayloadResponse json = assertInstanceOf(ProtocolUtils.JsonPayloadResponse.class, decoded);
+        assertRpcId(json.payload(), 74002);
+        assertTrue(ackNonce < 0);
+    }
+
+    private static byte[] buildEncryptedV10Frame(int protocol, int timestamp, String localKey,
+            byte[] plaintextPayload) {
+        try {
+            byte[] encryptedPayload = ProtocolUtils.encrypt(plaintextPayload,
+                    ProtocolUtils.encodeTimestamp(timestamp) + localKey + SALT);
+            byte[] frame = new byte[HEADER_LENGTH_WITHOUT_CRC + encryptedPayload.length + CRC_LENGTH];
+            frame[0] = '1';
+            frame[1] = '.';
+            frame[2] = '0';
+            ProtocolUtils.writeInt32BE(frame, 500001, SEQ_OFFSET);
+            ProtocolUtils.writeInt32BE(frame, 61111, RANDOM_OFFSET);
+            ProtocolUtils.writeInt32BE(frame, timestamp, TIMESTAMP_OFFSET);
+            ProtocolUtils.writeInt16BE(frame, protocol, PROTOCOL_OFFSET);
+            ProtocolUtils.writeInt16BE(frame, encryptedPayload.length, PAYLOAD_OFFSET);
+            System.arraycopy(encryptedPayload, 0, frame, HEADER_LENGTH_WITHOUT_CRC, encryptedPayload.length);
+
+            CRC32 crc32 = new CRC32();
+            crc32.update(frame, 0, frame.length - CRC_LENGTH);
+            ProtocolUtils.writeInt32BE(frame, (int) crc32.getValue(), frame.length - CRC_LENGTH);
+            return frame;
+        } catch (RoborockException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private static byte[] buildL01Frame(String localKey, int connectNonce, int ackNonce, String rpcPayload)
+            throws RoborockException {
+        int timestamp = (int) (System.currentTimeMillis() / 1000L);
+        int sequence = 600101;
+        int random = 70101;
+        String payloadJson = "{\"dps\":{\"102\":" + quoteJsonString(rpcPayload) + "}}";
+        byte[] encrypted = ProtocolUtils.encryptL01(payloadJson.getBytes(StandardCharsets.UTF_8), localKey, timestamp,
+                sequence, random, connectNonce, ackNonce);
+
+        byte[] frame = new byte[HEADER_LENGTH_WITHOUT_CRC + encrypted.length + CRC_LENGTH];
+        frame[0] = 'L';
+        frame[1] = '0';
+        frame[2] = '1';
+        ProtocolUtils.writeInt32BE(frame, sequence, SEQ_OFFSET);
+        ProtocolUtils.writeInt32BE(frame, random, RANDOM_OFFSET);
+        ProtocolUtils.writeInt32BE(frame, timestamp, TIMESTAMP_OFFSET);
+        ProtocolUtils.writeInt16BE(frame, 5, PROTOCOL_OFFSET);
+        ProtocolUtils.writeInt16BE(frame, encrypted.length, PAYLOAD_OFFSET);
+        System.arraycopy(encrypted, 0, frame, HEADER_LENGTH_WITHOUT_CRC, encrypted.length);
+
+        CRC32 crc32 = new CRC32();
+        crc32.update(frame, 0, frame.length - CRC_LENGTH);
+        ProtocolUtils.writeInt32BE(frame, (int) crc32.getValue(), frame.length - CRC_LENGTH);
+        return frame;
+    }
+
+    private static String quoteJsonString(String value) {
+        StringBuilder sb = new StringBuilder(value.length() + 8);
+        sb.append('"');
+        for (int i = 0; i < value.length(); i++) {
+            char ch = value.charAt(i);
+            switch (ch) {
+                case '\\':
+                    sb.append("\\\\");
+                    break;
+                case '"':
+                    sb.append("\\\"");
+                    break;
+                case '\n':
+                    sb.append("\\n");
+                    break;
+                case '\r':
+                    sb.append("\\r");
+                    break;
+                case '\t':
+                    sb.append("\\t");
+                    break;
+                default:
+                    if (ch < 0x20) {
+                        sb.append(String.format("\\u%04x", (int) ch));
+                    } else {
+                        sb.append(ch);
+                    }
+                    break;
+            }
+        }
+        sb.append('"');
+        return sb.toString();
+    }
+
+    private static void assertRpcId(String outerJson, int expectedId) {
+        JsonObject outer = JsonParser.parseString(outerJson).getAsJsonObject();
+        JsonObject dps = outer.getAsJsonObject("dps");
+        String rpc = dps.get("102").getAsString();
+        JsonObject rpcJson = JsonParser.parseString(rpc).getAsJsonObject();
+        assertEquals(expectedId, rpcJson.get("id").getAsInt(), outerJson);
+    }
+}

--- a/bundles/org.openhab.binding.roborock/src/test/java/org/openhab/binding/roborock/internal/util/ProtocolUtilsDirectJsonDecodeTest.java
+++ b/bundles/org.openhab.binding.roborock/src/test/java/org/openhab/binding/roborock/internal/util/ProtocolUtilsDirectJsonDecodeTest.java
@@ -20,12 +20,14 @@ import static org.openhab.binding.roborock.internal.RoborockBindingConstants.*;
 import java.nio.charset.StandardCharsets;
 import java.util.zip.CRC32;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.junit.jupiter.api.Test;
 import org.openhab.binding.roborock.internal.RoborockException;
 
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 
+@NonNullByDefault({})
 class ProtocolUtilsDirectJsonDecodeTest {
 
     @Test

--- a/bundles/org.openhab.binding.roborock/src/test/java/org/openhab/binding/roborock/internal/util/ProtocolUtilsMapDecodeTest.java
+++ b/bundles/org.openhab.binding.roborock/src/test/java/org/openhab/binding/roborock/internal/util/ProtocolUtilsMapDecodeTest.java
@@ -29,8 +29,10 @@ import javax.crypto.Cipher;
 import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.junit.jupiter.api.Test;
 
+@NonNullByDefault({})
 class ProtocolUtilsMapDecodeTest {
 
     @Test

--- a/bundles/org.openhab.binding.roborock/src/test/java/org/openhab/binding/roborock/internal/util/RequestCorrelationTrackerTest.java
+++ b/bundles/org.openhab.binding.roborock/src/test/java/org/openhab/binding/roborock/internal/util/RequestCorrelationTrackerTest.java
@@ -13,6 +13,7 @@
 package org.openhab.binding.roborock.internal.util;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -64,5 +65,80 @@ class RequestCorrelationTrackerTest {
         tracker.removeByRequestId(33333);
 
         assertNull(tracker.findMethodByRequestId(33333));
+    }
+
+    @Test
+    void cleanupExpiredRemovesOnlyStaleRequests() throws InterruptedException {
+        RequestCorrelationTracker tracker = new RequestCorrelationTracker();
+
+        tracker.register("stale", 44444);
+        Thread.sleep(20);
+        tracker.register("fresh", 55555);
+
+        tracker.cleanupExpired(10);
+
+        assertNull(tracker.findMethodByRequestId(44444));
+        assertEquals("fresh", tracker.findMethodByRequestId(55555));
+        assertFalse(tracker.isRequestIdInUse(44444));
+        assertTrue(tracker.isRequestIdInUse(55555));
+    }
+
+    @Test
+    void isMapRelatedMethodIdentifiesMapMethods() {
+        assertTrue(RequestCorrelationTracker.isMapRelatedMethod("getMap"));
+        assertTrue(RequestCorrelationTracker.isMapRelatedMethod("get_map_v1"));
+        assertTrue(RequestCorrelationTracker.isMapRelatedMethod("mapDownload"));
+        assertFalse(RequestCorrelationTracker.isMapRelatedMethod("getStatus"));
+        assertFalse(RequestCorrelationTracker.isMapRelatedMethod("get_consumable"));
+        assertFalse(RequestCorrelationTracker.isMapRelatedMethod(null));
+    }
+
+    @Test
+    void preRegistrationAllowsImmediateResponseCorrelation() {
+        RequestCorrelationTracker tracker = new RequestCorrelationTracker();
+
+        // Simulate pre-registration before send (to avoid race condition)
+        int requestId = 12345;
+        tracker.register("getMap", requestId);
+
+        // Verify correlation is immediately available for response handling
+        assertTrue(tracker.isRequestIdInUse(requestId));
+        assertEquals("getMap", tracker.findMethodByRequestId(requestId));
+    }
+
+    @Test
+    void cleanupOnSendFailureRemovesPreRegisteredCorrelation() {
+        RequestCorrelationTracker tracker = new RequestCorrelationTracker();
+
+        // Simulate pre-registration before send
+        int requestId = 12345;
+        tracker.register("getMap", requestId);
+        assertTrue(tracker.isRequestIdInUse(requestId));
+
+        // Simulate send failure - cleanup should remove correlation
+        tracker.removeByRequestId(requestId);
+
+        // Verify correlation is cleaned up
+        assertFalse(tracker.isRequestIdInUse(requestId));
+        assertNull(tracker.findMethodByRequestId(requestId));
+    }
+
+    @Test
+    void doubleRegistrationDoesNotCorruptState() {
+        RequestCorrelationTracker tracker = new RequestCorrelationTracker();
+
+        // First registration
+        tracker.register("getMap", 12345);
+
+        // Attempt double registration (should be idempotent or handled gracefully)
+        tracker.register("getMap", 12345);
+
+        // State should remain consistent
+        assertEquals("getMap", tracker.findMethodByRequestId(12345));
+        assertTrue(tracker.isRequestIdInUse(12345));
+
+        // Cleanup should work correctly
+        tracker.removeByRequestId(12345);
+        assertFalse(tracker.isRequestIdInUse(12345));
     }
 }

--- a/bundles/org.openhab.binding.roborock/src/test/java/org/openhab/binding/roborock/internal/util/RequestCorrelationTrackerTest.java
+++ b/bundles/org.openhab.binding.roborock/src/test/java/org/openhab/binding/roborock/internal/util/RequestCorrelationTrackerTest.java
@@ -17,8 +17,10 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.junit.jupiter.api.Test;
 
+@NonNullByDefault({})
 class RequestCorrelationTrackerTest {
 
     @Test


### PR DESCRIPTION
Added local protocol support - tested it with Roborck Saros 10 and Roborock S6. I posted few weeks ago the build over here https://community.openhab.org/t/roborock-binding-for-robot-vacuum-cleaners-5-0-0-0-5-1-0-0/164698/290 but I haven't received too much feedback. Anyway, I'm using it personally since then and it seems to work quite good. 

Local protocol was following principles from Mi IO binding and is using API mentioned in Roborock Python github repository

I've also introduced couple new refresh rates - Home Assistant does all those things under the hood and don't expose it as configurable parameters ( https://github.com/home-assistant/core/blob/84019955ce56752b188384b47b7f40296dfb25d0/homeassistant/components/roborock/const.py#L64-L69 ) . There are some reasonable minimal values in place. When robot is cleaning, refreshing of local and cloud items can be set to be much frequent, which allows for nice overview of robot cleaning.

There is one odd thing which I left for backward compatibility - there are multiple new controls for refresh time and they are all now using seconds, not minutes. I left minutes so that users are not locking themselves out of Roborock Cloud, which will silently block you if you will hit their API rate limits.


I've also included in this PR option action on robot thing to download RRMap - such map can be then used with Xiaomi Vacuum Map Viewer ( https://community.openhab.org/t/xiaomi-vacuum-map-viewer-to-find-coordinates-for-zone-cleaning/103500 ) 