### PR TITLE
[mecmeter] Add representation property information

### DIFF
--- a/bundles/org.openhab.binding.mecmeter/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.mecmeter/src/main/resources/OH-INF/thing/thing-types.xml
@@ -35,6 +35,8 @@
 			<channel-group id="app_energy_group" typeId="app_energy_group"/>
 		</channel-groups>
 
+		<representation-property>serialNumber</representation-property>
+
 		<config-description>
 			<parameter name="password" type="text" required="true">
 				<label>Password</label>


### PR DESCRIPTION
This change ensures that duplicate inbox entries are correctly ignored.