### PR TITLE
[sat] Suppress NullAnnotationsCheck for test source files

### DIFF
--- a/tools/static-code-analysis/checkstyle/suppressions.xml
+++ b/tools/static-code-analysis/checkstyle/suppressions.xml
@@ -11,6 +11,11 @@
     <!-- Homematic and Tellstick bindings are creating and configuring things dynamically, they will log false positives for unused configuration -->
     <!-- IO and Voice bundles have specific use cases - they use only the config .xml files and will log false positives as well -->
     <suppress files=".+org.openhab.binding.homematic.+|.+org.openhab.binding.tellstick.+|.+org.openhab.io.+|.+org.openhab.voice.+" checks="OhInfXmlCheck"/>
+    <!-- NullAnnotationsCheck is not applied to test sources: ECJ cannot model the JUnit
+         @BeforeEach lifecycle, so @NonNullByDefault on test classes forces either inline
+         field initialization or pervasive @Nullable annotations - adding noise without
+         runtime safety benefit. -->
+    <suppress files=".+[\\/]src[\\/]test[\\/].+\.java" checks="NullAnnotationsCheck"/>
     <!-- Some checks will be supressed for test bundles -->
     <suppress files=".+.test[\\/].+" checks="RequireBundleCheck"/>
     <!--  There is a single class inside org.openhab.voice.voicerss.tool, which is meant to be called from the command line.


### PR DESCRIPTION
## Summary

Suppress the `NullAnnotationsCheck` (i.e. the `@NonNullByDefault` requirement) for all Java files under `src/test/`.

## Rationale

ECJ's static null analysis cannot model the JUnit `@BeforeEach` lifecycle guarantee. When `@NonNullByDefault` is present on a test class, fields that are initialized in `@BeforeEach` (not at declaration time) are treated as uninitialized `@NonNull`, producing compilation errors.

Fixing this correctly requires one of:
- Initializing every field inline with a throwaway object (creates noise, obscures intent)
- Declaring all `@BeforeEach`-initialized fields as `@Nullable` and adding null guards at every usage site (very verbose, no safety benefit)

Neither option prevents real bugs: an NPE in a test fails the test immediately at development time — there is no silent production failure to guard against.

## Precedent

This aligns with the existing suppressions in this file:
- `NullAnnotationsCheck` is already suppressed for `DTO` and `dto/` classes for the same structural reason
- `RequireBundleCheck` is already suppressed for test bundles

## Scope

Only `src/test/` Java files are affected. Production source files under `src/main/` are unaffected.