### PR TITLE
[hue] Apply status description if battery is low

### DIFF
--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/HueBindingConstants.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/HueBindingConstants.java
@@ -135,6 +135,7 @@ public class HueBindingConstants {
     // I18N string references
     public static final String TEXT_OFFLINE_COMMUNICATION_ERROR = "@text/offline.communication-error";
     public static final String TEXT_OFFLINE_CONFIGURATION_ERROR_INVALID_SSL_CERIFICATE = "@text/offline.conf-error-invalid-ssl-certificate";
+    public static final String TEXT_ONLINE_BATTERY_LOW = "@text/online.battery-low";
 
     // Config status messages
     public static final String IP_ADDRESS_MISSING = "missing-ip-address-configuration";

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/Clip2ThingHandler.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/Clip2ThingHandler.java
@@ -87,6 +87,7 @@ import org.openhab.core.thing.Thing;
 import org.openhab.core.thing.ThingRegistry;
 import org.openhab.core.thing.ThingStatus;
 import org.openhab.core.thing.ThingStatusDetail;
+import org.openhab.core.thing.ThingStatusInfo;
 import org.openhab.core.thing.ThingTypeUID;
 import org.openhab.core.thing.ThingUID;
 import org.openhab.core.thing.binding.BaseThingHandler;
@@ -1060,6 +1061,7 @@ public class Clip2ThingHandler extends BaseThingHandler {
             case DEVICE_POWER:
                 updateState(CHANNEL_2_BATTERY_LEVEL, resource.getBatteryLevelState(), fullUpdate);
                 updateState(CHANNEL_2_BATTERY_LOW, resource.getBatteryLowState(), fullUpdate);
+                updateOnlineStatusDescription(resource.getBatteryLowState());
                 break;
 
             case LIGHT:
@@ -1708,5 +1710,32 @@ public class Clip2ThingHandler extends BaseThingHandler {
             // if there is no software update status preserve the caller-provided status information
         }
         super.updateStatus(thingStatus, detail, description);
+    }
+
+    /**
+     * Update thing status description based on the given battery low state. If the battery is low and the description
+     * is null, then the description is set to the respective battery low translatable text. If the battery is OK, and
+     * the description is the low battery translatable text, then the description message is cleared. If the thing is
+     * not ONLINE, or if it does not have a battery low channel then the description is not updated. NOTE: this method
+     * only updates the status description if the thing does not already have a status description for a different issue
+     * such as software update available or software installing.
+     */
+    private void updateOnlineStatusDescription(State batteryLowState) {
+        ThingStatusInfo statusInfo = getThing().getStatusInfo();
+        if (statusInfo.getStatus() == ThingStatus.ONLINE && thing.getChannel(CHANNEL_2_BATTERY_LOW) != null) {
+            String description = statusInfo.getDescription();
+
+            // if battery is OK and description is the low battery text then clear the description
+            if (batteryLowState == OnOffType.OFF && TEXT_ONLINE_BATTERY_LOW.equals(description)) {
+                super.updateStatus(statusInfo.getStatus(), statusInfo.getStatusDetail());
+                return;
+            }
+
+            // if battery is low and description is null then apply the low battery text
+            if (batteryLowState == OnOffType.ON && description == null) {
+                super.updateStatus(statusInfo.getStatus(), statusInfo.getStatusDetail(), TEXT_ONLINE_BATTERY_LOW);
+                return;
+            }
+        }
     }
 }

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/Clip2ThingHandler.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/Clip2ThingHandler.java
@@ -1732,7 +1732,7 @@ public class Clip2ThingHandler extends BaseThingHandler {
             }
 
             // if battery is low and description is null then apply the low battery text
-            if (OnOffType.ON.equals(batteryLowState) && description == null) {
+            if (OnOffType.ON.equals(batteryLowState) && (description == null || description.isBlank())) {
                 super.updateStatus(statusInfo.getStatus(), statusInfo.getStatusDetail(), TEXT_ONLINE_BATTERY_LOW);
                 return;
             }

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/Clip2ThingHandler.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/Clip2ThingHandler.java
@@ -1721,7 +1721,7 @@ public class Clip2ThingHandler extends BaseThingHandler {
      * such as software update available or software installing.
      */
     private void updateOnlineStatusDescription(State batteryLowState) {
-        ThingStatusInfo statusInfo = getThing().getStatusInfo();
+        ThingStatusInfo statusInfo = thing.getStatusInfo();
         if (statusInfo.getStatus() == ThingStatus.ONLINE && thing.getChannel(CHANNEL_2_BATTERY_LOW) != null) {
             String description = statusInfo.getDescription();
 

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/Clip2ThingHandler.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/Clip2ThingHandler.java
@@ -1726,13 +1726,13 @@ public class Clip2ThingHandler extends BaseThingHandler {
             String description = statusInfo.getDescription();
 
             // if battery is OK and description is the low battery text then clear the description
-            if (batteryLowState == OnOffType.OFF && TEXT_ONLINE_BATTERY_LOW.equals(description)) {
+            if (OnOffType.OFF.equals(batteryLowState) && TEXT_ONLINE_BATTERY_LOW.equals(description)) {
                 super.updateStatus(statusInfo.getStatus(), statusInfo.getStatusDetail());
                 return;
             }
 
             // if battery is low and description is null then apply the low battery text
-            if (batteryLowState == OnOffType.ON && description == null) {
+            if (OnOffType.ON.equals(batteryLowState) && description == null) {
                 super.updateStatus(statusInfo.getStatus(), statusInfo.getStatusDetail(), TEXT_ONLINE_BATTERY_LOW);
                 return;
             }

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/Clip2ThingHandler.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/Clip2ThingHandler.java
@@ -1060,8 +1060,9 @@ public class Clip2ThingHandler extends BaseThingHandler {
 
             case DEVICE_POWER:
                 updateState(CHANNEL_2_BATTERY_LEVEL, resource.getBatteryLevelState(), fullUpdate);
-                updateState(CHANNEL_2_BATTERY_LOW, resource.getBatteryLowState(), fullUpdate);
-                updateOnlineStatusDescription(resource.getBatteryLowState());
+                State batteryLowState = resource.getBatteryLowState();
+                updateState(CHANNEL_2_BATTERY_LOW, batteryLowState, fullUpdate);
+                updateOnlineStatusDescription(batteryLowState);
                 break;
 
             case LIGHT:

--- a/bundles/org.openhab.binding.hue/src/main/resources/OH-INF/i18n/hue.properties
+++ b/bundles/org.openhab.binding.hue/src/main/resources/OH-INF/i18n/hue.properties
@@ -358,6 +358,10 @@ offline.api2.conf-error.resource-id-missing = Resource ID is not configured.
 offline.api2.conf-error.not-authorized = The application key is not authorized.
 offline.api2.gone.resource-id-unknown = Resource ID is unknown to the bridge.
 
+# thing online status detail description messages
+ 
+online.battery-low = Battery level is low.
+
 # scene channel description
 
 scene.channel.activate = Activate the scene ''{0}''


### PR DESCRIPTION
This PR adds a Thing status description text when the thing has a low battery.

The consequence of  a Thing status description text is as follows:
1. The status description text is displayed on the WebUI Thing detail page
2. A 'blue dot' decorator is added to the Thing status badge on the WebUI Things overview list (new [WebUI feature](https://github.com/openhab/openhab-webui/pull/4069)).

It follows the analogy of #20498 where a Thing status description text is added to indicate availability of a software update.

Signed-off-by: Andrew Fiddian-Green <software@whitebear.ch>
