### PR TITLE
[tuya] Improve handling of battery devices

### DIFF
--- a/bundles/org.openhab.binding.tuya/src/main/java/org/openhab/binding/tuya/internal/TuyaBindingConstants.java
+++ b/bundles/org.openhab.binding.tuya/src/main/java/org/openhab/binding/tuya/internal/TuyaBindingConstants.java
@@ -52,6 +52,10 @@ public class TuyaBindingConstants {
     public static final List<String> DIMMER_CHANNEL_CODES = List.of("bright_value", "bright_value_1", "bright_value_2",
             "temp_value");
 
+    // The maximum length of time a connection to the device is maintained. After this we close
+    // and reconnect in an attempt to limit possible connection related, device-side memory leaks.
+    public static final int TCP_CONNECTION_MAX_LIFETIME = 86400; // Seconds
+
     // The heartbeat interval specifies the maximum amount of time that can pass without us
     // sending anything to a device. Once the heartbeat interval is reached we send a heartbeat
     // message to let the device know we are still present. Devices that do not receive traffic
@@ -62,13 +66,13 @@ public class TuyaBindingConstants {
     // The amount of time a device has to respond to a message. If we don't see anything from
     // the device for this long after sending a message we consider the connection dead, close
     // it, and start trying to reconnect.
-    public static final int TCP_CONNECTION_MESSAGE_RESPONSE = 1; // Seconds
+    public static final int TCP_CONNECTION_MESSAGE_RESPONSE = 200; // Milliseconds
 
     // How long to wait for a TCP session to connect before closing it and starting again. We do
     // not rely on TCP's own retry strategy because that varies between implementations so we
     // cannot know when the retry interval has become so great that it exceeds the amount of
     // time a battery device may be awake.
-    public static final int TCP_CONNECT_TIMEOUT = 1000; // Milliseconds
+    public static final int TCP_CONNECT_TIMEOUT = 500; // Milliseconds
 
     // How long to wait before attempting another connection after the previous closed or failed.
     // Note that if the previous attempt failed because the device was not reachable the interval
@@ -78,5 +82,19 @@ public class TuyaBindingConstants {
     // of TCP_CONNECT_TIMEOUT and TCP_CONNECT_RETRY_INTERVAL must therefore be small enough that at
     // least one, preferably two or three, connection attempts will be made during the time the
     // device is awake.
-    public static final int TCP_CONNECT_RETRY_INTERVAL = 1000; // Milliseconds
+    public static final int TCP_CONNECT_RETRY_INTERVAL = 50; // Milliseconds
+
+    // How long to wait before sending the initial query after connecting.
+    // We need to delay the initial query because some battery devices seem to ignore requests that
+    // come too soon and sometimes they claim DP_QUERY isn't supported when it really is. Perhaps the
+    // TCP stack is initialized before the API?
+    public static final int TCP_CONNECT_INITIAL_DELAY = 750; // Milliseconds
+
+    // How long to wait before attempting another connection after the first "Connection refused".
+    // When battery devices wake up their TCP can come online before the API server is started
+    // and even before the API backend is plugged in to the API server. Hammering battery devices
+    // (which tend to be especially slow) with connection attempts will just waste their CPU cycles
+    // and can mean they don't even come online until a second event has overwritten the first
+    // (especially a problem for contact sensors).
+    public static final int TCP_CONNECT_INITIAL_INTERVAL = 1000; // Milliseconds
 }

--- a/bundles/org.openhab.binding.tuya/src/main/java/org/openhab/binding/tuya/internal/handler/TuyaDeviceHandler.java
+++ b/bundles/org.openhab.binding.tuya/src/main/java/org/openhab/binding/tuya/internal/handler/TuyaDeviceHandler.java
@@ -147,17 +147,6 @@ public class TuyaDeviceHandler extends BaseThingHandler implements DeviceInfoSub
 
     @Override
     public void processDeviceStatus(Map<Integer, Object> deviceStatus) {
-        // Older devices may need to use the control method to request device status.
-        if (deviceStatus.isEmpty()) {
-            TuyaDevice tuyaDevice = this.tuyaDevice;
-            if (tuyaDevice != null) {
-                logger.debug("'{}' switching to control instead of query", thing.getUID());
-                tuyaDevice.setQueryUsesControl();
-                tuyaDevice.requestStatus(List.of());
-            }
-            return;
-        }
-
         // Changes to function DPs might lead to changes in status DPs. For instance, if a
         // power switch is turned on the measured current and power can be expected to change
         // within a few seconds.
@@ -178,6 +167,8 @@ public class TuyaDeviceHandler extends BaseThingHandler implements DeviceInfoSub
         }
 
         if (needRefresh && configuration.pollingInterval > 0) {
+            // We cannot assume that DPs are current or that the device will automatically
+            // re-measure on a function change.
             TuyaDevice tuyaDevice = this.tuyaDevice;
             if (tuyaDevice != null) {
                 ScheduledFuture<?> pollingJob = this.pollingJob;
@@ -186,7 +177,7 @@ public class TuyaDeviceHandler extends BaseThingHandler implements DeviceInfoSub
                 }
 
                 pollBurst = 3;
-                this.pollingJob = scheduler.scheduleWithFixedDelay(this::burstPoller, 1, 1, TimeUnit.SECONDS);
+                this.pollingJob = scheduler.scheduleWithFixedDelay(this::burstPoller, 0, 1, TimeUnit.SECONDS);
             }
         } else if (!missingStatus) {
             // If we have updates for everything we can stand down the burst polling.
@@ -200,19 +191,19 @@ public class TuyaDeviceHandler extends BaseThingHandler implements DeviceInfoSub
         TuyaDevice tuyaDevice = this.tuyaDevice;
         if (tuyaDevice != null) {
             if (pollBurst > 0) {
-                tuyaDevice.refreshStatus(List.of());
+                tuyaDevice.refreshStatus();
                 pollBurst = pollBurst - 1;
             } else {
                 ScheduledFuture<?> pollingJob = this.pollingJob;
                 if (pollingJob != null) {
                     this.pollingJob = null;
-                    pollingJob.cancel(true);
+                    pollingJob.cancel(false);
                 }
 
                 int pollingInterval = configuration.pollingInterval;
                 if (pollingInterval > 0) {
                     this.pollingJob = scheduler.scheduleWithFixedDelay(() -> {
-                        tuyaDevice.refreshStatus(List.of());
+                        tuyaDevice.refreshStatus();
                     }, pollingInterval, pollingInterval, TimeUnit.SECONDS);
                 }
             }
@@ -324,7 +315,7 @@ public class TuyaDeviceHandler extends BaseThingHandler implements DeviceInfoSub
     }
 
     @Override
-    public void connectionStatus(boolean status) {
+    public void connectionStatus(boolean status, int initialDelay) {
         if (status) {
             logger.debug("{}: connected", thing.getUID().getId());
 
@@ -335,17 +326,25 @@ public class TuyaDeviceHandler extends BaseThingHandler implements DeviceInfoSub
 
             TuyaDevice tuyaDevice = this.tuyaDevice;
             if (tuyaDevice != null) {
-                // When we first connect the device state is unknown so we want to know everything
-                // it is willing to tell us.
-                tuyaDevice.requestStatus(List.of());
-
                 if (pollingJob == null) {
-                    int pollingInterval = configuration.pollingInterval;
-                    if (pollingInterval > 0) {
-                        pollingJob = scheduler.scheduleWithFixedDelay(() -> {
-                            tuyaDevice.refreshStatus(List.of());
-                        }, pollingInterval, pollingInterval, TimeUnit.SECONDS);
-                    }
+                    // When we first connect the device state is unknown so we want to query for everything.
+                    // Some devices seem to initialize their stacks in the wrong order and
+                    // requests that come too soon can be either ignored completely or responded
+                    // to with a, "not supported". The lower level protocol handler suggests an
+                    // initial delay where it might be advisable.
+                    this.pollingJob = scheduler.schedule(() -> {
+                        tuyaDevice.requestStatus();
+
+                        // After that we poll for the measurable DPs.
+                        int pollingInterval = configuration.pollingInterval;
+                        if (pollingInterval > 0) {
+                            // The first refresh request is immediate because we do not know how old
+                            // the current status might be.
+                            pollingJob = scheduler.scheduleWithFixedDelay(() -> {
+                                tuyaDevice.refreshStatus();
+                            }, 0, pollingInterval, TimeUnit.SECONDS);
+                        }
+                    }, initialDelay, TimeUnit.MILLISECONDS);
                 } else {
                     logger.debug("{}: polling job already exists?!?", thing.getUID().getId());
                 }
@@ -586,7 +585,7 @@ public class TuyaDeviceHandler extends BaseThingHandler implements DeviceInfoSub
 
             this.tuyaDevice = new TuyaDevice(gson, this, eventLoopGroup, configuration.deviceId,
                     configuration.localKey.getBytes(StandardCharsets.UTF_8), configuration.ip, configuration.port,
-                    configuration.protocol);
+                    configuration.protocol, schemaDps.values().stream().map(e -> e.id).toList());
         } else {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_PENDING, "@text/offline.wait-for-ip");
         }
@@ -618,7 +617,7 @@ public class TuyaDeviceHandler extends BaseThingHandler implements DeviceInfoSub
 
                 this.tuyaDevice = new TuyaDevice(gson, this, eventLoopGroup, configuration.deviceId,
                         configuration.localKey.getBytes(StandardCharsets.UTF_8), configuration.ip, configuration.port,
-                        configuration.protocol);
+                        configuration.protocol, schemaDps.values().stream().map(e -> e.id).toList());
             } catch (IllegalArgumentException e) {
                 logger.warn("{}", e.getMessage());
                 updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, e.getMessage());

--- a/bundles/org.openhab.binding.tuya/src/main/java/org/openhab/binding/tuya/internal/local/CommandType.java
+++ b/bundles/org.openhab.binding.tuya/src/main/java/org/openhab/binding/tuya/internal/local/CommandType.java
@@ -58,8 +58,7 @@ public enum CommandType {
     LAN_REMOVE_GW(249),
     LAN_CHECK_GW_UPDATE(250),
     LAN_GW_UPDATE(251),
-    LAN_SET_GW_CHANNEL(252),
-    DP_QUERY_NOT_SUPPORTED(-1); // this is an internal value
+    LAN_SET_GW_CHANNEL(252);
 
     private final int code;
 

--- a/bundles/org.openhab.binding.tuya/src/main/java/org/openhab/binding/tuya/internal/local/DeviceStatusListener.java
+++ b/bundles/org.openhab.binding.tuya/src/main/java/org/openhab/binding/tuya/internal/local/DeviceStatusListener.java
@@ -25,5 +25,5 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 public interface DeviceStatusListener {
     void processDeviceStatus(Map<Integer, Object> deviceStatus);
 
-    void connectionStatus(boolean status);
+    void connectionStatus(boolean status, int initialDelay);
 }

--- a/bundles/org.openhab.binding.tuya/src/main/java/org/openhab/binding/tuya/internal/local/TuyaDevice.java
+++ b/bundles/org.openhab.binding.tuya/src/main/java/org/openhab/binding/tuya/internal/local/TuyaDevice.java
@@ -13,22 +13,27 @@
 package org.openhab.binding.tuya.internal.local;
 
 import static org.openhab.binding.tuya.internal.TuyaBindingConstants.TCP_CONNECTION_HEARTBEAT_INTERVAL;
+import static org.openhab.binding.tuya.internal.TuyaBindingConstants.TCP_CONNECTION_MAX_LIFETIME;
 import static org.openhab.binding.tuya.internal.TuyaBindingConstants.TCP_CONNECTION_MESSAGE_RESPONSE;
+import static org.openhab.binding.tuya.internal.TuyaBindingConstants.TCP_CONNECT_INITIAL_DELAY;
+import static org.openhab.binding.tuya.internal.TuyaBindingConstants.TCP_CONNECT_INITIAL_INTERVAL;
 import static org.openhab.binding.tuya.internal.TuyaBindingConstants.TCP_CONNECT_RETRY_INTERVAL;
 import static org.openhab.binding.tuya.internal.TuyaBindingConstants.TCP_CONNECT_TIMEOUT;
 import static org.openhab.binding.tuya.internal.local.CommandType.CONTROL;
 import static org.openhab.binding.tuya.internal.local.CommandType.CONTROL_NEW;
 import static org.openhab.binding.tuya.internal.local.CommandType.DP_QUERY;
+import static org.openhab.binding.tuya.internal.local.CommandType.DP_QUERY_NEW;
 import static org.openhab.binding.tuya.internal.local.CommandType.DP_REFRESH;
 import static org.openhab.binding.tuya.internal.local.CommandType.HEART_BEAT;
+import static org.openhab.binding.tuya.internal.local.CommandType.SESS_KEY_NEG_FINISH;
 import static org.openhab.binding.tuya.internal.local.CommandType.SESS_KEY_NEG_START;
+import static org.openhab.binding.tuya.internal.local.CommandType.STATUS;
 import static org.openhab.binding.tuya.internal.local.ProtocolVersion.V3_4;
 import static org.openhab.binding.tuya.internal.local.ProtocolVersion.V3_5;
 
-import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
@@ -46,6 +51,7 @@ import com.google.gson.Gson;
 
 import io.netty.bootstrap.Bootstrap;
 import io.netty.channel.Channel;
+import io.netty.channel.ChannelDuplexHandler;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
@@ -59,6 +65,7 @@ import io.netty.channel.socket.nio.NioSocketChannel;
 import io.netty.handler.timeout.IdleStateEvent;
 import io.netty.handler.timeout.IdleStateHandler;
 import io.netty.util.AttributeKey;
+import io.netty.util.concurrent.Future;
 
 /**
  * The {@link TuyaDevice} handles the device connection
@@ -84,11 +91,25 @@ public class TuyaDevice implements ChannelFutureListener {
     private final String address;
     private final int port;
     private final ProtocolVersion protocolVersion;
-    private @Nullable Channel channel;
 
-    private boolean queryUsesControl = false;
+    private @Nullable ChannelFuture channelFuture;
+
+    private final MessageWrapper<?> msgRequestAllControl;
+    private final MessageWrapper<?> msgRequestAllDpQuery;
+    private static final MessageWrapper<?> msgRefreshAll = new MessageWrapper<>(DP_REFRESH, Map.of("dpId", List.of()));
+
+    private boolean firstRefusal = true;
 
     private class HeartbeatSender extends IdleStateHandler {
+        private static final MessageWrapper<?> msgHeartbeat = new MessageWrapper<>(HEART_BEAT, Map.of());
+
+        // Battery operated sensors remain online for about 15 seconds after the last STATUS. They accept
+        // and acknowledge commands during that time but if they do not see another event that needs
+        // reporting they will then go offline without closing or resetting connections. Therefore if we
+        // see a STATUS we need a HEART_BEAT in 15 seconds time regardless of whether we have sent anything
+        // else in the meantime.
+        private boolean statusSeen = false;
+
         public HeartbeatSender() {
             super(0, TCP_CONNECTION_HEARTBEAT_INTERVAL, 0);
         }
@@ -97,45 +118,165 @@ public class TuyaDevice implements ChannelFutureListener {
         public void write(@Nullable ChannelHandlerContext ctx, @Nullable Object msg, @Nullable ChannelPromise promise)
                 throws Exception {
             if (ctx != null) {
-                // All messages sent to the device should trigger a timely response.
-                ctx.pipeline().replace(this, "idleHandler", new IdleHandler());
-                ctx.write(msg, promise);
+                // Some devices that do not have any refreshable DPs do not implement DP_REFRESH and
+                // simply ignore it. Some battery devices ignore anything sent too soon after they wake
+                // up or erroneously claim not to support DP_QUERY and do not respond to CONTROL at all
+                // if they have no function DPs and don't use CONTROL in place of DP_QUERY.
+                // Therefore these messages do not push back the heartbeat timeout.
+                if (!statusSeen && msg != null && msg instanceof MessageWrapper<?> m //
+                        && m.commandType != DP_REFRESH //
+                        && m.commandType != DP_QUERY && m.commandType != DP_QUERY_NEW //
+                        && m.commandType != CONTROL && m.commandType != CONTROL_NEW) {
+                    // Does reset the write timeout.
+                    // The next heartbeat will be one heartbeat interval from now.
+                    super.write(ctx, msg, promise);
+                } else {
+                    // Does NOT reset the write timeout.
+                    // The next heartbeat will be one heartbeat interval from when the status message was seen.
+                    ctx.write(msg, promise);
+                }
             }
-        }
-
-        @Override
-        protected void channelIdle(@Nullable ChannelHandlerContext ctx, @Nullable IdleStateEvent evt) throws Exception {
-            if (ctx != null) {
-                logger.trace("{}{}: Sending heart beat", deviceId, address);
-                ctx.channel().writeAndFlush(new MessageWrapper<>(HEART_BEAT, Map.of("dps", "")));
-            }
-        }
-    }
-
-    private class IdleHandler extends IdleStateHandler {
-        public IdleHandler() {
-            super(TCP_CONNECTION_MESSAGE_RESPONSE, 0, 0);
         }
 
         @Override
         public void channelRead(@Nullable ChannelHandlerContext ctx, @Nullable Object msg) throws Exception {
             if (ctx != null) {
-                ctx.pipeline().replace(this, "heartbeatSender", new HeartbeatSender());
-                ctx.fireChannelRead(msg);
+                if (msg != null && msg instanceof MessageWrapper<?> m && m.commandType == STATUS) {
+                    // The next heartbeat will be one heartbeat interval from now.
+                    resetWriteTimeout();
+                    statusSeen = true;
+                } else if (statusSeen && msg != null && msg instanceof MessageWrapper<?> m
+                        && m.commandType == HEART_BEAT) {
+                    // A heartbeat acknowledgement after a status message is proof-of-life
+                    // and we can revert to the normal heartbeat only if idle.
+                    statusSeen = false;
+                }
+
+                super.channelRead(ctx, msg);
             }
         }
 
         @Override
         protected void channelIdle(@Nullable ChannelHandlerContext ctx, @Nullable IdleStateEvent evt) throws Exception {
             if (ctx != null) {
-                logger.debug("{}{}: Connection seems to be dead.", deviceId, address);
+                ctx.channel().writeAndFlush(msgHeartbeat);
+            }
+        }
+    }
+
+    private class ResponseTimeoutHandler extends ChannelDuplexHandler {
+        private @Nullable Future<?> responseTimeout = null;
+        private @Nullable ChannelHandlerContext context = null;
+        private TimeoutTask timeoutTask = new TimeoutTask();
+
+        @Override
+        public void handlerAdded(@Nullable ChannelHandlerContext ctx) throws Exception {
+            this.context = ctx;
+
+            super.handlerAdded(ctx);
+        }
+
+        @Override
+        public void handlerRemoved(@Nullable ChannelHandlerContext ctx) throws Exception {
+            var future = responseTimeout;
+            if (future != null) {
+                future.cancel(false);
+            }
+
+            super.handlerRemoved(ctx);
+        }
+
+        @Override
+        public void write(@Nullable ChannelHandlerContext ctx, @Nullable Object msg, @Nullable ChannelPromise promise)
+                throws Exception {
+            if (ctx != null) {
+                ctx.write(msg, promise);
+
+                // Messages sent to the device should trigger a timely response. However, some devices
+                // that do not have any refreshable DPs do not implement DP_REFRESH and simply ignore it.
+                // Some battery devices ignore anything sent too soon after they wake up or erroneously
+                // claim not to support DP_QUERY and do not respond to CONTROL at all however at least
+                // one of a DP_QUERY/CONTROL pair should elicit a response. If we do not get a response
+                // the connection does not recover so we do need to reconnect. And finally, since we
+                // always send DP_QUERY and CONTROL in pairs (because some older devices require CONTROL
+                // rather than DP_QUERY) we do not need to set a timeout for DP_QUERY.
+                if (msg != null && msg instanceof MessageWrapper<?> m //
+                        && m.commandType != SESS_KEY_NEG_FINISH //
+                        && m.commandType != DP_REFRESH //
+                        && m.commandType != DP_QUERY && m.commandType != DP_QUERY_NEW //
+                ) {
+                    var future = responseTimeout;
+                    if (future != null) {
+                        future.cancel(false);
+                    }
+
+                    responseTimeout = ctx.executor().schedule(timeoutTask, //
+                            TCP_CONNECTION_MESSAGE_RESPONSE, TimeUnit.MILLISECONDS);
+                }
+            }
+        }
+
+        @Override
+        public void channelRead(@Nullable ChannelHandlerContext ctx, @Nullable Object msg) throws Exception {
+            if (ctx != null) {
+                if (msg != null && msg instanceof MessageWrapper<?> m) {
+                    // Almost anything can count as a response - it does not have to be specifically
+                    // a response to what we sent. The exceptions are CONTROL/CONTROL_NEW which are
+                    // ignored because there is normally some other response (DP_QUERY or STATUS)
+                    // as well. If there isn't either the device or API is not active. (Sometimes
+                    // devices seem to accept TCP connections before the API is fully initialized.)
+                    if (m.commandType != CONTROL_NEW && m.commandType != CONTROL //
+                    ) {
+                        var future = responseTimeout;
+                        if (future != null) {
+                            future.cancel(false);
+                            responseTimeout = null;
+                        }
+                    }
+                }
+
+                super.channelRead(ctx, msg);
+            }
+        }
+
+        private final class TimeoutTask implements Runnable {
+            @Override
+            public void run() {
+                var ctx = context;
+                if (ctx != null && ctx.channel().isOpen()) {
+                    logger.debug("{}/{}: Connection seems to be dead.", deviceId, address);
+                    ctx.close();
+                }
+            }
+        }
+    }
+
+    private class MaxLifetimeHandler extends IdleStateHandler {
+
+        public MaxLifetimeHandler() {
+            super(TCP_CONNECTION_MAX_LIFETIME, 0, 0);
+        }
+
+        // Override so that we never reset the read timeout.
+        @Override
+        public void channelReadComplete(@Nullable ChannelHandlerContext ctx) throws Exception {
+            if (ctx != null) {
+                ctx.fireChannelReadComplete();
+            }
+        }
+
+        @Override
+        protected void channelIdle(@Nullable ChannelHandlerContext ctx, @Nullable IdleStateEvent evt) throws Exception {
+            if (ctx != null) {
+                logger.debug("{}/{}: Maximum connection lifetime reached.", deviceId, address);
                 ctx.close();
             }
         }
     }
 
     public TuyaDevice(Gson gson, DeviceStatusListener deviceStatusListener, EventLoopGroup eventLoopGroup,
-            String deviceId, byte[] deviceKey, String address, int port, String protocolVersion) {
+            String deviceId, byte[] deviceKey, String address, int port, String protocolVersion,
+            List<Integer> allDpIds) {
         this.deviceStatusListener = deviceStatusListener;
         this.eventLoopGroup = eventLoopGroup;
         this.deviceId = deviceId;
@@ -143,6 +284,14 @@ public class TuyaDevice implements ChannelFutureListener {
         this.address = address;
         this.port = port;
         this.protocolVersion = ProtocolVersion.fromString(protocolVersion);
+
+        // CommandType commandType = (protocolVersion == V3_4 || protocolVersion == V3_5) ? DP_QUERY_NEW : DP_QUERY;
+        CommandType commandType = DP_QUERY;
+        msgRequestAllDpQuery = new MessageWrapper<>(commandType, Map.of("dps", allDpIds));
+
+        Map<Integer, @Nullable Object> allDpIdsMap = new HashMap<>();
+        allDpIds.forEach(dp -> allDpIdsMap.put(dp, null));
+        msgRequestAllControl = new MessageWrapper<>(CONTROL, Map.of("dps", allDpIdsMap));
 
         bootstrap.group(eventLoopGroup).channel(NioSocketChannel.class);
         bootstrap.option(ChannelOption.TCP_NODELAY, true).option(ChannelOption.CONNECT_TIMEOUT_MILLIS,
@@ -154,6 +303,8 @@ public class TuyaDevice implements ChannelFutureListener {
                 pipeline.addLast("messageEncoder", new TuyaEncoder(gson));
                 pipeline.addLast("messageDecoder", new TuyaDecoder(gson));
                 pipeline.addLast("heartbeatSender", new HeartbeatSender());
+                pipeline.addLast("responseTimeoutHandler", new ResponseTimeoutHandler());
+                pipeline.addLast("maxLifetimeHandler", new MaxLifetimeHandler());
                 pipeline.addLast("deviceHandler", new TuyaMessageHandler(deviceStatusListener));
                 pipeline.addLast("userEventHandler", new UserEventHandler());
             }
@@ -162,53 +313,37 @@ public class TuyaDevice implements ChannelFutureListener {
         connect();
     }
 
-    public void setQueryUsesControl() {
-        queryUsesControl = true;
-    }
-
     private void connect() {
         logger.trace("{}: connecting", deviceId);
 
-        bootstrap.connect(address, port).addListener(this);
+        channelFuture = bootstrap.connect(address, port).addListener(this);
     }
 
     public void set(Map<Integer, @Nullable Object> command) {
         CommandType commandType = (protocolVersion == V3_4 || protocolVersion == V3_5) ? CONTROL_NEW : CONTROL;
-        MessageWrapper<?> m = new MessageWrapper<>(commandType, Map.of("dps", command));
-        Channel channel = this.channel;
-        if (channel != null) {
-            channel.writeAndFlush(m);
+        ChannelFuture channelFuture = this.channelFuture;
+        if (channelFuture != null) {
+            channelFuture.channel().writeAndFlush(new MessageWrapper<>(commandType, Map.of("dps", command)));
         } else {
             logger.warn("{}: Setting {} failed. Device is not connected.", deviceId, command);
         }
     }
 
-    public void requestStatus(Collection<Integer> dps) {
-        if (!queryUsesControl) {
-            // CommandType commandType = (protocolVersion == V3_4 || protocolVersion == V3_5) ? DP_QUERY_NEW : DP_QUERY;
-            CommandType commandType = DP_QUERY;
-            MessageWrapper<?> m = new MessageWrapper<>(commandType, Map.of("dps", dps));
-            Channel channel = this.channel;
-            if (channel != null) {
-                channel.writeAndFlush(m);
-            } else {
-                logger.warn("{}: Querying status failed. Device is not connected.", deviceId);
-            }
-        } else {
-            Map<Integer, @Nullable Object> dpMap = new HashMap<>();
-            dps.forEach(dp -> dpMap.put(dp, null));
-            set(dpMap);
+    public void requestStatus() {
+        ChannelFuture channelFuture = this.channelFuture;
+        if (channelFuture == null) {
+            logger.warn("{}: Querying status failed. Device is not connected.", deviceId);
+            return;
         }
+
+        channelFuture.channel().writeAndFlush(msgRequestAllDpQuery);
+        channelFuture.channel().writeAndFlush(msgRequestAllControl);
     }
 
-    public void refreshStatus(Collection<Integer> dps) {
-        MessageWrapper<?> m = new MessageWrapper<>(DP_REFRESH, Map.of("dpId", dps));
-        Channel channel = this.channel;
-        if (channel != null) {
-            channel.writeAndFlush(m);
-            // We could try a requestStatus(dps) here however it shouldn't be necessary as
-            // once new values for the DPs have been sampled the device should send an update
-            // (but not necessarily if the new values are the same as the old).
+    public void refreshStatus() {
+        ChannelFuture channelFuture = this.channelFuture;
+        if (channelFuture != null) {
+            channelFuture.channel().writeAndFlush(msgRefreshAll);
         } else {
             logger.warn("{}: Refreshing status failed. Device is not connected.", deviceId);
         }
@@ -217,49 +352,53 @@ public class TuyaDevice implements ChannelFutureListener {
     public void dispose() {
         logger.debug("{}: disposed", deviceId);
 
-        Channel channel = this.channel;
-        this.channel = null;
-
-        if (channel != null) {
-            channel.closeFuture().cancel(true);
-        }
-
-        ScheduledFuture<?> future = reconnectFuture;
-        if (future != null) {
-            future.cancel(true);
+        synchronized (bootstrap) {
+            ScheduledFuture<?> future = reconnectFuture;
             reconnectFuture = null;
+
+            if (future != null) {
+                logger.trace("{}/{}: cancel reconnectFuture", deviceId, address);
+                future.cancel(true);
+            }
         }
 
-        if (channel != null) {
-            channel.close();
+        ChannelFuture channelFuture = this.channelFuture;
+        this.channelFuture = null;
+
+        if (channelFuture != null) {
+            logger.trace("{}/{}: cancel closeFuture", deviceId, address);
+            channelFuture.cancel(true);
+            channelFuture.channel().closeFuture().cancel(true);
+
+            logger.trace("{}/{}: close channel", deviceId, address);
+            channelFuture.channel().close();
         }
     }
 
     @Override
     public void operationComplete(@NonNullByDefault({}) ChannelFuture channelFuture) throws Exception {
         if (channelFuture.isSuccess()) {
-            logger.debug("{}{}: channel connected", deviceId,
-                    Objects.requireNonNullElse(channelFuture.channel().remoteAddress(), ""));
+            logger.debug("{}/{}: channel connected", deviceId, address);
+
+            firstRefusal = true;
 
             Channel channel = channelFuture.channel();
 
             if (channel != null) {
-                this.channel = channel;
-
                 channel.closeFuture().addListener(new ChannelFutureListener() {
                     @Override
                     public void operationComplete(@NonNullByDefault({}) ChannelFuture channelFuture) {
-                        logger.debug("{}{}: channel closed", deviceId,
-                                Objects.requireNonNullElse(channelFuture.channel().remoteAddress(), ""));
+                        logger.debug("{}/{}: channel closed", deviceId, address);
 
-                        deviceStatusListener.connectionStatus(false);
+                        channelFuture.channel().closeFuture().removeListener(this);
+                        deviceStatusListener.connectionStatus(false, 0);
 
-                        if (!channelFuture.isCancelled()) {
-                            reconnectFuture = eventLoopGroup.schedule(() -> {
-                                logger.debug("{}{}: reconnect", deviceId,
-                                        Objects.requireNonNullElse(channelFuture.channel().remoteAddress(), ""));
+                        synchronized (bootstrap) {
+                            if (!channelFuture.isCancelled()) {
                                 connect();
-                            }, TCP_CONNECT_RETRY_INTERVAL, TimeUnit.MILLISECONDS);
+                            } else {
+                                logger.debug("{}/{}: reconnect cancelled", deviceId, address);
+                            }
                         }
                     }
                 });
@@ -277,18 +416,40 @@ public class TuyaDevice implements ChannelFutureListener {
                     MessageWrapper<?> m = new MessageWrapper<>(SESS_KEY_NEG_START, sessionRandom);
                     channel.writeAndFlush(m);
                 } else {
-                    // no handshake for 3.1/3.3
-                    deviceStatusListener.connectionStatus(true);
+                    // No handshake for 3.1/3.3
+                    // Some devices seem to initialize their stacks in the wrong order and
+                    // requests that come too soon can be either ignored completely or responded
+                    // to with a, "not supported" so we suggest that the handler hold off initially.
+                    deviceStatusListener.connectionStatus(true, TCP_CONNECT_INITIAL_DELAY);
                 }
             }
         } else {
-            logger.trace("{}{}: Failed to connect: {}", deviceId,
-                    Objects.requireNonNullElse(channelFuture.channel().remoteAddress(), ""),
-                    channelFuture.cause().getMessage());
+            String cause = channelFuture.cause().getMessage();
+
+            logger.trace("{}/{}: Failed to connect: {}", deviceId, address, cause);
 
             channelFuture.channel().close();
 
-            reconnectFuture = eventLoopGroup.schedule(this::connect, TCP_CONNECT_RETRY_INTERVAL, TimeUnit.MILLISECONDS);
+            synchronized (bootstrap) {
+                if (!channelFuture.isCancelled()) {
+                    if (cause != null && cause.startsWith("connection timed out")) {
+                        connect();
+                    } else if (firstRefusal && cause != null && cause.startsWith("Connection refused")) {
+                        // Once a battery device is powering up we need to give it time to get its
+                        // stack together. Hammering it with connection attempts is not helpful.
+                        firstRefusal = false;
+                        logger.debug("{}/{}: scheduling initial reconnect", deviceId, address);
+                        reconnectFuture = eventLoopGroup.schedule(this::connect, //
+                                TCP_CONNECT_INITIAL_INTERVAL, TimeUnit.MILLISECONDS);
+                    } else {
+                        logger.trace("{}/{}: scheduling reconnect", deviceId, address);
+                        reconnectFuture = eventLoopGroup.schedule(this::connect, //
+                                TCP_CONNECT_RETRY_INTERVAL, TimeUnit.MILLISECONDS);
+                    }
+                } else {
+                    logger.trace("{}/{}: reconnect cancelled", deviceId, address);
+                }
+            }
         }
     }
 }

--- a/bundles/org.openhab.binding.tuya/src/main/java/org/openhab/binding/tuya/internal/local/handlers/TuyaDecoder.java
+++ b/bundles/org.openhab.binding.tuya/src/main/java/org/openhab/binding/tuya/internal/local/handlers/TuyaDecoder.java
@@ -14,7 +14,6 @@ package org.openhab.binding.tuya.internal.local.handlers;
 
 import static org.openhab.binding.tuya.internal.local.CommandType.BROADCAST_LPV34;
 import static org.openhab.binding.tuya.internal.local.CommandType.DP_QUERY;
-import static org.openhab.binding.tuya.internal.local.CommandType.DP_QUERY_NOT_SUPPORTED;
 import static org.openhab.binding.tuya.internal.local.CommandType.HEART_BEAT;
 import static org.openhab.binding.tuya.internal.local.CommandType.SESS_KEY_NEG_RESPONSE;
 import static org.openhab.binding.tuya.internal.local.CommandType.STATUS;
@@ -29,7 +28,6 @@ import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -235,13 +233,13 @@ public class TuyaDecoder extends ByteToMessageDecoder {
             decodedString = new String(decodedMessage).trim();
 
             try {
-                if (commandType == DP_QUERY && "json obj data unvalid".equals(decodedString)) {
-                    // "json obj data unvalid" would also result in a JSONSyntaxException but is a known error when
-                    // DP_QUERY is not supported by the device. Using a CONTROL message with null values is a known
+                if (commandType == DP_QUERY //
+                        && "json obj data unvalid".equals(decodedString) || "data format error".equals(decodedString) //
+                ) {
+                    // Some devices don't handle DP_QUERY. Using a CONTROL message with null values is a known
                     // workaround, cf. https://github.com/codetheweb/tuyapi/blob/master/index.js#L156
-                    logger.info("{}{}: DP_QUERY not supported. Trying to request with CONTROL.", deviceId,
-                            Objects.requireNonNullElse(ctx.channel().remoteAddress(), ""));
-                    m = new MessageWrapper<>(DP_QUERY_NOT_SUPPORTED, Map.of());
+                    // Since already we sent a CONTROL as well we can ignore this error.
+                    return;
                 } else if (commandType == STATUS || commandType == DP_QUERY) {
                     m = new MessageWrapper<>(commandType,
                             Objects.requireNonNull(gson.fromJson(decodedString, TcpStatusPayload.class)));
@@ -254,8 +252,9 @@ public class TuyaDecoder extends ByteToMessageDecoder {
                     m = new MessageWrapper<>(commandType, decodedString);
                 }
             } catch (JsonSyntaxException e) {
-                logger.warn("{}{} failed to parse JSON: {}", deviceId,
-                        Objects.requireNonNullElse(ctx.channel().remoteAddress(), ""), e.getMessage());
+                logger.warn("{}{} failed to parse JSON command={} json={}: {}", deviceId, //
+                        Objects.requireNonNullElse(ctx.channel().remoteAddress(), ""), //
+                        commandType, decodedString, e.getMessage());
                 return;
             }
         }

--- a/bundles/org.openhab.binding.tuya/src/main/java/org/openhab/binding/tuya/internal/local/handlers/TuyaDecoder.java
+++ b/bundles/org.openhab.binding.tuya/src/main/java/org/openhab/binding/tuya/internal/local/handlers/TuyaDecoder.java
@@ -233,9 +233,7 @@ public class TuyaDecoder extends ByteToMessageDecoder {
             decodedString = new String(decodedMessage).trim();
 
             try {
-                if (commandType == DP_QUERY //
-                        && "json obj data unvalid".equals(decodedString) || "data format error".equals(decodedString) //
-                ) {
+                if ("json obj data unvalid".equals(decodedString) || "data format error".equals(decodedString)) {
                     // Some devices don't handle DP_QUERY. Using a CONTROL message with null values is a known
                     // workaround, cf. https://github.com/codetheweb/tuyapi/blob/master/index.js#L156
                     // Since already we sent a CONTROL as well we can ignore this error.

--- a/bundles/org.openhab.binding.tuya/src/main/java/org/openhab/binding/tuya/internal/local/handlers/TuyaMessageHandler.java
+++ b/bundles/org.openhab.binding.tuya/src/main/java/org/openhab/binding/tuya/internal/local/handlers/TuyaMessageHandler.java
@@ -73,8 +73,6 @@ public class TuyaMessageHandler extends ChannelDuplexHandler {
                 if (stateMap != null && !stateMap.isEmpty()) {
                     deviceStatusListener.processDeviceStatus(stateMap);
                 }
-            } else if (m.commandType == CommandType.DP_QUERY_NOT_SUPPORTED) {
-                deviceStatusListener.processDeviceStatus(Map.of());
             } else if (m.commandType == CommandType.SESS_KEY_NEG_RESPONSE) {
                 if (!ctx.channel().hasAttr(TuyaDevice.SESSION_KEY_ATTR)
                         || !ctx.channel().hasAttr(TuyaDevice.SESSION_RANDOM_ATTR)) {
@@ -110,7 +108,8 @@ public class TuyaMessageHandler extends ChannelDuplexHandler {
                 }
                 ctx.channel().attr(TuyaDevice.SESSION_KEY_ATTR).set(newSessionKey);
 
-                deviceStatusListener.connectionStatus(true);
+                // No initial delay needed. We just negotiated a session key. The device MUST be ready.
+                deviceStatusListener.connectionStatus(true, 0);
             }
         }
     }


### PR DESCRIPTION
Battery powered devices only occasionally power up periodically and/or when there is a status change to report. They only stay powered up for a few seconds after their last status change report. So we have a race to connect while they are powered up. Plus we have to connect early enough after they have powered up to catch the initial status because it might change again before we see it (e.g. a contact sensor when a door opens and closes). On top of that some devices appear to initialize their stack in the wrong order and accept TCP connections before the API layer is plugged in leading to "not supported" responses, a situation that doesn't clear without a reconnect. And when the device powers down again it does not close or reset connections, just leaves them hanging.

So... we have to be fairly aggressive about trying to connect - without hammering the device as it's trying to boot up. We have to delay the initial query for some devices. We have to be fairly proactive in figuring out when devices have "gone away".

This also includes a maximum connection lifetime timeout. This isn't really related to battery devices and I don't _think_ it helps with issues I have with some smart plugs. But recycling connections now and again seems a sensible idea and it's simple enough to do.