### PR TITLE
[renault] Consolidate EU Gigya API key into shared constant (4.3.x)

### DIFF
--- a/bundles/org.openhab.binding.renault/pom.xml
+++ b/bundles/org.openhab.binding.renault/pom.xml
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
 

--- a/bundles/org.openhab.binding.renault/src/main/java/org/openhab/binding/renault/internal/api/Constants.java
+++ b/bundles/org.openhab.binding.renault/src/main/java/org/openhab/binding/renault/internal/api/Constants.java
@@ -24,6 +24,7 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 @NonNullByDefault
 public class Constants {
 
+    private static final String GIGYA_KEY_EU = "3_VgdkgtIRH3AdHvJm-cjV2ug2EFE0lxt0IJzMC4MFqZjFpn_GYFXVdNZ19L7wZX0N";
     private static final String GIGYA_URL_EU = "https://accounts.eu1.gigya.com";
     private static final String GIGYA_URL_US = "https://accounts.us1.gigya.com";
     private static final String KAMEREON_URL_EU = "https://api-wired-prod-1-euw1.wrd-aws.com";
@@ -37,22 +38,22 @@ public class Constants {
         switch (locale) {
             case "bg_BG":
                 gigyaRootUrl = GIGYA_URL_EU;
-                gigyaApiKey = "3__3ER_6lFvXEXHTP_faLtq6eEdbKDXd9F5GoKwzRyZq37ZQ-db7mXcLzR1Jtls5sn";
+                gigyaApiKey = GIGYA_KEY_EU;
                 kamereonRootUrl = KAMEREON_URL_EU;
                 break;
             case "cs_CZ":
                 gigyaRootUrl = GIGYA_URL_EU;
-                gigyaApiKey = "3_oRlKr5PCVL_sPWUZdJ8c5NOl5Ej8nIZw7VKG7S9Rg36UkDszFzfHfxCaUAUU5or2";
+                gigyaApiKey = GIGYA_KEY_EU;
                 kamereonRootUrl = KAMEREON_URL_EU;
                 break;
             case "da_DK":
                 gigyaRootUrl = GIGYA_URL_EU;
-                gigyaApiKey = "3_5x-2C8b1R4MJPQXkwTPdIqgBpcw653Dakw_ZaEneQRkTBdg9UW9Qg_5G-tMNrTMc";
+                gigyaApiKey = GIGYA_KEY_EU;
                 kamereonRootUrl = KAMEREON_URL_EU;
                 break;
             case "de_DE":
                 gigyaRootUrl = GIGYA_URL_EU;
-                gigyaApiKey = "3_7PLksOyBRkHv126x5WhHb-5pqC1qFR8pQjxSeLB6nhAnPERTUlwnYoznHSxwX668";
+                gigyaApiKey = GIGYA_KEY_EU;
                 kamereonRootUrl = KAMEREON_URL_EU;
                 break;
             case "de_AT":
@@ -62,47 +63,47 @@ public class Constants {
                 break;
             case "de_CH":
                 gigyaRootUrl = GIGYA_URL_EU;
-                gigyaApiKey = "3_UyiWZs_1UXYCUqK_1n7l7l44UiI_9N9hqwtREV0-UYA_5X7tOV-VKvnGxPBww4q2";
+                gigyaApiKey = GIGYA_KEY_EU;
                 kamereonRootUrl = KAMEREON_URL_EU;
                 break;
             case "en_GB":
                 gigyaRootUrl = GIGYA_URL_EU;
-                gigyaApiKey = "3_e8d4g4SE_Fo8ahyHwwP7ohLGZ79HKNN2T8NjQqoNnk6Epj6ilyYwKdHUyCw3wuxz";
+                gigyaApiKey = GIGYA_KEY_EU;
                 kamereonRootUrl = KAMEREON_URL_EU;
                 break;
             case "en_IE":
                 gigyaRootUrl = GIGYA_URL_EU;
-                gigyaApiKey = "3_Xn7tuOnT9raLEXuwSI1_sFFZNEJhSD0lv3gxkwFtGI-RY4AgiePBiJ9EODh8d9yo";
+                gigyaApiKey = GIGYA_KEY_EU;
                 kamereonRootUrl = KAMEREON_URL_EU;
                 break;
             case "es_ES":
                 gigyaRootUrl = GIGYA_URL_EU;
-                gigyaApiKey = "3_DyMiOwEaxLcPdBTu63Gv3hlhvLaLbW3ufvjHLeuU8U5bx3zx19t5rEKq7KMwk9f1";
+                gigyaApiKey = GIGYA_KEY_EU;
                 kamereonRootUrl = KAMEREON_URL_EU;
                 break;
             case "es_MX":
                 gigyaRootUrl = GIGYA_URL_US;
-                gigyaApiKey = "3_BFzR-2wfhMhUs5OCy3R8U8IiQcHS-81vF8bteSe8eFrboMTjEWzbf4pY1aHQ7cW0";
+                gigyaApiKey = "4_yTFqPSsGxVyRXPZUM7t1Iw";
                 kamereonRootUrl = KAMEREON_URL_US;
                 break;
             case "fi_FI":
                 gigyaRootUrl = GIGYA_URL_EU;
-                gigyaApiKey = "3_xSRCLDYhk1SwSeYQLI3DmA8t-etfAfu5un51fws125ANOBZHgh8Lcc4ReWSwaqNY";
+                gigyaApiKey = GIGYA_KEY_EU;
                 kamereonRootUrl = KAMEREON_URL_EU;
                 break;
             case "fr_FR":
                 gigyaRootUrl = GIGYA_URL_EU;
-                gigyaApiKey = "3_4LKbCcMMcvjDm3X89LU4z4mNKYKdl_W0oD9w-Jvih21WqgJKtFZAnb9YdUgWT9_a";
+                gigyaApiKey = GIGYA_KEY_EU;
                 kamereonRootUrl = KAMEREON_URL_EU;
                 break;
             case "fr_BE":
                 gigyaRootUrl = GIGYA_URL_EU;
-                gigyaApiKey = "3_ZK9x38N8pzEvdiG7ojWHeOAAej43APkeJ5Av6VbTkeoOWR4sdkRc-wyF72HzUB8X";
+                gigyaApiKey = GIGYA_KEY_EU;
                 kamereonRootUrl = KAMEREON_URL_EU;
                 break;
             case "fr_CH":
                 gigyaRootUrl = GIGYA_URL_EU;
-                gigyaApiKey = "3_h3LOcrKZ9mTXxMI9clb2R1VGAWPke6jMNqMw4yYLz4N7PGjYyD0hqRgIFAIHusSn";
+                gigyaApiKey = GIGYA_KEY_EU;
                 kamereonRootUrl = KAMEREON_URL_EU;
                 break;
             case "fr_LU":
@@ -112,76 +113,76 @@ public class Constants {
                 break;
             case "hr_HR":
                 gigyaRootUrl = GIGYA_URL_EU;
-                gigyaApiKey = "3_HcDC5GGZ89NMP1jORLhYNNCcXt7M3thhZ85eGrcQaM2pRwrgrzcIRWEYi_36cFj9";
+                gigyaApiKey = GIGYA_KEY_EU;
                 kamereonRootUrl = KAMEREON_URL_EU;
                 break;
             case "hu_HU":
                 gigyaRootUrl = GIGYA_URL_EU;
-                gigyaApiKey = "3_nGDWrkSGZovhnVFv5hdIxyuuCuJGZfNmlRGp7-5kEn9yb0bfIfJqoDa2opHOd3Mu";
+                gigyaApiKey = GIGYA_KEY_EU;
                 kamereonRootUrl = KAMEREON_URL_EU;
                 break;
             case "it_IT":
                 gigyaRootUrl = GIGYA_URL_EU;
-                gigyaApiKey = "3_js8th3jdmCWV86fKR3SXQWvXGKbHoWFv8NAgRbH7FnIBsi_XvCpN_rtLcI07uNuq";
+                gigyaApiKey = GIGYA_KEY_EU;
                 kamereonRootUrl = KAMEREON_URL_EU;
                 break;
             case "it_CH":
                 gigyaRootUrl = GIGYA_URL_EU;
-                gigyaApiKey = "3_gHkmHaGACxSLKXqD_uDDx415zdTw7w8HXAFyvh0qIP0WxnHPMF2B9K_nREJVSkGq";
+                gigyaApiKey = GIGYA_KEY_EU;
                 kamereonRootUrl = KAMEREON_URL_EU;
                 break;
             case "nl_NL":
                 gigyaRootUrl = GIGYA_URL_EU;
-                gigyaApiKey = "3_ZIOtjqmP0zaHdEnPK7h1xPuBYgtcOyUxbsTY8Gw31Fzy7i7Ltjfm-hhPh23fpHT5";
+                gigyaApiKey = GIGYA_KEY_EU;
                 kamereonRootUrl = KAMEREON_URL_EU;
                 break;
             case "nl_BE":
                 gigyaRootUrl = GIGYA_URL_EU;
-                gigyaApiKey = "3_yachztWczt6i1pIMhLIH9UA6DXK6vXXuCDmcsoA4PYR0g35RvLPDbp49YribFdpC";
+                gigyaApiKey = GIGYA_KEY_EU;
                 kamereonRootUrl = KAMEREON_URL_EU;
                 break;
             case "no_NO":
                 gigyaRootUrl = GIGYA_URL_EU;
-                gigyaApiKey = "3_QrPkEJr69l7rHkdCVls0owC80BB4CGz5xw_b0gBSNdn3pL04wzMBkcwtbeKdl1g9";
+                gigyaApiKey = GIGYA_KEY_EU;
                 kamereonRootUrl = KAMEREON_URL_EU;
                 break;
             case "pl_PL":
                 gigyaRootUrl = GIGYA_URL_EU;
-                gigyaApiKey = "3_2YBjydYRd1shr6bsZdrvA9z7owvSg3W5RHDYDp6AlatXw9hqx7nVoanRn8YGsBN8";
+                gigyaApiKey = GIGYA_KEY_EU;
                 kamereonRootUrl = KAMEREON_URL_EU;
                 break;
             case "pt_PT":
                 gigyaRootUrl = GIGYA_URL_EU;
-                gigyaApiKey = "3__afxovspi2-Ip1E5kNsAgc4_35lpLAKCF6bq4_xXj2I2bFPjIWxAOAQJlIkreKTD";
+                gigyaApiKey = GIGYA_KEY_EU;
                 kamereonRootUrl = KAMEREON_URL_EU;
                 break;
             case "ro_RO":
                 gigyaRootUrl = GIGYA_URL_EU;
-                gigyaApiKey = "3_WlBp06vVHuHZhiDLIehF8gchqbfegDJADPQ2MtEsrc8dWVuESf2JCITRo5I2CIxs";
+                gigyaApiKey = GIGYA_KEY_EU;
                 kamereonRootUrl = KAMEREON_URL_EU;
                 break;
             case "ru_RU":
                 gigyaRootUrl = GIGYA_URL_EU;
-                gigyaApiKey = "3_N_ecy4iDyoRtX8v5xOxewwZLKXBjRgrEIv85XxI0KJk8AAdYhJIi17LWb086tGXR";
+                gigyaApiKey = GIGYA_KEY_EU;
                 kamereonRootUrl = KAMEREON_URL_EU;
                 break;
             case "sk_SK":
                 gigyaRootUrl = GIGYA_URL_EU;
-                gigyaApiKey = "3_e8d4g4SE_Fo8ahyHwwP7ohLGZ79HKNN2T8NjQqoNnk6Epj6ilyYwKdHUyCw3wuxz";
+                gigyaApiKey = GIGYA_KEY_EU;
                 kamereonRootUrl = KAMEREON_URL_EU;
                 break;
             case "sl_SI":
                 gigyaRootUrl = GIGYA_URL_EU;
-                gigyaApiKey = "3_QKt0ADYxIhgcje4F3fj9oVidHsx3JIIk-GThhdyMMQi8AJR0QoHdA62YArVjbZCt";
+                gigyaApiKey = GIGYA_KEY_EU;
                 kamereonRootUrl = KAMEREON_URL_EU;
                 break;
             case "sv_SE":
                 gigyaRootUrl = GIGYA_URL_EU;
-                gigyaApiKey = "3_EN5Hcnwanu9_Dqot1v1Aky1YelT5QqG4TxveO0EgKFWZYu03WkeB9FKuKKIWUXIS";
+                gigyaApiKey = GIGYA_KEY_EU;
                 kamereonRootUrl = KAMEREON_URL_EU;
             default:
                 gigyaRootUrl = GIGYA_URL_EU;
-                gigyaApiKey = "3__B4KghyeUb0GlpU62ZXKrjSfb7CPzwBS368wioftJUL5qXE0Z_sSy0rX69klXuHy";
+                gigyaApiKey = GIGYA_KEY_EU;
                 kamereonRootUrl = KAMEREON_URL_EU;
                 break;
         }


### PR DESCRIPTION
## Description

Backport of #20769 to the `4.3.x` stable branch.

**Bugfix** — Users have been unable to log in to their Renault accounts because the per-locale Gigya API keys hardcoded in `Constants.java` are no longer valid. Renault rotated the keys upstream, and the [`hacf-fr/renault-api`](https://github.com/hacf-fr/renault-api) project (the reference implementation this binding is based on) has updated its constants accordingly.

This PR mirrors that fix: see https://github.com/hacf-fr/renault-api/pull/2101.

Most EU locales now share a single key, so this PR extracts it into a `GIGYA_KEY_EU` constant and references it from every EU locale, keeping only the locales with genuinely distinct keys (`de_AT`, `es_MX`, `fr_LU`) as inline literals.

The 4.3.x variant also includes a small `pom.xml` header reformat required to pass `spotless` on this branch.

Classification: bugfix.

## Testing

- `mvn clean install` passes locally for the Renault binding on `4.3.x`.
- Restores ability to authenticate with Renault accounts on the 4.3.x stable line.