### PR TITLE
Fix build

### DIFF
--- a/bundles/org.openhab.binding.boschshc/src/test/java/org/openhab/binding/boschshc/internal/devices/AbstractBoschSHCDeviceHandlerTest.java
+++ b/bundles/org.openhab.binding.boschshc/src/test/java/org/openhab/binding/boschshc/internal/devices/AbstractBoschSHCDeviceHandlerTest.java
@@ -90,7 +90,7 @@ public abstract class AbstractBoschSHCDeviceHandlerTest<T extends BoschSHCDevice
     @Test
     void initializeInvalidDeviceId() {
         getFixture().getThing().getConfiguration().remove("id");
-        getFixture().initialize();
+        getFixture().thingUpdated(getThing());
 
         verify(getCallback()).statusUpdated(any(Thing.class),
                 argThat(status -> status.getStatus().equals(ThingStatus.OFFLINE)

--- a/bundles/org.openhab.binding.boschshc/src/test/java/org/openhab/binding/boschshc/internal/devices/bridge/BridgeHandlerTest.java
+++ b/bundles/org.openhab.binding.boschshc/src/test/java/org/openhab/binding/boschshc/internal/devices/bridge/BridgeHandlerTest.java
@@ -1066,7 +1066,7 @@ class BridgeHandlerTest {
     void initializeNoIpAddress() {
         bridgeConfiguration.setProperties(new HashMap<String, Object>());
 
-        fixture.initialize();
+        fixture.thingUpdated(thing);
 
         ThingStatusInfo expectedStatus = ThingStatusInfoBuilder
                 .create(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR)
@@ -1080,7 +1080,7 @@ class BridgeHandlerTest {
         properties.put("ipAddress", "localhost");
         bridgeConfiguration.setProperties(properties);
 
-        fixture.initialize();
+        fixture.thingUpdated(thing);
 
         ThingStatusInfo expectedStatus = ThingStatusInfoBuilder
                 .create(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR)

--- a/bundles/org.openhab.binding.boschshc/src/test/java/org/openhab/binding/boschshc/internal/devices/userdefinedstate/UserStateHandlerTest.java
+++ b/bundles/org.openhab.binding.boschshc/src/test/java/org/openhab/binding/boschshc/internal/devices/userdefinedstate/UserStateHandlerTest.java
@@ -110,7 +110,7 @@ class UserStateHandlerTest extends AbstractBoschSHCHandlerTest<UserStateHandler>
     void initializeWithoutId() {
         when(getThing().getConfiguration()).thenReturn(new Configuration());
 
-        getFixture().initialize();
+        getFixture().thingUpdated(getThing());
 
         verify(getCallback()).statusUpdated(same(getThing()),
                 argThat(status -> status.getStatus().equals(ThingStatus.OFFLINE)

--- a/bundles/org.openhab.binding.casokitchen/src/test/java/org/openhab/binding/caso/internal/TestHandler.java
+++ b/bundles/org.openhab.binding.casokitchen/src/test/java/org/openhab/binding/caso/internal/TestHandler.java
@@ -88,8 +88,72 @@ class TestHandler {
     }
 
     @Test
-    void testConfigErrors() {
+    void testConfigErrorNoConfiguration() {
         ThingImpl thing = new ThingImpl(CasoKitchenBindingConstants.THING_TYPE_WINECOOLER, "test");
+
+        FactoryMock factory = new FactoryMock(prepareHttpResponse(), tzp);
+        ThingHandler handler = factory.createHandler(thing);
+        assertNotNull(handler);
+        assertTrue(handler instanceof TwoZonesWinecoolerHandler);
+        TwoZonesWinecoolerHandler winecoolerHandler = (TwoZonesWinecoolerHandler) handler;
+        winecoolerHandler.setCallback(new CallbackMock());
+        winecoolerHandler.initialize();
+
+        ThingStatusInfo tsi = thing.getStatusInfo();
+        assertEquals(ThingStatus.OFFLINE, tsi.getStatus());
+        assertEquals(ThingStatusDetail.CONFIGURATION_ERROR, tsi.getStatusDetail());
+        assertEquals("@text/casokitchen.winecooler-2z.status.api-key-missing", tsi.getDescription());
+    }
+
+    @Test
+    void testConfigErrorMissingDeviceId() {
+        ThingImpl thing = new ThingImpl(CasoKitchenBindingConstants.THING_TYPE_WINECOOLER, "test");
+        Configuration config = new Configuration();
+        config.put("apiKey", "abc");
+        thing.setConfiguration(config);
+
+        FactoryMock factory = new FactoryMock(prepareHttpResponse(), tzp);
+        ThingHandler handler = factory.createHandler(thing);
+        assertNotNull(handler);
+        assertTrue(handler instanceof TwoZonesWinecoolerHandler);
+        TwoZonesWinecoolerHandler winecoolerHandler = (TwoZonesWinecoolerHandler) handler;
+        winecoolerHandler.setCallback(new CallbackMock());
+        winecoolerHandler.initialize();
+
+        ThingStatusInfo tsi = thing.getStatusInfo();
+        assertEquals(ThingStatus.OFFLINE, tsi.getStatus());
+        assertEquals(ThingStatusDetail.CONFIGURATION_ERROR, tsi.getStatusDetail());
+        assertEquals("@text/casokitchen.winecooler-2z.status.device-id-missing", tsi.getDescription());
+    }
+
+    @Test
+    void testConfigErrorMissingApiKey() {
+        ThingImpl thing = new ThingImpl(CasoKitchenBindingConstants.THING_TYPE_WINECOOLER, "test");
+        Configuration config = new Configuration();
+        config.put("deviceId", "xyz");
+        thing.setConfiguration(config);
+
+        FactoryMock factory = new FactoryMock(prepareHttpResponse(), tzp);
+        ThingHandler handler = factory.createHandler(thing);
+        assertNotNull(handler);
+        assertTrue(handler instanceof TwoZonesWinecoolerHandler);
+        TwoZonesWinecoolerHandler winecoolerHandler = (TwoZonesWinecoolerHandler) handler;
+        winecoolerHandler.setCallback(new CallbackMock());
+        winecoolerHandler.initialize();
+
+        ThingStatusInfo tsi = thing.getStatusInfo();
+        assertEquals(ThingStatus.OFFLINE, tsi.getStatus());
+        assertEquals(ThingStatusDetail.CONFIGURATION_ERROR, tsi.getStatusDetail());
+        assertEquals("@text/casokitchen.winecooler-2z.status.api-key-missing", tsi.getDescription());
+    }
+
+    @Test
+    void testConfigValidConfigurationBecomesOnline() {
+        ThingImpl thing = new ThingImpl(CasoKitchenBindingConstants.THING_TYPE_WINECOOLER, "test");
+        Configuration config = new Configuration();
+        config.put("apiKey", "abc");
+        config.put("deviceId", "xyz");
+        thing.setConfiguration(config);
 
         FactoryMock factory = new FactoryMock(prepareHttpResponse(), tzp);
         ThingHandler handler = factory.createHandler(thing);
@@ -100,25 +164,8 @@ class TestHandler {
         winecoolerHandler.setCallback(callback);
         winecoolerHandler.initialize();
 
-        ThingStatusInfo tsi = thing.getStatusInfo();
-        assertEquals(ThingStatus.OFFLINE, tsi.getStatus());
-        assertEquals(ThingStatusDetail.CONFIGURATION_ERROR, tsi.getStatusDetail());
-        assertEquals("@text/casokitchen.winecooler-2z.status.api-key-missing", tsi.getDescription());
-
-        Configuration config = new Configuration();
-        config.put("apiKey", "abc");
-        thing.setConfiguration(config);
-        winecoolerHandler.initialize();
-        tsi = thing.getStatusInfo();
-        assertEquals(ThingStatus.OFFLINE, tsi.getStatus());
-        assertEquals(ThingStatusDetail.CONFIGURATION_ERROR, tsi.getStatusDetail());
-        assertEquals("@text/casokitchen.winecooler-2z.status.device-id-missing", tsi.getDescription());
-
-        config.put("deviceId", "xyz");
-        thing.setConfiguration(config);
-        winecoolerHandler.initialize();
         callback.waitForOnline();
-        tsi = thing.getStatusInfo();
+        ThingStatusInfo tsi = thing.getStatusInfo();
         assertEquals(ThingStatus.ONLINE, tsi.getStatus());
     }
 

--- a/bundles/org.openhab.binding.energyforecast/src/test/java/org/openhab/binding/energyforecast/HandlerTest.java
+++ b/bundles/org.openhab.binding.energyforecast/src/test/java/org/openhab/binding/energyforecast/HandlerTest.java
@@ -110,27 +110,32 @@ class HandlerTest {
     }
 
     @Test
-    void testConfigError() {
+    void testConfigErrorTokenEmpty() {
         List<?> testObjects = createHandler(null);
         EnergyForecastHandler tester = (EnergyForecastHandler) testObjects.get(0);
         assertNotNull(tester);
         CallbackMock callback = (CallbackMock) testObjects.get(1);
         assertNotNull(callback);
-        ThingImpl thing = (ThingImpl) testObjects.get(2);
-        assertNotNull(thing);
         tester.initialize();
 
         ThingStatusInfo statusInfo = callback.getStatus();
         assertEquals(ThingStatus.OFFLINE, statusInfo.getStatus());
         assertEquals(ThingStatusDetail.CONFIGURATION_ERROR, statusInfo.getStatusDetail());
         assertEquals("@text/thing-status.energyforecast.token-empty", statusInfo.getDescription());
+    }
 
+    @Test
+    void testConfigErrorZoneEmpty() {
         Configuration config = new Configuration();
         config.put("token", "abc");
-        thing.setConfiguration(config);
+        List<?> testObjects = createHandler(config);
+        EnergyForecastHandler tester = (EnergyForecastHandler) testObjects.get(0);
+        assertNotNull(tester);
+        CallbackMock callback = (CallbackMock) testObjects.get(1);
+        assertNotNull(callback);
         tester.initialize();
 
-        statusInfo = callback.getStatus();
+        ThingStatusInfo statusInfo = callback.getStatus();
         assertEquals(ThingStatus.OFFLINE, statusInfo.getStatus());
         assertEquals(ThingStatusDetail.CONFIGURATION_ERROR, statusInfo.getStatusDetail());
         assertEquals("@text/thing-status.energyforecast.zone-empty", statusInfo.getDescription());

--- a/bundles/org.openhab.binding.mercedesme/src/test/java/org/openhab/binding/mercedesme/StatusTests.java
+++ b/bundles/org.openhab.binding.mercedesme/src/test/java/org/openhab/binding/mercedesme/StatusTests.java
@@ -22,6 +22,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.jetty.client.api.ContentResponse;
 import org.eclipse.jetty.client.api.Request;
@@ -86,64 +87,91 @@ public class StatusTests {
         return httpClient;
     }
 
-    @Test
-    void testInvalidConfig() {
+    private static AccountHandlerMock createAccountHandler(Map<String, Object> config, int tokenResponseCode,
+            ThingCallbackListener tcl) {
         BridgeImpl bi = new BridgeImpl(new ThingTypeUID("test", "account"), "MB");
-        Map<String, Object> config = new HashMap<>();
         bi.setConfiguration(new Configuration(config));
-        AccountHandlerMock ahm = new AccountHandlerMock(bi, null, getHttpClient(404));
-        ThingCallbackListener tcl = new ThingCallbackListener();
+        AccountHandlerMock ahm = new AccountHandlerMock(bi, null, getHttpClient(tokenResponseCode));
         ahm.setCallback(tcl);
+        return ahm;
+    }
+
+    private static void assertOfflineStatus(ThingStatusInfo tsi, ThingStatusDetail expectedDetail,
+            @Nullable String expectedDescription, String messagePrefix) {
+        assertEquals(ThingStatus.OFFLINE, tsi.getStatus(), messagePrefix + " offline");
+        assertEquals(expectedDetail, tsi.getStatusDetail(), messagePrefix + " detail");
+        if (expectedDescription != null) {
+            assertEquals(expectedDescription, tsi.getDescription(), messagePrefix + " text");
+        }
+    }
+
+    @Test
+    void testInvalidConfigEmailMissing() {
+        Map<String, Object> config = new HashMap<>();
+        ThingCallbackListener tcl = new ThingCallbackListener();
+        AccountHandlerMock ahm = createAccountHandler(config, 404, tcl);
         ahm.initialize();
         ThingStatusInfo tsi = tcl.getThingStatus();
-        assertEquals(ThingStatus.OFFLINE, tsi.getStatus(), "EMail offline");
-        assertEquals(ThingStatusDetail.CONFIGURATION_ERROR, tsi.getStatusDetail(), "EMail config");
-        assertEquals("@text/mercedesme.account.status.config.email-missing", tsi.getDescription(), "EMail text");
+        assertOfflineStatus(tsi, ThingStatusDetail.CONFIGURATION_ERROR,
+                "@text/mercedesme.account.status.config.email-missing", "EMail");
         tearDown(ahm);
+    }
 
+    @Test
+    void testInvalidConfigPasswordMissing() {
+        Map<String, Object> config = new HashMap<>();
         config.put("email", JUNIT_EMAIL);
-        bi.setConfiguration(new Configuration(config));
-        tcl = new ThingCallbackListener();
-        ahm.setCallback(tcl);
+        ThingCallbackListener tcl = new ThingCallbackListener();
+        AccountHandlerMock ahm = createAccountHandler(config, 404, tcl);
         ahm.initialize();
-        tsi = tcl.getThingStatus();
-        assertEquals(ThingStatus.OFFLINE, tsi.getStatus(), "Password offline");
-        assertEquals(ThingStatusDetail.CONFIGURATION_ERROR, tsi.getStatusDetail(), "Password config");
-        assertEquals("@text/mercedesme.account.status.config.password-missing", tsi.getDescription(), "Password text");
+        ThingStatusInfo tsi = tcl.getThingStatus();
+        assertOfflineStatus(tsi, ThingStatusDetail.CONFIGURATION_ERROR,
+                "@text/mercedesme.account.status.config.password-missing", "Password");
         tearDown(ahm);
+    }
 
+    @Test
+    void testInvalidConfigRegionMissing() {
+        Map<String, Object> config = new HashMap<>();
+        config.put("email", JUNIT_EMAIL);
         config.put("password", JUNIT_PASSWORD);
-        bi.setConfiguration(new Configuration(config));
-        tcl = new ThingCallbackListener();
-        ahm.setCallback(tcl);
+        ThingCallbackListener tcl = new ThingCallbackListener();
+        AccountHandlerMock ahm = createAccountHandler(config, 404, tcl);
         ahm.initialize();
-        tsi = tcl.getThingStatus();
-        assertEquals(ThingStatus.OFFLINE, tsi.getStatus(), "Region offline");
-        assertEquals(ThingStatusDetail.CONFIGURATION_ERROR, tsi.getStatusDetail(), "Region config");
-        assertEquals("@text/mercedesme.account.status.config.region-missing", tsi.getDescription(), "Region text");
+        ThingStatusInfo tsi = tcl.getThingStatus();
+        assertOfflineStatus(tsi, ThingStatusDetail.CONFIGURATION_ERROR,
+                "@text/mercedesme.account.status.config.region-missing", "Region");
         tearDown(ahm);
+    }
 
+    @Test
+    void testInvalidConfigAuthFailure() {
+        Map<String, Object> config = new HashMap<>();
+        config.put("email", JUNIT_EMAIL);
+        config.put("password", JUNIT_PASSWORD);
         config.put("region", "row");
-        bi.setConfiguration(new Configuration(config));
-        tcl = new ThingCallbackListener();
-        ahm.setCallback(tcl);
+        ThingCallbackListener tcl = new ThingCallbackListener();
+        AccountHandlerMock ahm = createAccountHandler(config, 404, tcl);
         ahm.initialize();
         ahm.refresh();
-        tsi = tcl.getThingStatus();
-        assertEquals(ThingStatus.OFFLINE, tsi.getStatus(), "Auth offline");
-        assertEquals(ThingStatusDetail.COMMUNICATION_ERROR, tsi.getStatusDetail(), "Auth detail");
+        ThingStatusInfo tsi = tcl.getThingStatus();
+        assertOfflineStatus(tsi, ThingStatusDetail.COMMUNICATION_ERROR, null, "Auth");
         tearDown(ahm);
+    }
 
+    @Test
+    void testInvalidConfigRefreshIntervalInvalid() {
+        Map<String, Object> config = new HashMap<>();
+        config.put("email", JUNIT_EMAIL);
+        config.put("password", JUNIT_PASSWORD);
+        config.put("region", "row");
         config.put("refreshInterval", 0);
-        bi.setConfiguration(new Configuration(config));
-        tcl = new ThingCallbackListener();
-        ahm.setCallback(tcl);
+        ThingCallbackListener tcl = new ThingCallbackListener();
+        AccountHandlerMock ahm = createAccountHandler(config, 404, tcl);
         ahm.initialize();
-        tsi = tcl.getThingStatus();
-        assertEquals(ThingStatus.OFFLINE, tsi.getStatus(), "Refresh offline");
-        assertEquals(ThingStatusDetail.CONFIGURATION_ERROR, tsi.getStatusDetail(), "Refresh config");
-        assertEquals("@text/mercedesme.account.status.config.refresh-invalid[\"0\"]", tsi.getDescription(),
-                "Refresh text");
+        ThingStatusInfo tsi = tcl.getThingStatus();
+        assertOfflineStatus(tsi, ThingStatusDetail.CONFIGURATION_ERROR,
+                "@text/mercedesme.account.status.config.refresh-invalid[\"0\"]", "Refresh");
         tearDown(ahm);
     }
 

--- a/bundles/org.openhab.binding.remehaheating/src/test/java/org/openhab/binding/remehaheating/internal/RemehaHeatingHandlerTest.java
+++ b/bundles/org.openhab.binding.remehaheating/src/test/java/org/openhab/binding/remehaheating/internal/RemehaHeatingHandlerTest.java
@@ -15,7 +15,6 @@ package org.openhab.binding.remehaheating.internal;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
-import static org.mockito.Mockito.lenient;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.junit.jupiter.api.BeforeEach;
@@ -73,8 +72,7 @@ public class RemehaHeatingHandlerTest {
         RemehaHeatingConfiguration config = new RemehaHeatingConfiguration();
         config.email = "";
         config.password = "";
-
-        when(configuration.as(RemehaHeatingConfiguration.class)).thenReturn(config);
+        lenient().when(configuration.as(RemehaHeatingConfiguration.class)).thenReturn(config);
 
         handler.initialize();
 

--- a/bundles/org.openhab.binding.yamahareceiver/src/test/java/org/openhab/binding/yamahareceiver/internal/YamahaReceiverHandlerTest.java
+++ b/bundles/org.openhab.binding.yamahareceiver/src/test/java/org/openhab/binding/yamahareceiver/internal/YamahaReceiverHandlerTest.java
@@ -18,13 +18,12 @@ import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
+import java.util.HashMap;
 import java.util.List;
-import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
-import org.openhab.binding.yamahareceiver.internal.config.YamahaBridgeConfig;
 import org.openhab.binding.yamahareceiver.internal.discovery.ZoneDiscoveryService;
 import org.openhab.binding.yamahareceiver.internal.handler.YamahaBridgeHandler;
 import org.openhab.binding.yamahareceiver.internal.protocol.ConnectionStateListener;
@@ -47,8 +46,6 @@ public class YamahaReceiverHandlerTest extends AbstractXMLProtocolTest {
 
     private YamahaBridgeHandler subject;
 
-    private @Mock YamahaBridgeConfig bridgeConfig;
-    private @Mock Configuration configuration;
     private @Mock ProtocolFactory protocolFactory;
     private @Mock DeviceInformation deviceInformation;
     private @Mock SystemControl systemControl;
@@ -63,11 +60,11 @@ public class YamahaReceiverHandlerTest extends AbstractXMLProtocolTest {
         ctx.respondWith("<Main_Zone><Input><Input_Sel_Item>GetParam</Input_Sel_Item></Input></Main_Zone>",
                 "Main_Zone_Input_Input_Sel.xml");
 
-        when(bridgeConfig.getHostWithPort()).thenReturn(Optional.of("localhost:80"));
-        when(bridgeConfig.getInputMapping()).thenReturn("");
-        when(bridgeConfig.getRefreshInterval()).thenReturn(10);
-
-        when(configuration.as(YamahaBridgeConfig.class)).thenReturn(bridgeConfig);
+        Configuration configuration = new Configuration(new HashMap<>());
+        configuration.put("host", "localhost");
+        configuration.put("port", 80);
+        configuration.put("inputMapping", "");
+        configuration.put("refreshInterval", 10);
         when(bridge.getConfiguration()).thenReturn(configuration);
 
         when(protocolFactory.DeviceInformation(any(), any())).thenReturn(deviceInformation);


### PR DESCRIPTION
Somehow the change of configuration and re-use of the handler is no longer possible in tests. Probably some core PR merged around 17-05-2026 casued this to fail.

**casokitchen**, **energyforecast**, **mercedesme**
When the test cases are splitted they work as expected, prevent the re-use. As splitting is better anyway, i did not care to look up all details and fix it inline.

**remehaheating**, **yamahareceiver**
Changed way the configuration is added in the unit tests

**boschsh**
Probably same cause. For the boschsh the call for `initialize` could be replaced by `thingUpdated` and it worked as expected.

For reference:
https://github.com/openhab/openhab-addons/pull/20751#issuecomment-4489951681 pointed to 

Originated from changes in https://github.com/openhab/openhab-core/pull/5568

When merging, please don't squash the commits.