### PR TITLE
[kaleidescape] Fix thing status text

### DIFF
--- a/bundles/org.openhab.binding.kaleidescape/src/main/java/org/openhab/binding/kaleidescape/internal/handler/KaleidescapeHandler.java
+++ b/bundles/org.openhab.binding.kaleidescape/src/main/java/org/openhab/binding/kaleidescape/internal/handler/KaleidescapeHandler.java
@@ -93,7 +93,6 @@ public class KaleidescapeHandler extends BaseThingHandler implements Kaleidescap
     protected boolean isMuted = false;
     protected boolean isLoadHighlightedDetails = false;
     protected boolean isLoadAlbumDetails = false;
-    protected String friendlyName = EMPTY;
     protected Object sequenceLock = new Object();
 
     public KaleidescapeHandler(Thing thing, SerialPortManager serialPortManager, HttpClient httpClient) {
@@ -327,7 +326,7 @@ public class KaleidescapeHandler extends BaseThingHandler implements Kaleidescap
 
             if (ThingStatusDetail.BRIDGE_OFFLINE.equals(thing.getStatusInfo().getStatusDetail())) {
                 // no longer in standby, update the status
-                updateStatus(ThingStatus.ONLINE, ThingStatusDetail.NONE, this.friendlyName);
+                updateStatus(ThingStatus.ONLINE, ThingStatusDetail.NONE);
             }
         } catch (IllegalArgumentException e) {
             logger.debug("Unhandled message: key {} = {}", evt.getKey(), evt.getValue());
@@ -400,7 +399,7 @@ public class KaleidescapeHandler extends BaseThingHandler implements Kaleidescap
                         updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, error);
                         return;
                     }
-                    updateStatus(ThingStatus.ONLINE, ThingStatusDetail.NONE, this.friendlyName);
+                    updateStatus(ThingStatus.ONLINE, ThingStatusDetail.NONE);
                     lastEventReceived = System.currentTimeMillis();
                 }
             }

--- a/bundles/org.openhab.binding.kaleidescape/src/main/java/org/openhab/binding/kaleidescape/internal/handler/KaleidescapeMessageHandler.java
+++ b/bundles/org.openhab.binding.kaleidescape/src/main/java/org/openhab/binding/kaleidescape/internal/handler/KaleidescapeMessageHandler.java
@@ -604,8 +604,6 @@ public enum KaleidescapeMessageHandler {
     FRIENDLY_NAME {
         @Override
         public void handleMessage(String message, KaleidescapeHandler handler) {
-            // example: 'Living Room'
-            handler.friendlyName = message;
             handler.updateThingProperty(PROPERTY_FRIENDLY_NAME, message);
         }
     };


### PR DESCRIPTION
When the Thing becomes ONLINE, the Thing status is set to ONLINE and the status description is set to the friendly name (usually the zone). This value is also exposed separately as the Thing property `Friendly Name`.

This behavior has now been normalized to no longer update the Thing status description. The friendly name (zone) does not describe the operational state of the Thing itself. At most, it represents contextual or location-related information, which is already modelled through Thing properties.

For reference: https://github.com/openhab/openhab-core/issues/5587