### PR TITLE
[nuvo] Fix thing status text

### DIFF
--- a/bundles/org.openhab.binding.nuvo/src/main/java/org/openhab/binding/nuvo/internal/handler/NuvoHandler.java
+++ b/bundles/org.openhab.binding.nuvo/src/main/java/org/openhab/binding/nuvo/internal/handler/NuvoHandler.java
@@ -154,7 +154,6 @@ public class NuvoHandler extends BaseThingHandler implements NuvoMessageEventLis
     private NuvoConnector connector = new NuvoIpConnector();
     private long lastEventReceived = System.currentTimeMillis();
     private int numZones = 1;
-    private String versionString = BLANK;
     private boolean isGConcerto = false;
     private Object sequenceLock = new Object();
 
@@ -702,14 +701,14 @@ public class NuvoHandler extends BaseThingHandler implements NuvoMessageEventLis
         final String updateData = evt.getValue().trim();
 
         if (this.getThing().getStatus() != ThingStatus.ONLINE) {
-            updateStatus(ThingStatus.ONLINE, ThingStatusDetail.NONE, this.versionString);
+            updateStatus(ThingStatus.ONLINE);
         }
 
         switch (evt.getType()) {
             case TYPE_VERSION:
-                this.versionString = updateData;
+                getThing().setProperty(Thing.PROPERTY_MODEL_ID, updateData);
                 // Determine if we are a Grand Concerto or not
-                if (this.versionString.contains(GC_STR)) {
+                if (updateData.contains(GC_STR)) {
                     logger.debug("Grand Concerto detected");
                     this.isGConcerto = true;
                     connector.setEssentia(false);

--- a/bundles/org.openhab.binding.nuvo/src/main/java/org/openhab/binding/nuvo/internal/handler/NuvoHandler.java
+++ b/bundles/org.openhab.binding.nuvo/src/main/java/org/openhab/binding/nuvo/internal/handler/NuvoHandler.java
@@ -706,7 +706,7 @@ public class NuvoHandler extends BaseThingHandler implements NuvoMessageEventLis
 
         switch (evt.getType()) {
             case TYPE_VERSION:
-                getThing().setProperty(Thing.PROPERTY_MODEL_ID, updateData);
+                updateProperty(Thing.PROPERTY_MODEL_ID, updateData);
                 // Determine if we are a Grand Concerto or not
                 if (updateData.contains(GC_STR)) {
                     logger.debug("Grand Concerto detected");


### PR DESCRIPTION
When the Thing becomes ONLINE, the Thing status is set to ONLINE and the status description is set to the version string / model.

This behavior has now been normalized to no longer update the Thing status description. The version string / model does not describe the operational state of the Thing itself. It represents the device's model identifier that is commonly modelled as Thing property.

For reference: https://github.com/openhab/openhab-core/issues/5587