### PR TITLE
[velux] Fix thing status text

### DIFF
--- a/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/handler/VeluxBindingHandler.java
+++ b/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/handler/VeluxBindingHandler.java
@@ -139,7 +139,7 @@ public class VeluxBindingHandler extends ExtendedBaseThingHandler {
             if (currentNumberOfBridges < 1) {
                 updateStatus(ThingStatus.ONLINE, ThingStatusDetail.CONFIGURATION_PENDING);
             } else {
-                updateStatus(ThingStatus.ONLINE, ThingStatusDetail.NONE);
+                updateStatus(ThingStatus.ONLINE);
             }
             logger.trace("updateVisibleInformation(): updating all channels.");
             for (Channel channel : thing.getChannels()) {

--- a/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/handler/VeluxBindingHandler.java
+++ b/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/handler/VeluxBindingHandler.java
@@ -137,9 +137,9 @@ public class VeluxBindingHandler extends ExtendedBaseThingHandler {
         if (this.isInitialized()) {
             logger.trace("updateVisibleInformation(): updating thing status.");
             if (currentNumberOfBridges < 1) {
-                updateStatus(ThingStatus.ONLINE, ThingStatusDetail.CONFIGURATION_PENDING, bridgeCountToString());
+                updateStatus(ThingStatus.ONLINE, ThingStatusDetail.CONFIGURATION_PENDING);
             } else {
-                updateStatus(ThingStatus.ONLINE, ThingStatusDetail.NONE, bridgeCountToString());
+                updateStatus(ThingStatus.ONLINE, ThingStatusDetail.NONE);
             }
             logger.trace("updateVisibleInformation(): updating all channels.");
             for (Channel channel : thing.getChannels()) {


### PR DESCRIPTION
The count of bridge was previously added to the thing state description, the thing property and as a channel. 
This PR de-duplicates this information and removes it from the bridge state, but leaves it as property and channel