### PR TITLE
[homematic] Fix deadlock on stopping discovery

### DIFF
--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/discovery/HomematicDeviceDiscoveryService.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/discovery/HomematicDeviceDiscoveryService.java
@@ -112,14 +112,17 @@ public class HomematicDeviceDiscoveryService
     }
 
     @Override
-    public synchronized void stopScan() {
+    public void stopScan() {
         logger.debug("Stopping Homematic discovery scan");
-        disableInstallMode();
-        final HomematicGateway gateway = thingHandler.getGateway();
-        if (gateway != null) {
-            gateway.cancelLoadAllDeviceMetadata();
+        final HomematicGateway gateway;
+        synchronized (this) {
+            disableInstallMode();
+            gateway = thingHandler.getGateway();
+            if (gateway != null) {
+                gateway.cancelLoadAllDeviceMetadata();
+            }
         }
-        waitForScanFinishing();
+        waitForScanFinishing(gateway);
         super.stopScan();
     }
 
@@ -153,8 +156,11 @@ public class HomematicDeviceDiscoveryService
     }
 
     private void waitForLoadDevicesFinished() throws InterruptedException, ExecutionException {
-        Future<?> loadFuture;
-        if ((loadFuture = loadDevicesFuture) != null) {
+        final Future<?> loadFuture;
+        synchronized (this) {
+            loadFuture = this.loadDevicesFuture;
+        }
+        if (loadFuture != null) {
             loadFuture.get();
         }
     }
@@ -162,7 +168,7 @@ public class HomematicDeviceDiscoveryService
     /**
      * Waits for the discovery scan to finish and then returns.
      */
-    public void waitForScanFinishing() {
+    public void waitForScanFinishing(HomematicGateway gateway) {
         logger.debug("Waiting for finishing Homematic device discovery scan");
         try {
             waitForInstallModeFinished(DISCOVER_TIMEOUT_SECONDS * 1000);
@@ -172,8 +178,6 @@ public class HomematicDeviceDiscoveryService
         } catch (Exception ex) {
             logger.error("Error waiting for device discovery scan: {}", ex.getMessage(), ex);
         }
-        HomematicBridgeHandler bridgeHandler = thingHandler;
-        HomematicGateway gateway = bridgeHandler.getGateway();
         String gatewayId = gateway != null ? gateway.getId() : "UNKNOWN";
         logger.debug("Finished Homematic device discovery scan on gateway '{}'", gatewayId);
     }

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/handler/HomematicBridgeHandler.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/handler/HomematicBridgeHandler.java
@@ -121,7 +121,7 @@ public class HomematicBridgeHandler extends BaseBridgeHandler implements Homemat
                 // scan for already known devices (new devices will not be discovered,
                 // since installMode==true is only achieved if the bridge is online
                 discoveryService.startScan(null);
-                discoveryService.waitForScanFinishing();
+                discoveryService.waitForScanFinishing(gateway);
 
                 updateStatus(ThingStatus.ONLINE);
                 if (!config.getGatewayInfo().isHomegear()) {


### PR DESCRIPTION
If the scan takes longer than the maximum scan time (120s by default), it's automatically stopped by stopScan(), which in turn cancels the load operation and waits for it to finish. It did so, however, with the 'this' lock held [1], and tried to acquire the same lock during the wait operation [2], which led to a deadlock. Fix this by running the wait operation without lock held.

[1] HomematicDeviceDiscoveryService::stopScan
  -> HomematicDeviceDiscoveryService::waitForScanFinishing
  -> HomematicDeviceDiscoveryService::waitForLoadDevicesFinished
[2] Scheduler callback in HomematicDeviceDiscoveryService::loadDevices
  -> AbstractDiscoveryService::getTimestampOfLastScan
