### PR TITLE
[enocean] Restore datagram injector outbound telegrams

### DIFF
--- a/bundles/org.openhab.binding.enocean/src/main/java/org/openhab/binding/enocean/internal/handler/EnOceanDatagramInjectorHandler.java
+++ b/bundles/org.openhab.binding.enocean/src/main/java/org/openhab/binding/enocean/internal/handler/EnOceanDatagramInjectorHandler.java
@@ -31,6 +31,7 @@ import org.openhab.binding.enocean.internal.eep.EEPFactory;
 import org.openhab.binding.enocean.internal.eep.EEPType;
 import org.openhab.binding.enocean.internal.injector.InjectorProfileType;
 import org.openhab.binding.enocean.internal.messages.BasePacket;
+import org.openhab.core.config.core.Configuration;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.thing.Channel;
 import org.openhab.core.thing.ChannelUID;
@@ -194,13 +195,14 @@ public class EnOceanDatagramInjectorHandler extends EnOceanBaseThingHandler {
         String channelId = channelUID.getId();
         ChannelTypeUID channelTypeUID = channel.getChannelTypeUID();
         String channelTypeId = (channelTypeUID != null) ? channelTypeUID.getId() : "";
+        Configuration channelConfig = channel.getConfiguration();
 
         if (!localSendingProfileType.isChannelSupported(channelId, channelTypeId)) {
             return;
         }
 
         try {
-            boolean wasSent = sendMessage(localSendingProfileType, channelId, command);
+            boolean wasSent = sendMessage(localSendingProfileType, channelId, command, channelConfig);
             if (wasSent && localSendingProfileType.getChannelId().equals(channelId) && command instanceof State state) {
                 updateState(channelUID, state);
             }
@@ -208,7 +210,7 @@ public class EnOceanDatagramInjectorHandler extends EnOceanBaseThingHandler {
             if (localSendingProfileType == InjectorProfileType.MOTION_A5_07_01
                     && localSendingProfileType.getChannelId().equals(channelId) && command instanceof OnOffType onOff) {
                 if (onOff == OnOffType.ON) {
-                    startMotionRetriggerJob(localSendingProfileType, channelId);
+                    startMotionRetriggerJob(localSendingProfileType, channelId, channelConfig);
                 } else {
                     stopMotionRetriggerJob();
                     updateState(channelUID, OnOffType.OFF);
@@ -219,7 +221,8 @@ public class EnOceanDatagramInjectorHandler extends EnOceanBaseThingHandler {
         }
     }
 
-    private synchronized void startMotionRetriggerJob(InjectorProfileType profileType, String channelId) {
+    private synchronized void startMotionRetriggerJob(InjectorProfileType profileType, String channelId,
+            Configuration channelConfig) {
         stopMotionRetriggerJob();
         motionRetriggerJob = scheduler.scheduleWithFixedDelay(() -> {
             try {
@@ -227,7 +230,7 @@ public class EnOceanDatagramInjectorHandler extends EnOceanBaseThingHandler {
                     logger.debug("Motion retrigger skipped: injector not operational");
                     return;
                 }
-                sendMessage(profileType, channelId, OnOffType.ON);
+                sendMessage(profileType, channelId, OnOffType.ON, channelConfig);
             } catch (Exception e) {
                 logger.debug("Motion retrigger send failed", e);
             }
@@ -264,10 +267,11 @@ public class EnOceanDatagramInjectorHandler extends EnOceanBaseThingHandler {
         }
     }
 
-    private boolean sendMessage(InjectorProfileType profileType, String channelId, Command command) {
+    private boolean sendMessage(InjectorProfileType profileType, String channelId, Command command,
+            Configuration channelConfig) {
         EEP eep = EEPFactory.createEEP(profileType.getSendingEEPType());
-        ChannelUID channelUID = new ChannelUID(getThing().getUID(), channelId);
-        if (eep.convertFromCommand(getThing(), channelUID, command, id -> getCurrentState(id), null).hasData()) {
+        if (eep.convertFromCommand(channelId, profileType.getEepChannelTypeId(), command, id -> getCurrentState(id),
+                channelConfig).hasData()) {
             BasePacket msg = eep.setSenderId(senderId).setDestinationId(destinationId)
                     .setSuppressRepeating(getConfiguration().suppressRepeating).getERP1Message();
             if (msg == null) {

--- a/bundles/org.openhab.binding.enocean/src/main/java/org/openhab/binding/enocean/internal/injector/InjectorProfileType.java
+++ b/bundles/org.openhab.binding.enocean/src/main/java/org/openhab/binding/enocean/internal/injector/InjectorProfileType.java
@@ -13,6 +13,7 @@
 package org.openhab.binding.enocean.internal.injector;
 
 import static org.openhab.binding.enocean.internal.EnOceanBindingConstants.CHANNEL_CONTACT;
+import static org.openhab.binding.enocean.internal.EnOceanBindingConstants.CHANNEL_GENERAL_SWITCHING;
 import static org.openhab.binding.enocean.internal.EnOceanBindingConstants.CHANNEL_MOTIONDETECTION;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -23,19 +24,23 @@ import org.openhab.binding.enocean.internal.eep.EEPType;
  */
 @NonNullByDefault
 public enum InjectorProfileType {
-    FTK_D5_00_01("FTK_D5_00_01", EEPType.ContactAndSwitch01, "switch", CHANNEL_CONTACT),
-    MOTION_A5_07_01("MOTION_A5_07_01", EEPType.OCCUPANCYSENSOR_A5_07_01, "switch", CHANNEL_MOTIONDETECTION);
+    FTK_D5_00_01("FTK_D5_00_01", EEPType.ContactAndSwitch01, "switch", CHANNEL_GENERAL_SWITCHING, CHANNEL_CONTACT),
+    MOTION_A5_07_01("MOTION_A5_07_01", EEPType.OCCUPANCYSENSOR_A5_07_01, "switch", CHANNEL_GENERAL_SWITCHING,
+            CHANNEL_MOTIONDETECTION);
 
     private final String id;
     private final EEPType sendingEEPType;
     private final String channelId;
     private final String channelTypeId;
+    private final String eepChannelTypeId;
 
-    InjectorProfileType(String id, EEPType sendingEEPType, String channelId, String channelTypeId) {
+    InjectorProfileType(String id, EEPType sendingEEPType, String channelId, String channelTypeId,
+            String eepChannelTypeId) {
         this.id = id;
         this.sendingEEPType = sendingEEPType;
         this.channelId = channelId;
         this.channelTypeId = channelTypeId;
+        this.eepChannelTypeId = eepChannelTypeId;
     }
 
     public EEPType getSendingEEPType() {
@@ -50,6 +55,10 @@ public enum InjectorProfileType {
         return channelTypeId;
     }
 
+    public String getEepChannelTypeId() {
+        return eepChannelTypeId;
+    }
+
     public static boolean isProfileChannelId(String channelId) {
         for (InjectorProfileType type : values()) {
             if (type.channelId.equals(channelId)) {
@@ -60,7 +69,15 @@ public enum InjectorProfileType {
     }
 
     public boolean isChannelSupported(String channelId, String channelTypeId) {
-        return this.channelId.equals(channelId) && this.channelTypeId.equals(channelTypeId);
+        if (!this.channelId.equals(channelId)) {
+            return false;
+        }
+        return matchesChannelType(channelTypeId, this.channelTypeId)
+                || matchesChannelType(channelTypeId, eepChannelTypeId);
+    }
+
+    private boolean matchesChannelType(String candidateTypeId, String expectedTypeId) {
+        return expectedTypeId.equals(candidateTypeId) || candidateTypeId.endsWith(":" + expectedTypeId);
     }
 
     public static InjectorProfileType getType(String id) {


### PR DESCRIPTION
## Summary
- Restore datagram injector outbound telegrams after regression
- Keep generalSwitching as the user-facing channel type
- Map outbound conversion to EEP-supported channel types

## Root Cause
- Regression introduced by [commit 4eb3f4a4e7](https://github.com/openhab/openhab-addons/pull/20235/changes/4eb3f4a4e79f9c186190e2d82e32e649fcfdbc38). The channel type was changed to contact/motionDetection and tolerant matching was removed, so EEP validation rejected switch-based outbound commands and no telegrams were sent.

## Fix
- Keep injector channels on generalSwitching
- Route outbound conversion through the EEP-supported channel type

## Testing
- Tested FTK datagram injection for FSB14 device to be functional.