### PR TITLE
[homekit] Improve stability against `NullPointerException`

### DIFF
--- a/bundles/org.openhab.binding.homekit/src/main/java/org/openhab/binding/homekit/internal/dto/Characteristic.java
+++ b/bundles/org.openhab.binding.homekit/src/main/java/org/openhab/binding/homekit/internal/dto/Characteristic.java
@@ -937,7 +937,7 @@ public class Characteristic {
 
         ChannelDefinitionBuilder channelDefBuilder = new ChannelDefinitionBuilder(channelDefinitionIdentifier,
                 channelTypeUid).withLabel(getChannelLabel(characteristicType, i18nProvider, bundle))
-                        .withProperties(props);
+                .withProperties(props);
         Optional.ofNullable(getChannelDescription()).ifPresent(d -> channelDefBuilder.withDescription(d));
         return new Content.ChannelDefinition(channelDefBuilder.build());
     }
@@ -981,12 +981,5 @@ public class Characteristic {
 
     public @Nullable StatusCode getStatusCode() {
         return status instanceof Integer code ? StatusCode.from(code) : null;
-    }
-
-    /**
-     * Check if the characteristic is non null and its 'aid' and 'iid' fields are also not null
-     */
-    public static boolean nonNullAndHasAidAndIid(@Nullable Characteristic characteristic) {
-        return characteristic != null && characteristic.aid != null && characteristic.iid != null;
     }
 }

--- a/bundles/org.openhab.binding.homekit/src/main/java/org/openhab/binding/homekit/internal/dto/Characteristic.java
+++ b/bundles/org.openhab.binding.homekit/src/main/java/org/openhab/binding/homekit/internal/dto/Characteristic.java
@@ -937,7 +937,7 @@ public class Characteristic {
 
         ChannelDefinitionBuilder channelDefBuilder = new ChannelDefinitionBuilder(channelDefinitionIdentifier,
                 channelTypeUid).withLabel(getChannelLabel(characteristicType, i18nProvider, bundle))
-                .withProperties(props);
+                        .withProperties(props);
         Optional.ofNullable(getChannelDescription()).ifPresent(d -> channelDefBuilder.withDescription(d));
         return new Content.ChannelDefinition(channelDefBuilder.build());
     }
@@ -984,9 +984,9 @@ public class Characteristic {
     }
 
     /**
-     * Return true if the characteristic is valid i.e. itself and its aid and iid fields are not null
+     * Check if the characteristic is non null and its 'aid' and 'iid' fields are also not null
      */
-    public static boolean isValid(@Nullable Characteristic characteristic) {
+    public static boolean nonNullAndHasAidAndIid(@Nullable Characteristic characteristic) {
         return characteristic != null && characteristic.aid != null && characteristic.iid != null;
     }
 }

--- a/bundles/org.openhab.binding.homekit/src/main/java/org/openhab/binding/homekit/internal/dto/Characteristic.java
+++ b/bundles/org.openhab.binding.homekit/src/main/java/org/openhab/binding/homekit/internal/dto/Characteristic.java
@@ -982,4 +982,11 @@ public class Characteristic {
     public @Nullable StatusCode getStatusCode() {
         return status instanceof Integer code ? StatusCode.from(code) : null;
     }
+
+    /**
+     * Return true if the characteristic is valid i.e. itself and its aid and iid fields are not null
+     */
+    public static boolean isValid(@Nullable Characteristic characteristic) {
+        return characteristic != null && characteristic.aid != null && characteristic.iid != null;
+    }
 }

--- a/bundles/org.openhab.binding.homekit/src/main/java/org/openhab/binding/homekit/internal/handler/HomekitAccessoryHandler.java
+++ b/bundles/org.openhab.binding.homekit/src/main/java/org/openhab/binding/homekit/internal/handler/HomekitAccessoryHandler.java
@@ -790,6 +790,10 @@ public class HomekitAccessoryHandler extends HomekitBaseAccessoryHandler {
         if (aid == null) {
             return;
         }
+        List<Service> services = accessory.services;
+        if (services == null) {
+            return;
+        }
 
         for (Channel channel : channels.values()) {
             final ChannelUID channelUID = channel.getUID();
@@ -797,7 +801,7 @@ public class HomekitAccessoryHandler extends HomekitBaseAccessoryHandler {
                 continue; // skip camera snapshot channel
             }
             if (isLinked(channelUID)) {
-                Long iid = 0L;
+                Long iid;
                 boolean checkChannelLinkByIID = !channelUID.equals(lightModelClientHSBTypeChannel);
                 if (checkChannelLinkByIID && channel.getProperties().get(PROPERTY_IID) instanceof String iidProperty) {
                     try {
@@ -805,12 +809,21 @@ public class HomekitAccessoryHandler extends HomekitBaseAccessoryHandler {
                     } catch (NumberFormatException e) {
                         continue; // error will already have been logged elsewhere
                     }
+                } else {
+                    iid = null;
+                }
+                if (checkChannelLinkByIID && iid == null) {
+                    continue;
                 }
 
                 nestedLoops: // break marker for nested loops below
-                for (Service service : accessory.services) {
+                for (Service service : services) {
+                    if (service == null || service.characteristics == null) {
+                        continue;
+                    }
                     for (Characteristic characteristic : service.characteristics) {
-                        if ((checkChannelLinkByIID && iid.equals(characteristic.iid))
+                        if (Characteristic.isValid(characteristic)
+                                && (checkChannelLinkByIID && characteristic.iid.equals(iid))
                                 || LIGHT_MODEL_RELEVANT_TYPES.contains(characteristic.getCharacteristicType())) {
                             Characteristic entry = new Characteristic();
                             entry.aid = aid;

--- a/bundles/org.openhab.binding.homekit/src/main/java/org/openhab/binding/homekit/internal/handler/HomekitAccessoryHandler.java
+++ b/bundles/org.openhab.binding.homekit/src/main/java/org/openhab/binding/homekit/internal/handler/HomekitAccessoryHandler.java
@@ -818,23 +818,23 @@ public class HomekitAccessoryHandler extends HomekitBaseAccessoryHandler {
 
                 nestedLoops: // break marker for nested loops below
                 for (Service service : services) {
-                    if (service == null || service.characteristics == null) {
+                    if (service.characteristics == null) {
                         continue;
                     }
                     for (Characteristic characteristic : service.characteristics) {
-                        if (Characteristic.nonNullAndHasAidAndIid(characteristic)
+                        if ((characteristic != null && characteristic.iid != null)
                                 && ((checkChannelLinkByIID && characteristic.iid.equals(iid))
                                         || LIGHT_MODEL_RELEVANT_TYPES
                                                 .contains(characteristic.getCharacteristicType()))) {
                             Characteristic entry = new Characteristic();
                             entry.aid = aid;
                             entry.iid = characteristic.iid;
-                            polledCharacteristics.put(AID_IID_FORMAT.formatted(entry.aid, entry.iid), entry);
+                            polledCharacteristics.put(AID_IID_FORMAT.formatted(aid, characteristic.iid), entry);
                             if (characteristic.perms instanceof List<String> perms && perms.contains("ev")) {
                                 entry = new Characteristic();
                                 entry.aid = aid;
                                 entry.iid = characteristic.iid;
-                                eventedCharacteristics.put(AID_IID_FORMAT.formatted(entry.aid, entry.iid), entry);
+                                eventedCharacteristics.put(AID_IID_FORMAT.formatted(aid, characteristic.iid), entry);
                             }
                             if (checkChannelLinkByIID) {
                                 break nestedLoops; // unique match found; continue to next channel

--- a/bundles/org.openhab.binding.homekit/src/main/java/org/openhab/binding/homekit/internal/handler/HomekitAccessoryHandler.java
+++ b/bundles/org.openhab.binding.homekit/src/main/java/org/openhab/binding/homekit/internal/handler/HomekitAccessoryHandler.java
@@ -797,61 +797,62 @@ public class HomekitAccessoryHandler extends HomekitBaseAccessoryHandler {
             return;
         }
 
-        Map<String, Characteristic> newEvented = new HashMap<>();
-        Map<String, Characteristic> newPolled = new HashMap<>();
-
         for (Channel channel : channels.values()) {
             final ChannelUID channelUID = channel.getUID();
             if (CHANNEL_SNAPSHOT.equals(channelUID.getId())) {
                 continue; // skip camera snapshot channel
             }
-            if (isLinked(channelUID)) {
-                Long iid;
-                boolean checkChannelLinkByIID = !channelUID.equals(lightModelClientHSBTypeChannel);
-                if (checkChannelLinkByIID && channel.getProperties().get(PROPERTY_IID) instanceof String iidProperty) {
+            if (!isLinked(channelUID)) {
+                continue; // skip non-linked channels
+            }
+            Long channelIID = null;
+            boolean checkChannelLinkByIID = !channelUID.equals(lightModelClientHSBTypeChannel);
+            if (checkChannelLinkByIID) {
+                if (channel.getProperties().get(PROPERTY_IID) instanceof String iidProperty) {
                     try {
-                        iid = Long.parseLong(iidProperty);
+                        channelIID = Long.parseLong(iidProperty);
                     } catch (NumberFormatException e) {
                         continue; // error will already have been logged elsewhere
                     }
                 } else {
-                    iid = null;
+                    continue; // error will already have been logged elsewhere
                 }
-                if (checkChannelLinkByIID && iid == null) {
+            }
+
+            boolean iidMatched = false;
+            for (Service service : services) {
+                final List<Characteristic> characteristics = service.characteristics;
+                if (characteristics == null) {
                     continue;
                 }
-
-                nestedLoops: // break marker for nested loops below
-                for (Service service : services) {
-                    final List<Characteristic> characteristics = service.characteristics;
-                    if (characteristics == null) {
+                for (Characteristic characteristic : characteristics) {
+                    if (characteristic.iid == null) {
                         continue;
                     }
-                    for (Characteristic characteristic : characteristics) {
-                        if ((characteristic != null && characteristic.iid != null)
-                                && ((checkChannelLinkByIID && characteristic.iid.equals(iid))
-                                        || LIGHT_MODEL_RELEVANT_TYPES
-                                                .contains(characteristic.getCharacteristicType()))) {
-                            Characteristic entry = new Characteristic();
+                    if (checkChannelLinkByIID ? characteristic.iid.equals(channelIID)
+                            : LIGHT_MODEL_RELEVANT_TYPES.contains(characteristic.getCharacteristicType())) {
+                        String key = AID_IID_FORMAT.formatted(aid, characteristic.iid);
+                        Characteristic entry = new Characteristic();
+                        entry.aid = aid;
+                        entry.iid = characteristic.iid;
+                        polledCharacteristics.put(key, entry);
+                        if (characteristic.perms instanceof List<String> perms && perms.contains("ev")) {
+                            entry = new Characteristic();
                             entry.aid = aid;
                             entry.iid = characteristic.iid;
-                            newPolled.put(AID_IID_FORMAT.formatted(aid, characteristic.iid), entry);
-                            if (characteristic.perms instanceof List<String> perms && perms.contains("ev")) {
-                                entry = new Characteristic();
-                                entry.aid = aid;
-                                entry.iid = characteristic.iid;
-                                newEvented.put(AID_IID_FORMAT.formatted(aid, characteristic.iid), entry);
-                            }
-                            if (checkChannelLinkByIID) {
-                                break nestedLoops; // unique match found; continue to next channel
-                            }
+                            eventedCharacteristics.put(key, entry);
+                        }
+                        if (checkChannelLinkByIID) {
+                            iidMatched = true;
+                            break; // unique IID match found; break inner loop; continue to next channel
                         }
                     }
                 }
+                if (iidMatched) {
+                    break; // unique IID match found; continue to next channel
+                }
             }
         }
-        polledCharacteristics.putAll(newPolled);
-        eventedCharacteristics.putAll(newEvented);
     }
 
     /**

--- a/bundles/org.openhab.binding.homekit/src/main/java/org/openhab/binding/homekit/internal/handler/HomekitAccessoryHandler.java
+++ b/bundles/org.openhab.binding.homekit/src/main/java/org/openhab/binding/homekit/internal/handler/HomekitAccessoryHandler.java
@@ -830,7 +830,7 @@ public class HomekitAccessoryHandler extends HomekitBaseAccessoryHandler {
                         continue;
                     }
                     if (checkChannelLinkByIID ? characteristic.iid.equals(channelIID)
-                            : LIGHT_MODEL_RELEVANT_TYPES.contains(characteristic.getCharacteristicType())) {
+                            : requiredByLightModel(characteristic)) {
                         String key = AID_IID_FORMAT.formatted(aid, characteristic.iid);
                         Characteristic entry = new Characteristic();
                         entry.aid = aid;
@@ -853,6 +853,15 @@ public class HomekitAccessoryHandler extends HomekitBaseAccessoryHandler {
                 }
             }
         }
+    }
+
+    /**
+     * Helper that returns true if the light model requires the given characteristic type.
+     */
+    private boolean requiredByLightModel(Characteristic characteristic) {
+        return characteristic.type instanceof String characteristicType
+                ? LIGHT_MODEL_RELEVANT_TYPES.contains(Characteristic.getCharacteristicType(characteristicType))
+                : false;
     }
 
     /**

--- a/bundles/org.openhab.binding.homekit/src/main/java/org/openhab/binding/homekit/internal/handler/HomekitAccessoryHandler.java
+++ b/bundles/org.openhab.binding.homekit/src/main/java/org/openhab/binding/homekit/internal/handler/HomekitAccessoryHandler.java
@@ -788,12 +788,17 @@ public class HomekitAccessoryHandler extends HomekitBaseAccessoryHandler {
 
         final Long aid = getAccessoryId();
         if (aid == null) {
+            logger.debug("{} accessory has no ID", thing.getUID());
             return;
         }
-        List<Service> services = accessory.services;
+        final List<Service> services = accessory.services;
         if (services == null) {
+            logger.debug("{} accessory has no services", thing.getUID());
             return;
         }
+
+        Map<String, Characteristic> newEvented = new HashMap<>();
+        Map<String, Characteristic> newPolled = new HashMap<>();
 
         for (Channel channel : channels.values()) {
             final ChannelUID channelUID = channel.getUID();
@@ -818,10 +823,11 @@ public class HomekitAccessoryHandler extends HomekitBaseAccessoryHandler {
 
                 nestedLoops: // break marker for nested loops below
                 for (Service service : services) {
-                    if (service.characteristics == null) {
+                    final List<Characteristic> characteristics = service.characteristics;
+                    if (characteristics == null) {
                         continue;
                     }
-                    for (Characteristic characteristic : service.characteristics) {
+                    for (Characteristic characteristic : characteristics) {
                         if ((characteristic != null && characteristic.iid != null)
                                 && ((checkChannelLinkByIID && characteristic.iid.equals(iid))
                                         || LIGHT_MODEL_RELEVANT_TYPES
@@ -829,12 +835,12 @@ public class HomekitAccessoryHandler extends HomekitBaseAccessoryHandler {
                             Characteristic entry = new Characteristic();
                             entry.aid = aid;
                             entry.iid = characteristic.iid;
-                            polledCharacteristics.put(AID_IID_FORMAT.formatted(aid, characteristic.iid), entry);
+                            newPolled.put(AID_IID_FORMAT.formatted(aid, characteristic.iid), entry);
                             if (characteristic.perms instanceof List<String> perms && perms.contains("ev")) {
                                 entry = new Characteristic();
                                 entry.aid = aid;
                                 entry.iid = characteristic.iid;
-                                eventedCharacteristics.put(AID_IID_FORMAT.formatted(aid, characteristic.iid), entry);
+                                newEvented.put(AID_IID_FORMAT.formatted(aid, characteristic.iid), entry);
                             }
                             if (checkChannelLinkByIID) {
                                 break nestedLoops; // unique match found; continue to next channel
@@ -844,6 +850,8 @@ public class HomekitAccessoryHandler extends HomekitBaseAccessoryHandler {
                 }
             }
         }
+        polledCharacteristics.putAll(newPolled);
+        eventedCharacteristics.putAll(newEvented);
     }
 
     /**

--- a/bundles/org.openhab.binding.homekit/src/main/java/org/openhab/binding/homekit/internal/handler/HomekitAccessoryHandler.java
+++ b/bundles/org.openhab.binding.homekit/src/main/java/org/openhab/binding/homekit/internal/handler/HomekitAccessoryHandler.java
@@ -822,9 +822,10 @@ public class HomekitAccessoryHandler extends HomekitBaseAccessoryHandler {
                         continue;
                     }
                     for (Characteristic characteristic : service.characteristics) {
-                        if (Characteristic.isValid(characteristic)
-                                && (checkChannelLinkByIID && characteristic.iid.equals(iid))
-                                || LIGHT_MODEL_RELEVANT_TYPES.contains(characteristic.getCharacteristicType())) {
+                        if (Characteristic.nonNullAndHasAidAndIid(characteristic)
+                                && ((checkChannelLinkByIID && characteristic.iid.equals(iid))
+                                        || LIGHT_MODEL_RELEVANT_TYPES
+                                                .contains(characteristic.getCharacteristicType()))) {
                             Characteristic entry = new Characteristic();
                             entry.aid = aid;
                             entry.iid = characteristic.iid;

--- a/bundles/org.openhab.binding.homekit/src/main/java/org/openhab/binding/homekit/internal/handler/HomekitBaseAccessoryHandler.java
+++ b/bundles/org.openhab.binding.homekit/src/main/java/org/openhab/binding/homekit/internal/handler/HomekitBaseAccessoryHandler.java
@@ -684,11 +684,10 @@ public abstract class HomekitBaseAccessoryHandler extends BaseThingHandler imple
         }
         Service service = new Service();
         service.characteristics = new ArrayList<>();
-        service.characteristics
-                .addAll(getEventedCharacteristics().values().stream().filter(Objects::nonNull).map(cxx -> {
-                    cxx.ev = enable;
-                    return cxx;
-                }).toList());
+        service.characteristics.addAll(getEventedCharacteristics().values().stream().map(cxx -> {
+            cxx.ev = enable;
+            return cxx;
+        }).toList());
         if (service.characteristics.isEmpty()) {
             return;
         }
@@ -707,7 +706,7 @@ public abstract class HomekitBaseAccessoryHandler extends BaseThingHandler imple
      */
     private synchronized void refresh() {
         List<String> queries = getPolledCharacteristics().values().stream()
-                .filter(c -> c != null && c.iid != null && c.aid != null).map(c -> "%s.%s".formatted(c.aid, c.iid))
+                .filter(cxx -> cxx.iid != null && cxx.aid != null).map(cxx -> "%s.%s".formatted(cxx.aid, cxx.iid))
                 .toList();
         if (queries.isEmpty()) {
             return;

--- a/bundles/org.openhab.binding.homekit/src/main/java/org/openhab/binding/homekit/internal/handler/HomekitBaseAccessoryHandler.java
+++ b/bundles/org.openhab.binding.homekit/src/main/java/org/openhab/binding/homekit/internal/handler/HomekitBaseAccessoryHandler.java
@@ -706,7 +706,7 @@ public abstract class HomekitBaseAccessoryHandler extends BaseThingHandler imple
      */
     private synchronized void refresh() {
         List<String> queries = getPolledCharacteristics().values().stream()
-                .filter(cxx -> cxx.iid != null && cxx.aid != null).map(cxx -> "%s.%s".formatted(cxx.aid, cxx.iid))
+                .filter(c -> c.iid != null && c.aid != null).map(c -> "%s.%s".formatted(c.aid, c.iid))
                 .toList();
         if (queries.isEmpty()) {
             return;

--- a/bundles/org.openhab.binding.homekit/src/main/java/org/openhab/binding/homekit/internal/handler/HomekitBaseAccessoryHandler.java
+++ b/bundles/org.openhab.binding.homekit/src/main/java/org/openhab/binding/homekit/internal/handler/HomekitBaseAccessoryHandler.java
@@ -685,7 +685,7 @@ public abstract class HomekitBaseAccessoryHandler extends BaseThingHandler imple
         Service service = new Service();
         service.characteristics = new ArrayList<>();
         service.characteristics
-                .addAll(getEventedCharacteristics().values().stream().filter(Characteristic::isValid).map(cxx -> {
+                .addAll(getEventedCharacteristics().values().stream().filter(Characteristic::nonNullAndHasAidAndIid).map(cxx -> {
                     cxx.ev = enable;
                     return cxx;
                 }).toList());
@@ -706,7 +706,7 @@ public abstract class HomekitBaseAccessoryHandler extends BaseThingHandler imple
      * Called periodically by the refresh task and on-demand when RefreshType.REFRESH is called.
      */
     private synchronized void refresh() {
-        List<String> queries = getPolledCharacteristics().values().stream().filter(Characteristic::isValid)
+        List<String> queries = getPolledCharacteristics().values().stream().filter(Characteristic::nonNullAndHasAidAndIid)
                 .map(c -> "%s.%s".formatted(c.aid, c.iid)).toList();
         if (queries.isEmpty()) {
             return;
@@ -967,7 +967,7 @@ public abstract class HomekitBaseAccessoryHandler extends BaseThingHandler imple
      *            expanded to the i18n text id "error.event-subscribe-error" for the UI
      */
     protected void onCommunicationError(Exception exception, String i18nSuffix) {
-        String message = exception.getMessage();
+        String message = exception.toString();
         logger.debug("{} {} {}, reconnecting..", thing.getUID(), i18nSuffix, message);
         if (logger.isTraceEnabled()) {
             try (StringWriter sw = new StringWriter(); PrintWriter pw = new PrintWriter(sw)) {

--- a/bundles/org.openhab.binding.homekit/src/main/java/org/openhab/binding/homekit/internal/handler/HomekitBaseAccessoryHandler.java
+++ b/bundles/org.openhab.binding.homekit/src/main/java/org/openhab/binding/homekit/internal/handler/HomekitBaseAccessoryHandler.java
@@ -971,7 +971,7 @@ public abstract class HomekitBaseAccessoryHandler extends BaseThingHandler imple
         if (logger.isTraceEnabled()) {
             try (StringWriter sw = new StringWriter(); PrintWriter pw = new PrintWriter(sw)) {
                 exception.printStackTrace(pw);
-                logger.trace("{}", sw.toString().trim());
+                logger.trace("{} stack trace:\n{}", thing.getUID(), sw.toString().trim());
             } catch (IOException e) {
             }
         }

--- a/bundles/org.openhab.binding.homekit/src/main/java/org/openhab/binding/homekit/internal/handler/HomekitBaseAccessoryHandler.java
+++ b/bundles/org.openhab.binding.homekit/src/main/java/org/openhab/binding/homekit/internal/handler/HomekitBaseAccessoryHandler.java
@@ -685,7 +685,7 @@ public abstract class HomekitBaseAccessoryHandler extends BaseThingHandler imple
         Service service = new Service();
         service.characteristics = new ArrayList<>();
         service.characteristics
-                .addAll(getEventedCharacteristics().values().stream().filter(Characteristic::nonNullAndHasAidAndIid).map(cxx -> {
+                .addAll(getEventedCharacteristics().values().stream().filter(Objects::nonNull).map(cxx -> {
                     cxx.ev = enable;
                     return cxx;
                 }).toList());
@@ -706,8 +706,9 @@ public abstract class HomekitBaseAccessoryHandler extends BaseThingHandler imple
      * Called periodically by the refresh task and on-demand when RefreshType.REFRESH is called.
      */
     private synchronized void refresh() {
-        List<String> queries = getPolledCharacteristics().values().stream().filter(Characteristic::nonNullAndHasAidAndIid)
-                .map(c -> "%s.%s".formatted(c.aid, c.iid)).toList();
+        List<String> queries = getPolledCharacteristics().values().stream()
+                .filter(c -> c != null && c.iid != null && c.aid != null).map(c -> "%s.%s".formatted(c.aid, c.iid))
+                .toList();
         if (queries.isEmpty()) {
             return;
         }

--- a/bundles/org.openhab.binding.homekit/src/main/java/org/openhab/binding/homekit/internal/handler/HomekitBaseAccessoryHandler.java
+++ b/bundles/org.openhab.binding.homekit/src/main/java/org/openhab/binding/homekit/internal/handler/HomekitBaseAccessoryHandler.java
@@ -15,6 +15,8 @@ package org.openhab.binding.homekit.internal.handler;
 import static org.openhab.binding.homekit.internal.HomekitBindingConstants.*;
 
 import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
 import java.security.NoSuchAlgorithmException;
@@ -682,10 +684,11 @@ public abstract class HomekitBaseAccessoryHandler extends BaseThingHandler imple
         }
         Service service = new Service();
         service.characteristics = new ArrayList<>();
-        service.characteristics.addAll(getEventedCharacteristics().values().stream().map(cxx -> {
-            cxx.ev = enable;
-            return cxx;
-        }).toList());
+        service.characteristics
+                .addAll(getEventedCharacteristics().values().stream().filter(Characteristic::isValid).map(cxx -> {
+                    cxx.ev = enable;
+                    return cxx;
+                }).toList());
         if (service.characteristics.isEmpty()) {
             return;
         }
@@ -703,7 +706,7 @@ public abstract class HomekitBaseAccessoryHandler extends BaseThingHandler imple
      * Called periodically by the refresh task and on-demand when RefreshType.REFRESH is called.
      */
     private synchronized void refresh() {
-        List<String> queries = getPolledCharacteristics().values().stream().filter(c -> c.iid != null && c.aid != null)
+        List<String> queries = getPolledCharacteristics().values().stream().filter(Characteristic::isValid)
                 .map(c -> "%s.%s".formatted(c.aid, c.iid)).toList();
         if (queries.isEmpty()) {
             return;
@@ -966,7 +969,13 @@ public abstract class HomekitBaseAccessoryHandler extends BaseThingHandler imple
     protected void onCommunicationError(Exception exception, String i18nSuffix) {
         String message = exception.getMessage();
         logger.debug("{} {} {}, reconnecting..", thing.getUID(), i18nSuffix, message);
-        logger.trace("{} stack trace", thing.getUID(), exception);
+        if (logger.isTraceEnabled()) {
+            try (StringWriter sw = new StringWriter(); PrintWriter pw = new PrintWriter(sw)) {
+                exception.printStackTrace(pw);
+                logger.trace("{}", sw.toString().trim());
+            } catch (IOException e) {
+            }
+        }
         String description = THING_STATUS_FMT.formatted("error." + i18nSuffix.replace(' ', '-'), message);
         updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, description);
         scheduleConnectionAttempt();

--- a/bundles/org.openhab.binding.homekit/src/main/java/org/openhab/binding/homekit/internal/handler/HomekitBaseAccessoryHandler.java
+++ b/bundles/org.openhab.binding.homekit/src/main/java/org/openhab/binding/homekit/internal/handler/HomekitBaseAccessoryHandler.java
@@ -705,9 +705,8 @@ public abstract class HomekitBaseAccessoryHandler extends BaseThingHandler imple
      * Called periodically by the refresh task and on-demand when RefreshType.REFRESH is called.
      */
     private synchronized void refresh() {
-        List<String> queries = getPolledCharacteristics().values().stream()
-                .filter(c -> c.iid != null && c.aid != null).map(c -> "%s.%s".formatted(c.aid, c.iid))
-                .toList();
+        List<String> queries = getPolledCharacteristics().values().stream().filter(c -> c.iid != null && c.aid != null)
+                .map(c -> "%s.%s".formatted(c.aid, c.iid)).toList();
         if (queries.isEmpty()) {
             return;
         }


### PR DESCRIPTION
Resolves #20786 

As reported in #20786 the Thing was toggling offline/online once per polling refresh cycle. The debug log showed an NPE during polling, but the log did not contain the stack trace, so I could not pin down the exact NPE error line. Also (un-) luckily while investigating the issue I did a factory reset of the device which updated its firmware. So the original issue is no longer reproducible on it.

Nevertheless in this PR I have:

1. Improved the stack trace logging, and
2. Hardened points in the polling code path that could have caused the NPEs

Signed-off-by: Andrew Fiddian-Green <software@whitebear.ch>
