### PR TITLE
[gpstracker] Improve Owntracks Android ≥ 2.5.x support

### DIFF
--- a/bundles/org.openhab.binding.gpstracker/src/main/java/org/openhab/binding/gpstracker/internal/provider/AbstractCallbackServlet.java
+++ b/bundles/org.openhab.binding.gpstracker/src/main/java/org/openhab/binding/gpstracker/internal/provider/AbstractCallbackServlet.java
@@ -78,8 +78,9 @@ public abstract class AbstractCallbackServlet extends HttpServlet {
      *
      * <p>
      * On success the response always contains HTTP 200 with {@code Content-Type: application/json}
-     * and a body of {@code []} (empty JSON array), optionally containing notification objects.
-     * This conforms to the OwnTracks HTTP protocol specification:
+     * and a JSON array body, possibly empty. The empty case is {@code []}; when notifications are
+     * returned, the array contains notification objects. This conforms to the OwnTracks HTTP
+     * protocol specification:
      * <a href="https://owntracks.org/booklet/tech/http/">https://owntracks.org/booklet/tech/http/</a>
      * </p>
      * <p>

--- a/bundles/org.openhab.binding.gpstracker/src/main/java/org/openhab/binding/gpstracker/internal/provider/AbstractCallbackServlet.java
+++ b/bundles/org.openhab.binding.gpstracker/src/main/java/org/openhab/binding/gpstracker/internal/provider/AbstractCallbackServlet.java
@@ -74,7 +74,19 @@ public abstract class AbstractCallbackServlet extends HttpServlet {
     protected abstract String getPath();
 
     /**
-     * Process the HTTP requests from tracker applications
+     * Process the HTTP requests from tracker applications.
+     *
+     * <p>
+     * On success the response always contains HTTP 200 with {@code Content-Type: application/json}
+     * and a body of {@code []} (empty JSON array), optionally containing notification objects.
+     * This conforms to the OwnTracks HTTP protocol specification:
+     * <a href="https://owntracks.org/booklet/tech/http/">https://owntracks.org/booklet/tech/http/</a>
+     * </p>
+     * <p>
+     * OwnTracks Android &ge; 2.5.x strictly parses the response body. An empty body causes a
+     * {@code JsonDecodingException} in the client, which re-queues every sent message indefinitely
+     * and stops location updates from reaching openHAB.
+     * </p>
      *
      * @param req HTTP request
      * @param resp HTTP response
@@ -94,14 +106,19 @@ public abstract class AbstractCallbackServlet extends HttpServlet {
             String json = jb.toString().replaceAll("\\p{Z}", "");
             logger.debug("Post message received from {} tracker: {}", getProvider(), json);
 
+            List<? extends LocationMessage> responseMessages = Collections.emptyList();
             LocationMessage message = messageUtil.fromJson(json);
             if (message != null) {
-                List<? extends LocationMessage> response = processMessage(message);
-                if (response != null) {
-                    resp.getWriter().append(messageUtil.toJson(response)).flush();
-                }
+                responseMessages = processMessage(message);
             }
+
+            // Set status and Content-Type before writing the body (servlet spec requirement).
+            // The OwnTracks HTTP spec mandates "[]" as the response body on HTTP 200, even when
+            // there are no notifications to return.
             resp.setStatus(HttpServletResponse.SC_OK);
+            resp.setContentType("application/json");
+            resp.setCharacterEncoding("UTF-8");
+            resp.getWriter().append(messageUtil.toJson(responseMessages)).flush();
         } catch (Exception e) {
             logger.error("Error processing location report:", e);
             resp.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);


### PR DESCRIPTION
**Problem**
OwnTracks Android ≥ 2.5.x fails with JsonDecodingException on every HTTP POST because the binding returns HTTP 200 with an empty body. Messages are re-queued indefinitely (queue grows to 100+) and location updates stop reaching openHAB.

**Root cause — three bugs in doPost()**

1. resp.setStatus() called after resp.getWriter() — violates servlet spec (headers must be set before body)
2. Content-Type: application/json never set
3. When messageUtil.fromJson() returns null, getWriter() is never called → empty body → client crash

**Fix**
Always write [] as response body with correct headers, regardless of whether the message was parsed:
```
javaresp.setStatus(HttpServletResponse.SC_OK);
resp.setContentType("application/json");
resp.setCharacterEncoding("UTF-8");
resp.getWriter().append(messageUtil.toJson(responseMessages)).flush();
```
Per [OwnTracks HTTP spec](https://owntracks.org/booklet/tech/http/): "If the HTTP endpoint returns a status code 200 it will typically return an empty JSON payload array []."

**Testing**
Verified with OwnTracks Android 2.5.9 + openHAB 5.2. Queue drains to 0, location items update normally.