### PR TITLE
Modify Graal engine creation to allow dynamic creation

### DIFF
--- a/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/GraalJSScriptEngineFactory.java
+++ b/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/GraalJSScriptEngineFactory.java
@@ -71,6 +71,8 @@ public class GraalJSScriptEngineFactory implements ScriptEngineFactory {
      */
     private final Engine engine;
 
+    private final @Nullable Language language;
+
     private final JSScriptServiceUtil jsScriptServiceUtil;
     private final JSDependencyTracker jsDependencyTracker;
 
@@ -83,31 +85,39 @@ public class GraalJSScriptEngineFactory implements ScriptEngineFactory {
         this.jsScriptServiceUtil = jsScriptServiceUtil;
         this.configuration = new GraalJSScriptEngineConfiguration(config);
 
-        if (configuration.isDebuggerEnabled()) {
-            Engine.Builder engineBuilder = createEngineBuilder();
-            engineBuilder //
-                    .option("inspect", "0.0.0.0:" + configuration.getDebuggerPort()) //
-                    .option("inspect.Suspend", "false") // Don't pause at startup waiting for debugger to attach
-                    .option("inspect.WaitAttached", "false") // Don't block code execution waiting for debugger to
-                                                             // attach
-                    .option("inspect.Secure", "false"); // Disable TLS
-            Engine engine;
-            try {
-                engine = engineBuilder.build();
-            } catch (RuntimeException e) {
-                logger.error(
-                        "Failed to initialize Graal JavaScript engine with debugger support. Continuing without debugger support.",
-                        e);
-                engine = createEngineBuilder().build();
+        Thread thread = Thread.currentThread();
+        ClassLoader original = thread.getContextClassLoader();
+        try {
+            thread.setContextClassLoader(GraalJSScriptEngineFactory.class.getClassLoader());
+            if (configuration.isDebuggerEnabled()) {
+                Engine.Builder engineBuilder = createEngineBuilder();
+                engineBuilder //
+                        .option("inspect", "0.0.0.0:" + configuration.getDebuggerPort()) //
+                        .option("inspect.Suspend", "false") // Don't pause at startup waiting for debugger to attach
+                        .option("inspect.WaitAttached", "false") // Don't block code execution waiting for debugger to
+                                                                 // attach
+                        .option("inspect.Secure", "false"); // Disable TLS
+                Engine engine;
+                try {
+                    engine = engineBuilder.build();
+                } catch (RuntimeException e) {
+                    logger.error(
+                            "Failed to initialize Graal JavaScript engine with debugger support. Continuing without debugger support.",
+                            e);
+                    engine = createEngineBuilder().build();
+                }
+                logger.info("Debugger support is enabled for JavaScript Scripting.");
+                this.engine = engine;
+            } else {
+                this.engine = createEngineBuilder().build();
             }
-            logger.info("Debugger support is enabled for JavaScript Scripting.");
-            this.engine = engine;
-        } else {
-            this.engine = createEngineBuilder().build();
-        }
 
-        if (getLanguage() == null) {
-            logger.error(LANG_NOT_INITIALIZED_MSG);
+            this.language = engine.getLanguages().get(OpenhabGraalJSScriptEngine.LANGUAGE_ID);
+            if (this.language == null) {
+                logger.error(LANG_NOT_INITIALIZED_MSG);
+            }
+        } finally {
+            thread.setContextClassLoader(original);
         }
     }
 
@@ -167,6 +177,6 @@ public class GraalJSScriptEngineFactory implements ScriptEngineFactory {
      * @return the Graal language of {@link OpenhabGraalJSScriptEngine} or {@code null} if not available
      */
     private @Nullable Language getLanguage() {
-        return engine.getLanguages().get(OpenhabGraalJSScriptEngine.LANGUAGE_ID);
+        return language;
     }
 }

--- a/bundles/org.openhab.automation.pythonscripting/src/main/java/org/openhab/automation/pythonscripting/internal/PythonScriptEngineFactory.java
+++ b/bundles/org.openhab.automation.pythonscripting/src/main/java/org/openhab/automation/pythonscripting/internal/PythonScriptEngineFactory.java
@@ -28,6 +28,7 @@ import org.graalvm.polyglot.Language;
 import org.openhab.automation.pythonscripting.internal.fs.PythonDependencyTracker;
 import org.openhab.automation.pythonscripting.internal.scriptengine.graal.GraalPythonScriptEngine;
 import org.openhab.automation.pythonscripting.internal.scriptengine.graal.GraalPythonScriptEngine.ScriptEngineProvider;
+import org.openhab.automation.pythonscripting.internal.scriptengine.graal.GraalPythonScriptEngineFactory;
 import org.openhab.core.automation.module.script.ScriptDependencyTracker;
 import org.openhab.core.automation.module.script.ScriptEngineFactory;
 import org.openhab.core.config.core.ConfigurableService;
@@ -69,6 +70,8 @@ public class PythonScriptEngineFactory implements ScriptEngineFactory, ScriptEng
      */
     private final Engine engine;
 
+    private final @Nullable Language language;
+
     @Activate
     public PythonScriptEngineFactory(final @Reference PythonDependencyTracker pythonDependencyTracker,
             final @Reference TimeZoneProvider timeZoneProvider, Map<String, Object> config) {
@@ -87,33 +90,41 @@ public class PythonScriptEngineFactory implements ScriptEngineFactory, ScriptEng
         this.configuration.init(this);
 
         Engine.Builder engineBuilder = createEngineBuilder();
-        if (configuration.isDebuggerEnabled()) {
-            engineBuilder //
-                    .option("inspect", "0.0.0.0:" + configuration.getDebuggerPort()) //
-                    .option("inspect.Suspend", "false") // Don't pause at startup waiting for debugger to attach
-                    .option("inspect.WaitAttached", "false") // Don't block code execution waiting for debugger to
-                                                             // attach
-                    .option("inspect.Secure", "false"); // Disable TLS
+        Thread thread = Thread.currentThread();
+        ClassLoader original = thread.getContextClassLoader();
+        try {
+            thread.setContextClassLoader(GraalPythonScriptEngineFactory.class.getClassLoader());
+            if (configuration.isDebuggerEnabled()) {
+                engineBuilder //
+                        .option("inspect", "0.0.0.0:" + configuration.getDebuggerPort()) //
+                        .option("inspect.Suspend", "false") // Don't pause at startup waiting for debugger to attach
+                        .option("inspect.WaitAttached", "false") // Don't block code execution waiting for debugger to
+                                                                 // attach
+                        .option("inspect.Secure", "false"); // Disable TLS
 
-            Engine engine;
-            try {
-                engine = engineBuilder.build();
-                logger.info("Debugger support is enabled for Python Scripting on port {}",
-                        configuration.getDebuggerPort());
-            } catch (RuntimeException e) {
-                logger.error(
-                        "Failed to initialize Graal Python engine with debugger support. Continuing without debugger support.",
-                        e);
-                engine = createEngineBuilder().build();
+                Engine engine;
+                try {
+                    engine = engineBuilder.build();
+                    logger.info("Debugger support is enabled for Python Scripting on port {}",
+                            configuration.getDebuggerPort());
+                } catch (RuntimeException e) {
+                    logger.error(
+                            "Failed to initialize Graal Python engine with debugger support. Continuing without debugger support.",
+                            e);
+                    engine = createEngineBuilder().build();
+                }
+                this.engine = engine;
+            } else {
+                this.engine = createEngineBuilder().build();
             }
-            this.engine = engine;
-        } else {
-            this.engine = createEngineBuilder().build();
-        }
 
-        if (getLanguage() == null) {
-            logger.error(
-                    "Graal Python language not initialized. Restart openHAB to initialize available Graal languages properly.");
+            this.language = engine.getLanguages().get(GraalPythonScriptEngine.LANGUAGE_ID);
+            if (this.language == null) {
+                logger.error(
+                        "Graal Python language not initialized. Restart openHAB to initialize available Graal languages properly.");
+            }
+        } finally {
+            thread.setContextClassLoader(original);
         }
     }
 
@@ -184,6 +195,6 @@ public class PythonScriptEngineFactory implements ScriptEngineFactory, ScriptEng
      * @return the Graal language of {@link PythonScriptEngine} or {@code null} if not available
      */
     public @Nullable Language getLanguage() {
-        return engine.getLanguages().get(GraalPythonScriptEngine.LANGUAGE_ID);
+        return language;
     }
 }


### PR DESCRIPTION
This alters the classloader used during engine registration and `Language` retrieval, and caches the `Language` instance. It must be seen together with https://github.com/openhab/openhab-core/pull/5614, and the goal is to allow dynamic registration of Graal engines.

A description of both changes is given [here](https://community.openhab.org/t/running-org-openhab-demo-app-with-org-openhab-automation-jsscripting-enabled/162466/21), and this should allow installing and uninstalling Graal based add-ons without having to restart OH. It should also prevent the risk of one of them being unavailable if the timing of their creation during startup is unfortunate.

It needs proper testing to make sure that creating these using the alternative classloader don't have other side effects, like failing to see resources that it previously could. I'm ill-equipped to do this testing, as I don't use any of these languages myself, and lack both "source rules" and the knowledge of how to properly test it.