### PR TITLE
[nuki] Deprecations

### DIFF
--- a/bundles/org.openhab.binding.nuki/src/main/java/org/openhab/binding/nuki/internal/dataexchange/NukiHttpClient.java
+++ b/bundles/org.openhab.binding.nuki/src/main/java/org/openhab/binding/nuki/internal/dataexchange/NukiHttpClient.java
@@ -97,7 +97,7 @@ public class NukiHttpClient {
     }
 
     public BridgeInfoResponse getBridgeInfo() {
-        logger.debug("getBridgeInfo() in thread {}", Thread.currentThread().getId());
+        logger.debug("getBridgeInfo() in thread {}", Thread.currentThread().threadId());
         try {
             ContentResponse contentResponse = executeRequest(linkBuilder.info());
             int status = contentResponse.getStatus();
@@ -118,7 +118,7 @@ public class NukiHttpClient {
     }
 
     public BridgeListResponse getList() {
-        logger.debug("getList() in thread {}", Thread.currentThread().getId());
+        logger.debug("getList() in thread {}", Thread.currentThread().threadId());
         try {
             ContentResponse contentResponse = executeRequest(linkBuilder.list());
             int status = contentResponse.getStatus();
@@ -141,7 +141,7 @@ public class NukiHttpClient {
     }
 
     public BridgeLockStateResponse getBridgeLockState(String nukiId, int deviceType) {
-        logger.debug("getBridgeLockState({}) in thread {}", nukiId, Thread.currentThread().getId());
+        logger.debug("getBridgeLockState({}) in thread {}", nukiId, Thread.currentThread().threadId());
 
         try {
             ContentResponse contentResponse = executeRequest(linkBuilder.lockState(nukiId, deviceType));
@@ -171,7 +171,7 @@ public class NukiHttpClient {
     }
 
     private BridgeLockActionResponse getBridgeLockAction(String nukiId, int lockAction, int deviceType) {
-        logger.debug("getBridgeLockAction({}, {}) in thread {}", nukiId, lockAction, Thread.currentThread().getId());
+        logger.debug("getBridgeLockAction({}, {}) in thread {}", nukiId, lockAction, Thread.currentThread().threadId());
         try {
             ContentResponse contentResponse = executeRequest(linkBuilder.lockAction(nukiId, deviceType, lockAction));
             int status = contentResponse.getStatus();
@@ -192,7 +192,7 @@ public class NukiHttpClient {
     }
 
     public BridgeCallbackAddResponse getBridgeCallbackAdd(String callbackUrl) {
-        logger.debug("getBridgeCallbackAdd({}) in thread {}", callbackUrl, Thread.currentThread().getId());
+        logger.debug("getBridgeCallbackAdd({}) in thread {}", callbackUrl, Thread.currentThread().threadId());
         try {
             ContentResponse contentResponse = executeRequest(linkBuilder.callbackAdd(callbackUrl));
             int status = contentResponse.getStatus();
@@ -214,7 +214,7 @@ public class NukiHttpClient {
     }
 
     public BridgeCallbackListResponse getBridgeCallbackList() {
-        logger.debug("getBridgeCallbackList() in thread {}", Thread.currentThread().getId());
+        logger.debug("getBridgeCallbackList() in thread {}", Thread.currentThread().threadId());
         try {
             ContentResponse contentResponse = executeRequest(linkBuilder.callbackList());
             int status = contentResponse.getStatus();
@@ -236,7 +236,7 @@ public class NukiHttpClient {
     }
 
     public BridgeCallbackRemoveResponse getBridgeCallbackRemove(int id) {
-        logger.debug("getBridgeCallbackRemove({}) in thread {}", id, Thread.currentThread().getId());
+        logger.debug("getBridgeCallbackRemove({}) in thread {}", id, Thread.currentThread().threadId());
         try {
             ContentResponse contentResponse = executeRequest(linkBuilder.callbackRemove(id));
             int status = contentResponse.getStatus();


### PR DESCRIPTION
Handle deprecation warnings inn [Thread](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/lang/Thread.html#getId())
~~~
[WARNING] org.openhab.binding.nuki\src\main\java\org\openhab\binding\nuki\internal\dataexchange\NukiHttpClient.java:[100,77] The method getId() from the type java.lang.Thread is deprecated since version 19
[WARNING] org.openhab.binding.nuki\src\main\java\org\openhab\binding\nuki\internal\dataexchange\NukiHttpClient.java:[121,71] The method getId() from the type java.lang.Thread is deprecated since version 19
[WARNING] org.openhab.binding.nuki\src\main\java\org\openhab\binding\nuki\internal\dataexchange\NukiHttpClient.java:[144,92] The method getId() from the type java.lang.Thread is deprecated since version 19
[WARNING] org.openhab.binding.nuki\src\main\java\org\openhab\binding\nuki\internal\dataexchange\NukiHttpClient.java:[174,109] The method getId() from the type java.lang.Thread is deprecated since version 19
[WARNING] org.openhab.binding.nuki\src\main\java\org\openhab\binding\nuki\internal\dataexchange\NukiHttpClient.java:[195,99] The method getId() from the type java.lang.Thread is deprecated since version 19
[WARNING] org.openhab.binding.nuki\src\main\java\org\openhab\binding\nuki\internal\dataexchange\NukiHttpClient.java:[217,85] The method getId() from the type java.lang.Thread is deprecated since version 19
[WARNING] org.openhab.binding.nuki\src\main\java\org\openhab\binding\nuki\internal\dataexchange\NukiHttpClient.java:[239,93] The method getId() from the type java.lang.Thread is deprecated since version 19
~~~
<!--
Thanks for contributing to the openHAB project!
Please describe the goal and effect of your PR here.
Pay attention to the below notes and to *the guidelines* for this repository.
Feel free to delete any comment sections in the template (starting with "<!--").

ATTENTION: Don't use "git merge" when working with your pull request branch!
This can clutter your Git history and make your PR unusable.
Use "git rebase" instead. See this forum post for further details:
https://community.openhab.org/t/rebase-your-code-or-how-to-fix-your-git-history-before-requesting-a-pull/129358

All PRs should be created using the "main" branch as base.
Important bugfixes are cherry-picked by maintainers to the patch release branch after a PR has been merged.

Add one or more appropriate labels to make your PR show up in the release notes.
E.g. enhancement, bug, documentation, new binding
This can only be done by yourself if you already contributed to this repo.

If your PR's code is not backward compatible with previous releases (which
should be avoided), add a message to the release notes by filing another PR:
https://github.com/openhab/openhab-distro/blob/main/distributions/openhab/src/main/resources/bin/update.lst

# Title

Provide a short summary in the *Title* above. It will show up in the release notes.
For example:
- [homematic] Improve communication with weak signal devices
- [timemachine][WIP] Initial contribution

# Description

Please give a few sentences describing the overall goals of the pull request.
Give enough details to make the improvement and changes of the PR understandable
to both developers and tech-savy users.

Please keep the following in mind:
- What is the classification of the PR, e.g. Bugfix, Improvement, Novel Addition, ... ?
- Did you describe the PRs motivation and goal?
- Did you provide a link to any prior discussion, e.g. an issue or community forum thread?
- Did you describe new features for the end user?
- Did you describe any noteworthy changes in usage for the end user?
- Was the documentation updated accordingly, e.g. the add-on README?
- Does your contribution follow the coding guidelines:
  https://www.openhab.org/docs/developer/guidelines.html
- Did you check for any (relevant) issues from the static code analysis:
  https://www.openhab.org/docs/developer/bindings/#include-the-binding-in-the-build
- Did you sign-off your work:
  https://www.openhab.org/docs/developer/contributing.html#sign-your-work

# Testing

Your pull request will automatically be built and available under the following folder:
https://openhab.jfrog.io/ui/native/libs-pullrequest-local/org/openhab/addons/bundles/

It is a good practice to add a URL to your built JAR in this pull request description,
so it is easier for the community to test your Add-on.
If your pull request contains a new binding, it will likely take some time
before it is reviewed and processed by maintainers.
That said, consider submitting your Add-on in the Marketplace:
https://community.openhab.org/c/marketplace/69

Don't forget to submit a thread about your Add-on in the openHAB community:
https://community.openhab.org/c/add-ons 
-->
