### PR TITLE
[amazonechocontrol] Deprecations

### DIFF
--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/smarthome/AlexaColor.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/smarthome/AlexaColor.java
@@ -15,6 +15,8 @@ package org.openhab.binding.amazonechocontrol.internal.smarthome;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.binding.amazonechocontrol.internal.AmazonEchoControlBindingConstants;
 import org.openhab.core.library.types.HSBType;
+import org.openhab.core.library.types.PercentType;
+import org.openhab.core.util.ColorUtil;
 
 /**
  * The {@link AlexaColor} defines the Alexa color names
@@ -63,9 +65,10 @@ public class AlexaColor {
     }
 
     private static double[] getLabFromHSB(HSBType value) {
-        double r = value.getRed().doubleValue() / 100.0;
-        double g = value.getGreen().doubleValue() / 100.0;
-        double b = value.getBlue().doubleValue() / 100.0;
+        PercentType[] rgb = ColorUtil.hsbToRgbPercent(value);
+        double r = rgb[0].doubleValue() / 100.0;
+        double g = rgb[1].doubleValue() / 100.0;
+        double b = rgb[2].doubleValue() / 100.0;
 
         // D65, 10 degree
         double xn = 94.811;


### PR DESCRIPTION
Fixes deprecation warnings regarding [HSBType](https://www.openhab.org/javadoc/latest/org/openhab/core/library/types/hsbtype#getRed()):

~~~
[WARNING] org.openhab.binding.amazonechocontrol\src\main\java\org\openhab\binding\amazonechocontrol\internal\smarthome\AlexaColor.java:[66,26] The method getRed() from the type org.openhab.core.library.types.HSBType is deprecated
[WARNING] org.openhab.binding.amazonechocontrol\src\main\java\org\openhab\binding\amazonechocontrol\internal\smarthome\AlexaColor.java:[67,26] The method getGreen() from the type org.openhab.core.library.types.HSBType is deprecated
[WARNING] org.openhab.binding.amazonechocontrol\src\main\java\org\openhab\binding\amazonechocontrol\internal\smarthome\AlexaColor.java:[68,26] The method getBlue() from the type org.openhab.core.library.types.HSBType is deprecated
~~~

<!--
Thanks for contributing to the openHAB project!
Please describe the goal and effect of your PR here.
Pay attention to the below notes and to *the guidelines* for this repository.
Feel free to delete any comment sections in the template (starting with "<!--").

ATTENTION: Don't use "git merge" when working with your pull request branch!
This can clutter your Git history and make your PR unusable.
Use "git rebase" instead. See this forum post for further details:
https://community.openhab.org/t/rebase-your-code-or-how-to-fix-your-git-history-before-requesting-a-pull/129358

All PRs should be created using the "main" branch as base.
Important bugfixes are cherry-picked by maintainers to the patch release branch after a PR has been merged.

Add one or more appropriate labels to make your PR show up in the release notes.
E.g. enhancement, bug, documentation, new binding
This can only be done by yourself if you already contributed to this repo.

If your PR's code is not backward compatible with previous releases (which
should be avoided), add a message to the release notes by filing another PR:
https://github.com/openhab/openhab-distro/blob/main/distributions/openhab/src/main/resources/bin/update.lst

# Title

Provide a short summary in the *Title* above. It will show up in the release notes.
For example:
- [homematic] Improve communication with weak signal devices
- [timemachine][WIP] Initial contribution

# Description

Please give a few sentences describing the overall goals of the pull request.
Give enough details to make the improvement and changes of the PR understandable
to both developers and tech-savy users.

Please keep the following in mind:
- What is the classification of the PR, e.g. Bugfix, Improvement, Novel Addition, ... ?
- Did you describe the PRs motivation and goal?
- Did you provide a link to any prior discussion, e.g. an issue or community forum thread?
- Did you describe new features for the end user?
- Did you describe any noteworthy changes in usage for the end user?
- Was the documentation updated accordingly, e.g. the add-on README?
- Does your contribution follow the coding guidelines:
  https://www.openhab.org/docs/developer/guidelines.html
- Did you check for any (relevant) issues from the static code analysis:
  https://www.openhab.org/docs/developer/bindings/#include-the-binding-in-the-build
- Did you sign-off your work:
  https://www.openhab.org/docs/developer/contributing.html#sign-your-work

# Testing

Your pull request will automatically be built and available under the following folder:
https://openhab.jfrog.io/ui/native/libs-pullrequest-local/org/openhab/addons/bundles/

It is a good practice to add a URL to your built JAR in this pull request description,
so it is easier for the community to test your Add-on.
If your pull request contains a new binding, it will likely take some time
before it is reviewed and processed by maintainers.
That said, consider submitting your Add-on in the Marketplace:
https://community.openhab.org/c/marketplace/69

Don't forget to submit a thread about your Add-on in the openHAB community:
https://community.openhab.org/c/add-ons 
-->
