### PR TITLE
[tuya] Immediate discover after cloud login

### DIFF
--- a/bundles/org.openhab.binding.tuya/src/main/java/org/openhab/binding/tuya/internal/TuyaDiscoveryService.java
+++ b/bundles/org.openhab.binding.tuya/src/main/java/org/openhab/binding/tuya/internal/TuyaDiscoveryService.java
@@ -72,7 +72,23 @@ public class TuyaDiscoveryService extends AbstractThingHandlerDiscoveryService<P
     }
 
     @Override
-    protected void startScan() {
+    public void initialize() {
+        ((ProjectHandler) thingHandler).setDiscoveryService(this);
+
+        super.initialize();
+    }
+
+    @Override
+    public void dispose() {
+        super.dispose();
+
+        removeOlderResults(Instant.now());
+
+        ((ProjectHandler) thingHandler).setDiscoveryService(null);
+    }
+
+    @Override
+    public void startScan() {
         TuyaOpenAPI api = thingHandler.getApi();
         if (!api.isConnected()) {
             logger.debug("Tried to start scan but API for bridge '{}' is not connected.",
@@ -147,12 +163,6 @@ public class TuyaDiscoveryService extends AbstractThingHandlerDiscoveryService<P
         }
         removeOlderResults(getTimestampOfLastScan());
         super.stopScan();
-    }
-
-    @Override
-    public void dispose() {
-        super.dispose();
-        removeOlderResults(Instant.now());
     }
 
     @Override

--- a/bundles/org.openhab.binding.tuya/src/main/java/org/openhab/binding/tuya/internal/handler/ProjectHandler.java
+++ b/bundles/org.openhab.binding.tuya/src/main/java/org/openhab/binding/tuya/internal/handler/ProjectHandler.java
@@ -46,6 +46,7 @@ import com.google.gson.Gson;
 @NonNullByDefault
 public class ProjectHandler extends BaseThingHandler implements ApiStatusCallback {
     private final TuyaOpenAPI api;
+    protected @Nullable TuyaDiscoveryService discoveryService = null;
 
     private @Nullable ScheduledFuture<?> apiConnectFuture;
 
@@ -82,6 +83,14 @@ public class ProjectHandler extends BaseThingHandler implements ApiStatusCallbac
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR);
         } else {
             stopApiConnectFuture();
+
+            if (thing.getStatus() != ThingStatus.ONLINE) {
+                var discoveryService = this.discoveryService;
+                if (discoveryService != null) {
+                    discoveryService.startScan();
+                }
+            }
+
             updateStatus(ThingStatus.ONLINE);
         }
     }
@@ -116,6 +125,10 @@ public class ProjectHandler extends BaseThingHandler implements ApiStatusCallbac
     public void dispose() {
         stopApiConnectFuture();
         api.disconnect();
+    }
+
+    public void setDiscoveryService(@Nullable TuyaDiscoveryService discoveryService) {
+        this.discoveryService = discoveryService;
     }
 
     @Override


### PR DESCRIPTION
Plug the discovery service back into the thing handler so that it can initiate a discovery immediately after cloud login completes.