### PR TITLE
Fix mockito for newer Java versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -422,6 +422,7 @@ Import-Package: \
           <configuration>
             <argLine>--add-opens java.base/java.lang=ALL-UNNAMED
               --add-opens java.base/java.util=ALL-UNNAMED
+              -javaagent:"${settings.localRepository}/org/mockito/mockito-core/${mockito.version}/mockito-core-${mockito.version}.jar"
               -Xshare:off</argLine>
             <systemPropertyVariables>
               <junit.jupiter.execution.timeout.default>15 m</junit.jupiter.execution.timeout.default>


### PR DESCRIPTION
The same fix went into openhab-core a while back but doesn't seem to have made it to addons.