### PR TITLE
[lgthinq] Deprecations

### DIFF
--- a/bundles/org.openhab.binding.lgthinq/src/main/java/org/openhab/binding/lgthinq/lgservices/model/AbstractCapabilityFactory.java
+++ b/bundles/org.openhab.binding.lgthinq/src/main/java/org/openhab/binding/lgthinq/lgservices/model/AbstractCapabilityFactory.java
@@ -14,7 +14,6 @@ package org.openhab.binding.lgthinq.lgservices.model;
 
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -136,8 +135,7 @@ public abstract class AbstractCapabilityFactory<T extends CapabilityDefinition> 
             return Collections.emptyMap();
         }
         Map<String, CommandDefinition> commands = new HashMap<>();
-        for (Iterator<Map.Entry<String, JsonNode>> it = commandNode.fields(); it.hasNext();) {
-            Map.Entry<String, JsonNode> e = it.next();
+        for (Map.Entry<String, JsonNode> e : commandNode.properties()) {
             String commandName = e.getKey();
             CommandDefinition cd = new CommandDefinition();
             JsonNode thisCommandNode = e.getValue();

--- a/bundles/org.openhab.binding.lgthinq/src/main/java/org/openhab/binding/lgthinq/lgservices/model/devices/ac/ACCapabilityFactoryV1.java
+++ b/bundles/org.openhab.binding.lgthinq/src/main/java/org/openhab/binding/lgthinq/lgservices/model/devices/ac/ACCapabilityFactoryV1.java
@@ -45,7 +45,7 @@ public class ACCapabilityFactoryV1 extends AbstractACCapabilityFactory {
     @Override
     protected Map<String, String> extractFeatureOptions(JsonNode optionsNode) {
         Map<String, String> options = new HashMap<>();
-        optionsNode.fields().forEachRemaining(o -> {
+        optionsNode.properties().forEach(o -> {
             options.put(o.getKey(), o.getValue().asText());
         });
         return options;

--- a/bundles/org.openhab.binding.lgthinq/src/main/java/org/openhab/binding/lgthinq/lgservices/model/devices/ac/ACCapabilityFactoryV2.java
+++ b/bundles/org.openhab.binding.lgthinq/src/main/java/org/openhab/binding/lgthinq/lgservices/model/devices/ac/ACCapabilityFactoryV2.java
@@ -131,7 +131,7 @@ public class ACCapabilityFactoryV2 extends AbstractACCapabilityFactory {
     @Override
     protected Map<String, String> extractFeatureOptions(JsonNode optionsNode) {
         Map<String, String> options = new HashMap<>();
-        optionsNode.fields().forEachRemaining(o -> {
+        optionsNode.properties().forEach(o -> {
             options.put(o.getKey(), o.getValue().path("label").asText());
         });
         return options;

--- a/bundles/org.openhab.binding.lgthinq/src/main/java/org/openhab/binding/lgthinq/lgservices/model/devices/ac/AbstractACCapabilityFactory.java
+++ b/bundles/org.openhab.binding.lgthinq/src/main/java/org/openhab/binding/lgthinq/lgservices/model/devices/ac/AbstractACCapabilityFactory.java
@@ -241,10 +241,10 @@ public abstract class AbstractACCapabilityFactory extends AbstractCapabilityFact
         if (HEAT_PUMP.equals(acCap.getDeviceType())) {
             JsonNode supHpAirSwitchNode = valuesNode.path(getHpAirWaterSwitchNodeName()).path(getOptionsMapNodeName());
             if (!supHpAirSwitchNode.isMissingNode()) {
-                //TODO no-op code for future use
-                //supHpAirSwitchNode.properties().forEach(r -> {
-                //    r.getValue().asText();
-                //});
+                // TODO no-op code for future use
+                // supHpAirSwitchNode.properties().forEach(r -> {
+                // r.getValue().asText();
+                // });
             }
         }
 

--- a/bundles/org.openhab.binding.lgthinq/src/main/java/org/openhab/binding/lgthinq/lgservices/model/devices/ac/AbstractACCapabilityFactory.java
+++ b/bundles/org.openhab.binding.lgthinq/src/main/java/org/openhab/binding/lgthinq/lgservices/model/devices/ac/AbstractACCapabilityFactory.java
@@ -241,9 +241,10 @@ public abstract class AbstractACCapabilityFactory extends AbstractCapabilityFact
         if (HEAT_PUMP.equals(acCap.getDeviceType())) {
             JsonNode supHpAirSwitchNode = valuesNode.path(getHpAirWaterSwitchNodeName()).path(getOptionsMapNodeName());
             if (!supHpAirSwitchNode.isMissingNode()) {
-                supHpAirSwitchNode.properties().forEach(r -> {
-                    r.getValue().asText();
-                });
+                //TODO no-op code for future use
+                //supHpAirSwitchNode.properties().forEach(r -> {
+                //    r.getValue().asText();
+                //});
             }
         }
 

--- a/bundles/org.openhab.binding.lgthinq/src/main/java/org/openhab/binding/lgthinq/lgservices/model/devices/ac/AbstractACCapabilityFactory.java
+++ b/bundles/org.openhab.binding.lgthinq/src/main/java/org/openhab/binding/lgthinq/lgservices/model/devices/ac/AbstractACCapabilityFactory.java
@@ -76,7 +76,7 @@ public abstract class AbstractACCapabilityFactory extends AbstractCapabilityFact
             throw new LGThinqApiException("Error extracting options supported by the device");
         } else {
             List<String> values = new ArrayList<>();
-            optionsNode.fields().forEachRemaining(e -> {
+            optionsNode.properties().forEach(e -> {
                 values.add(e.getValue().asText());
             });
             return values;
@@ -89,7 +89,7 @@ public abstract class AbstractACCapabilityFactory extends AbstractCapabilityFact
             return Collections.emptyMap();
         } else {
             Map<String, String> modes = new HashMap<String, String>();
-            optionsNode.fields().forEachRemaining(e -> {
+            optionsNode.properties().forEach(e -> {
                 if (invertKeyValue) {
                     modes.put(e.getValue().asText(), e.getKey());
                 } else {
@@ -145,7 +145,7 @@ public abstract class AbstractACCapabilityFactory extends AbstractCapabilityFact
 
         JsonNode supRacSubModeOps = valuesNode.path(getSupSubRacModeNodeName()).path(getOptionsMapNodeName());
         if (!supRacSubModeOps.isMissingNode()) {
-            supRacSubModeOps.fields().forEachRemaining(f -> {
+            supRacSubModeOps.properties().forEach(f -> {
                 if (CAP_AC_SUB_MODE_COOL_JET.equals(f.getValue().asText())) {
                     acCap.setJetModeAvailable(true);
                 }
@@ -162,7 +162,7 @@ public abstract class AbstractACCapabilityFactory extends AbstractCapabilityFact
         if (acCap.isJetModeAvailable()) {
             JsonNode jetModeOps = valuesNode.path(getJetModeNodeName()).path(getOptionsMapNodeName());
             if (!jetModeOps.isMissingNode()) {
-                jetModeOps.fields().forEachRemaining(j -> {
+                jetModeOps.properties().forEach(j -> {
                     String value = j.getValue().asText();
                     if (CAP_AC_COOL_JET.containsKey(value)) {
                         acCap.setCoolJetModeCommandOn(j.getKey());
@@ -194,7 +194,7 @@ public abstract class AbstractACCapabilityFactory extends AbstractCapabilityFact
         JsonNode supRACModeOps = valuesNode.path(getSupRacModeNodeName()).path(getOptionsMapNodeName());
 
         if (!supRACModeOps.isMissingNode()) {
-            supRACModeOps.fields().forEachRemaining(r -> {
+            supRACModeOps.properties().forEach(r -> {
                 String racOpValue = r.getValue().asText();
                 switch (racOpValue) {
                     case CAP_AC_AUTODRY:
@@ -241,7 +241,7 @@ public abstract class AbstractACCapabilityFactory extends AbstractCapabilityFact
         if (HEAT_PUMP.equals(acCap.getDeviceType())) {
             JsonNode supHpAirSwitchNode = valuesNode.path(getHpAirWaterSwitchNodeName()).path(getOptionsMapNodeName());
             if (!supHpAirSwitchNode.isMissingNode()) {
-                supHpAirSwitchNode.fields().forEachRemaining(r -> {
+                supHpAirSwitchNode.properties().forEach(r -> {
                     r.getValue().asText();
                 });
             }

--- a/bundles/org.openhab.binding.lgthinq/src/main/java/org/openhab/binding/lgthinq/lgservices/model/devices/commons/washers/Utils.java
+++ b/bundles/org.openhab.binding.lgthinq/src/main/java/org/openhab/binding/lgthinq/lgservices/model/devices/commons/washers/Utils.java
@@ -32,7 +32,7 @@ public class Utils {
     public static Map<String, CourseDefinition> getGenericCourseDefinitions(JsonNode courseNode, CourseType type,
             String notSelectedCourseKey) {
         Map<String, CourseDefinition> coursesDef = new HashMap<>();
-        courseNode.fields().forEachRemaining(e -> {
+        courseNode.properties().forEach(e -> {
             CourseDefinition cd = new CourseDefinition();
             JsonNode thisCourseNode = e.getValue();
             cd.setCourseName(thisCourseNode.path("_comment").textValue());

--- a/bundles/org.openhab.binding.lgthinq/src/main/java/org/openhab/binding/lgthinq/lgservices/model/devices/commons/washers/WasherFeatureDefinition.java
+++ b/bundles/org.openhab.binding.lgthinq/src/main/java/org/openhab/binding/lgthinq/lgservices/model/devices/commons/washers/WasherFeatureDefinition.java
@@ -48,7 +48,7 @@ public class WasherFeatureDefinition {
         JsonNode valuesMappingNode = featureNode.path("option");
         if (!valuesMappingNode.isMissingNode()) {
             Map<String, String> valuesMapping = new HashMap<>();
-            valuesMappingNode.fields().forEachRemaining(e -> {
+            valuesMappingNode.properties().forEach(e -> {
                 // collect values as:
                 //
                 // "option":{

--- a/bundles/org.openhab.binding.lgthinq/src/main/java/org/openhab/binding/lgthinq/lgservices/model/devices/dishwasher/AbstractDishWasherCapabilityFactory.java
+++ b/bundles/org.openhab.binding.lgthinq/src/main/java/org/openhab/binding/lgthinq/lgservices/model/devices/dishwasher/AbstractDishWasherCapabilityFactory.java
@@ -63,7 +63,7 @@ public abstract class AbstractDishWasherCapabilityFactory extends AbstractCapabi
         Map<String, CourseDefinition> convertedAllCourses = new HashMap<>();
         // change the Key to the reverse MapCourses coming from LG API
         BiConsumer<Map<String, CourseDefinition>, JsonNode> convertCoursesRules = (courseMap, node) -> {
-            node.fields().forEachRemaining(e -> {
+            node.properties().forEach(e -> {
                 CourseDefinition df = courseMap.get(e.getKey());
                 if (df != null) {
                     convertedAllCourses.put(e.getValue().asText(), df);

--- a/bundles/org.openhab.binding.lgthinq/src/main/java/org/openhab/binding/lgthinq/lgservices/model/devices/fridge/FridgeCapabilityFactoryV1.java
+++ b/bundles/org.openhab.binding.lgthinq/src/main/java/org/openhab/binding/lgthinq/lgservices/model/devices/fridge/FridgeCapabilityFactoryV1.java
@@ -47,7 +47,7 @@ public class FridgeCapabilityFactoryV1 extends AbstractFridgeCapabilityFactory {
 
     private void loadGenericFeatNode(JsonNode featNode, Map<String, String> capMap,
             final Map<String, String> constantsMap) {
-        featNode.fields().forEachRemaining(f -> {
+        featNode.properties().forEach(f -> {
             // for each node like ' "1": {"index" : 1, "label" : "7", "_comment" : ""} '
             String translatedValue = constantsMap.get(f.getValue().asText());
             translatedValue = translatedValue == null ? f.getValue().asText() : translatedValue;

--- a/bundles/org.openhab.binding.lgthinq/src/main/java/org/openhab/binding/lgthinq/lgservices/model/devices/fridge/FridgeCapabilityFactoryV2.java
+++ b/bundles/org.openhab.binding.lgthinq/src/main/java/org/openhab/binding/lgthinq/lgservices/model/devices/fridge/FridgeCapabilityFactoryV2.java
@@ -57,7 +57,7 @@ public class FridgeCapabilityFactoryV2 extends AbstractFridgeCapabilityFactory {
 
     private void loadGenericFeatNode(JsonNode featNode, Map<String, String> capMap,
             final Map<String, String> constantsMap) {
-        featNode.fields().forEachRemaining(f -> {
+        featNode.properties().forEach(f -> {
             // for each node like ' "1": {"index" : 1, "label" : "7", "_comment" : ""} '
             if (!"IGNORE".equals(f.getKey())) {
                 String translatedValue = constantsMap.get(f.getValue().path("label").asText());

--- a/bundles/org.openhab.binding.lgthinq/src/main/java/org/openhab/binding/lgthinq/lgservices/model/devices/washerdryer/WasherDryerCapabilityFactoryV2.java
+++ b/bundles/org.openhab.binding.lgthinq/src/main/java/org/openhab/binding/lgthinq/lgservices/model/devices/washerdryer/WasherDryerCapabilityFactoryV2.java
@@ -15,7 +15,6 @@ package org.openhab.binding.lgthinq.lgservices.model.devices.washerdryer;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
@@ -83,7 +82,7 @@ public class WasherDryerCapabilityFactoryV2 extends AbstractWasherDryerCapabilit
         JsonNode valuesMappingNode = featureNode.path("valueMapping");
         if (!valuesMappingNode.isMissingNode()) {
             Map<String, String> valuesMapping = new HashMap<>();
-            valuesMappingNode.fields().forEachRemaining(e -> {
+            valuesMappingNode.properties().forEach(e -> {
                 // collect values as:
                 //
                 // "POWEROFF": {
@@ -206,8 +205,7 @@ public class WasherDryerCapabilityFactoryV2 extends AbstractWasherDryerCapabilit
             return Collections.emptyMap();
         }
         Map<String, CommandDefinition> commands = new HashMap<>();
-        for (Iterator<Map.Entry<String, JsonNode>> it = commandNode.fields(); it.hasNext();) {
-            Map.Entry<String, JsonNode> e = it.next();
+        for (Map.Entry<String, JsonNode> e : commandNode.properties()) {
             String commandName = e.getKey();
             if ("vtCtrl".equals(commandName)) {
                 // ignore command
@@ -219,7 +217,7 @@ public class WasherDryerCapabilityFactoryV2 extends AbstractWasherDryerCapabilit
             JsonNode dataValues = thisCommandNode.path("data").path("washerDryer");
             if (!dataValues.isMissingNode()) {
                 Map<String, Object> data = new HashMap<>();
-                dataValues.fields().forEachRemaining(f -> {
+                dataValues.properties().forEach(f -> {
                     // only load features outside escape.
                     if (!escapeDataValues.contains(f.getKey())) {
                         if (f.getValue().isValueNode()) {


### PR DESCRIPTION
Handle deprecations regarding [JsonNode:fields](https://www.javadoc.io/doc/com.fasterxml.jackson.core/jackson-databind/latest/com/fasterxml/jackson/databind/JsonNode.html#fields--)

~~~
lgthinq\src\main\java\org\openhab\binding\lgthinq\lgservices\model\AbstractCapabilityFactory.java:[139,69] The method fields() from the type com.fasterxml.jackson.databind.JsonNode is deprecated
lgthinq\src\main\java\org\openhab\binding\lgthinq\lgservices\model\devices\ac\ACCapabilityFactoryV1.java:[48,21] The method fields() from the type com.fasterxml.jackson.databind.JsonNode is deprecated
lgthinq\src\main\java\org\openhab\binding\lgthinq\lgservices\model\devices\ac\ACCapabilityFactoryV2.java:[134,21] The method fields() from the type com.fasterxml.jackson.databind.JsonNode is deprecated
lgthinq\src\main\java\org\openhab\binding\lgthinq\lgservices\model\devices\ac\AbstractACCapabilityFactory.java:[79,25] The method fields() from the type com.fasterxml.jackson.databind.JsonNode is deprecated
lgthinq\src\main\java\org\openhab\binding\lgthinq\lgservices\model\devices\ac\AbstractACCapabilityFactory.java:[92,25] The method fields() from the type com.fasterxml.jackson.databind.JsonNode is deprecated
lgthinq\src\main\java\org\openhab\binding\lgthinq\lgservices\model\devices\ac\AbstractACCapabilityFactory.java:[148,30] The method fields() from the type com.fasterxml.jackson.databind.JsonNode is deprecated
lgthinq\src\main\java\org\openhab\binding\lgthinq\lgservices\model\devices\ac\AbstractACCapabilityFactory.java:[165,28] The method fields() from the type com.fasterxml.jackson.databind.JsonNode is deprecated
lgthinq\src\main\java\org\openhab\binding\lgthinq\lgservices\model\devices\ac\AbstractACCapabilityFactory.java:[197,27] The method fields() from the type com.fasterxml.jackson.databind.JsonNode is deprecated
lgthinq\src\main\java\org\openhab\binding\lgthinq\lgservices\model\devices\ac\AbstractACCapabilityFactory.java:[244,36] The method fields() from the type com.fasterxml.jackson.databind.JsonNode is deprecated
lgthinq\src\main\java\org\openhab\binding\lgthinq\lgservices\model\devices\commons\washers\Utils.java:[35,20] The method fields() from the type com.fasterxml.jackson.databind.JsonNode is deprecated
lgthinq\src\main\java\org\openhab\binding\lgthinq\lgservices\model\devices\commons\washers\WasherFeatureDefinition.java:[51,31] The method fields() from the type com.fasterxml.jackson.databind.JsonNode is deprecated
lgthinq\src\main\java\org\openhab\binding\lgthinq\lgservices\model\devices\dishwasher\AbstractDishWasherCapabilityFactory.java:[66,18] The method fields() from the type com.fasterxml.jackson.databind.JsonNode is deprecated
lgthinq\src\main\java\org\openhab\binding\lgthinq\lgservices\model\devices\fridge\FridgeCapabilityFactoryV1.java:[50,18] The method fields() from the type com.fasterxml.jackson.databind.JsonNode is deprecated
lgthinq\src\main\java\org\openhab\binding\lgthinq\lgservices\model\devices\fridge\FridgeCapabilityFactoryV2.java:[60,18] The method fields() from the type com.fasterxml.jackson.databind.JsonNode is deprecated
lgthinq\src\main\java\org\openhab\binding\lgthinq\lgservices\model\devices\washerdryer\WasherDryerCapabilityFactoryV2.java:[86,31] The method fields() from the type com.fasterxml.jackson.databind.JsonNode is deprecated
lgthinq\src\main\java\org\openhab\binding\lgthinq\lgservices\model\devices\washerdryer\WasherDryerCapabilityFactoryV2.java:[209,69] The method fields() from the type com.fasterxml.jackson.databind.JsonNode is deprecated
lgthinq\src\main\java\org\openhab\binding\lgthinq\lgservices\model\devices\washerdryer\WasherDryerCapabilityFactoryV2.java:[222,28] The method fields() from the type com.fasterxml.jackson.databind.JsonNode is deprecated
~~~

<!--
Thanks for contributing to the openHAB project!
Please describe the goal and effect of your PR here.
Pay attention to the below notes and to *the guidelines* for this repository.
Feel free to delete any comment sections in the template (starting with "<!--").

ATTENTION: Don't use "git merge" when working with your pull request branch!
This can clutter your Git history and make your PR unusable.
Use "git rebase" instead. See this forum post for further details:
https://community.openhab.org/t/rebase-your-code-or-how-to-fix-your-git-history-before-requesting-a-pull/129358

All PRs should be created using the "main" branch as base.
Important bugfixes are cherry-picked by maintainers to the patch release branch after a PR has been merged.

Add one or more appropriate labels to make your PR show up in the release notes.
E.g. enhancement, bug, documentation, new binding
This can only be done by yourself if you already contributed to this repo.

If your PR's code is not backward compatible with previous releases (which
should be avoided), add a message to the release notes by filing another PR:
https://github.com/openhab/openhab-distro/blob/main/distributions/openhab/src/main/resources/bin/update.lst

# Title

Provide a short summary in the *Title* above. It will show up in the release notes.
For example:
- [homematic] Improve communication with weak signal devices
- [timemachine][WIP] Initial contribution

# Description

Please give a few sentences describing the overall goals of the pull request.
Give enough details to make the improvement and changes of the PR understandable
to both developers and tech-savy users.

Please keep the following in mind:
- What is the classification of the PR, e.g. Bugfix, Improvement, Novel Addition, ... ?
- Did you describe the PRs motivation and goal?
- Did you provide a link to any prior discussion, e.g. an issue or community forum thread?
- Did you describe new features for the end user?
- Did you describe any noteworthy changes in usage for the end user?
- Was the documentation updated accordingly, e.g. the add-on README?
- Does your contribution follow the coding guidelines:
  https://www.openhab.org/docs/developer/guidelines.html
- Did you check for any (relevant) issues from the static code analysis:
  https://www.openhab.org/docs/developer/bindings/#include-the-binding-in-the-build
- Did you sign-off your work:
  https://www.openhab.org/docs/developer/contributing.html#sign-your-work

# Testing

Your pull request will automatically be built and available under the following folder:
https://openhab.jfrog.io/ui/native/libs-pullrequest-local/org/openhab/addons/bundles/

It is a good practice to add a URL to your built JAR in this pull request description,
so it is easier for the community to test your Add-on.
If your pull request contains a new binding, it will likely take some time
before it is reviewed and processed by maintainers.
That said, consider submitting your Add-on in the Marketplace:
https://community.openhab.org/c/marketplace/69

Don't forget to submit a thread about your Add-on in the openHAB community:
https://community.openhab.org/c/add-ons 
-->
