### PR TITLE
[epsonprojector] Add password authentication

### DIFF
--- a/bundles/org.openhab.binding.epsonprojector/README.md
+++ b/bundles/org.openhab.binding.epsonprojector/README.md
@@ -45,10 +45,10 @@ Some notes:
 - The _source_ channel includes a dropdown with the most common source inputs.
 - When the `loadSourceList` configuration option is set to true, the binding attempts to retrieve the available sources list from the projector and loads them into the _source_ channel.
 - The command to retrieve the sources list is not supported by older projectors and in this case the pre-defined sources list is used instead.
-- If your projector has a source input that is not in the dropdown, the two character hex code to access that input will be displayed by the _source_ channel when that input is selected by the remote control.
+- If your projector has a source input that is not in the dropdown, the two-character hex code to access that input will be displayed by the _source_ channel when that input is selected by the remote control.
 - By using the sitemap mapping or a rule to send the input's code back to the _source_ channel, any source on the projector can be accessed by the binding.
 - The following channels _aspectratio_, _colormode_, _luminance_, _gamma_ and _background_ are pre-populated with a full set of options but not every option will be useable on all projectors.
-- If your projector has an option in one of the above mentioned channels that is not recognized by the binding, the channel will display 'UNKNOWN' if that un-recognized option is selected by the remote control.
+- If your projector has an option in one of the above-mentioned channels that is not recognized by the binding, the channel will display 'UNKNOWN' if that un-recognized option is selected by the remote control.
 - The volume channel is a dimmer (0-100%) that is scaled to the range on the projector, either 0-20 or 0-40 per the maxVolume configuration setting. If your projector uses a different range, then the volume channel will not work.
 - If the projector power is switched to off in the middle of a polling operation, some of the channel values may become undefined until the projector is switched on again.
 - If the binding fails to connect to the projector using the direct IP connection, ensure that a password is supplied if configured on the projector.
@@ -117,44 +117,46 @@ connection: &conEpson
 epsonprojector:projector-serial:hometheater "Projector" [ serialPort="COM5", pollingInterval=10, maxVolume=20 ]
 
 // direct IP or serial over IP connection
-epsonprojector:projector-tcp:hometheater "Projector" [ host="192.168.0.10", port=3629, pollingInterval=10, maxVolume=20 ]
+epsonprojector:projector-tcp:hometheater "Projector" [ host="192.168.0.10", port=3629, pollingInterval=10, maxVolume=20, password="1234" ]
 
 ```
 
 ### `epson.items` Example
 
 ```java
-Switch epsonPower                                      { channel="epsonprojector:projector-serial:hometheater:power" }
-String epsonSource       "Source [%s]"                 { channel="epsonprojector:projector-serial:hometheater:source" }
-String epsonAspectRatio  "Aspect Ratio [%s]"           { channel="epsonprojector:projector-serial:hometheater:aspectratio" }
-String epsonColorMode    "Color Mode [%s]"             { channel="epsonprojector:projector-serial:hometheater:colormode" }
-Switch epsonFreeze                                     { channel="epsonprojector:projector-serial:hometheater:freeze" }
-Switch epsonMute                                       { channel="epsonprojector:projector-serial:hometheater:mute" }
-Dimmer epsonVolume                                     { channel="epsonprojector:projector-serial:hometheater:volume" }
-String epsonLuminance    "Lamp Mode [%s]"              { channel="epsonprojector:projector-serial:hometheater:luminance" }
+// Note: replace `-serial` with `-tcp` for `projector-tcp` thing type
 
-Number epsonBrightness                                 { channel="epsonprojector:projector-serial:hometheater:brightness" }
-Number epsonContrast                                   { channel="epsonprojector:projector-serial:hometheater:contrast" }
-Number epsonDensity                                    { channel="epsonprojector:projector-serial:hometheater:density" }
-Number epsonTint                                       { channel="epsonprojector:projector-serial:hometheater:tint" }
-Number epsonColorTemperature                           { channel="epsonprojector:projector-serial:hometheater:colortemperature" }
-Number epsonFleshTemperature                           { channel="epsonprojector:projector-serial:hometheater:fleshtemperature" }
-String epsonGamma        "Gamma [%s]"                  { channel="epsonprojector:projector-serial:hometheater:gamma" }
+Switch epsonPower                                     { channel="epsonprojector:projector-serial:hometheater:power" }
+String epsonSource      "Source [%s]"                 { channel="epsonprojector:projector-serial:hometheater:source" }
+String epsonAspectRatio "Aspect Ratio [%s]"           { channel="epsonprojector:projector-serial:hometheater:aspectratio" }
+String epsonColorMode   "Color Mode [%s]"             { channel="epsonprojector:projector-serial:hometheater:colormode" }
+Switch epsonFreeze                                    { channel="epsonprojector:projector-serial:hometheater:freeze" }
+Switch epsonMute                                      { channel="epsonprojector:projector-serial:hometheater:mute" }
+Dimmer epsonVolume                                    { channel="epsonprojector:projector-serial:hometheater:volume" }
+String epsonLuminance   "Lamp Mode [%s]"              { channel="epsonprojector:projector-serial:hometheater:luminance" }
 
-Switch epsonAutokeystone                               { channel="epsonprojector:projector-serial:hometheater:autokeystone" }
-Number epsonVerticalKeystone                           { channel="epsonprojector:projector-serial:hometheater:verticalkeystone" }
-Number epsonHorizontalKeystone                         { channel="epsonprojector:projector-serial:hometheater:horizontalkeystone" }
-Number epsonVerticalPosition                           { channel="epsonprojector:projector-serial:hometheater:verticalposition" }
-Number epsonHorizontalPosition                         { channel="epsonprojector:projector-serial:hometheater:horizontalposition" }
-Switch epsonVerticalReverse                            { channel="epsonprojector:projector-serial:hometheater:verticalreverse" }
-Switch epsonHorizontalReverse                          { channel="epsonprojector:projector-serial:hometheater:horizontalreverse" }
+Number epsonBrightness                                { channel="epsonprojector:projector-serial:hometheater:brightness" }
+Number epsonContrast                                  { channel="epsonprojector:projector-serial:hometheater:contrast" }
+Number epsonDensity                                   { channel="epsonprojector:projector-serial:hometheater:density" }
+Number epsonTint                                      { channel="epsonprojector:projector-serial:hometheater:tint" }
+Number epsonColorTemperature                          { channel="epsonprojector:projector-serial:hometheater:colortemperature" }
+Number epsonFleshTemperature                          { channel="epsonprojector:projector-serial:hometheater:fleshtemperature" }
+String epsonGamma       "Gamma [%s]"                  { channel="epsonprojector:projector-serial:hometheater:gamma" }
 
-String epsonBackground  "Background [%s]"              { channel="epsonprojector:projector-serial:hometheater:background" }
-String epsonKeyCode     "Key Code [%s]"                { channel="epsonprojector:projector-serial:hometheater:keycode" }
-String epsonPowerState  "Power State [%s]"   <switch>  { channel="epsonprojector:projector-serial:hometheater:powerstate" }
-Number epsonLampTime    "Lamp Time [%d h]"   <switch>  { channel="epsonprojector:projector-serial:hometheater:lamptime" }
-Number epsonErrCode     "Error Code [%d]"    <error>   { channel="epsonprojector:projector-serial:hometheater:errcode" }
-String epsonErrMessage  "Error Message [%s]" <error>   { channel="epsonprojector:projector-serial:hometheater:errmessage" }
+Switch epsonAutokeystone                              { channel="epsonprojector:projector-serial:hometheater:autokeystone" }
+Number epsonVerticalKeystone                          { channel="epsonprojector:projector-serial:hometheater:verticalkeystone" }
+Number epsonHorizontalKeystone                        { channel="epsonprojector:projector-serial:hometheater:horizontalkeystone" }
+Number epsonVerticalPosition                          { channel="epsonprojector:projector-serial:hometheater:verticalposition" }
+Number epsonHorizontalPosition                        { channel="epsonprojector:projector-serial:hometheater:horizontalposition" }
+Switch epsonVerticalReverse                           { channel="epsonprojector:projector-serial:hometheater:verticalreverse" }
+Switch epsonHorizontalReverse                         { channel="epsonprojector:projector-serial:hometheater:horizontalreverse" }
+
+String epsonBackground  "Background [%s]"             { channel="epsonprojector:projector-serial:hometheater:background" }
+String epsonKeyCode     "Key Code [%s]"               { channel="epsonprojector:projector-serial:hometheater:keycode" }
+String epsonPowerState  "Power State [%s]"   <switch> { channel="epsonprojector:projector-serial:hometheater:powerstate" }
+Number epsonLampTime    "Lamp Time [%d h]"   <switch> { channel="epsonprojector:projector-serial:hometheater:lamptime" }
+Number epsonErrCode     "Error Code [%d]"    <error>  { channel="epsonprojector:projector-serial:hometheater:errcode" }
+String epsonErrMessage  "Error Message [%s]" <error>  { channel="epsonprojector:projector-serial:hometheater:errmessage" }
 ```
 
 ### `epson.sitemap` Example
@@ -175,10 +177,16 @@ sitemap epson label="Epson Projector"
         Buttongrid item=epsonKeyCode label="Navigation" staticIcon=material:tv_remote buttons=[1:1:"03"="Menu", 1:2:"35"="Up"=f7:arrowtriangle_up, 3:2:"36"="Down"=f7:arrowtriangle_down, 2:1:"37"="Left"=f7:arrowtriangle_left, 2:3:"38"="Right"=f7:arrowtriangle_right, 2:2:"16"="Enter"]
     }
     Frame label="Adjust Image" {
+        Selection  item=epsonAspectRatio
+        Selection  item=epsonLuminance
         Setpoint   item=epsonBrightness         label="Brightness"
         Setpoint   item=epsonContrast           label="Contrast"
         Setpoint   item=epsonDensity            label="Color Saturation"
         Setpoint   item=epsonTint               label="Tint"
+        Selection  item=epsonColorMode
+        Selection  item=epsonGamma
+        Setpoint   item=epsonColorTemperature   label="Color Temperature"
+        Setpoint   item=epsonFleshTemperature   label="Flesh Temperature"
         Switch     item=epsonAutokeystone       label="Auto Keystone"
         Setpoint   item=epsonVerticalKeystone   label="Vertical Keystone"
         Setpoint   item=epsonHorizontalKeystone label="Horizontal Keystone"
@@ -187,16 +195,10 @@ sitemap epson label="Epson Projector"
         Selection  item=epsonBackground         label="Background"
     }
     Frame label="Flip Projection" {
-        Switch  item=epsonVerticalReverse   label="Vertical Reverse"
-        Switch  item=epsonHorizontalReverse label="Horizontal Reverse"
+        Switch  item=epsonVerticalReverse       label="Vertical Reverse"
+        Switch  item=epsonHorizontalReverse     label="Horizontal Reverse"
     }
     Frame label="Info" {
-        Text  item=epsonAspectRatio
-        Text  item=epsonColorMode
-        Text  item=epsonColorTemperature    label="Color Temperature"
-        Text  item=epsonFleshTemperature    label="Flesh Temperature"
-        Text  item=epsonGamma
-        Text  item=epsonLuminance
         Text  item=epsonPowerState
         Text  item=epsonLampTime
         Text  item=epsonErrCode

--- a/bundles/org.openhab.binding.epsonprojector/README.md
+++ b/bundles/org.openhab.binding.epsonprojector/README.md
@@ -37,6 +37,7 @@ The `projector-tcp` thing has the following configuration parameters:
 | pollingInterval | Polling Interval | Polling interval in seconds to update channel states, range 5-60 seconds; default 10 seconds.                                                  | no       |
 | loadSourceList  | Load Source List | Attempt to load source list options from the projector when True; default True.                                                                | no       |
 | maxVolume       | Volume Range     | Set to the maximum volume level available in the projector's OSD to select the correct range for the volume control. e.g. 20 or 40; default 20 | no       |
+| password        | Password         | The 'Monitor' password that allows the binding to authenticate with the projector if configured, must be <= 16 alpha numeric or @ characters.  | no       |
 
 Some notes:
 
@@ -50,7 +51,7 @@ Some notes:
 - If your projector has an option in one of the above mentioned channels that is not recognized by the binding, the channel will display 'UNKNOWN' if that un-recognized option is selected by the remote control.
 - The volume channel is a dimmer (0-100%) that is scaled to the range on the projector, either 0-20 or 0-40 per the maxVolume configuration setting. If your projector uses a different range, then the volume channel will not work.
 - If the projector power is switched to off in the middle of a polling operation, some of the channel values may become undefined until the projector is switched on again.
-- If the binding fails to connect to the projector using the direct IP connection, ensure that no password is configured on the projctor.
+- If the binding fails to connect to the projector using the direct IP connection, ensure that a password is supplied if configured on the projctor.
 
 - On Linux, you may get an error stating the serial port cannot be opened when the epsonprojector binding tries to load.
 - You can get around this by adding the `openhab` user to the `dialout` group like this: `usermod -a -G dialout openhab`.

--- a/bundles/org.openhab.binding.epsonprojector/README.md
+++ b/bundles/org.openhab.binding.epsonprojector/README.md
@@ -51,7 +51,7 @@ Some notes:
 - If your projector has an option in one of the above mentioned channels that is not recognized by the binding, the channel will display 'UNKNOWN' if that un-recognized option is selected by the remote control.
 - The volume channel is a dimmer (0-100%) that is scaled to the range on the projector, either 0-20 or 0-40 per the maxVolume configuration setting. If your projector uses a different range, then the volume channel will not work.
 - If the projector power is switched to off in the middle of a polling operation, some of the channel values may become undefined until the projector is switched on again.
-- If the binding fails to connect to the projector using the direct IP connection, ensure that a password is supplied if configured on the projctor.
+- If the binding fails to connect to the projector using the direct IP connection, ensure that a password is supplied if configured on the projector.
 
 - On Linux, you may get an error stating the serial port cannot be opened when the epsonprojector binding tries to load.
 - You can get around this by adding the `openhab` user to the `dialout` group like this: `usermod -a -G dialout openhab`.

--- a/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/EpsonProjectorDevice.java
+++ b/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/EpsonProjectorDevice.java
@@ -105,7 +105,7 @@ public class EpsonProjectorDevice {
     }
 
     public EpsonProjectorDevice(EpsonProjectorConfiguration config) {
-        connection = new EpsonProjectorTcpConnector(config.host, config.port);
+        connection = new EpsonProjectorTcpConnector(config.host, config.port, config.password);
     }
 
     public boolean isReady() {
@@ -680,5 +680,19 @@ public class EpsonProjectorDevice {
             logger.debug("getSourceList(): {}", e.getMessage());
         }
         return sourceListOptions;
+    }
+
+    /*
+     * Projector Model
+     */
+    public String getModel() throws EpsonProjectorCommandException, EpsonProjectorException {
+        return queryString("PJINFO?");
+    }
+
+    /*
+     * Projector Serial Number
+     */
+    public String getSerialNumber() throws EpsonProjectorCommandException, EpsonProjectorException {
+        return queryString("SNO?");
     }
 }

--- a/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/EpsonProjectorPasswordException.java
+++ b/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/EpsonProjectorPasswordException.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.epsonprojector.internal;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * Exception for Epson projector password errors.
+ *
+ * @author Michael Lobstein - Initial contribution
+ */
+@NonNullByDefault
+public class EpsonProjectorPasswordException extends EpsonProjectorException {
+
+    private static final long serialVersionUID = -8048415193494625296L;
+
+    public EpsonProjectorPasswordException(String message) {
+        super(message);
+    }
+}

--- a/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/configuration/EpsonProjectorConfiguration.java
+++ b/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/configuration/EpsonProjectorConfiguration.java
@@ -48,7 +48,12 @@ public class EpsonProjectorConfiguration {
     public int maxVolume = 20;
 
     /**
-     * Boolean to indicate if source list should be retrieved from projector
+     * Boolean to indicate if source list should be retrieved from projector.
      */
     public boolean loadSourceList;
+
+    /**
+     * 'Monitor' password used to authenticate with the projector.
+     */
+    public String password = "";
 }

--- a/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/connector/EpsonProjectorTcpConnector.java
+++ b/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/connector/EpsonProjectorTcpConnector.java
@@ -23,6 +23,7 @@ import java.nio.charset.StandardCharsets;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.epsonprojector.internal.EpsonProjectorException;
+import org.openhab.binding.epsonprojector.internal.EpsonProjectorPasswordException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -34,19 +35,21 @@ import org.slf4j.LoggerFactory;
  */
 @NonNullByDefault
 public class EpsonProjectorTcpConnector implements EpsonProjectorConnector {
-    private static final String ESC_VP_HANDSHAKE = "ESC/VP.net\u0010\u0003\u0000\u0000\u0000\u0000";
+    private static final String ESC_VP_REQUEST_COMMON = "ESC/VP.net\u0010\u0003\u0000\u0000\u0000";
 
     private final Logger logger = LoggerFactory.getLogger(EpsonProjectorTcpConnector.class);
     private final String ip;
     private final int port;
+    private final String password;
 
     private @Nullable Socket socket = null;
     private @Nullable InputStream in = null;
     private @Nullable OutputStream out = null;
 
-    public EpsonProjectorTcpConnector(String ip, int port) {
+    public EpsonProjectorTcpConnector(String ip, int port, String password) {
         this.ip = ip;
         this.port = port;
+        this.password = password;
     }
 
     @Override
@@ -64,11 +67,16 @@ public class EpsonProjectorTcpConnector implements EpsonProjectorConnector {
 
         // Projectors with built in Ethernet listen on 3629, we must send the handshake to initialize the connection
         if (port == DEFAULT_PORT) {
-            try {
-                String response = sendMessage(ESC_VP_HANDSHAKE, 5000);
-                logger.debug("Response to initialisation of ESC/VP.net is: {}", response);
-            } catch (EpsonProjectorException e) {
-                logger.debug("Error within initialisation of ESC/VP.net: {}", e.getMessage());
+            final String response = sendMessage(createEscVpRequest(), 5000);
+            logger.debug("Response to initialisation of ESC/VP.net is: {}", response);
+
+            if (response.length() == 16) {
+                if (response.charAt(14) == '\u0041') {
+                    throw new EpsonProjectorPasswordException(
+                            "No password provided, but device requires authentication");
+                } else if (response.charAt(14) == '\u0043') {
+                    throw new EpsonProjectorPasswordException("Authentication error, wrong password provided?");
+                }
             }
         }
     }
@@ -192,5 +200,16 @@ public class EpsonProjectorTcpConnector implements EpsonProjectorConnector {
             }
         }
         return resp;
+    }
+
+    private String createEscVpRequest() {
+        if (password.isBlank()) {
+            // connect request + no header follows (16 bytes)
+            return ESC_VP_REQUEST_COMMON + "\u0000";
+        } else {
+            // connect request + header follows + password header + password present + password padded (34 bytes)
+            return ESC_VP_REQUEST_COMMON + "\u0001\u0001\u0001"
+                    + String.format("%-16s", password).replace(' ', '\u0000');
+        }
     }
 }

--- a/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/enums/ErrorMessage.java
+++ b/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/enums/ErrorMessage.java
@@ -13,6 +13,7 @@
 package org.openhab.binding.epsonprojector.internal.enums;
 
 import java.util.Arrays;
+import java.util.Locale;
 import java.util.NoSuchElementException;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -68,7 +69,7 @@ public enum ErrorMessage {
         } catch (NoSuchElementException e) {
             // for example, will display 10 as '0A' to match format of error codes in the epson documentation
             return "Unknown error code (hex): "
-                    + String.format("%2s", Integer.toHexString(code)).replace(' ', '0').toUpperCase();
+                    + String.format("%2s", Integer.toHexString(code)).replace(' ', '0').toUpperCase(Locale.ENGLISH);
         }
     }
 }

--- a/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/handler/EpsonProjectorHandler.java
+++ b/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/handler/EpsonProjectorHandler.java
@@ -26,6 +26,7 @@ import org.openhab.binding.epsonprojector.internal.EpsonProjectorCommandExceptio
 import org.openhab.binding.epsonprojector.internal.EpsonProjectorCommandType;
 import org.openhab.binding.epsonprojector.internal.EpsonProjectorDevice;
 import org.openhab.binding.epsonprojector.internal.EpsonProjectorException;
+import org.openhab.binding.epsonprojector.internal.EpsonProjectorPasswordException;
 import org.openhab.binding.epsonprojector.internal.EpsonStateDescriptionOptionProvider;
 import org.openhab.binding.epsonprojector.internal.configuration.EpsonProjectorConfiguration;
 import org.openhab.binding.epsonprojector.internal.enums.AspectRatio;
@@ -75,6 +76,7 @@ public class EpsonProjectorHandler extends BaseThingHandler {
 
     private boolean loadSourceList = false;
     private boolean isSourceListLoaded = false;
+    private boolean isMetadataLoaded = false;
     private boolean isPowerOn = false;
     private int maxVolume = 20;
     private int curVolumeStep = -1;
@@ -154,7 +156,7 @@ public class EpsonProjectorHandler extends BaseThingHandler {
     @Override
     public void dispose() {
         cancelPollingJob();
-        closeConnection();
+        closeConnection(null);
         super.dispose();
     }
 
@@ -206,6 +208,22 @@ public class EpsonProjectorHandler extends BaseThingHandler {
                             sourceListOptions);
                     isSourceListLoaded = true;
                 }
+            }
+
+            // When polling for PWR status, also try to get projector model and serial number
+            if (EpsonProjectorCommandType.POWER == commandType && !isMetadataLoaded) {
+                try {
+                    thing.setProperty(Thing.PROPERTY_MODEL_ID, remoteController.getModel());
+                } catch (EpsonProjectorCommandException e) {
+                    logger.debug("PJINFO? command is not supported");
+                }
+
+                try {
+                    thing.setProperty(Thing.PROPERTY_SERIAL_NUMBER, remoteController.getSerialNumber());
+                } catch (EpsonProjectorCommandException e) {
+                    logger.debug("SNO? command is not supported");
+                }
+                isMetadataLoaded = true;
             }
 
             switch (commandType) {
@@ -316,9 +334,12 @@ public class EpsonProjectorHandler extends BaseThingHandler {
         } catch (EpsonProjectorCommandException e) {
             logger.debug("Error executing command '{}', {}", commandType, e.getMessage());
             return UnDefType.UNDEF;
+        } catch (EpsonProjectorPasswordException e) {
+            logger.debug("Password error: {}", e.getMessage());
+            closeConnection(e.getMessage());
         } catch (EpsonProjectorException e) {
             logger.debug("Couldn't execute command '{}', {}", commandType, e.getMessage());
-            closeConnection();
+            closeConnection(null);
             return null;
         }
 
@@ -439,20 +460,35 @@ public class EpsonProjectorHandler extends BaseThingHandler {
             }
         } catch (EpsonProjectorCommandException e) {
             logger.debug("Error executing command '{}', {}", commandType, e.getMessage());
+        } catch (EpsonProjectorPasswordException e) {
+            logger.debug("Password error: {}", e.getMessage());
+            closeConnection(e.getMessage());
         } catch (EpsonProjectorException e) {
             logger.warn("Couldn't execute command '{}', {}", commandType, e.getMessage());
-            closeConnection();
+            closeConnection(null);
         }
     }
 
-    private void closeConnection() {
+    /**
+     * Method to handle connection closing and updating ThingStatus
+     *
+     * @param passwordError sends password error info to the ThingStatusDetail and stops the polling
+     */
+    private void closeConnection(@Nullable String passwordError) {
         if (device.isPresent()) {
             try {
                 logger.debug("Closing connection to device '{}'", this.thing.getUID());
                 device.get().disconnect();
+                isSourceListLoaded = false;
+                isMetadataLoaded = false;
                 isPowerOn = false;
 
-                updateStatus(ThingStatus.OFFLINE);
+                if (passwordError != null) {
+                    updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, passwordError);
+                    cancelPollingJob();
+                } else {
+                    updateStatus(ThingStatus.OFFLINE);
+                }
                 if (isLinked(CHANNEL_TYPE_POWERSTATE)) {
                     updateState(CHANNEL_TYPE_POWERSTATE, new StringType(PowerStatus.OFFLINE.toString()));
                 }

--- a/bundles/org.openhab.binding.epsonprojector/src/main/resources/OH-INF/i18n/epsonprojector.properties
+++ b/bundles/org.openhab.binding.epsonprojector/src/main/resources/OH-INF/i18n/epsonprojector.properties
@@ -31,6 +31,8 @@ thing-type.config.epsonprojector.projector-tcp.maxVolume.label = Volume Range
 thing-type.config.epsonprojector.projector-tcp.maxVolume.description = Set to Match the Volume Range Seen in the Projector's OSD
 thing-type.config.epsonprojector.projector-tcp.maxVolume.option.20 = Volume range is 0-20
 thing-type.config.epsonprojector.projector-tcp.maxVolume.option.40 = Volume range is 0-40
+thing-type.config.epsonprojector.projector-tcp.password.label = Password
+thing-type.config.epsonprojector.projector-tcp.password.description = Projector 'Monitor' password - must be <= 16 alpha numeric or @ characters (optional)
 thing-type.config.epsonprojector.projector-tcp.pollingInterval.label = Polling Interval
 thing-type.config.epsonprojector.projector-tcp.pollingInterval.description = Configures How Often to Poll the Projector for Updates (5-60; Default 10)
 thing-type.config.epsonprojector.projector-tcp.port.label = Port

--- a/bundles/org.openhab.binding.epsonprojector/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.epsonprojector/src/main/resources/OH-INF/thing/thing-types.xml
@@ -42,6 +42,8 @@
 
 		<properties>
 			<property name="thingTypeVersion">1</property>
+			<property name="modelId">Unknown</property>
+			<property name="serialNumber">Unknown</property>
 		</properties>
 
 		<config-description>
@@ -114,6 +116,8 @@
 
 		<properties>
 			<property name="thingTypeVersion">1</property>
+			<property name="modelId">Unknown</property>
+			<property name="serialNumber">Unknown</property>
 		</properties>
 
 		<representation-property>macAddress</representation-property>
@@ -148,6 +152,11 @@
 					<option value="40">Volume range is 0-40</option>
 				</options>
 				<default>20</default>
+			</parameter>
+			<parameter name="password" type="text" required="false" pattern="[A-Za-z0-9@]{0,16}">
+				<context>password</context>
+				<label>Password</label>
+				<description>Projector 'Monitor' password - must be &lt;= 16 alpha numeric or @ characters (optional)</description>
 			</parameter>
 		</config-description>
 


### PR DESCRIPTION
Epson projectors that implement the ESC/VP21 network control protocol have the ability to secure the connection with a password. This PR allows the binding to supply the password from the Thing configuration parameter when the connection is established. The password is configured on the projector in the OSD or WebUI and is usually referred to as the 'Monitor' password. The password is limited to a maximum of 16 alpha numeric and @ characters.

Also, if the projector supports the `PJINFO?` and `SNO?` commands, the projector model name and serial number will now be displayed in the Thing Properties.