### PR TITLE
[bluetooth] Support custom GATT specifications via a configurable folder

### DIFF
--- a/bundles/org.openhab.binding.bluetooth.generic/README.md
+++ b/bundles/org.openhab.binding.bluetooth.generic/README.md
@@ -15,6 +15,14 @@ Only a single thing type is added by this binding:
 As any other Bluetooth device, generic bluetooth devices are discovered automatically by the corresponding bridge.
 Generic bluetooth devices will be discovered for any connectable bluetooth device that doesn't match another bluetooth binding.
 
+## Binding Configuration
+
+| Parameter            | Required | Default          | Description                                                                                                                                                                                                                                                                                                                                            |
+|----------------------|----------|------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| gattExtensionsFolder | no       | `gatt-extensions` | Folder with custom GATT specification XML files for non-standard services and characteristics, so they are exposed as typed channels instead of raw hexadecimal `Unknown` channels. The folder must contain `characteristic` and/or `service` sub-folders with XML files in the Bluetooth SIG GATT XML format. A relative path is resolved against the openHAB configuration folder; an absolute path is used as-is. |
+
+The XML files follow the Bluetooth SIG GATT specification format (see the [bluetooth-gatt-parser](https://github.com/sputnikdev/bluetooth-gatt-parser) project for examples).
+
 ## Thing Configuration
 
 | Parameter       | Required | Default | Description                                                         |

--- a/bundles/org.openhab.binding.bluetooth.generic/README.md
+++ b/bundles/org.openhab.binding.bluetooth.generic/README.md
@@ -17,11 +17,14 @@ Generic bluetooth devices will be discovered for any connectable bluetooth devic
 
 ## Binding Configuration
 
-| Parameter            | Required | Default          | Description                                                                                                                                                                                                                                                                                                                                            |
-|----------------------|----------|------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| gattExtensionsFolder | no       | `gatt-extensions` | Folder with custom GATT specification XML files for non-standard services and characteristics, so they are exposed as typed channels instead of raw hexadecimal `Unknown` channels. The folder must contain `characteristic` and/or `service` sub-folders with XML files in the Bluetooth SIG GATT XML format. A relative path is resolved against the openHAB configuration folder; an absolute path is used as-is. |
+| Parameter            | Default           |
+|----------------------|-------------------|
+| gattExtensionsFolder | `gatt-extensions` |
 
-The XML files follow the Bluetooth SIG GATT specification format (see the [bluetooth-gatt-parser](https://github.com/sputnikdev/bluetooth-gatt-parser) project for examples).
+The optional `gattExtensionsFolder` contains custom GATT specification XML files for non-standard services and characteristics, so they are exposed as typed channels instead of raw hexadecimal `Unknown` channels.
+It must contain `characteristic` and/or `service` sub-folders with XML files in the Bluetooth SIG GATT XML format.
+A relative path is resolved against the openHAB configuration folder; an absolute path is used as-is.
+See the [bluetooth-gatt-parser](https://github.com/sputnikdev/bluetooth-gatt-parser) project for examples.
 
 ## Thing Configuration
 

--- a/bundles/org.openhab.binding.bluetooth.generic/src/main/java/org/openhab/binding/bluetooth/generic/internal/GenericBluetoothHandlerFactory.java
+++ b/bundles/org.openhab.binding.bluetooth.generic/src/main/java/org/openhab/binding/bluetooth/generic/internal/GenericBluetoothHandlerFactory.java
@@ -12,10 +12,14 @@
  */
 package org.openhab.binding.bluetooth.generic.internal;
 
+import java.io.File;
+import java.util.Map;
 import java.util.Set;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.bluetooth.gattparser.BluetoothGattParserFactory;
+import org.openhab.core.OpenHAB;
 import org.openhab.core.thing.Thing;
 import org.openhab.core.thing.ThingTypeUID;
 import org.openhab.core.thing.binding.BaseThingHandlerFactory;
@@ -24,6 +28,8 @@ import org.openhab.core.thing.binding.ThingHandlerFactory;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The {@link GenericBluetoothHandlerFactory} is responsible for creating things and thing
@@ -35,14 +41,69 @@ import org.osgi.service.component.annotations.Reference;
 @Component(configurationPid = "binding.bluetooth.generic", service = ThingHandlerFactory.class)
 public class GenericBluetoothHandlerFactory extends BaseThingHandlerFactory {
 
+    /**
+     * Binding configuration key for the folder holding custom GATT specification XML files.
+     * A relative value is resolved against the openHAB config folder ({@link OpenHAB#getConfigFolder()},
+     * e.g. {@code conf/} or {@code /etc/openhab}), which keeps it portable across operating systems;
+     * an absolute value is used as-is. The folder must contain {@code characteristic/} and/or
+     * {@code service/} sub-folders with XML files in the Bluetooth SIG GATT XML format.
+     */
+    private static final String CONFIG_GATT_EXTENSIONS_FOLDER = "gattExtensionsFolder";
+
+    /**
+     * Default (relative) location for the custom GATT extensions folder when not configured.
+     */
+    private static final String DEFAULT_GATT_EXTENSIONS_FOLDER = "gatt-extensions";
+
+    private final Logger logger = LoggerFactory.getLogger(GenericBluetoothHandlerFactory.class);
+
     private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Set
             .of(GenericBindingConstants.THING_TYPE_GENERIC);
 
     private final CharacteristicChannelTypeProvider channelTypeProvider;
 
     @Activate
-    public GenericBluetoothHandlerFactory(@Reference CharacteristicChannelTypeProvider channelTypeProvider) {
+    public GenericBluetoothHandlerFactory(@Reference CharacteristicChannelTypeProvider channelTypeProvider,
+            Map<String, Object> config) {
         this.channelTypeProvider = channelTypeProvider;
+        loadGattExtensions(config);
+    }
+
+    /**
+     * Loads custom GATT specifications from the configured folder (if present) into the shared
+     * default parser. The parser is a singleton used by both the channel-type provider and the
+     * handlers, so loading here — once, before any handler is created — makes custom characteristics
+     * known for both channel building and value parsing.
+     */
+    private void loadGattExtensions(Map<String, Object> config) {
+        File folder = resolveGattExtensionsFolder(config, OpenHAB.getConfigFolder());
+        if (!folder.isDirectory()) {
+            logger.debug("No custom GATT extensions folder at {}; skipping.", folder);
+            return;
+        }
+        try {
+            BluetoothGattParserFactory.getDefault().loadExtensionsFromFolder(folder.getAbsolutePath());
+            logger.info("Loaded custom GATT extensions from {}", folder);
+        } catch (RuntimeException e) {
+            logger.warn("Failed to load custom GATT extensions from {}", folder, e);
+        }
+    }
+
+    /**
+     * Resolves the custom GATT extensions folder from the binding configuration. A blank/missing
+     * value falls back to {@link #DEFAULT_GATT_EXTENSIONS_FOLDER}. A relative location is resolved
+     * against {@code configFolder} (the openHAB config folder) so the same configuration is portable
+     * across operating systems; an absolute location is returned as-is.
+     *
+     * @param config the binding configuration
+     * @param configFolder the openHAB configuration folder to resolve relative locations against
+     * @return the folder to load custom GATT specifications from
+     */
+    static File resolveGattExtensionsFolder(Map<String, Object> config, String configFolder) {
+        Object configured = config.get(CONFIG_GATT_EXTENSIONS_FOLDER);
+        String location = configured instanceof String s && !s.isBlank() ? s.trim() : DEFAULT_GATT_EXTENSIONS_FOLDER;
+        File folder = new File(location);
+        return folder.isAbsolute() ? folder : new File(configFolder, location);
     }
 
     @Override

--- a/bundles/org.openhab.binding.bluetooth.generic/src/main/resources/OH-INF/config/config.xml
+++ b/bundles/org.openhab.binding.bluetooth.generic/src/main/resources/OH-INF/config/config.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<config-description:config-descriptions
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:config-description="https://openhab.org/schemas/config-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/config-description/v1.0.0
+		https://openhab.org/schemas/config-description-1.0.0.xsd">
+
+	<config-description uri="binding:bluetooth:generic">
+		<parameter name="gattExtensionsFolder" type="text">
+			<label>Custom GATT Extensions Folder</label>
+			<description>Folder containing custom GATT specification XML files for non-standard services and
+				characteristics,
+				letting the generic Bluetooth handler recognise them and expose typed channels instead of
+				raw hexadecimal. The folder
+				must contain "characteristic" and/or "service" sub-folders with XML files in the
+				Bluetooth SIG GATT XML format. A
+				relative path is resolved against the openHAB configuration folder
+				(portable across operating systems); an absolute
+				path is used as-is. Defaults to "gatt-extensions" under the
+				configuration folder.</description>
+			<advanced>true</advanced>
+			<default>gatt-extensions</default>
+		</parameter>
+	</config-description>
+
+</config-description:config-descriptions>

--- a/bundles/org.openhab.binding.bluetooth.generic/src/main/resources/OH-INF/config/config.xml
+++ b/bundles/org.openhab.binding.bluetooth.generic/src/main/resources/OH-INF/config/config.xml
@@ -8,16 +8,11 @@
 	<config-description uri="binding:bluetooth:generic">
 		<parameter name="gattExtensionsFolder" type="text">
 			<label>Custom GATT Extensions Folder</label>
-			<description>Folder containing custom GATT specification XML files for non-standard services and
-				characteristics,
-				letting the generic Bluetooth handler recognise them and expose typed channels instead of
-				raw hexadecimal. The folder
-				must contain "characteristic" and/or "service" sub-folders with XML files in the
-				Bluetooth SIG GATT XML format. A
-				relative path is resolved against the openHAB configuration folder
-				(portable across operating systems); an absolute
-				path is used as-is. Defaults to "gatt-extensions" under the
-				configuration folder.</description>
+			<description>Folder containing custom GATT specification XML files for non-standard services and characteristics,
+				letting the generic Bluetooth handler recognise them and expose typed channels instead of raw hexadecimal. The
+				folder must contain "characteristic" and/or "service" sub-folders with XML files in the Bluetooth SIG GATT XML
+				format. A relative path is resolved against the openHAB configuration folder (portable across operating systems); an
+				absolute path is used as-is. Defaults to "gatt-extensions" under the configuration folder.</description>
 			<advanced>true</advanced>
 			<default>gatt-extensions</default>
 		</parameter>

--- a/bundles/org.openhab.binding.bluetooth.generic/src/test/java/org/openhab/binding/bluetooth/generic/internal/GattExtensionsFolderTest.java
+++ b/bundles/org.openhab.binding.bluetooth.generic/src/test/java/org/openhab/binding/bluetooth/generic/internal/GattExtensionsFolderTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.bluetooth.generic.internal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.File;
+import java.util.Map;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link GenericBluetoothHandlerFactory#resolveGattExtensionsFolder(Map, String)}.
+ *
+ * @author Vlad Kolotoff - Initial contribution
+ */
+@NonNullByDefault
+class GattExtensionsFolderTest {
+
+    private static final String CONF = "/etc/openhab";
+
+    @Test
+    void defaultsToGattExtensionsUnderConfigFolderWhenUnset() {
+        File folder = GenericBluetoothHandlerFactory.resolveGattExtensionsFolder(Map.of(), CONF);
+        assertEquals(new File(CONF, "gatt-extensions"), folder);
+    }
+
+    @Test
+    void defaultsWhenValueIsBlank() {
+        File folder = GenericBluetoothHandlerFactory.resolveGattExtensionsFolder(Map.of("gattExtensionsFolder", "   "),
+                CONF);
+        assertEquals(new File(CONF, "gatt-extensions"), folder);
+    }
+
+    @Test
+    void resolvesRelativeLocationAgainstConfigFolder() {
+        File folder = GenericBluetoothHandlerFactory
+                .resolveGattExtensionsFolder(Map.of("gattExtensionsFolder", "my-gatt"), CONF);
+        assertEquals(new File(CONF, "my-gatt"), folder);
+    }
+
+    @Test
+    void trimsAndResolvesRelativeLocation() {
+        File folder = GenericBluetoothHandlerFactory
+                .resolveGattExtensionsFolder(Map.of("gattExtensionsFolder", "  my-gatt  "), CONF);
+        assertEquals(new File(CONF, "my-gatt"), folder);
+    }
+
+    @Test
+    void honoursAbsoluteLocationAsIs() {
+        String absolute = new File("/opt/custom-gatt").getAbsolutePath();
+        File folder = GenericBluetoothHandlerFactory
+                .resolveGattExtensionsFolder(Map.of("gattExtensionsFolder", absolute), CONF);
+        assertEquals(new File(absolute), folder);
+    }
+}


### PR DESCRIPTION
Hey, I'm the author of the https://github.com/sputnikdev/bluetooth-gatt-parser that is used by the official binding.
This PR adds an ability to add custom GATT definitions via a shared folder in OH. This is useful for testing and also just for adding new devices in general.

The generic Bluetooth handler maps characteristics to channels using a built-in database of standardized GATT services and characteristics. Vendor-specific (non-standard) characteristics aren't in that database, so they fall back to raw hexadecimal `Unknown` channels.

`bluetooth-gatt-parser` already supports loading extra specifications from a folder; this just exposes that. A new binding configuration parameter `gattExtensionsFolder` points to a folder of custom GATT specification XML files (Bluetooth SIG GATT XML format, in `characteristic`/`service` sub-folders), loaded once into the shared parser at startup so custom characteristics are recognised for both channel building and value parsing.

A relative path is resolved against the openHAB config folder (portable across OSes); an absolute path is used as-is. Defaults to `gatt-extensions`.

Tested on a running 5.x instance: the parameter is settable via the `binding.bluetooth.generic` config, the folder is loaded, and a vendor characteristic shows up as a typed channel instead of a raw hex `Unknown` channel. Includes unit tests for the path resolution.

<img width="1224" height="733" alt="image" src="https://github.com/user-attachments/assets/e51f9871-1f30-4213-8204-718c0e5df1ba" />


