### PR TITLE
[bluetooth] Bump bluez-dbus-osgi to 0.3.4

### DIFF
--- a/bundles/org.openhab.binding.bluetooth.bluez/pom.xml
+++ b/bundles/org.openhab.binding.bluetooth.bluez/pom.xml
@@ -26,7 +26,7 @@
     <dependency>
       <groupId>com.github.hypfvieh</groupId>
       <artifactId>bluez-dbus-osgi</artifactId>
-      <version>0.3.2</version>
+      <version>0.3.3</version>
       <scope>provided</scope>
     </dependency>
 

--- a/bundles/org.openhab.binding.bluetooth.bluez/pom.xml
+++ b/bundles/org.openhab.binding.bluetooth.bluez/pom.xml
@@ -26,7 +26,7 @@
     <dependency>
       <groupId>com.github.hypfvieh</groupId>
       <artifactId>bluez-dbus-osgi</artifactId>
-      <version>0.3.3</version>
+      <version>0.3.4</version>
       <scope>provided</scope>
     </dependency>
 

--- a/bundles/org.openhab.binding.bluetooth.bluez/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.bluetooth.bluez/src/main/feature/feature.xml
@@ -4,7 +4,7 @@
 
 	<feature name="openhab-binding-bluetooth-bluez" description="Bluetooth Binding Bluez" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
-		<bundle dependency="true">mvn:com.github.hypfvieh/bluez-dbus-osgi/0.3.3</bundle>
+		<bundle dependency="true">mvn:com.github.hypfvieh/bluez-dbus-osgi/0.3.4</bundle>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.bluetooth/${project.version}</bundle>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.bluetooth.bluez/${project.version}</bundle>
 	</feature>

--- a/bundles/org.openhab.binding.bluetooth.bluez/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.bluetooth.bluez/src/main/feature/feature.xml
@@ -4,7 +4,7 @@
 
 	<feature name="openhab-binding-bluetooth-bluez" description="Bluetooth Binding Bluez" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
-		<bundle dependency="true">mvn:com.github.hypfvieh/bluez-dbus-osgi/0.3.2</bundle>
+		<bundle dependency="true">mvn:com.github.hypfvieh/bluez-dbus-osgi/0.3.3</bundle>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.bluetooth/${project.version}</bundle>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.bluetooth.bluez/${project.version}</bundle>
 	</feature>

--- a/features/openhab-addons/src/main/resources/footer.xml
+++ b/features/openhab-addons/src/main/resources/footer.xml
@@ -2,7 +2,7 @@
 	<feature name="openhab-binding-bluetooth" description="Bluetooth Binding" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
 		<feature>openhab-transport-serial</feature>
-		<bundle dependency="true">mvn:com.github.hypfvieh/bluez-dbus-osgi/0.3.2</bundle>
+		<bundle dependency="true">mvn:com.github.hypfvieh/bluez-dbus-osgi/0.3.4</bundle>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.bluetooth/${project.version}</bundle>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.bluetooth.airthings/${project.version}</bundle>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.bluetooth.am43/${project.version}</bundle>


### PR DESCRIPTION
Bumps the BlueZ binding dependency and Karaf feature from 0.3.2 to released version 0.3.4.

This picks up the corrected and real-hardware-verified BlueZ recovery work from hypfvieh/bluez-dbus#74:

- use the removed object path from the InterfacesRemoved signal source
- evict cached adapter and device wrappers after BlueZ object removal
- notify consumers so they can reset their cached state
- keep empty or failed GATT service discovery retryable

Version 0.3.3 was released, but real-hardware testing found that its InterfacesRemoved handling reads the ObjectManager signal envelope path (`/`) instead of the removed object path, so its intended device eviction does not occur.

Version 0.3.4 is now available from Maven Central.