### PR TITLE
[influxdb] Fix InfluxDB 2 selectors and pagination on multi-series measurements

### DIFF
--- a/bundles/org.openhab.persistence.influxdb/src/main/java/org/openhab/persistence/influxdb/internal/influx2/InfluxDB2FilterCriteriaQueryCreatorImpl.java
+++ b/bundles/org.openhab.persistence.influxdb/src/main/java/org/openhab/persistence/influxdb/internal/influx2/InfluxDB2FilterCriteriaQueryCreatorImpl.java
@@ -83,9 +83,9 @@ public class InfluxDB2FilterCriteriaQueryCreatorImpl implements FilterCriteriaQu
             flux = flux.filter(restrictions);
         }
 
-        // Apply ordering/pagination before keep() so that last()/sort()/limit() can benefit
-        // from InfluxDB's pushdown optimisations. Applying keep() first drops _field, which
-        // both prevents state-value filtering from working correctly and blocks last() pushdown.
+        // Apply grouping/ordering/pagination before keep() so they can push down to the storage
+        // layer, and so that the state-value filter above (which relies on _field) still sees that
+        // column. keep() runs last, purely to project the output columns.
         flux = applyOrderingAndPageSize(criteria, flux);
 
         if (needsItemTag) {
@@ -99,8 +99,21 @@ public class InfluxDB2FilterCriteriaQueryCreatorImpl implements FilterCriteriaQu
     }
 
     private Flux applyOrderingAndPageSize(FilterCriteria criteria, Flux flux) {
+        // Only the first page may use last(); pageNumber > 0 requires an offset, which last()
+        // cannot express (it would always return the most recent point), so fall back to
+        // sort()/limit() in that case.
         var lastOptimization = criteria.getOrdering() == FilterCriteria.Ordering.DESCENDING
-                && criteria.getPageSize() == 1;
+                && criteria.getPageSize() == 1 && criteria.getPageNumber() == 0;
+
+        // A single measurement can map to several InfluxDB series: incidental tags such as
+        // category/type/label, or schema changes over the item's lifetime, split the data into
+        // distinct series under the same measurement. last(), sort() and limit() all operate per
+        // series, so collapse the series into a single per-measurement table first; otherwise
+        // last() returns one (arbitrary, possibly stale) row per series and sort()/limit()/offset
+        // are applied per series, corrupting ordering and pagination. group() stays adjacent to
+        // the storage read, so the query still pushes down (group() + last() in particular fuses
+        // into a single ReadGroupAggregate that seeks straight to the most recent point).
+        flux = flux.groupBy(new String[] { FIELD_MEASUREMENT_NAME });
 
         if (lastOptimization) {
             flux = flux.last();

--- a/bundles/org.openhab.persistence.influxdb/src/test/java/org/openhab/persistence/influxdb/internal/InfluxFilterCriteriaQueryCreatorImplTest.java
+++ b/bundles/org.openhab.persistence.influxdb/src/test/java/org/openhab/persistence/influxdb/internal/InfluxFilterCriteriaQueryCreatorImplTest.java
@@ -85,6 +85,7 @@ public class InfluxFilterCriteriaQueryCreatorImplTest {
                 from(bucket:"origin")
                 \t|> range(start:-100y, stop:100y)
                 \t|> filter(fn: (r) => r["_measurement"] == "sampleItem")
+                \t|> group(columns:["_measurement"])
                 \t|> sort(desc:true, columns:["_time"])
                 \t|> keep(columns:["_measurement", "_time", "_value"])"""));
     }
@@ -108,6 +109,7 @@ public class InfluxFilterCriteriaQueryCreatorImplTest {
                 from(bucket:"origin")
                 \t|> range(start:%s, stop:%s)
                 \t|> filter(fn: (r) => r["_measurement"] == "sampleItem")
+                \t|> group(columns:["_measurement"])
                 \t|> sort(desc:true, columns:["_time"])
                 \t|> keep(columns:["_measurement", "_time", "_value"])""",
                 INFLUX2_DATE_FORMATTER.format(now.toInstant()), INFLUX2_DATE_FORMATTER.format(tomorrow.toInstant()));
@@ -130,6 +132,7 @@ public class InfluxFilterCriteriaQueryCreatorImplTest {
                 \t|> range(start:-100y, stop:100y)
                 \t|> filter(fn: (r) => r["_measurement"] == "sampleItem")
                 \t|> filter(fn: (r) => (r["_field"] == "value" and r["_value"] <= 90))
+                \t|> group(columns:["_measurement"])
                 \t|> sort(desc:true, columns:["_time"])
                 \t|> keep(columns:["_measurement", "_time", "_value"])"""));
     }
@@ -149,6 +152,7 @@ public class InfluxFilterCriteriaQueryCreatorImplTest {
                 from(bucket:"origin")
                 \t|> range(start:-100y, stop:100y)
                 \t|> filter(fn: (r) => r["_measurement"] == "sampleItem")
+                \t|> group(columns:["_measurement"])
                 \t|> sort(desc:true, columns:["_time"])
                 \t|> limit(n:10, offset:20)
                 \t|> keep(columns:["_measurement", "_time", "_value"])"""));
@@ -168,6 +172,7 @@ public class InfluxFilterCriteriaQueryCreatorImplTest {
                 from(bucket:"origin")
                 \t|> range(start:-100y, stop:100y)
                 \t|> filter(fn: (r) => r["_measurement"] == "sampleItem")
+                \t|> group(columns:["_measurement"])
                 \t|> sort(desc:false, columns:["_time"])
                 \t|> keep(columns:["_measurement", "_time", "_value"])"""));
     }
@@ -178,10 +183,13 @@ public class InfluxFilterCriteriaQueryCreatorImplTest {
         criteria.setOrdering(FilterCriteria.Ordering.DESCENDING);
         criteria.setPageSize(1);
         String queryV2 = instanceV2.createQuery(criteria, RETENTION_POLICY, null);
+        // group() collapses the per-series tables so last() returns the single most recent point
+        // across the whole measurement; group() + last() pushes down as one ReadGroupAggregate.
         assertThat(queryV2, equalTo("""
                 from(bucket:"origin")
                 \t|> range(start:-100y, stop:100y)
                 \t|> filter(fn: (r) => r["_measurement"] == "sampleItem")
+                \t|> group(columns:["_measurement"])
                 \t|> last()
                 \t|> keep(columns:["_measurement", "_time", "_value"])"""));
     }
@@ -201,8 +209,28 @@ public class InfluxFilterCriteriaQueryCreatorImplTest {
                 \t|> range(start:-100y, stop:100y)
                 \t|> filter(fn: (r) => r["_measurement"] == "measurementName")
                 \t|> filter(fn: (r) => r["item"] == "aliasName")
+                \t|> group(columns:["_measurement"])
                 \t|> sort(desc:true, columns:["_time"])
                 \t|> keep(columns:["_measurement", "_time", "_value", "item"])"""));
+    }
+
+    @Test
+    public void testPageSizeOneWithOffsetDoesNotUseLast() {
+        // pageSize == 1 but pageNumber > 0 needs an offset, so the last() optimization must not
+        // kick in; it would ignore the offset and always return the most recent point.
+        FilterCriteria criteria = createBaseCriteria();
+        criteria.setOrdering(FilterCriteria.Ordering.DESCENDING);
+        criteria.setPageSize(1);
+        criteria.setPageNumber(3);
+        String queryV2 = instanceV2.createQuery(criteria, RETENTION_POLICY, null);
+        assertThat(queryV2, equalTo("""
+                from(bucket:"origin")
+                \t|> range(start:-100y, stop:100y)
+                \t|> filter(fn: (r) => r["_measurement"] == "sampleItem")
+                \t|> group(columns:["_measurement"])
+                \t|> sort(desc:true, columns:["_time"])
+                \t|> limit(n:1, offset:3)
+                \t|> keep(columns:["_measurement", "_time", "_value"])"""));
     }
 
     private FilterCriteria createBaseCriteria() {
@@ -229,6 +257,7 @@ public class InfluxFilterCriteriaQueryCreatorImplTest {
                 \t|> range(start:-100y, stop:100y)
                 \t|> filter(fn: (r) => r["_measurement"] == "measurementName")
                 \t|> filter(fn: (r) => r["item"] == "sampleItem")
+                \t|> group(columns:["_measurement"])
                 \t|> sort(desc:true, columns:["_time"])
                 \t|> keep(columns:["_measurement", "_time", "_value", "item"])"""));
         when(metadataRegistry.get(metadataKey))
@@ -243,6 +272,7 @@ public class InfluxFilterCriteriaQueryCreatorImplTest {
                 from(bucket:"origin")
                 \t|> range(start:-100y, stop:100y)
                 \t|> filter(fn: (r) => r["_measurement"] == "sampleItem")
+                \t|> group(columns:["_measurement"])
                 \t|> sort(desc:true, columns:["_time"])
                 \t|> keep(columns:["_measurement", "_time", "_value"])"""));
     }


### PR DESCRIPTION
Fix InfluxDB 2 queries returning per-series instead of per-item results

A single measurement can map to several InfluxDB series when incidental tags (category/type/label) or the item tag are added/removed over the item's lifetime (e.g. schema changes across upgrades). Flux's last(), sort() and limit() all operate per series, so after #20654 moved keep() to the end of the pipeline these ran against the un-collapsed series:

- last() (persistedState/restore) returned one row per series and the caller read an arbitrary, often stale, value regardless of the requested timestamp;
- sort()/limit()/offset were applied per series, corrupting ordering and pagination for multi-series measurements.

Collapse the series into a single per-measurement table with group(columns:["_measurement"]) before the selector. This corrects the group key of the existing pushed-down read rather than adding a VM step: group() + last() fuses into a single ReadGroupAggregate (verified via the query profiler on InfluxDB 2.8.0), so the restore-on-startup pushdown that #20654 introduced is preserved while results are now per item.

Verified against a real two-series measurement that the query returns the single most recent point. Note the existing string-level tests assert query shape only and cannot catch this execution-semantics regression.

(I guess another fix would be a migration job which merged / fixed the duplicate tables people have...)