### PR TITLE
[shelly] Fix BLU event reception after WiFi disconnect of gateway device

### DIFF
--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/Shelly2ApiRpc.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/Shelly2ApiRpc.java
@@ -281,37 +281,47 @@ public class Shelly2ApiRpc extends Shelly2ApiClient implements ShellyApiInterfac
                 }
             }
 
-            boolean restart = false;
             if (ourId == -1) {
                 // script not installed -> install it
                 upload = true;
             } else {
                 try {
-                    // verify that the same code version is active (avoid unnesesary flash updates)
+                    // verify that the same code version is active (avoid unnecessary flash updates)
                     ShellyScriptResponse rsp = apiRequest(
                             new Shelly2RpcRequest().withMethod(SHELLYRPC_METHOD_SCRIPT_GETCODE).withId(ourId),
                             ShellyScriptResponse.class);
                     if (!rsp.data.trim().equals(code.trim())) {
-                        logger.debug("{}: A script version was found, update to newest one", thingName);
+                        logger.debug("{}: A newer script version was found, updating", thingName);
                         upload = true;
+                    } else if (running) {
+                        // Same version already running — nothing to do; leave it undisturbed so no
+                        // event gap is created and no risk of a silent restart failure.
+                        logger.debug("{}: Script {} already running with current version, leaving it", thingName,
+                                script);
+                        enableScript(script, ourId, true); // ensure auto-start flag is set
+                        return;
                     } else {
-                        logger.debug("{}: Same script version was found, restart", thingName);
-                        restart = true;
+                        // Same version but not running — start it
+                        logger.debug("{}: Script {} installed but not running, starting it", thingName, script);
+                        enableScript(script, ourId, true);
+                        if (!startScript(ourId, true)) {
+                            logger.warn("{}: Failed to start script {}", thingName, script);
+                        }
+                        return;
                     }
                 } catch (ShellyApiException e) {
-                    logger.debug("{}: Unable to read current script code -> force update (deviced returned: {})",
+                    logger.debug("{}: Unable to read current script code -> force update (device returned: {})",
                             thingName, e.getMessage());
                     upload = true;
                 }
             }
 
-            if (restart || (running && upload)) {
-                // first stop running script
+            // upload=true from here: stop and delete the old script before uploading new code
+            if (running) {
                 startScript(ourId, false);
                 running = false;
             }
             if (upload && ourId != -1) {
-                // Delete existing script
                 deleteScript(ourId);
             }
 
@@ -320,7 +330,6 @@ public class Shelly2ApiRpc extends Shelly2ApiClient implements ShellyApiInterfac
 
                 if (ourId == -1) {
                     // find free script id
-                    ourId = 0;
                     for (ourId = 1; ourId <= MAX_SCRIPT_ID; ourId++) {
                         if (!testScriptId(scriptList, ourId)) {
                             break;
@@ -334,10 +343,9 @@ public class Shelly2ApiRpc extends Shelly2ApiClient implements ShellyApiInterfac
                             ShellyScriptResponse.class);
                     ourId = rsp.id;
                     logger.debug("{}: Script has been created, id={}", thingName, ourId);
-                    upload = true;
                 } else {
-                    logger.debug("{}: Too many scripts installed on this device", thingName);
-                    upload = false;
+                    logger.warn("{}: Too many scripts installed on this device, cannot install {}", thingName, script);
+                    return;
                 }
             }
 
@@ -357,16 +365,13 @@ public class Shelly2ApiRpc extends Shelly2ApiClient implements ShellyApiInterfac
                     chunk++;
                     parms.append = true;
                 } while (processed < length);
-                running = false;
-            }
-            if (enableScript(script, ourId, true) && upload) {
-                logger.info("{}: Script {} was {} installed successful", thingName, thingName, script);
+                if (enableScript(script, ourId, true)) {
+                    logger.info("{}: Script {} installed successfully", thingName, script);
+                }
             }
 
-            if (!running) {
-                running = startScript(ourId, true);
-                logger.debug("{}: Script {} {}", thingName, script,
-                        running ? "was successfully started" : "failed to start");
+            if (!startScript(ourId, true)) {
+                logger.warn("{}: Failed to start script {} after installation", thingName, script);
             }
         } catch (ShellyApiException e) {
             ShellyApiResult res = e.getApiResult();

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/Shelly2RpcSocket.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/Shelly2RpcSocket.java
@@ -361,12 +361,12 @@ public class Shelly2RpcSocket implements WriteCallback {
                             for (Shelly2NotifyEvent e : events.params.events) {
                                 if (getString(e.event).startsWith(SHELLY2_EVENT_BLUPREFIX)) {
                                     String address = getString(e.blu != null ? e.blu.addr : "").replace(":", "");
-                                    if (thingTable.findThing(address) != null) {
-                                        // known device
-                                        ShellyThingInterface thing = thingTable.getThing(address);
-                                        Shelly2ApiRpc api = (Shelly2ApiRpc) thing.getApi();
-                                        handler = api.getRpcHandler();
-                                        handler.onNotifyEvent(receivedMessage);
+                                    ShellyThingInterface bluThing = thingTable.findThing(address);
+                                    if (bluThing != null) {
+                                        // known device — route to the BLU thing's own handler
+                                        Shelly2RpctInterface bluHandler = ((Shelly2ApiRpc) bluThing.getApi())
+                                                .getRpcHandler();
+                                        bluHandler.onNotifyEvent(receivedMessage);
                                     } else {
                                         // new device
                                         if (SHELLY2_EVENT_BLUSCAN.equals(e.event)) {
@@ -378,6 +378,7 @@ public class Shelly2RpcSocket implements WriteCallback {
                                         }
                                     }
                                 } else {
+                                    // non-BLU event: always use the hub's handler, never the BLU one
                                     handler.onNotifyEvent(receivedMessage);
                                 }
                             }

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/Shelly2RpcSocket.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/Shelly2RpcSocket.java
@@ -364,9 +364,12 @@ public class Shelly2RpcSocket implements WriteCallback {
                                     ShellyThingInterface bluThing = thingTable.findThing(address);
                                     if (bluThing != null) {
                                         // known device — route to the BLU thing's own handler
-                                        Shelly2RpctInterface bluHandler = ((Shelly2ApiRpc) bluThing.getApi())
-                                                .getRpcHandler();
-                                        bluHandler.onNotifyEvent(receivedMessage);
+                                        if (bluThing.getApi() instanceof Shelly2ApiRpc bluApi) {
+                                            bluApi.getRpcHandler().onNotifyEvent(receivedMessage);
+                                        } else {
+                                            logger.debug("{}: BLU thing {} has unexpected API type, skipping event",
+                                                    thingName, address);
+                                        }
                                     } else {
                                         // new device
                                         if (SHELLY2_EVENT_BLUSCAN.equals(e.event)) {

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/ShellyBluApi.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/ShellyBluApi.java
@@ -61,6 +61,7 @@ public class ShellyBluApi extends Shelly2ApiRpc {
     private ShellySettingsStatus deviceStatus = new ShellySettingsStatus();
     private int lastPid = -1;
     private static final int PID_CYCLE_TRESHHOLD = 50;
+    private double lastEventTimestamp = 0; // epoch seconds of the most recent BLU event from any gateway
 
     /**
      * Regular constructor - called by Thing handler
@@ -138,7 +139,10 @@ public class ShellyBluApi extends Shelly2ApiRpc {
     @Override
     public ShellySettingsStatus getStatus() throws ShellyApiException {
         if (!connected) {
-            throw new ShellyApiException("Thing is not yet initialized -> status not available");
+            throw new ShellyApiException("offline.status-error-blu-not-connected");
+        }
+        if (lastEventTimestamp > 0 && (now() - lastEventTimestamp) > getProfile().updatePeriod) {
+            throw new ShellyApiException("offline.status-error-blu-timeout");
         }
         return deviceStatus;
     }
@@ -146,9 +150,8 @@ public class ShellyBluApi extends Shelly2ApiRpc {
     @Override
     public ShellyStatusSensor getSensorStatus() throws ShellyApiException {
         if (!connected) {
-            throw new ShellyApiException("Thing is not yet initialized -> sensor data not available");
+            throw new ShellyApiException("offline.status-error-blu-sensor-unavailable");
         }
-
         return sensorData;
     }
 
@@ -167,6 +170,7 @@ public class ShellyBluApi extends Shelly2ApiRpc {
             Shelly2RpcNotifyEvent message = fromJson(gson, eventJSON, Shelly2RpcNotifyEvent.class);
 
             t.incProtMessages();
+            lastEventTimestamp = now(); // any event from any gateway keeps the watchdog alive
             if (!connected) {
                 connected = true;
                 t.setThingOnline();

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/ShellyBluApi.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/ShellyBluApi.java
@@ -61,7 +61,6 @@ public class ShellyBluApi extends Shelly2ApiRpc {
     private ShellySettingsStatus deviceStatus = new ShellySettingsStatus();
     private int lastPid = -1;
     private static final int PID_CYCLE_TRESHHOLD = 50;
-    private double lastEventTimestamp = 0; // epoch seconds of the most recent BLU event from any gateway
 
     /**
      * Regular constructor - called by Thing handler
@@ -141,9 +140,6 @@ public class ShellyBluApi extends Shelly2ApiRpc {
         if (!connected) {
             throw new ShellyApiException("offline.status-error-blu-not-connected");
         }
-        if (lastEventTimestamp > 0 && (now() - lastEventTimestamp) > getProfile().updatePeriod) {
-            throw new ShellyApiException("offline.status-error-blu-timeout");
-        }
         return deviceStatus;
     }
 
@@ -170,7 +166,6 @@ public class ShellyBluApi extends Shelly2ApiRpc {
             Shelly2RpcNotifyEvent message = fromJson(gson, eventJSON, Shelly2RpcNotifyEvent.class);
 
             t.incProtMessages();
-            lastEventTimestamp = now(); // any event from any gateway keeps the watchdog alive
             if (!connected) {
                 connected = true;
                 t.setThingOnline();

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/handler/ShellyBaseHandler.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/handler/ShellyBaseHandler.java
@@ -240,7 +240,7 @@ public abstract class ShellyBaseHandler extends BaseThingHandler
             errorCode = ThingStatusDetail.CONFIGURATION_ERROR;
             retry = false;
         } else if (isWatchdogExpired()) {
-            status = "offline.status-error-watchdog";
+            status = profile.isBlu ? "offline.status-error-blu-timeout" : "offline.status-error-watchdog";
         } else if (res.httpCode >= 400) {
             logger.debug("{}: Unexpected API result: {}/{}", thingName, res.httpCode, res.httpReason, e);
             status = "offline.status-error-unexpected-api-result";
@@ -754,6 +754,7 @@ public abstract class ShellyBaseHandler extends BaseThingHandler
         }
         api.close(); // Gen2: disconnect WS/close http sessions
         watchdog = 0;
+        profile.initialized = false; // force full re-init (incl. asyncApiRequest) on next reconnect
         channelsCreated = false; // check for new channels after devices gets re-initialized (e.g. new
     }
 

--- a/bundles/org.openhab.binding.shelly/src/main/resources/OH-INF/i18n/shelly.properties
+++ b/bundles/org.openhab.binding.shelly/src/main/resources/OH-INF/i18n/shelly.properties
@@ -791,6 +791,9 @@ message.offline.status-error-watchdog = Device is not responding, seems to be un
 message.offline.status-error-restarted = The device has restarted and will be re-initialized.
 message.offline.status-error-fwupgrade = Firmware upgrade in progress.
 message.offline.status-error-fwcompleted = Firmware upgrade completed, device is restarting.
+message.offline.status-error-blu-not-connected = BLU device not yet connected - no events received from any gateway.
+message.offline.status-error-blu-sensor-unavailable = BLU sensor data not yet available - no events received from any gateway.
+message.offline.status-error-blu-timeout = BLU device stopped reporting: no event received within expected update period.
 
 # general messages
 

--- a/bundles/org.openhab.binding.shelly/src/test/java/org/openhab/binding/shelly/internal/api2/ShellyBluApiTest.java
+++ b/bundles/org.openhab.binding.shelly/src/test/java/org/openhab/binding/shelly/internal/api2/ShellyBluApiTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.shelly.internal.api2;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+import static org.openhab.binding.shelly.internal.ShellyDevices.*;
+
+import java.lang.reflect.Field;
+import java.util.Map;
+import java.util.concurrent.ScheduledExecutorService;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.websocket.client.WebSocketClient;
+import org.junit.jupiter.api.Test;
+import org.openhab.binding.shelly.internal.api.ShellyApiException;
+import org.openhab.binding.shelly.internal.api.ShellyDeviceProfile;
+import org.openhab.binding.shelly.internal.config.ShellyApiConfiguration;
+import org.openhab.binding.shelly.internal.config.ShellyBindingConfiguration;
+import org.openhab.binding.shelly.internal.config.ShellyBindingRuntimeConfig;
+import org.openhab.binding.shelly.internal.handler.ShellyThingInterface;
+import org.openhab.binding.shelly.internal.handler.ShellyThingTable;
+import org.openhab.core.net.NetworkAddressChangeListener;
+import org.openhab.core.net.NetworkAddressService;
+import org.openhab.core.thing.Thing;
+import org.openhab.core.thing.ThingTypeUID;
+
+/**
+ * Unit tests for {@link ShellyBluApi} — connection state guards.
+ *
+ * @author Markus Michels - Initial contribution
+ */
+@NonNullByDefault
+public class ShellyBluApiTest {
+
+    // ── getStatus() connection guard ─────────────────────────────────────────
+
+    @Test
+    void getStatusThrowsWhenNotConnected() throws Exception {
+        ShellyBluApi api = buildBluApi();
+        ShellyApiException ex = assertThrows(ShellyApiException.class, api::getStatus);
+        assertThat(ex.getMessage(), is("offline.status-error-blu-not-connected"));
+    }
+
+    @Test
+    void getStatusSucceedsWhenConnected() throws Exception {
+        ShellyBluApi api = buildBluApi();
+        setField(api, "connected", true);
+        assertDoesNotThrow(api::getStatus);
+    }
+
+    // ── getSensorStatus() connection guard ───────────────────────────────────
+
+    @Test
+    void getSensorStatusThrowsWhenNotConnected() throws Exception {
+        ShellyBluApi api = buildBluApi();
+        ShellyApiException ex = assertThrows(ShellyApiException.class, api::getSensorStatus);
+        assertThat(ex.getMessage(), is("offline.status-error-blu-sensor-unavailable"));
+    }
+
+    @Test
+    void getSensorStatusSucceedsWhenConnected() throws Exception {
+        ShellyBluApi api = buildBluApi();
+        setField(api, "connected", true);
+        assertDoesNotThrow(api::getSensorStatus);
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    private ShellyBluApi buildBluApi() {
+        ThingTypeUID thingTypeUID = THING_TYPE_SHELLYBLUBUTTON1;
+
+        Thing ohThing = mock(Thing.class);
+        when(ohThing.getThingTypeUID()).thenReturn(thingTypeUID);
+
+        ShellyDeviceProfile deviceProfile = new ShellyDeviceProfile(thingTypeUID);
+
+        HttpClient httpClient = mock(HttpClient.class);
+        ShellyThingInterface thing = mock(ShellyThingInterface.class);
+        when(thing.getThing()).thenReturn(ohThing);
+        when(thing.getHttpClient()).thenReturn(httpClient);
+        when(thing.getProfile()).thenReturn(deviceProfile);
+
+        ShellyBindingConfiguration raw = ShellyBindingConfiguration
+                .fromProperties(Map.of(ShellyBindingConfiguration.CONFIG_LOCAL_IP, "192.168.1.1"));
+        ShellyBindingRuntimeConfig bindingConfig = new ShellyBindingRuntimeConfig(raw, 8080, nullNas());
+        ShellyApiConfiguration config = new ShellyApiConfiguration(bindingConfig, "test-blu", "");
+
+        return new ShellyBluApi("test-blu", mock(ShellyThingTable.class), thing, config, mock(WebSocketClient.class),
+                mock(ScheduledExecutorService.class));
+    }
+
+    private static void setField(Object target, String fieldName, Object value) throws Exception {
+        Field f = target.getClass().getDeclaredField(fieldName);
+        f.setAccessible(true);
+        f.set(target, value);
+    }
+
+    private static NetworkAddressService nullNas() {
+        return new NetworkAddressService() {
+            @Override
+            public @Nullable String getPrimaryIpv4HostAddress() {
+                return null;
+            }
+
+            @Override
+            public @Nullable String getConfiguredBroadcastAddress() {
+                return null;
+            }
+
+            @Override
+            public boolean isUseOnlyOneAddress() {
+                return false;
+            }
+
+            @Override
+            public boolean isUseIPv6() {
+                return false;
+            }
+
+            @Override
+            public void addNetworkAddressChangeListener(NetworkAddressChangeListener listener) {
+            }
+
+            @Override
+            public void removeNetworkAddressChangeListener(NetworkAddressChangeListener listener) {
+            }
+        };
+    }
+}


### PR DESCRIPTION
Problem:
BLU devices (BLU Motion, BLU Button, etc.) stopped delivering channel updates after the hub device temporarily lost its WiFi connection and came back online.

Two root causes combined to produce the failure:

1. Script restart on every initialization — installScript() stopped the running BLU scanner script unconditionally, even when the same version was already running. If the subsequent startScript() call failed silently (race with hub reboot), BLU events were permanently lost until the next manual restart.

2. Stale profile on hub reconnect — setThingOfflineAndDisconnect() did not reset profile.initialized. On reconnect the handler came back ONLINE but skipped asyncApiRequest and the script-restart sequence because the profile appeared already initialized.

Two additional minor bugs were fixed opportunistically while tracing the above:

- BLU event routing corrupted hub handler — Shelly2RpcSocket modified the shared handler field when routing BLU events, so any non-BLU event arriving after a BLU event was dispatched to the wrong (BLU thing's) handler instead of the hub's.
- Unhelpful offline message for BLU things — the generic "Device is not responding" watchdog message appeared for BLU things instead of a BLU-specific explanation.
