### PR TITLE
[tesla] Improve OFFLINE status description

### DIFF
--- a/bundles/org.openhab.binding.tesla/src/main/java/org/openhab/binding/tesla/internal/handler/TeslaAccountHandler.java
+++ b/bundles/org.openhab.binding.tesla/src/main/java/org/openhab/binding/tesla/internal/handler/TeslaAccountHandler.java
@@ -303,7 +303,7 @@ public class TeslaAccountHandler extends BaseBridgeHandler {
             this.logonToken = ssoHandler.getAccessToken(refreshToken);
             if (this.logonToken == null) {
                 return new ThingStatusInfo(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
-                        "Failed to obtain access token for API.");
+                        "Failed to obtain access token for API - the refresh token might be invalid.");
             }
         }
 
@@ -422,7 +422,8 @@ public class TeslaAccountHandler extends BaseBridgeHandler {
                 } else if (authenticationResult.getStatusDetail() == ThingStatusDetail.CONFIGURATION_ERROR) {
                     // make sure to set thing to CONFIGURATION_ERROR in case of failed authentication in order not to
                     // hit request limit on retries on the Tesla SSO endpoints.
-                    updateStatus(ThingStatus.OFFLINE, authenticationResult.getStatusDetail());
+                    updateStatus(ThingStatus.OFFLINE, authenticationResult.getStatusDetail(),
+                            authenticationResult.getDescription());
                 }
             }
         } catch (Exception e) {


### PR DESCRIPTION
When an invalid refresh token is in the configuration, the Thing status reports look like:

```
00:29:10.402 [INFO ] [ab.event.ThingStatusInfoChangedEvent] - Thing 'tesla:account:1' changed from UNKNOWN to OFFLINE (CONFIGURATION_ERROR): Failed to obtain access token for API.
00:29:10.403 [INFO ] [ab.event.ThingStatusInfoChangedEvent] - Thing 'tesla:account:1' changed from OFFLINE (CONFIGURATION_ERROR): Failed to obtain access token for API. to OFFLINE (CONFIGURATION_ERROR)
```
The first line does not tell the user that the issue might be with the refresh token, the second line immediately wipes ANY description of the status, which leaves the user in the dark.

With this PR, there's only a single status update:
```
00:37:14.568 [INFO ] [ab.event.ThingStatusInfoChangedEvent] - Thing 'tesla:account:1' changed from UNKNOWN to OFFLINE (CONFIGURATION_ERROR): Failed to obtain access token for API - the refresh token might be invalid.
```