### PR TITLE
[matter] Fix Thread device commissioning regressions (matter.js 0.17)

### DIFF
--- a/bundles/org.openhab.binding.matter/matter-server/src/client/ControllerNode.ts
+++ b/bundles/org.openhab.binding.matter/matter-server/src/client/ControllerNode.ts
@@ -6,7 +6,7 @@ import { Endpoint, NodeStates, PairedNode } from "@project-chip/matter.js/device
 import { WebSocketSession } from "../app";
 import { EventType, NodeState } from "../MessageTypes";
 import { printError } from "../util/error";
-import { SoftwareUpdateManager } from "@matter/node";
+import { ControllerBehavior, SoftwareUpdateManager } from "@matter/node";
 import { DclOtaUpdateService, PhysicalDeviceProperties } from "@matter/main/protocol";
 
 const logger = Logger.get("ControllerNode");
@@ -144,6 +144,12 @@ export class ControllerNode {
         }
 
         await this.commissioningController.start();
+
+        // matter.js 0.17 defaults to sequential operational node IDs starting at NodeId(1). The counter is not
+        // restored consistently with the fabric across restarts, so it re-attempts low IDs that are already
+        // commissioned ("Node ID X is already commissioned and can not be reused"). Switch to the documented
+        // random allocation strategy (CHANGELOG: set ControllerBehavior state nodeIdAssignment to "random").
+        await this.commissioningController.node.setStateOf(ControllerBehavior, { nodeIdAssignment: "random" });
 
         //Set up observers for OTA updates, matter.js checks every 24 hours by default.
         this.observers = this.observers ?? new ObserverGroup(this.environment.runtime);

--- a/bundles/org.openhab.binding.matter/matter-server/src/client/ControllerNode.ts
+++ b/bundles/org.openhab.binding.matter/matter-server/src/client/ControllerNode.ts
@@ -219,8 +219,34 @@ export class ControllerNode {
             return new Promise((resolve, reject) => {
                 let timeoutId: NodeJS.Timeout | undefined;
 
+                // initializedFromRemote only fires on the very first connect of a PairedNode instance; a later
+                // reconnect re-asserts the Connected state but never emits it again. So we also resolve on a live
+                // stateChanged -> Connected transition, otherwise an already-initialized node that has to reconnect
+                // here would wait for an event that never comes and run into the timeout (Thing flips OFFLINE).
+                const onStateChanged = (state: NodeStates): void => {
+                    if (state === NodeStates.Connected) {
+                        finish("reconnected");
+                    }
+                };
+                const finish = (reason: string): void => {
+                    if (timeoutId) clearTimeout(timeoutId);
+                    node?.events.initializedFromRemote.off(onInitialized);
+                    node?.events.stateChanged.off(onStateChanged);
+                    logger.info(`Node ${node?.nodeId} ${reason}`);
+                    // Send a connected event so the client knows the resume completed
+                    this.ws.sendEvent(EventType.NodeStateInformation, {
+                        nodeId: node!.nodeId,
+                        state: NodeStates[NodeStates.Connected],
+                        physicalProperties: extractPhysicalProperties(node),
+                    });
+                    resolve();
+                };
+                const onInitialized = (): void => finish("initialized from remote");
+
                 if (connectionTimeout && connectionTimeout > 0) {
                     timeoutId = setTimeout(() => {
+                        node?.events.initializedFromRemote.off(onInitialized);
+                        node?.events.stateChanged.off(onStateChanged);
                         logger.info(`Node ${node?.nodeId} state: ${node?.state}`);
                         if (
                             node?.connectionState === NodeStates.Disconnected ||
@@ -234,18 +260,15 @@ export class ControllerNode {
                     }, connectionTimeout);
                 }
 
-                // Cancel timer if node initializes
-                node?.events.initializedFromRemote.once(() => {
-                    logger.info(`Node ${node?.nodeId} initialized from remote`);
-                    if (timeoutId) clearTimeout(timeoutId);
-                    // Send a connected event so the client knows the resume completed
-                    this.ws.sendEvent(EventType.NodeStateInformation, {
-                        nodeId: node!.nodeId,
-                        state: NodeStates[NodeStates.Connected],
-                        physicalProperties: extractPhysicalProperties(node),
-                    });
-                    resolve();
-                });
+                // The node may already be Connected again by the time we get here (between the guard above and
+                // triggerReconnect), so check once before waiting for an event.
+                if (node?.connectionState === NodeStates.Connected) {
+                    finish("already connected");
+                    return;
+                }
+
+                node?.events.initializedFromRemote.once(onInitialized);
+                node?.events.stateChanged.on(onStateChanged);
             });
         }
 

--- a/bundles/org.openhab.binding.matter/matter-server/src/client/ControllerNode.ts
+++ b/bundles/org.openhab.binding.matter/matter-server/src/client/ControllerNode.ts
@@ -197,12 +197,9 @@ export class ControllerNode {
 
         let node = this.nodes.get(NodeId(BigInt(nodeId)));
         if (node !== undefined) {
-            // If the node already completed its remote initialization (e.g. it was enumerated during a discovery
-            // scan before its Thing existed), the initializedFromRemote event has already fired and will not fire
-            // again. Re-announce the connected state synchronously so the client re-enumerates instead of waiting
-            // for an event that never comes - otherwise this runs into the 300s timeout and the Thing flips OFFLINE
-            // (and ends up without channels) shortly after being added.
-            if (node.remoteInitializationDone) {
+            // We are already connected so there is nothing to reconnect. Send the connected state so the
+            // client refreshes, otherwise we would wait for an init event that never fires again and time out.
+            if (node.connectionState === NodeStates.Connected) {
                 this.ws.sendEvent(EventType.NodeStateInformation, {
                     nodeId: node.nodeId,
                     state: NodeStates[NodeStates.Connected],

--- a/bundles/org.openhab.binding.matter/matter-server/src/client/ControllerNode.ts
+++ b/bundles/org.openhab.binding.matter/matter-server/src/client/ControllerNode.ts
@@ -197,6 +197,20 @@ export class ControllerNode {
 
         let node = this.nodes.get(NodeId(BigInt(nodeId)));
         if (node !== undefined) {
+            // If the node already completed its remote initialization (e.g. it was enumerated during a discovery
+            // scan before its Thing existed), the initializedFromRemote event has already fired and will not fire
+            // again. Re-announce the connected state synchronously so the client re-enumerates instead of waiting
+            // for an event that never comes - otherwise this runs into the 300s timeout and the Thing flips OFFLINE
+            // (and ends up without channels) shortly after being added.
+            if (node.remoteInitializationDone) {
+                this.ws.sendEvent(EventType.NodeStateInformation, {
+                    nodeId: node.nodeId,
+                    state: NodeStates[NodeStates.Connected],
+                    physicalProperties: extractPhysicalProperties(node),
+                });
+                return;
+            }
+
             node.triggerReconnect();
 
             return new Promise((resolve, reject) => {
@@ -269,7 +283,9 @@ export class ControllerNode {
         // to avoid forwarding the init state updates as user visible updates. Use once() so they are
         // wired exactly once per registration; the inner handlers are tracked by the observer group
         // (reset above) so they are still removed in bulk on re-registration or decommission.
-        node.events.initializedFromRemote.once(() => {
+        // Wire up the user-visible event forwarding and emit the connected event once the node has completed
+        // its remote initialization.
+        const handleInitialized = () => {
             observers.on(node!.events.attributeChanged, data => {
                 data.path.nodeId = node!.nodeId;
                 this.ws.sendEvent(EventType.AttributeChanged, data);
@@ -287,7 +303,18 @@ export class ControllerNode {
                 state: NodeStates[NodeStates.Connected],
                 physicalProperties: extractPhysicalProperties(node),
             });
-        });
+        };
+
+        // matter.js auto-connects a node immediately after commissioning, so by the time we get here the
+        // initializedFromRemote event may have already fired and will not fire again. In that case finish
+        // synchronously instead of waiting for an event that never comes - otherwise initializeNode runs into
+        // its timeout after a successful commissioning and the new node never surfaces to the client.
+        if (node.remoteInitializationDone) {
+            handleInitialized();
+            return;
+        }
+
+        node.events.initializedFromRemote.once(handleInitialized);
 
         node.connect();
 

--- a/bundles/org.openhab.binding.matter/matter-server/src/client/namespaces/Nodes.ts
+++ b/bundles/org.openhab.binding.matter/matter-server/src/client/namespaces/Nodes.ts
@@ -1,4 +1,3 @@
-import { randomBytes } from "node:crypto";
 import { Logger, ObserverGroup, SoftwareUpdateManager } from "@matter/main";
 import { GeneralCommissioning, OperationalCredentialsCluster, OtaSoftwareUpdateRequestor, OtaSoftwareUpdateRequestorCluster } from "@matter/main/clusters";
 import { FabricIndex, ManualPairingCodeCodec, NodeId, QrCode, QrPairingCodeCodec } from "@matter/types";
@@ -132,24 +131,6 @@ export class Nodes {
             throw new Error("CommissioningController not initialized");
         }
 
-        // matter.js 0.17 assigns operational node IDs from a sequential counter starting at 1, and that counter is
-        // not restored after a controller restart. It then re-allocates low IDs that may already be commissioned,
-        // producing "Node ID X is already commissioned and can not be reused". When the pairing code does not carry
-        // an explicit node ID, assign a random operational node ID ourselves (as the Matter spec recommends and as
-        // pre-0.17 did), making sure it is not already in use.
-        let assignedNodeId = nodeId;
-        if (assignedNodeId === undefined) {
-            const usedNodeIds = new Set(
-                this.controllerNode.commissioningController.getCommissionedNodes().map(id => id.toString()),
-            );
-            let candidate: bigint;
-            do {
-                // 63-bit random keeps the value inside the valid operational node ID range (1 .. 0xFFFFFFEFFFFFFFFF)
-                candidate = randomBytes(8).readBigUInt64BE() & 0x7fffffffffffffffn;
-            } while (candidate < 1n || usedNodeIds.has(candidate.toString()));
-            assignedNodeId = NodeId(candidate);
-        }
-
         const options = {
             discovery: {
                 knownAddress: ip !== undefined && ipPort !== undefined ? { ip, port: ipPort, type: "udp" } : undefined,
@@ -170,7 +151,7 @@ export class Nodes {
         } as NodeCommissioningOptions;
 
         options.commissioning = {
-            nodeId: assignedNodeId,
+            nodeId: nodeId !== undefined ? NodeId(nodeId) : undefined,
             regulatoryLocation: GeneralCommissioning.RegulatoryLocationType.Outdoor, // Set to the most restrictive if relevant
             regulatoryCountryCode: "XX",
         };

--- a/bundles/org.openhab.binding.matter/matter-server/src/client/namespaces/Nodes.ts
+++ b/bundles/org.openhab.binding.matter/matter-server/src/client/namespaces/Nodes.ts
@@ -1,3 +1,4 @@
+import { randomBytes } from "node:crypto";
 import { Logger, ObserverGroup, SoftwareUpdateManager } from "@matter/main";
 import { GeneralCommissioning, OperationalCredentialsCluster, OtaSoftwareUpdateRequestor, OtaSoftwareUpdateRequestorCluster } from "@matter/main/clusters";
 import { FabricIndex, ManualPairingCodeCodec, NodeId, QrCode, QrPairingCodeCodec } from "@matter/types";
@@ -131,6 +132,24 @@ export class Nodes {
             throw new Error("CommissioningController not initialized");
         }
 
+        // matter.js 0.17 assigns operational node IDs from a sequential counter starting at 1, and that counter is
+        // not restored after a controller restart. It then re-allocates low IDs that may already be commissioned,
+        // producing "Node ID X is already commissioned and can not be reused". When the pairing code does not carry
+        // an explicit node ID, assign a random operational node ID ourselves (as the Matter spec recommends and as
+        // pre-0.17 did), making sure it is not already in use.
+        let assignedNodeId = nodeId;
+        if (assignedNodeId === undefined) {
+            const usedNodeIds = new Set(
+                this.controllerNode.commissioningController.getCommissionedNodes().map(id => id.toString()),
+            );
+            let candidate: bigint;
+            do {
+                // 63-bit random keeps the value inside the valid operational node ID range (1 .. 0xFFFFFFEFFFFFFFFF)
+                candidate = randomBytes(8).readBigUInt64BE() & 0x7fffffffffffffffn;
+            } while (candidate < 1n || usedNodeIds.has(candidate.toString()));
+            assignedNodeId = NodeId(candidate);
+        }
+
         const options = {
             discovery: {
                 knownAddress: ip !== undefined && ipPort !== undefined ? { ip, port: ipPort, type: "udp" } : undefined,
@@ -151,22 +170,24 @@ export class Nodes {
         } as NodeCommissioningOptions;
 
         options.commissioning = {
-            nodeId: nodeId !== undefined ? NodeId(nodeId) : undefined,
+            nodeId: assignedNodeId,
             regulatoryLocation: GeneralCommissioning.RegulatoryLocationType.Outdoor, // Set to the most restrictive if relevant
             regulatoryCountryCode: "XX",
         };
 
-        if (this.controllerNode.Store.has("WiFiSsid") && this.controllerNode.Store.has("WiFiPassword")) {
-            options.commissioning.wifiNetwork = {
-                wifiSsid: await this.controllerNode.Store.get<string>("WiFiSsid", ""),
-                wifiCredentials: await this.controllerNode.Store.get<string>("WiFiPassword", ""),
-            };
+        // Only pass network credentials when they are actually present and non-empty. matter.js 0.17 rejects an
+        // empty wifiNetwork/threadNetwork with "must not be empty" before commissioning even starts. Devices that
+        // are already on their operational network (e.g. a Thread device joined externally beforehand) are
+        // commissioned over IP without re-provisioning, so omitting the credentials here is the correct behaviour.
+        const wifiSsid = await this.controllerNode.Store.get<string>("WiFiSsid", "");
+        const wifiCredentials = await this.controllerNode.Store.get<string>("WiFiPassword", "");
+        if (wifiSsid.length > 0 && wifiCredentials.length > 0) {
+            options.commissioning.wifiNetwork = { wifiSsid, wifiCredentials };
         }
-        if (this.controllerNode.Store.has("ThreadName") && this.controllerNode.Store.has("ThreadOperationalDataset")) {
-            options.commissioning.threadNetwork = {
-                networkName: await this.controllerNode.Store.get<string>("ThreadName", ""),
-                operationalDataset: await this.controllerNode.Store.get<string>("ThreadOperationalDataset", ""),
-            };
+        const threadName = await this.controllerNode.Store.get<string>("ThreadName", "");
+        const threadOperationalDataset = await this.controllerNode.Store.get<string>("ThreadOperationalDataset", "");
+        if (threadName.length > 0 && threadOperationalDataset.length > 0) {
+            options.commissioning.threadNetwork = { networkName: threadName, operationalDataset: threadOperationalDataset };
         }
 
         const commissionedNodeId = await this.controllerNode.commissioningController.commissionNode(options);

--- a/bundles/org.openhab.binding.matter/src/main/java/org/openhab/binding/matter/internal/handler/ControllerHandler.java
+++ b/bundles/org.openhab.binding.matter/src/main/java/org/openhab/binding/matter/internal/handler/ControllerHandler.java
@@ -165,6 +165,11 @@ public class ControllerHandler extends BaseBridgeHandler implements MatterClient
         if (childHandler instanceof NodeHandler handler) {
             BigInteger nodeId = handler.getNodeId();
             linkedNodes.put(nodeId, handler);
+            // A freshly linked handler has no node data yet. Drop any "already enumerated" marker so the full data is
+            // actually (re)requested for it. Otherwise requestAllNodeDataIfNeeded skips the request for sleepy nodes
+            // that were enumerated before their Thing existed (e.g. discovered via a scan), leaving the Thing online
+            // but without any channels.
+            enumeratedNodes.remove(nodeId);
             PhysicalDeviceProperties pending = pendingPhysicalProperties.remove(nodeId);
             if (pending != null) {
                 handler.applyPhysicalProperties(pending);


### PR DESCRIPTION
# Situation

When testing the Matter binding from the latest main branch, I saw that I was not able anymore to add new Matter things via the Inbox with a 11 digit commissioning pairing code.
I assume it got broken with the recent Matter.js 0.17.0 upgrade (https://github.com/openhab/openhab-addons/pull/20816).

The trace log revealed multiple issues:

- `[TRACE] [ternal.client.MatterWebsocketService] -         "stack": "Error: Thread operational dataset must not be empty\n    at #validateCommissioningOptions (webpack://matter-server/./node_modules/@matter/protocol/dist/cjs/peer/ControllerCommissioner.js?:271:15)\n    at ControllerCommissioner.commission (webpack://matter-server/./node_modules/@matter/protocol/dist/cjs/peer/ControllerCommissioner.js?:128:39)\n    at CommissioningClient.commission (webpack://matter-server/./node_modules/@matter/node/dist/cjs/behavior/system/commissioning/CommissioningClient.js?:207:56)\n    at async Peers.runCommissioning (webpack://matter-server/./node_modules/@matter/node/dist/cjs/node/client/Peers.js?:285:14)",` 
- `Node ID 1 is already commissioned and can not be reused` - It seems Matter.js doesn't generate random node IDs anymore, but uses enumerative IDs (starting with 1) that are not persisted
- Thing channels were not correctly initialized after commissioning, even tho the thing was "online".

## Tested hardware
* Version: openHAB 5.2.0.M5
* Matter binding version: main branch latest
* Border router: SONOFF Zigbee 3.0 USB Dongle Plus MG24 / Openthread
* Raspberry PI with native OTBR agent installation (systemd)

# Bugfix / Solution

- pairNode assigns a random unused operational node ID (avoids "Node ID X already commissioned" from the 0.17 sequential-counter reset)
- only pass threadNetwork/wifiNetwork when the stored credentials are non-empty (0.17 rejects empty datasets before commissioning)
- initializeNode finishes synchronously when the node is already initialized (avoids the 300s timeout / OFFLINE after commissioning)
- childHandlerInitialized clears the "enumerated" marker so freshly linked sleepy nodes actually fetch data and get channels

# Tests

## Manual

- Comission a new Matter device with the Things inbox multiple times. Check if the channels are initialized correctly.
