### PR TITLE
[matter] Documentation: Needs node.js 20+, not 18+ / Fix OTA updates

### DIFF
--- a/bundles/org.openhab.binding.matter/DEVELOPMENT.md
+++ b/bundles/org.openhab.binding.matter/DEVELOPMENT.md
@@ -9,7 +9,7 @@ This document describes how to set up your development environment and contribut
 ## General Build Requirements
 
 - Java 17 or higher
-- Node.js 20 or higher
+- Node.js 22 or higher
 - npm 9 or higher
 
 ## Building the Project

--- a/bundles/org.openhab.binding.matter/DEVELOPMENT.md
+++ b/bundles/org.openhab.binding.matter/DEVELOPMENT.md
@@ -9,7 +9,7 @@ This document describes how to set up your development environment and contribut
 ## General Build Requirements
 
 - Java 17 or higher
-- Node.js 18 or higher
+- Node.js 20 or higher
 - npm 9 or higher
 
 ## Building the Project

--- a/bundles/org.openhab.binding.matter/README.md
+++ b/bundles/org.openhab.binding.matter/README.md
@@ -21,7 +21,7 @@ For more information on the Matter specification, see the [Matter Ecosystem Over
 
 This binding uses the excellent [matter.js](https://github.com/project-chip/matter.js) implementation of the Matter 1.5.1 protocol.
 
-As such, this binding requires NodesJS 20+ and will attempt to download and cache an appropriate version when started if a version is not already installed on the system.
+As such, this binding requires Node.js 20+ and will attempt to download and cache an appropriate version when started if a version is not already installed on the system.
 Alpine Linux users (typically docker) and those on older Linux distributions will need to install this manually as the official NodeJS versions are not compatible.
 
 ## Matter and IPv6

--- a/bundles/org.openhab.binding.matter/README.md
+++ b/bundles/org.openhab.binding.matter/README.md
@@ -21,7 +21,7 @@ For more information on the Matter specification, see the [Matter Ecosystem Over
 
 This binding uses the excellent [matter.js](https://github.com/project-chip/matter.js) implementation of the Matter 1.5.1 protocol.
 
-As such, this binding requires NodesJS 18+ and will attempt to download and cache an appropriate version when started if a version is not already installed on the system.
+As such, this binding requires NodesJS 20+ and will attempt to download and cache an appropriate version when started if a version is not already installed on the system.
 Alpine Linux users (typically docker) and those on older Linux distributions will need to install this manually as the official NodeJS versions are not compatible.
 
 ## Matter and IPv6

--- a/bundles/org.openhab.binding.matter/README.md
+++ b/bundles/org.openhab.binding.matter/README.md
@@ -21,7 +21,7 @@ For more information on the Matter specification, see the [Matter Ecosystem Over
 
 This binding uses the excellent [matter.js](https://github.com/project-chip/matter.js) implementation of the Matter 1.5.1 protocol.
 
-As such, this binding requires Node.js 20+ and will attempt to download and cache an appropriate version when started if a version is not already installed on the system.
+As such, this binding requires Node.js 22+ and will attempt to download and cache an appropriate version when started if a version is not already installed on the system.
 Alpine Linux users (typically docker) and those on older Linux distributions will need to install this manually as the official NodeJS versions are not compatible.
 
 ## Matter and IPv6

--- a/bundles/org.openhab.binding.matter/src/main/java/org/openhab/binding/matter/internal/client/NodeJSRuntimeManager.java
+++ b/bundles/org.openhab.binding.matter/src/main/java/org/openhab/binding/matter/internal/client/NodeJSRuntimeManager.java
@@ -65,7 +65,7 @@ class NodeJSRuntimeManager {
 
     private static final String NODE_BASE_VERSION = "v22";
     private static final String NODE_DEFAULT_VERSION = "v22.12.0";
-    private static final String NODE_MIN_VERSION = "v20.0.0";
+    private static final String NODE_MIN_VERSION = "v22.0.0";
 
     private static final String NODE_INDEX_URL = "https://nodejs.org/dist/index.json";
 

--- a/bundles/org.openhab.binding.matter/src/main/java/org/openhab/binding/matter/internal/client/NodeJSRuntimeManager.java
+++ b/bundles/org.openhab.binding.matter/src/main/java/org/openhab/binding/matter/internal/client/NodeJSRuntimeManager.java
@@ -65,7 +65,7 @@ class NodeJSRuntimeManager {
 
     private static final String NODE_BASE_VERSION = "v22";
     private static final String NODE_DEFAULT_VERSION = "v22.12.0";
-    private static final String NODE_MIN_VERSION = "v18.0.0";
+    private static final String NODE_MIN_VERSION = "v20.0.0";
 
     private static final String NODE_INDEX_URL = "https://nodejs.org/dist/index.json";
 


### PR DESCRIPTION
# Situation

I had Node JS 18 installed on my RPI system and noticed that the OTA check are throwing errors:

```
2026-06-06 18:48:38.216 [TRACE] [ternal.client.MatterWebsocketService] - matter: Sending response: {"type":"response","message":{"type":"resultSuccess","id":"8d36ba9c-7e08-4427-8569-981e2c102f00","result":null,"error":null,"errorId":null}}
2026-06-06 18:48:38.216 [DEBUG] [al.controller.MatterControllerClient] - onWebSocketText {"type":"response","message":{"type":"resultSuccess","id":"8d36ba9c-7e08-4427-8569-981e2c102f00","result":null,"error":null,"errorId":null}}
2026-06-06 18:48:38.217 [TRACE] [ternal.client.MatterWebsocketService] -     at DclOtaUpdateService.downloadUpdate (webpack://matter-server/./node_modules/@matter/protocol/dist/cjs/dcl/DclOtaUpdateService.js?:401:24)
2026-06-06 18:48:38.218 [DEBUG] [al.controller.MatterControllerClient] - result type: resultSuccess 
2026-06-06 18:48:38.219 [TRACE] [ternal.client.MatterWebsocketService] -     at async #checkProductForUpdates (webpack://matter-server/./node_modules/@matter/node/dist/cjs/behavior/system/software-update/SoftwareUpdateManager.js?:360:16)
2026-06-06 18:48:38.220 [TRACE] [ternal.client.MatterWebsocketService] -     at async SoftwareUpdateManager.queryUpdates (webpack://matter-server/./node_modules/@matter/node/dist/cjs/behavior/system/software-update/SoftwareUpdateManager.js?:324:23)
2026-06-06 18:48:38.225 [TRACE] [ternal.client.MatterWebsocketService] -     at async Nodes.otaQueryForUpdates (webpack://matter-server/./src/client/namespaces/Nodes.ts?:278:25)
2026-06-06 18:48:38.225 [TRACE] [ternal.client.MatterWebsocketService] -     at async ClientController.handleRequest (webpack://matter-server/./src/Controller.ts?:25:37)
2026-06-06 18:48:38.226 [TRACE] [ternal.client.MatterWebsocketService] -   Caused by: (0 , import_node_fs.openAsBlob) is not a function
2026-06-06 18:48:38.226 [TRACE] [ternal.client.MatterWebsocketService] -     at FlatFileBlobStorageDriver.openBlob (webpack://matter-server/./node_modules/@matter/nodejs/dist/cjs/storage/fs/FlatFileBlobStorageDriver.js?:61:48)
2026-06-06 18:48:38.227 [TRACE] [ternal.client.MatterWebsocketService] -     at PersistedFileDesignator.openBlob (webpack://matter-server/./node_modules/@matter/protocol/dist/cjs/bdx/PersistedFileDesignator.js?:72:43)
2026-06-06 18:48:38.227 [TRACE] [ternal.client.MatterWebsocketService] -     at async #verifyUpdate (webpack://matter-server/./node_modules/@matter/protocol/dist/cjs/dcl/DclOtaUpdateService.js?:277:24)
2026-06-06 18:48:38.220 [DEBUG] [.matter.internal.handler.NodeHandler] - Update Available: false for node 16732287852879254987
2026-06-06 18:48:38.228 [TRACE] [ternal.client.MatterWebsocketService] -     at async DclOtaUpdateService.store (webpack://matter-server/./node_modules/@matter/protocol/dist/cjs/dcl/DclOtaUpdateService.js?:323:7)
2026-06-06 18:48:38.230 [TRACE] [ternal.client.MatterWebsocketService] -     at async DclOtaUpdateService.downloadUpdate (webpack://matter-server/./node_modules/@matter/protocol/dist/cjs/dcl/DclOtaUpdateService.js?:398:14)
2026-06-06 18:48:38.231 [TRACE] [ternal.client.MatterWebsocketService] -     at async #checkProductForUpdates (webpack://matter-server/./node_modules/@matter/node/dist/cjs/behavior/system/software-update/SoftwareUpdateManager.js?:360:16)
2026-06-06 18:48:38.231 [DEBUG] [tter.internal.MatterFirmwareProvider] - Getting firmwares for thing matter:node:mattercontroller:my-window-sensor
2026-06-06 18:48:38.236 [TRACE] [ternal.client.MatterWebsocketService] -     (see parent frames)
```

# Solution / Bugfix

Fix the documentation, it needs Node JS 20+

https://github.com/matter-js/matter.js#javascriptnodejs-compatibility
