### PR TITLE
[jsscripting] Upgrade to openhab-js 5.18.2

### DIFF
--- a/bundles/org.openhab.automation.jsscripting/pom.xml
+++ b/bundles/org.openhab.automation.jsscripting/pom.xml
@@ -17,7 +17,7 @@
   <properties>
     <!-- Remember to check if the fix https://github.com/openhab/openhab-core/pull/4437 still works when upgrading GraalJS -->
     <node.version>v22.17.1</node.version>
-    <ohjs.version>openhab@5.18.1</ohjs.version>
+    <ohjs.version>openhab@5.18.2</ohjs.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
This includes a critical regression fix.