### PR TITLE
[Matter] Feature: Add Matter thing action "Refresh all data from Matter device"

### DIFF
--- a/bundles/org.openhab.binding.matter/matter-server/src/client/namespaces/Nodes.ts
+++ b/bundles/org.openhab.binding.matter/matter-server/src/client/namespaces/Nodes.ts
@@ -51,6 +51,22 @@ export class Nodes {
     }
 
     /**
+     * Forces a fresh remote read of all attributes for a node, bypassing the local subscription cache, and pushes
+     * the result so the node's properties (e.g. firmware version) and channels/converters are rebuilt from the
+     * device's current data. Backs the manual "refresh data" thing action. This is a full remote read and can be
+     * slow on Thread / sleepy devices.
+     * @param nodeId
+     */
+    async refreshAllData(nodeId: string | number) {
+        const node = this.controllerNode.getNode(nodeId);
+        if (node.initialized) {
+            return this.controllerNode.sendSerializedNode(node, undefined, true);
+        } else {
+            throw new Error(`Node ${nodeId} not initialized`);
+        }
+    }
+
+    /**
      * Requests all attributes data for all nodes for debugging purposes
      * @returns
      */

--- a/bundles/org.openhab.binding.matter/src/main/java/org/openhab/binding/matter/internal/MatterBindingConstants.java
+++ b/bundles/org.openhab.binding.matter/src/main/java/org/openhab/binding/matter/internal/MatterBindingConstants.java
@@ -439,6 +439,9 @@ public class MatterBindingConstants {
     public static final String THING_ACTION_LABEL_NODE_CANCEL_FIRMWARE_UPDATE = "@text/thing-action.node.cancelFirmwareUpdate.label";
     public static final String THING_ACTION_DESC_NODE_CANCEL_FIRMWARE_UPDATE = "@text/thing-action.node.cancelFirmwareUpdate.description";
     public static final String THING_ACTION_LABEL_NODE_CANCEL_FIRMWARE_UPDATE_RESULT = "@text/thing-action.node.cancelFirmwareUpdate.result.label";
+    public static final String THING_ACTION_LABEL_NODE_REFRESH_DATA = "@text/thing-action.node.refreshData.label";
+    public static final String THING_ACTION_DESC_NODE_REFRESH_DATA = "@text/thing-action.node.refreshData.description";
+    public static final String THING_ACTION_LABEL_NODE_REFRESH_DATA_RESULT = "@text/thing-action.node.refreshData.result.label";
 
     // Action Result Messages
     public static final String THING_ACTION_RESULT_SUCCESS = "@text/thing-action.result.success";
@@ -448,6 +451,7 @@ public class MatterBindingConstants {
     public static final String THING_ACTION_RESULT_FIRMWARE_UPDATE_AVAILABLE = "@text/thing-action.result.firmware-update-available";
     public static final String THING_ACTION_RESULT_FIRMWARE_UPDATE_STARTED = "@text/thing-action.result.firmware-update-started";
     public static final String THING_ACTION_RESULT_FIRMWARE_UPDATE_CANCELLED = "@text/thing-action.result.firmware-update-cancelled";
+    public static final String THING_ACTION_RESULT_REFRESH_REQUESTED = "@text/thing-action.result.refresh-requested";
 
     // Matter OTBR Actions
     public static final String THING_ACTION_LABEL_OTBR_LOAD_EXTERNAL_DATASET = "@text/thing-action.otbr.loadExternalDataset.label";

--- a/bundles/org.openhab.binding.matter/src/main/java/org/openhab/binding/matter/internal/actions/MatterNodeActions.java
+++ b/bundles/org.openhab.binding.matter/src/main/java/org/openhab/binding/matter/internal/actions/MatterNodeActions.java
@@ -253,4 +253,28 @@ public class MatterNodeActions implements ThingActions {
         }
         return translationService.getTranslation(MatterBindingConstants.THING_ACTION_RESULT_NO_HANDLER);
     }
+
+    @RuleAction(label = MatterBindingConstants.THING_ACTION_LABEL_NODE_REFRESH_DATA, description = MatterBindingConstants.THING_ACTION_DESC_NODE_REFRESH_DATA)
+    public @ActionOutputs({
+            @ActionOutput(name = "result", label = MatterBindingConstants.THING_ACTION_LABEL_NODE_REFRESH_DATA_RESULT, type = "java.lang.String") }) String refreshDeviceData() {
+        NodeHandler handler = this.handler;
+        if (handler != null) {
+            MatterControllerClient client = handler.getClient();
+            if (client != null) {
+                try {
+                    client.refreshNodeData(handler.getNodeId()).get(30, TimeUnit.SECONDS);
+                    return translationService
+                            .getTranslation(MatterBindingConstants.THING_ACTION_RESULT_REFRESH_REQUESTED);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    logger.debug("Failed to refresh data for device {}", handler.getNodeId(), e);
+                    return Objects.requireNonNull(Optional.ofNullable(e.getLocalizedMessage()).orElse(e.toString()));
+                } catch (ExecutionException | TimeoutException e) {
+                    logger.debug("Failed to refresh data for device {}", handler.getNodeId(), e);
+                    return Objects.requireNonNull(Optional.ofNullable(e.getLocalizedMessage()).orElse(e.toString()));
+                }
+            }
+        }
+        return translationService.getTranslation(MatterBindingConstants.THING_ACTION_RESULT_NO_HANDLER);
+    }
 }

--- a/bundles/org.openhab.binding.matter/src/main/java/org/openhab/binding/matter/internal/controller/MatterControllerClient.java
+++ b/bundles/org.openhab.binding.matter/src/main/java/org/openhab/binding/matter/internal/controller/MatterControllerClient.java
@@ -102,6 +102,22 @@ public class MatterControllerClient extends MatterWebsocketClient {
     }
 
     /**
+     * Forces a fresh remote read of all data for a node, bypassing the local cache, so its properties and
+     * channels/converters are rebuilt from the device's current data. The returned future completes once the
+     * refresh has been requested; the refreshed data is applied asynchronously when it arrives.
+     *
+     * @param nodeId the node ID to refresh
+     * @return a future that completes when the refresh has been requested
+     * @throws MatterRequestException if the request fails
+     */
+    public CompletableFuture<Void> refreshNodeData(BigInteger nodeId) {
+        CompletableFuture<JsonElement> future = sendMessage("nodes", "refreshAllData", new Object[] { nodeId });
+        return future.thenAccept(obj -> {
+            // Do nothing, just to complete the future
+        });
+    }
+
+    /**
      * Request all cluster attribute data for all nodes for debugging purposes
      * 
      * @return a future that completes when the data is requested

--- a/bundles/org.openhab.binding.matter/src/main/resources/OH-INF/i18n/matter.properties
+++ b/bundles/org.openhab.binding.matter/src/main/resources/OH-INF/i18n/matter.properties
@@ -384,6 +384,9 @@ thing-action.node.startFirmwareUpdate.result.label = Firmware update start resul
 thing-action.node.cancelFirmwareUpdate.label = OTA: Cancel firmware update
 thing-action.node.cancelFirmwareUpdate.description = Cancels the firmware update process for this device if the download is in progress. Updates will not be possible for approximately 10 minutes after cancellation.
 thing-action.node.cancelFirmwareUpdate.result.label = Firmware update cancel result
+thing-action.node.refreshData.label = Refresh all data from Matter device
+thing-action.node.refreshData.description = Re-reads all attributes directly from the device (bypassing the cache) and rebuilds its channels and properties. This is a full remote read and can take a while for battery or Thread devices.
+thing-action.node.refreshData.result.label = Refresh result
 
 # action results
 
@@ -394,6 +397,7 @@ thing-action.result.no-firmware-update = No firmware update available
 thing-action.result.firmware-update-available = Update available: Version {0} (Vendor: {1}, Product: {2}, Version: {3})
 thing-action.result.firmware-update-started = Firmware update started. Check the Thing status for download progress.
 thing-action.result.firmware-update-cancelled = Firmware update cancelled successfully. Updates will not be possible for approximately 10 minutes.
+thing-action.result.refresh-requested = Data refresh requested. Channels and properties will update shortly.
 thing-action.result.no-converter = Error: No converter found
 thing-action.result.invalid-json = Error: Invalid JSON dataset
 thing-action.result.error-generating-key = Error generating master key

--- a/bundles/org.openhab.binding.matter/src/main/resources/OH-INF/i18n/matter.properties
+++ b/bundles/org.openhab.binding.matter/src/main/resources/OH-INF/i18n/matter.properties
@@ -384,9 +384,9 @@ thing-action.node.startFirmwareUpdate.result.label = Firmware update start resul
 thing-action.node.cancelFirmwareUpdate.label = OTA: Cancel firmware update
 thing-action.node.cancelFirmwareUpdate.description = Cancels the firmware update process for this device if the download is in progress. Updates will not be possible for approximately 10 minutes after cancellation.
 thing-action.node.cancelFirmwareUpdate.result.label = Firmware update cancel result
-thing-action.node.refreshData.label = Refresh all data from Matter device
+thing-action.node.refreshData.label = Refresh Device Data
 thing-action.node.refreshData.description = Re-reads all attributes directly from the device (bypassing the cache) and rebuilds its channels and properties. This is a full remote read and can take a while for battery or Thread devices.
-thing-action.node.refreshData.result.label = Refresh result
+thing-action.node.refreshData.result.label = Refresh Result
 
 # action results
 


### PR DESCRIPTION
### Feature

This adds a matter thing action `Refresh all data from Matter device` to forcefully refresh all thing attributes / channels.
When you do an OTA update on a Matter device outside Openhab, Openhab/this binding would use stale device properties or channels, this action helps with this.

Could be useful, but if you don't think this is necessary, I'm also fine with closing the PR again :)

### Tests

#### Manual

```
#Remove all properties from the thing
curl -X PUT http://localhost:8080/rest/things/matter:node:mattercontroller:badezimmer-temperature \
  -H "Authorization: Bearer xyz" \
  -H "Content-Type: application/json" \
  -d '{"properties": {}}'
```

1. Run the refresh action
2. wait
3. All properties should be back
