### PR TITLE
[bluetooth.bluez] Bump bluez-dbus-osgi to 0.3.5

### DIFF
--- a/bundles/org.openhab.binding.bluetooth.bluez/pom.xml
+++ b/bundles/org.openhab.binding.bluetooth.bluez/pom.xml
@@ -26,7 +26,7 @@
     <dependency>
       <groupId>com.github.hypfvieh</groupId>
       <artifactId>bluez-dbus-osgi</artifactId>
-      <version>0.3.4</version>
+      <version>0.3.5</version>
       <scope>provided</scope>
     </dependency>
 

--- a/bundles/org.openhab.binding.bluetooth.bluez/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.bluetooth.bluez/src/main/feature/feature.xml
@@ -4,7 +4,7 @@
 
 	<feature name="openhab-binding-bluetooth-bluez" description="Bluetooth Binding Bluez" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
-		<bundle dependency="true">mvn:com.github.hypfvieh/bluez-dbus-osgi/0.3.4</bundle>
+		<bundle dependency="true">mvn:com.github.hypfvieh/bluez-dbus-osgi/0.3.5</bundle>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.bluetooth/${project.version}</bundle>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.bluetooth.bluez/${project.version}</bundle>
 	</feature>

--- a/features/openhab-addons/src/main/resources/footer.xml
+++ b/features/openhab-addons/src/main/resources/footer.xml
@@ -2,7 +2,7 @@
 	<feature name="openhab-binding-bluetooth" description="Bluetooth Binding" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
 		<feature>openhab-transport-serial</feature>
-		<bundle dependency="true">mvn:com.github.hypfvieh/bluez-dbus-osgi/0.3.4</bundle>
+		<bundle dependency="true">mvn:com.github.hypfvieh/bluez-dbus-osgi/0.3.5</bundle>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.bluetooth/${project.version}</bundle>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.bluetooth.airthings/${project.version}</bundle>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.bluetooth.am43/${project.version}</bundle>


### PR DESCRIPTION
Bumps the BlueZ binding dependency and Karaf features from 0.3.4 to released version 0.3.5.

This picks up the upstream fix from hypfvieh/bluez-dbus#75: `DeviceManager.getDevices()` now returns a snapshot of the device list, so the binding iterates stable data instead of a live, mutable list. Previously, when BlueZ mutated the device list during iteration, a `ConcurrentModificationException` could be thrown, taking the bridge offline and stalling updates until a restart. Real-hardware testing confirmed the bridge stopped flapping and updates resumed after the fix.

Version 0.3.5 is now available from Maven Central.

Updates all three references: the bundle dependency (`pom.xml`), the BlueZ Karaf feature (`feature.xml`), and the aggregated Bluetooth feature (`footer.xml`).