### PR TITLE
[hueemulation] Map semantic equipment tags to archetypes

### DIFF
--- a/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/SemanticHueModelBuilder.java
+++ b/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/SemanticHueModelBuilder.java
@@ -66,6 +66,21 @@ public class SemanticHueModelBuilder {
             Map.entry(Location.LAUNDRY_ROOM, "Laundry room"), //
             Map.entry(Location.PORCH, "Porch")); //
 
+    private static final Map<SemanticTag, String> EQUIPMENT_TO_ARCHETYPE = Map.ofEntries( //
+            Map.entry(Equipment.ACCENT_LIGHT, "huebloom"), //
+            Map.entry(Equipment.CHANDELIER, "ceilinground"), //
+            Map.entry(Equipment.DOWNLIGHT, "recessedceiling"), //
+            Map.entry(Equipment.FLOOD_LIGHT, "floodbulb"), //
+            Map.entry(Equipment.LAMP, "tableshade"), //
+            Map.entry(Equipment.LIGHT_STRIP, "huelightstrip"), //
+            Map.entry(Equipment.LIGHT_STRIPE, "huelightstrip"), //
+            Map.entry(Equipment.LIGHTBULB, "classicbulb"), //
+            Map.entry(Equipment.PENDANT, "pendantround"), //
+            Map.entry(Equipment.SCONCE, "wallshade"), //
+            Map.entry(Equipment.SPOT_LIGHT, "singlespot"), //
+            Map.entry(Equipment.TRACK_LIGHT, "singlespot"), //
+            Map.entry(Equipment.WALL_LIGHT, "wallshade")); //
+
     private final ItemRegistry itemRegistry;
     private final ConfigStore configStore;
 
@@ -154,8 +169,10 @@ public class SemanticHueModelBuilder {
             String hueID = configStore.mapItemUIDtoHueID(member);
             String name = lightSource.getLabel();
 
-            lightEntries.add(new HueLightEntry(genericItem, configStore.getHueUniqueId(hueID), targetType,
-                    name != null ? name : ""));
+            var entry = new HueLightEntry(genericItem, configStore.getHueUniqueId(hueID), targetType,
+                    name != null ? name : "");
+            entry.config = new HueLightEntry.Config(getArchetype(lightSource));
+            lightEntries.add(entry);
         }
 
         return lightEntries;
@@ -169,6 +186,16 @@ public class SemanticHueModelBuilder {
             }
         }
         return HueGroupEntry.DEFAULT_ROOM_CLASS;
+    }
+
+    private String getArchetype(GroupItem lightSource) {
+        for (Map.Entry<SemanticTag, String> entry : EQUIPMENT_TO_ARCHETYPE.entrySet()) {
+            Class<? extends Tag> tagClass = SemanticTags.getById(entry.getKey().getUID());
+            if (tagClass != null && SemanticsPredicates.isA(tagClass).test(lightSource)) {
+                return entry.getValue();
+            }
+        }
+        return HueLightEntry.DEFAULT_ARCHETYPE;
     }
 
     private static boolean isSemanticItem(Item item, SemanticTag tag) {

--- a/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/dto/HueLightEntry.java
+++ b/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/dto/HueLightEntry.java
@@ -36,6 +36,9 @@ import com.google.gson.JsonSerializer;
  */
 @NonNullByDefault
 public class HueLightEntry {
+
+    public static final String DEFAULT_ARCHETYPE = "unknownarchetype";
+
     public AbstractHueState state = new AbstractHueState();
     public final String type;
     public final String modelid;
@@ -46,7 +49,6 @@ public class HueLightEntry {
     public final @Nullable String luminaireuniqueid = null;
     public final @Nullable String swconfigid;
     public final @Nullable String productid;
-    public @Nullable Boolean friendsOfHue = true;
     public final @Nullable String colorGamut;
     public @Nullable Boolean hascolor = null;
 
@@ -58,12 +60,16 @@ public class HueLightEntry {
     public transient @Nullable HueStateChange lastHueChange = null;
 
     public static class Config {
-        public final String archetype = "classicbulb";
+        public final String archetype;
         public final String function = "functional";
         public final String direction = "omnidirectional";
+
+        public Config(String archetype) {
+            this.archetype = archetype;
+        }
     }
 
-    public Config config = new Config();
+    public Config config = new Config("classicbulb");
 
     public static class Streaming {
         public boolean renderer = false;
@@ -146,20 +152,16 @@ public class HueLightEntry {
                 break;
             case SwitchType:
             default:
-                /**
-                 * Pretend to be an OSRAM plug, there is no native Philips Hue plug on the market.
-                 * Those are supported by most of the external apps and Alexa.
-                 */
-                this.type = "On/off light";
-                this.modelid = "Plug 01";
+                this.type = "On/Off plug-in unit";
+                this.modelid = "LOM001";
                 this.colorGamut = null;
-                this.manufacturername = "OSRAM";
-                this.productname = "On/Off plug";
-                this.swconfigid = null;
-                this.swversion = "V1.04.12";
-                this.productid = null;
+                this.manufacturername = "Signify Netherlands B.V.";
+                this.swconfigid = "0CF38B30";
+                this.swversion = "1.145.2";
+                this.productid = "SmartPlug_OnOff_v01-00_01";
                 this.hascolor = false;
-                this.friendsOfHue = null;
+                this.productname = "Hue smart plug";
+                this.capabilities.certified = true;
                 break;
         }
 


### PR DESCRIPTION
This slightly improves #19922 by also mapping light source specializations into Hue archetypes.

Additionally, `SwitchType` is now emulated as a Hue smart plug, which hit the market after the binding was made.