### PR TITLE
[tuya] Percent channels can be dimmers

### DIFF
--- a/bundles/org.openhab.binding.tuya/src/main/java/org/openhab/binding/tuya/internal/TuyaChannelTypeProvider.java
+++ b/bundles/org.openhab.binding.tuya/src/main/java/org/openhab/binding/tuya/internal/TuyaChannelTypeProvider.java
@@ -373,7 +373,8 @@ public class TuyaChannelTypeProvider implements ChannelTypeProvider {
 
         if (!schemaDp.unit.isEmpty() && acceptedItemType.startsWith(NUMBER + ":")) {
             channelTypeBuilder.withUnitHint(schemaDp.unit);
-        } else if (!schemaDp.unit.isEmpty() && !acceptedItemType.contains(":")) {
+        } else if (!schemaDp.unit.isEmpty() && !acceptedItemType.contains(":")
+                && (!"%".equals(schemaDp.unit) || !DIMMER.equals(acceptedItemType))) {
             logger.error("Channel {} creation aborted, unit  \"{}\" has no known dimension, please report as bug.",
                     channelTypeId, schemaDp.unit);
             return null;


### PR DESCRIPTION
Channels that have a unit of "%" could have an accepted Item type of dimmer rather than a dimensioned number.