### PR TITLE
[paradoxalarm] Fix channel-type UID collision across thing types

### DIFF
--- a/bundles/org.openhab.binding.paradoxalarm/src/main/resources/OH-INF/thing/ip150connector.xml
+++ b/bundles/org.openhab.binding.paradoxalarm/src/main/resources/OH-INF/thing/ip150connector.xml
@@ -10,9 +10,13 @@
 		<semantic-equipment-tag>NetworkAppliance</semantic-equipment-tag>
 
 		<channels>
-			<channel id="communicationCommand" typeId="command"/>
+			<channel id="communicationCommand" typeId="bridgeCommand"/>
 			<channel id="communicationState" typeId="communicationState"/>
 		</channels>
+
+		<properties>
+			<property name="thingTypeVersion">1</property>
+		</properties>
 
 		<config-description>
 			<parameter name="refresh" type="integer" min="1" max="600">
@@ -68,7 +72,7 @@
 		</config-description>
 	</bridge-type>
 
-	<channel-type id="command">
+	<channel-type id="bridgeCommand">
 		<item-type>String</item-type>
 		<label>Communicator Command</label>
 		<description>Send Command</description>

--- a/bundles/org.openhab.binding.paradoxalarm/src/main/resources/OH-INF/thing/partition.xml
+++ b/bundles/org.openhab.binding.paradoxalarm/src/main/resources/OH-INF/thing/partition.xml
@@ -33,11 +33,11 @@
 			<channel id="bypassReady" typeId="bypassReady"/>
 			<channel id="inhibitReady" typeId="inhibitReady"/>
 			<channel id="allZonesClosed" typeId="allZonesClosed"/>
-			<channel id="command" typeId="command"/>
+			<channel id="command" typeId="partitionCommand"/>
 		</channels>
 
 		<properties>
-			<property name="thingTypeVersion">1</property>
+			<property name="thingTypeVersion">2</property>
 		</properties>
 
 		<config-description>
@@ -192,7 +192,7 @@
 		</tags>
 		<state readOnly="true" pattern="%s"/>
 	</channel-type>
-	<channel-type id="command">
+	<channel-type id="partitionCommand">
 		<item-type>String</item-type>
 		<label>Partition Command</label>
 		<description>Send command</description>

--- a/bundles/org.openhab.binding.paradoxalarm/src/main/resources/OH-INF/thing/zone.xml
+++ b/bundles/org.openhab.binding.paradoxalarm/src/main/resources/OH-INF/thing/zone.xml
@@ -17,7 +17,7 @@
 			<channel id="opened" typeId="openedState"/>
 			<channel id="tampered" typeId="tamperedState"/>
 			<channel id="lowBattery" typeId="system.low-battery"/>
-			<channel id="command" typeId="command"/>
+			<channel id="command" typeId="zoneCommand"/>
 
 			<channel id="supervisionTrouble" typeId="supervisionTrouble"/>
 			<channel id="inTxDelay" typeId="inTxDelay"/>
@@ -28,6 +28,10 @@
 			<channel id="presentlyInAlarm" typeId="presentlyInAlarm"/>
 			<channel id="generatedAlarm" typeId="generatedAlarm"/>
 		</channels>
+
+		<properties>
+			<property name="thingTypeVersion">1</property>
+		</properties>
 
 		<config-description>
 			<parameter name="id" type="integer" min="1" max="192" required="true">
@@ -63,7 +67,7 @@
 		</tags>
 		<state readOnly="true" pattern="%s"/>
 	</channel-type>
-	<channel-type id="command">
+	<channel-type id="zoneCommand">
 		<item-type>String</item-type>
 		<label>Zone Command</label>
 		<description>Send command for a zone</description>

--- a/bundles/org.openhab.binding.paradoxalarm/src/main/resources/OH-INF/update/ip150_bridge_update.xml
+++ b/bundles/org.openhab.binding.paradoxalarm/src/main/resources/OH-INF/update/ip150_bridge_update.xml
@@ -3,16 +3,10 @@
 	xmlns:update="https://openhab.org/schemas/update-description/v1.0.0"
 	xsi:schemaLocation="https://openhab.org/schemas/update-description/v1.0.0 https://openhab.org/schemas/update-description-1.0.0.xsd">
 
-	<thing-type uid="paradoxalarm:partition">
+	<thing-type uid="paradoxalarm:ip150">
 		<instruction-set targetVersion="1">
-			<add-channel id="detailedState">
-				<type>paradoxalarm:detailedState</type>
-			</add-channel>
-		</instruction-set>
-
-		<instruction-set targetVersion="2">
-			<update-channel id="command">
-				<type>paradoxalarm:partitionCommand</type>
+			<update-channel id="communicationCommand">
+				<type>paradoxalarm:bridgeCommand</type>
 			</update-channel>
 		</instruction-set>
 	</thing-type>

--- a/bundles/org.openhab.binding.paradoxalarm/src/main/resources/OH-INF/update/zone_type_update.xml
+++ b/bundles/org.openhab.binding.paradoxalarm/src/main/resources/OH-INF/update/zone_type_update.xml
@@ -3,16 +3,10 @@
 	xmlns:update="https://openhab.org/schemas/update-description/v1.0.0"
 	xsi:schemaLocation="https://openhab.org/schemas/update-description/v1.0.0 https://openhab.org/schemas/update-description-1.0.0.xsd">
 
-	<thing-type uid="paradoxalarm:partition">
+	<thing-type uid="paradoxalarm:zone">
 		<instruction-set targetVersion="1">
-			<add-channel id="detailedState">
-				<type>paradoxalarm:detailedState</type>
-			</add-channel>
-		</instruction-set>
-
-		<instruction-set targetVersion="2">
 			<update-channel id="command">
-				<type>paradoxalarm:partitionCommand</type>
+				<type>paradoxalarm:zoneCommand</type>
 			</update-channel>
 		</instruction-set>
 	</thing-type>


### PR DESCRIPTION
## Summary

All three thing XML files in the paradoxalarm binding registered a `<channel-type id="command">` under the same binding scope, producing the identical UID `paradoxalarm:command`. The last file parsed at runtime won, causing the Main UI to show whichever options that file defined for *all* thing types — bridge, zone, and partition.

Changes:
- `ip150connector.xml`: `command` → `bridgeCommand` (adds LOGIN / LOGOUT / RESET / SYNC_TIME options), `thingTypeVersion=1`, fixes `<properties>` element ordering (XSD requires it before `<config-description>`)
- `zone.xml`: `command` → `zoneCommand`, `thingTypeVersion=1`
- `partition.xml`: `command` → `partitionCommand`, `thingTypeVersion` bumped 1 → 2
- `OH-INF/update/ip150_bridge_update.xml`: new — migrates stored `channelTypeUID` for bridge things in jsondb
- `OH-INF/update/zone_type_update.xml`: new — migrates stored `channelTypeUID` for zone things in jsondb
- `OH-INF/update/partition_type_update.xml`: adds `instruction-set targetVersion="2"` for partition things in jsondb

File-based `.things` / `.items` configurations are unaffected (channel *instance* IDs are unchanged; only the channel-type UID reference changes, which openHAB resolves via the update descriptors).

## Test plan

- [x] Deploy binding JAR on a live openHAB instance with existing paradoxalarm jsondb things
- [x] Verify bundle starts `Active` with no XML parse errors in the log
- [x] Verify Main UI shows correct command options per thing type (bridge: LOGIN/LOGOUT/RESET/SYNC_TIME; zone: ARM/DISARM etc.; partition: ARM/DISARM etc.)
- [x] Verify no channel-type UID errors in the log after restart