### PR TITLE
[yamlcomposer] Remove snakeyaml-engine from feature dependency

### DIFF
--- a/.github/scripts/maven-build
+++ b/.github/scripts/maven-build
@@ -115,12 +115,15 @@ function addon_projects() {
     # include BOMs
     projects="$projects,:org.openhab.addons.bom.openhab-core-index,:org.openhab.addons.bom.runtime-index,:org.openhab.addons.bom.test-index"
 
+    # exclude features
+    projects="$projects,-:org.openhab.addons.reactor.features.karaf,-:org.openhab.addons.features.karaf.openhab-addons,-:org.openhab.addons.features.karaf.openhab-addons-external"
+
     echo $projects
 }
 
 function build_addon() {
     local addon="$1"
-    local command="./mvnw $ARGUMENTS -am -pl $(addon_projects $addon)"
+    local command="./mvnw $ARGUMENTS -am -amd -pl $(addon_projects $addon)"
 
     echo
     echo "Building add-on: $addon"

--- a/.github/scripts/maven-build
+++ b/.github/scripts/maven-build
@@ -115,15 +115,12 @@ function addon_projects() {
     # include BOMs
     projects="$projects,:org.openhab.addons.bom.openhab-core-index,:org.openhab.addons.bom.runtime-index,:org.openhab.addons.bom.test-index"
 
-    # exclude features
-    projects="$projects,-:org.openhab.addons.reactor.features.karaf,-:org.openhab.addons.features.karaf.openhab-addons,-:org.openhab.addons.features.karaf.openhab-addons-external"
-
     echo $projects
 }
 
 function build_addon() {
     local addon="$1"
-    local command="./mvnw $ARGUMENTS -am -amd -pl $(addon_projects $addon)"
+    local command="./mvnw $ARGUMENTS -am -pl $(addon_projects $addon)"
 
     echo
     echo "Building add-on: $addon"

--- a/bundles/org.openhab.io.yamlcomposer/src/main/feature/feature.xml
+++ b/bundles/org.openhab.io.yamlcomposer/src/main/feature/feature.xml
@@ -5,7 +5,6 @@
 	<feature name="openhab-misc-yamlcomposer" description="YAML Composer" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
 		<feature dependency="true">openhab.tp-commons-net</feature>
-		<bundle dependency="true">mvn:org.snakeyaml/snakeyaml-engine/3.0.1</bundle>
 		<bundle dependency="true">mvn:org.openhab.osgiify/com.hubspot.jinjava.jinjava/2.7.4</bundle>
 		<bundle dependency="true">mvn:org.openhab.osgiify/com.google.re2j.re2j/1.2</bundle>
 		<bundle dependency="true">mvn:ch.obermuhlner/big-math/2.3.2</bundle>


### PR DESCRIPTION
The feature dependency failed since we do not allow actual maven central as source. It isn't needed, since the bundle build already embeds runtime dependencies into the yamlcomposer JAR.

Need to test this again after this is merged.

Note: There seems to be a bug in the maven-build script that caused the CI to fail when it's trying to figure out how to do a partial build. I don't think a full build or even a proper partial build would fail.