### PR TITLE
[meross] Fix mqtt cloud connection fallback

### DIFF
--- a/bundles/org.openhab.binding.meross/src/main/java/org/openhab/binding/meross/internal/api/MerossManager.java
+++ b/bundles/org.openhab.binding.meross/src/main/java/org/openhab/binding/meross/internal/api/MerossManager.java
@@ -71,6 +71,7 @@ public class MerossManager implements MqttMessageSubscriber {
     private @Nullable MerossHttpConnector httpConnector;
     private String deviceUUID;
     private MerossDeviceHandlerCallback callback;
+    private MqttMessageBuilder mqttMessageBuilder;
 
     private String deviceRequestTopic;
 
@@ -86,8 +87,9 @@ public class MerossManager implements MqttMessageSubscriber {
 
     public MerossManager(HttpClient httpClient, MerossMqttConnector mqttConnector, String deviceUUID,
             MerossDeviceHandlerCallback callback) {
+        this.mqttMessageBuilder = mqttConnector.getMqttMessageBuilder();
         this.deviceUUID = deviceUUID;
-        this.deviceRequestTopic = MqttMessageBuilder.buildDeviceRequestTopic(deviceUUID);
+        this.deviceRequestTopic = mqttMessageBuilder.buildDeviceRequestTopic(deviceUUID);
         this.callback = callback;
         this.httpClient = httpClient;
         this.mqttConnector = mqttConnector;
@@ -187,7 +189,7 @@ public class MerossManager implements MqttMessageSubscriber {
     }
 
     private CompletableFuture<Boolean> getSystemAll() throws MqttException, InterruptedException {
-        byte[] message = MqttMessageBuilder.buildMqttMessage("GET", MerossEnum.Namespace.SYSTEM_ALL.value(), deviceUUID,
+        byte[] message = mqttMessageBuilder.buildMqttMessage("GET", MerossEnum.Namespace.SYSTEM_ALL.value(), deviceUUID,
                 Collections.emptyMap());
         CompletableFuture<Boolean> ipInitialized = new CompletableFuture<Boolean>();
         publishMessage(deviceRequestTopic, message);
@@ -201,7 +203,7 @@ public class MerossManager implements MqttMessageSubscriber {
     }
 
     private void getAbilities() throws MqttException, InterruptedException {
-        byte[] message = MqttMessageBuilder.buildMqttMessage("GET", MerossEnum.Namespace.SYSTEM_ABILITY.value(),
+        byte[] message = mqttMessageBuilder.buildMqttMessage("GET", MerossEnum.Namespace.SYSTEM_ABILITY.value(),
                 deviceUUID, Collections.emptyMap());
         publishMessage(deviceRequestTopic, message);
     }
@@ -225,7 +227,7 @@ public class MerossManager implements MqttMessageSubscriber {
         }
 
         MerossCommand command = modeFactory.commandMode(commandMode, deviceChannel);
-        byte[] commandMessage = command.command(deviceUUID);
+        byte[] commandMessage = command.command(mqttMessageBuilder, deviceUUID);
 
         publishMessage(deviceRequestTopic, commandMessage);
     }
@@ -246,12 +248,12 @@ public class MerossManager implements MqttMessageSubscriber {
     }
 
     private void getState(String ability) throws MqttException, InterruptedException {
-        byte[] message = MqttMessageBuilder.buildMqttMessage("GET", ability, deviceUUID, Collections.emptyMap());
+        byte[] message = mqttMessageBuilder.buildMqttMessage("GET", ability, deviceUUID, Collections.emptyMap());
         publishMessage(deviceRequestTopic, message);
     }
 
     private void getStateLocal(String ability) throws IOException {
-        byte[] message = MqttMessageBuilder.buildMqttMessage("GET", ability, deviceUUID, Collections.emptyMap());
+        byte[] message = mqttMessageBuilder.buildMqttMessage("GET", ability, deviceUUID, Collections.emptyMap());
         publishMessageLocal(deviceRequestTopic, message);
     }
 

--- a/bundles/org.openhab.binding.meross/src/main/java/org/openhab/binding/meross/internal/api/MerossMqttConnector.java
+++ b/bundles/org.openhab.binding.meross/src/main/java/org/openhab/binding/meross/internal/api/MerossMqttConnector.java
@@ -21,6 +21,7 @@ import java.util.concurrent.TimeoutException;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.meross.internal.dto.CloudCredentials;
 import org.openhab.binding.meross.internal.dto.MqttMessageBuilder;
 import org.openhab.binding.meross.internal.handler.MerossBridgeHandler;
 import org.openhab.core.io.transport.mqtt.MqttBrokerConnection;
@@ -57,24 +58,31 @@ public class MerossMqttConnector implements MqttConnectionObserver {
     private MerossBridgeHandler callback;
     private ScheduledExecutorService scheduler;
 
+    private MqttMessageBuilder mqttMessageBuilder = new MqttMessageBuilder();
     private @Nullable MqttBrokerConnection mqttConnection;
     private @Nullable CompletableFuture<Boolean> stoppedFuture;
     private @Nullable ScheduledFuture<?> disconnectFuture;
     private CompletableFuture<Boolean> connected = new CompletableFuture<>();
 
-    public MerossMqttConnector(MerossBridgeHandler callback, ScheduledExecutorService scheduler) {
+    public MerossMqttConnector(MerossBridgeHandler callback, CloudCredentials credentials,
+            ScheduledExecutorService scheduler) {
         this.callback = callback;
         this.scheduler = scheduler;
 
-        String brokerAddress = MqttMessageBuilder.brokerAddress;
-        String userId = MqttMessageBuilder.userId;
+        String userId = credentials.userId();
+        mqttMessageBuilder.setUserId(userId);
+        String key = credentials.key();
+        mqttMessageBuilder.setKey(key);
+        String brokerAddress = credentials.mqttDomain();
+        mqttMessageBuilder.setBrokerAddress(brokerAddress);
+
         if (brokerAddress == null || userId == null) {
             logger.debug("MQTT broker not configured");
             return;
         }
-        String clearPassword = "%s%s".formatted(MqttMessageBuilder.userId, MqttMessageBuilder.key);
+        String clearPassword = "%s%s".formatted(mqttMessageBuilder.userId, mqttMessageBuilder.key);
         String hashedPassword = MD5Util.getMD5String(clearPassword);
-        String clientId = MqttMessageBuilder.getClientId();
+        String clientId = mqttMessageBuilder.getClientId();
 
         MqttBrokerConnection connection = mqttConnection = new MqttBrokerConnection(Protocol.TCP, MqttVersion.V3,
                 brokerAddress, SECURE_TCP_PORT, true, clientId);
@@ -84,6 +92,15 @@ public class MerossMqttConnector implements MqttConnectionObserver {
         connection.setKeepAliveInterval(KEEP_ALIVE_SECONDS);
         connection.setCleanSessionStart(false);
         connection.addConnectionObserver(this);
+    }
+
+    /**
+     * Get the mqtt message builder for this connection.
+     *
+     * @return the mqtt message builder
+     */
+    public MqttMessageBuilder getMqttMessageBuilder() {
+        return mqttMessageBuilder;
     }
 
     /**
@@ -116,7 +133,7 @@ public class MerossMqttConnector implements MqttConnectionObserver {
         }
 
         logger.debug("Starting connection...");
-        logger.trace("Connecting with clientId: {}", MqttMessageBuilder.getClientId());
+        logger.trace("Connecting with clientId: {}", mqttMessageBuilder.getClientId());
         try {
             connected = mqttConnection.start();
             if (!connected.get(RECEPTION_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
@@ -193,15 +210,15 @@ public class MerossMqttConnector implements MqttConnectionObserver {
     }
 
     public void addClientUserTopicSubscriber(MqttMessageSubscriber subscriber) {
-        addTopicSubscriber(MqttMessageBuilder.buildClientUserTopic(), subscriber);
+        addTopicSubscriber(mqttMessageBuilder.buildClientUserTopic(), subscriber);
     }
 
     public void addClientResponseTopicSubscriber(MqttMessageSubscriber subscriber) {
-        addTopicSubscriber(MqttMessageBuilder.buildClientResponseTopic(), subscriber);
+        addTopicSubscriber(mqttMessageBuilder.buildClientResponseTopic(), subscriber);
     }
 
     public void addDeviceRequestTopicSubscriber(MqttMessageSubscriber subscriber, String deviceUUID) {
-        addTopicSubscriber(MqttMessageBuilder.buildDeviceRequestTopic(deviceUUID), subscriber);
+        addTopicSubscriber(mqttMessageBuilder.buildDeviceRequestTopic(deviceUUID), subscriber);
     }
 
     private void addTopicSubscriber(String topic, MqttMessageSubscriber subscriber) {
@@ -215,15 +232,15 @@ public class MerossMqttConnector implements MqttConnectionObserver {
     }
 
     public void removeClientUserTopicSubscriber(MqttMessageSubscriber subscriber) {
-        removeTopicSubscriber(MqttMessageBuilder.buildClientUserTopic(), subscriber);
+        removeTopicSubscriber(mqttMessageBuilder.buildClientUserTopic(), subscriber);
     }
 
     public void removeClientResponseTopicSubscriber(MqttMessageSubscriber subscriber) {
-        removeTopicSubscriber(MqttMessageBuilder.buildClientResponseTopic(), subscriber);
+        removeTopicSubscriber(mqttMessageBuilder.buildClientResponseTopic(), subscriber);
     }
 
     public void removeDeviceRequestTopicSubscriber(MqttMessageSubscriber subscriber, String deviceUUID) {
-        removeTopicSubscriber(MqttMessageBuilder.buildDeviceRequestTopic(deviceUUID), subscriber);
+        removeTopicSubscriber(mqttMessageBuilder.buildDeviceRequestTopic(deviceUUID), subscriber);
     }
 
     private void removeTopicSubscriber(String topic, MqttMessageSubscriber subscriber) {

--- a/bundles/org.openhab.binding.meross/src/main/java/org/openhab/binding/meross/internal/api/MerossMqttConnector.java
+++ b/bundles/org.openhab.binding.meross/src/main/java/org/openhab/binding/meross/internal/api/MerossMqttConnector.java
@@ -149,6 +149,7 @@ public class MerossMqttConnector implements MqttConnectionObserver {
         }
 
         logger.debug("Stopping connection...");
+        connected.complete(false);
         ScheduledFuture<?> disconnectFuture = this.disconnectFuture;
         if (disconnectFuture != null) {
             disconnectFuture.cancel(true);
@@ -250,6 +251,7 @@ public class MerossMqttConnector implements MqttConnectionObserver {
                 callback.updateBridgeStatus(ThingStatus.ONLINE, ThingStatusDetail.NONE);
                 break;
             case MqttConnectionState.DISCONNECTED:
+                connected = new CompletableFuture<>();
                 // The transport tries to reconnect anyway. If we put the bridge offline immediately, it will trigger a
                 // re-initialization of all devices creating a lot of traffic. Devices can still be commanded through
                 // local http connections even if the connection to the Meross MQTT broker is disrupted. So don't put

--- a/bundles/org.openhab.binding.meross/src/main/java/org/openhab/binding/meross/internal/api/MerossMqttConnector.java
+++ b/bundles/org.openhab.binding.meross/src/main/java/org/openhab/binding/meross/internal/api/MerossMqttConnector.java
@@ -76,7 +76,7 @@ public class MerossMqttConnector implements MqttConnectionObserver {
         String brokerAddress = credentials.mqttDomain();
         mqttMessageBuilder.setBrokerAddress(brokerAddress);
 
-        if (brokerAddress == null || userId == null) {
+        if (brokerAddress == null || key == null || userId == null) {
             logger.debug("MQTT broker not configured");
             return;
         }

--- a/bundles/org.openhab.binding.meross/src/main/java/org/openhab/binding/meross/internal/api/MerossMqttConnector.java
+++ b/bundles/org.openhab.binding.meross/src/main/java/org/openhab/binding/meross/internal/api/MerossMqttConnector.java
@@ -70,17 +70,17 @@ public class MerossMqttConnector implements MqttConnectionObserver {
         this.scheduler = scheduler;
 
         String userId = credentials.userId();
-        mqttMessageBuilder.setUserId(userId);
         String key = credentials.key();
-        mqttMessageBuilder.setKey(key);
         String brokerAddress = credentials.mqttDomain();
-        mqttMessageBuilder.setBrokerAddress(brokerAddress);
 
         if (brokerAddress == null || key == null || userId == null) {
             logger.debug("MQTT broker not configured");
             return;
         }
-        String clearPassword = "%s%s".formatted(mqttMessageBuilder.userId, mqttMessageBuilder.key);
+        mqttMessageBuilder.setUserId(userId);
+        mqttMessageBuilder.setKey(key);
+
+        String clearPassword = "%s%s".formatted(userId, key);
         String hashedPassword = MD5Util.getMD5String(clearPassword);
         String clientId = mqttMessageBuilder.getClientId();
 

--- a/bundles/org.openhab.binding.meross/src/main/java/org/openhab/binding/meross/internal/api/MerossMqttConnector.java
+++ b/bundles/org.openhab.binding.meross/src/main/java/org/openhab/binding/meross/internal/api/MerossMqttConnector.java
@@ -249,6 +249,7 @@ public class MerossMqttConnector implements MqttConnectionObserver {
                     this.disconnectFuture = null;
                 }
                 callback.updateBridgeStatus(ThingStatus.ONLINE, ThingStatusDetail.NONE);
+                connected.complete(true);
                 break;
             case MqttConnectionState.DISCONNECTED:
                 connected = new CompletableFuture<>();

--- a/bundles/org.openhab.binding.meross/src/main/java/org/openhab/binding/meross/internal/api/MerossMqttConnector.java
+++ b/bundles/org.openhab.binding.meross/src/main/java/org/openhab/binding/meross/internal/api/MerossMqttConnector.java
@@ -257,9 +257,9 @@ public class MerossMqttConnector implements MqttConnectionObserver {
     public void connectionStateChanged(MqttConnectionState state, @Nullable Throwable error) {
         logger.trace("Connection state changed: {}", state);
         switch (state) {
-            case MqttConnectionState.CONNECTING:
+            case CONNECTING:
                 break;
-            case MqttConnectionState.CONNECTED:
+            case CONNECTED:
                 ScheduledFuture<?> disconnectFuture = this.disconnectFuture;
                 if (disconnectFuture != null) {
                     disconnectFuture.cancel(true);
@@ -268,7 +268,7 @@ public class MerossMqttConnector implements MqttConnectionObserver {
                 callback.updateBridgeStatus(ThingStatus.ONLINE, ThingStatusDetail.NONE);
                 connected.complete(true);
                 break;
-            case MqttConnectionState.DISCONNECTED:
+            case DISCONNECTED:
                 connected = new CompletableFuture<>();
                 // The transport tries to reconnect anyway. If we put the bridge offline immediately, it will trigger a
                 // re-initialization of all devices creating a lot of traffic. Devices can still be commanded through

--- a/bundles/org.openhab.binding.meross/src/main/java/org/openhab/binding/meross/internal/api/MerossMqttConnector.java
+++ b/bundles/org.openhab.binding.meross/src/main/java/org/openhab/binding/meross/internal/api/MerossMqttConnector.java
@@ -44,8 +44,9 @@ import org.slf4j.LoggerFactory;
 @NonNullByDefault
 public class MerossMqttConnector implements MqttConnectionObserver {
 
-    private static final int SECURE_WEB_SOCKET_PORT = 443;
+    private static final int SECURE_TCP_PORT = 443;
     private static final int RECEPTION_TIMEOUT_SECONDS = 5;
+    private static final int CONNECTION_TIMEOUT_SECONDS = 5;
     private static final int MQTT_DISCONNECT_DELAY_SECONDS = 60;
     private static final int KEEP_ALIVE_SECONDS = 30;
     private static final int QOS_AT_MOST_ONCE = 0;
@@ -66,20 +67,22 @@ public class MerossMqttConnector implements MqttConnectionObserver {
         this.scheduler = scheduler;
 
         String brokerAddress = MqttMessageBuilder.brokerAddress;
-        String clientId = MqttMessageBuilder.clientId;
         String userId = MqttMessageBuilder.userId;
-        if (brokerAddress == null || clientId == null || userId == null) {
+        if (brokerAddress == null || userId == null) {
             logger.debug("MQTT broker not configured");
             return;
         }
         String clearPassword = "%s%s".formatted(MqttMessageBuilder.userId, MqttMessageBuilder.key);
         String hashedPassword = MD5Util.getMD5String(clearPassword);
+        String clientId = MqttMessageBuilder.getClientId();
 
-        MqttBrokerConnection connection = mqttConnection = new MqttBrokerConnection(Protocol.TCP, MqttVersion.V5,
-                brokerAddress, SECURE_WEB_SOCKET_PORT, true, clientId);
+        MqttBrokerConnection connection = mqttConnection = new MqttBrokerConnection(Protocol.TCP, MqttVersion.V3,
+                brokerAddress, SECURE_TCP_PORT, true, clientId);
+        connection.setTimeoutExecutor(scheduler, CONNECTION_TIMEOUT_SECONDS * 1000);
         connection.setCredentials(userId, hashedPassword);
         connection.setQos(QOS_AT_LEAST_ONCE);
         connection.setKeepAliveInterval(KEEP_ALIVE_SECONDS);
+        connection.setCleanSessionStart(false);
         connection.addConnectionObserver(this);
     }
 
@@ -113,13 +116,13 @@ public class MerossMqttConnector implements MqttConnectionObserver {
         }
 
         logger.debug("Starting connection...");
+        logger.trace("Connecting with clientId: {}", MqttMessageBuilder.getClientId());
         try {
-            connected = new CompletableFuture<>();
-            if (!mqttConnection.start().get(RECEPTION_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+            connected = mqttConnection.start();
+            if (!connected.get(RECEPTION_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
                 logger.debug("error connecting");
                 throw new MqttException("Connection execution exception");
             }
-            connected.get(RECEPTION_TIMEOUT_SECONDS, TimeUnit.SECONDS);
         } catch (InterruptedException e) {
             logger.debug("connection interrupted exception");
             if (Thread.interrupted()) {
@@ -146,7 +149,6 @@ public class MerossMqttConnector implements MqttConnectionObserver {
         }
 
         logger.debug("Stopping connection...");
-        connected.complete(false);
         ScheduledFuture<?> disconnectFuture = this.disconnectFuture;
         if (disconnectFuture != null) {
             disconnectFuture.cancel(true);
@@ -246,17 +248,15 @@ public class MerossMqttConnector implements MqttConnectionObserver {
                     this.disconnectFuture = null;
                 }
                 callback.updateBridgeStatus(ThingStatus.ONLINE, ThingStatusDetail.NONE);
-                connected.complete(true);
                 break;
             case MqttConnectionState.DISCONNECTED:
-                connected = new CompletableFuture<Boolean>();
                 // The transport tries to reconnect anyway. If we put the bridge offline immediately, it will trigger a
                 // re-initialization of all devices creating a lot of traffic. Devices can still be commanded through
                 // local http connections even if the connection to the Meross MQTT broker is disrupted. So don't put
                 // the bridge offline immediately.
+                logger.debug("Disconnected", error);
                 if (this.disconnectFuture == null) {
                     this.disconnectFuture = scheduler.schedule(() -> {
-                        logger.trace("Disconnecting", error);
                         callback.updateBridgeStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR);
                     }, MQTT_DISCONNECT_DELAY_SECONDS, TimeUnit.SECONDS);
                 }

--- a/bundles/org.openhab.binding.meross/src/main/java/org/openhab/binding/meross/internal/command/DoorStateCommand.java
+++ b/bundles/org.openhab.binding.meross/src/main/java/org/openhab/binding/meross/internal/command/DoorStateCommand.java
@@ -37,9 +37,9 @@ public class DoorStateCommand {
         }
 
         @Override
-        public byte[] command(String deviceUUID) {
+        public byte[] command(MqttMessageBuilder mqttMessageBuilder, String deviceUUID) {
             Map<String, Object> payload = Map.of("state", Map.of("open", openValue, "channel", deviceChannel));
-            return MqttMessageBuilder.buildMqttMessage("SET", MerossEnum.Namespace.GARAGE_DOOR_STATE.value(),
+            return mqttMessageBuilder.buildMqttMessage("SET", MerossEnum.Namespace.GARAGE_DOOR_STATE.value(),
                     deviceUUID, payload);
         }
     }

--- a/bundles/org.openhab.binding.meross/src/main/java/org/openhab/binding/meross/internal/command/MerossCommand.java
+++ b/bundles/org.openhab.binding.meross/src/main/java/org/openhab/binding/meross/internal/command/MerossCommand.java
@@ -13,6 +13,7 @@
 package org.openhab.binding.meross.internal.command;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.binding.meross.internal.dto.MqttMessageBuilder;
 
 /**
  * The {@link MerossCommand} interface is responsible for implementing command type
@@ -22,5 +23,5 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
  */
 @NonNullByDefault
 public interface MerossCommand {
-    byte[] command(String deviceUUID);
+    byte[] command(MqttMessageBuilder mqttMessageBuilder, String deviceUUID);
 }

--- a/bundles/org.openhab.binding.meross/src/main/java/org/openhab/binding/meross/internal/command/TogglexCommand.java
+++ b/bundles/org.openhab.binding.meross/src/main/java/org/openhab/binding/meross/internal/command/TogglexCommand.java
@@ -38,9 +38,9 @@ public class TogglexCommand {
         }
 
         @Override
-        public byte[] command(String deviceUUID) {
+        public byte[] command(MqttMessageBuilder mqttMessageBuilder, String deviceUUID) {
             Map<String, Object> payload = Map.of("togglex", Map.of("onoff", onOffValue, "channel", deviceChannel));
-            return MqttMessageBuilder.buildMqttMessage("SET", MerossEnum.Namespace.CONTROL_TOGGLEX.value(), deviceUUID,
+            return mqttMessageBuilder.buildMqttMessage("SET", MerossEnum.Namespace.CONTROL_TOGGLEX.value(), deviceUUID,
                     payload);
         }
     }

--- a/bundles/org.openhab.binding.meross/src/main/java/org/openhab/binding/meross/internal/dto/MqttMessageBuilder.java
+++ b/bundles/org.openhab.binding.meross/src/main/java/org/openhab/binding/meross/internal/dto/MqttMessageBuilder.java
@@ -33,10 +33,10 @@ import com.google.gson.Gson;
  */
 @NonNullByDefault
 public class MqttMessageBuilder {
-    public static @Nullable String brokerAddress;
-    public static @Nullable String userId;
-    public static @Nullable String appId;
-    public static @Nullable String key;
+    public @Nullable String brokerAddress;
+    public @Nullable String userId;
+    public volatile @Nullable String appId;
+    public @Nullable String key;
 
     /**
      * @param method The method
@@ -44,7 +44,7 @@ public class MqttMessageBuilder {
      * @param payload The payload
      * @return the message
      */
-    public static byte[] buildMqttMessage(String method, String namespace, @Nullable String destinationDeviceUUID,
+    public byte[] buildMqttMessage(String method, String namespace, @Nullable String destinationDeviceUUID,
             Map<String, Object> payload) {
         int timestamp = Math.round(Instant.now().getEpochSecond());
         String randomString = UUID.randomUUID().toString().replace("-", "").substring(0, 16);
@@ -74,15 +74,15 @@ public class MqttMessageBuilder {
      *
      * @return The client user topic
      */
-    public static String buildClientUserTopic() {
-        return "/app/" + MqttMessageBuilder.userId + "/subscribe";
+    public String buildClientUserTopic() {
+        return "/app/" + userId + "/subscribe";
     }
 
-    public static String getAppId() {
-        String appId = MqttMessageBuilder.appId;
+    public synchronized String getAppId() {
+        String appId = this.appId;
         if (appId == null) {
             String randomString = "API" + UUID.randomUUID();
-            MqttMessageBuilder.appId = appId = MD5Util.getMD5String(randomString);
+            this.appId = appId = MD5Util.getMD5String(randomString);
         }
         return appId;
     }
@@ -94,11 +94,11 @@ public class MqttMessageBuilder {
      *
      * @return The response topic
      */
-    public static String buildClientResponseTopic() {
-        return "/app/" + MqttMessageBuilder.userId + "-" + getAppId() + "/subscribe";
+    public String buildClientResponseTopic() {
+        return "/app/" + userId + "-" + getAppId() + "/subscribe";
     }
 
-    public static String getClientId() {
+    public String getClientId() {
         return "app:" + getAppId();
     }
 
@@ -109,19 +109,19 @@ public class MqttMessageBuilder {
      * @return The topic to be published
      */
 
-    public static String buildDeviceRequestTopic(String deviceUUID) {
+    public String buildDeviceRequestTopic(String deviceUUID) {
         return "/appliance/" + deviceUUID + "/subscribe";
     }
 
-    public static void setUserId(String userId) {
-        MqttMessageBuilder.userId = userId;
+    public void setUserId(String userId) {
+        this.userId = userId;
     }
 
-    public static void setBrokerAddress(String brokerAddress) {
-        MqttMessageBuilder.brokerAddress = brokerAddress;
+    public void setBrokerAddress(String brokerAddress) {
+        this.brokerAddress = brokerAddress;
     }
 
-    public static void setKey(String key) {
-        MqttMessageBuilder.key = key;
+    public void setKey(String key) {
+        this.key = key;
     }
 }

--- a/bundles/org.openhab.binding.meross/src/main/java/org/openhab/binding/meross/internal/dto/MqttMessageBuilder.java
+++ b/bundles/org.openhab.binding.meross/src/main/java/org/openhab/binding/meross/internal/dto/MqttMessageBuilder.java
@@ -45,7 +45,7 @@ public class MqttMessageBuilder {
      */
     public byte[] buildMqttMessage(String method, String namespace, @Nullable String destinationDeviceUUID,
             Map<String, Object> payload) {
-        int timestamp = Math.round(Instant.now().getEpochSecond());
+        long timestamp = Instant.now().getEpochSecond();
         String randomString = UUID.randomUUID().toString().replace("-", "").substring(0, 16);
         String messageId = MD5Util.getMD5String(randomString.toLowerCase());
         String signatureToHash = "%s%s%d".formatted(messageId, key, timestamp);

--- a/bundles/org.openhab.binding.meross/src/main/java/org/openhab/binding/meross/internal/dto/MqttMessageBuilder.java
+++ b/bundles/org.openhab.binding.meross/src/main/java/org/openhab/binding/meross/internal/dto/MqttMessageBuilder.java
@@ -33,10 +33,9 @@ import com.google.gson.Gson;
  */
 @NonNullByDefault
 public class MqttMessageBuilder {
-    public @Nullable String brokerAddress;
-    public @Nullable String userId;
-    public volatile @Nullable String appId;
-    public @Nullable String key;
+    private @Nullable String userId;
+    private volatile @Nullable String appId;
+    private @Nullable String key;
 
     /**
      * @param method The method
@@ -115,10 +114,6 @@ public class MqttMessageBuilder {
 
     public void setUserId(String userId) {
         this.userId = userId;
-    }
-
-    public void setBrokerAddress(String brokerAddress) {
-        this.brokerAddress = brokerAddress;
     }
 
     public void setKey(String key) {

--- a/bundles/org.openhab.binding.meross/src/main/java/org/openhab/binding/meross/internal/dto/MqttMessageBuilder.java
+++ b/bundles/org.openhab.binding.meross/src/main/java/org/openhab/binding/meross/internal/dto/MqttMessageBuilder.java
@@ -35,7 +35,7 @@ import com.google.gson.Gson;
 public class MqttMessageBuilder {
     public static @Nullable String brokerAddress;
     public static @Nullable String userId;
-    public static @Nullable String clientId;
+    public static @Nullable String appId;
     public static @Nullable String key;
 
     /**
@@ -65,7 +65,7 @@ public class MqttMessageBuilder {
         dataMap.put("header", headerMap);
         dataMap.put("payload", payload);
         String jsonString = new Gson().toJson(dataMap);
-        return StandardCharsets.UTF_8.encode(jsonString).array();
+        return jsonString.getBytes(StandardCharsets.UTF_8);
     }
 
     /**
@@ -78,10 +78,14 @@ public class MqttMessageBuilder {
         return "/app/" + MqttMessageBuilder.userId + "/subscribe";
     }
 
-    public static String buildAppId() {
+    public static String getAppId() {
+        String appId = MqttMessageBuilder.appId;
+        if (appId != null) {
+            return appId;
+        }
         String randomString = "API" + UUID.randomUUID();
-        String encodedString = StandardCharsets.UTF_8.encode(randomString).toString();
-        return MD5Util.getMD5String(encodedString);
+        appId = MD5Util.getMD5String(randomString);
+        return appId;
     }
 
     /**
@@ -92,11 +96,11 @@ public class MqttMessageBuilder {
      * @return The response topic
      */
     public static String buildClientResponseTopic() {
-        return "/app/" + MqttMessageBuilder.userId + "-" + buildAppId() + "/subscribe";
+        return "/app/" + MqttMessageBuilder.userId + "-" + getAppId() + "/subscribe";
     }
 
-    public static String buildClientId() {
-        return "app:" + buildAppId();
+    public static String getClientId() {
+        return "app:" + getAppId();
     }
 
     /**
@@ -112,10 +116,6 @@ public class MqttMessageBuilder {
 
     public static void setUserId(String userId) {
         MqttMessageBuilder.userId = userId;
-    }
-
-    public static void setClientId(String clientId) {
-        MqttMessageBuilder.clientId = clientId;
     }
 
     public static void setBrokerAddress(String brokerAddress) {

--- a/bundles/org.openhab.binding.meross/src/main/java/org/openhab/binding/meross/internal/dto/MqttMessageBuilder.java
+++ b/bundles/org.openhab.binding.meross/src/main/java/org/openhab/binding/meross/internal/dto/MqttMessageBuilder.java
@@ -80,11 +80,10 @@ public class MqttMessageBuilder {
 
     public static String getAppId() {
         String appId = MqttMessageBuilder.appId;
-        if (appId != null) {
-            return appId;
+        if (appId == null) {
+            String randomString = "API" + UUID.randomUUID();
+            MqttMessageBuilder.appId = appId = MD5Util.getMD5String(randomString);
         }
-        String randomString = "API" + UUID.randomUUID();
-        appId = MD5Util.getMD5String(randomString);
         return appId;
     }
 

--- a/bundles/org.openhab.binding.meross/src/main/java/org/openhab/binding/meross/internal/handler/MerossBridgeHandler.java
+++ b/bundles/org.openhab.binding.meross/src/main/java/org/openhab/binding/meross/internal/handler/MerossBridgeHandler.java
@@ -63,8 +63,6 @@ public class MerossBridgeHandler extends BaseBridgeHandler {
     private @Nullable CloudCredentials credentials;
     private List<Device> devices = List.of();
 
-    private @Nullable String clientId;
-
     private final Logger logger = LoggerFactory.getLogger(MerossBridgeHandler.class);
 
     public MerossBridgeHandler(Thing thing, HttpClient httpClient) {
@@ -155,15 +153,6 @@ public class MerossBridgeHandler extends BaseBridgeHandler {
      *
      */
     private void initializeMerossMqttConnector() throws MqttException, InterruptedException {
-        // Make sure to keep the clientId when restarting the connection
-        String clientId = this.clientId;
-        if (clientId == null) {
-            clientId = MqttMessageBuilder.buildClientId();
-            this.clientId = clientId;
-        } else {
-            MqttMessageBuilder.setClientId(clientId);
-        }
-        MqttMessageBuilder.setClientId(clientId);
         CloudCredentials credentials = this.credentials;
         if (credentials == null) {
             logger.debug("No credentials found");

--- a/bundles/org.openhab.binding.meross/src/main/java/org/openhab/binding/meross/internal/handler/MerossBridgeHandler.java
+++ b/bundles/org.openhab.binding.meross/src/main/java/org/openhab/binding/meross/internal/handler/MerossBridgeHandler.java
@@ -130,11 +130,8 @@ public class MerossBridgeHandler extends BaseBridgeHandler {
     }
 
     public synchronized List<Device> discoverDevices() throws ConnectException {
-        if (ThingStatus.ONLINE.equals(thing.getStatus())) {
-            devices = merossHttpConnector.getDevices();
-            return devices;
-        }
-        return List.of();
+        devices = merossHttpConnector.getDevices();
+        return devices;
     }
 
     public List<Device> getDevices() {

--- a/bundles/org.openhab.binding.meross/src/main/java/org/openhab/binding/meross/internal/handler/MerossBridgeHandler.java
+++ b/bundles/org.openhab.binding.meross/src/main/java/org/openhab/binding/meross/internal/handler/MerossBridgeHandler.java
@@ -28,7 +28,6 @@ import org.openhab.binding.meross.internal.config.MerossBridgeConfiguration;
 import org.openhab.binding.meross.internal.discovery.MerossDiscoveryService;
 import org.openhab.binding.meross.internal.dto.CloudCredentials;
 import org.openhab.binding.meross.internal.dto.Device;
-import org.openhab.binding.meross.internal.dto.MqttMessageBuilder;
 import org.openhab.binding.meross.internal.exception.MerossApiException;
 import org.openhab.core.io.transport.mqtt.MqttException;
 import org.openhab.core.thing.Bridge;
@@ -57,7 +56,6 @@ public class MerossBridgeHandler extends BaseBridgeHandler {
     private MerossBridgeConfiguration config = new MerossBridgeConfiguration();
     private @NonNullByDefault({}) MerossCloudHttpConnector merossHttpConnector;
     private @NonNullByDefault({}) MerossMqttConnector merossMqttConnector;
-    private MqttMessageBuilder mqttMessageBuilder = new MqttMessageBuilder();
     private @Nullable MerossDiscoveryService discoveryService;
     private final HttpClient httpClient;
 
@@ -90,6 +88,7 @@ public class MerossBridgeHandler extends BaseBridgeHandler {
     public void dispose() {
         if (merossMqttConnector != null) {
             merossMqttConnector.stopConnection();
+            merossMqttConnector = null;
         }
         super.dispose();
     }

--- a/bundles/org.openhab.binding.meross/src/main/java/org/openhab/binding/meross/internal/handler/MerossBridgeHandler.java
+++ b/bundles/org.openhab.binding.meross/src/main/java/org/openhab/binding/meross/internal/handler/MerossBridgeHandler.java
@@ -57,6 +57,7 @@ public class MerossBridgeHandler extends BaseBridgeHandler {
     private MerossBridgeConfiguration config = new MerossBridgeConfiguration();
     private @NonNullByDefault({}) MerossCloudHttpConnector merossHttpConnector;
     private @NonNullByDefault({}) MerossMqttConnector merossMqttConnector;
+    private MqttMessageBuilder mqttMessageBuilder = new MqttMessageBuilder();
     private @Nullable MerossDiscoveryService discoveryService;
     private final HttpClient httpClient;
 
@@ -157,15 +158,8 @@ public class MerossBridgeHandler extends BaseBridgeHandler {
         if (credentials == null) {
             logger.debug("No credentials found");
         } else {
-            String userId = credentials.userId();
-            MqttMessageBuilder.setUserId(userId);
-            String key = credentials.key();
-            MqttMessageBuilder.setKey(key);
-            String brokerAddress = credentials.mqttDomain();
-            MqttMessageBuilder.setBrokerAddress(brokerAddress);
-
             if (merossMqttConnector == null) {
-                merossMqttConnector = new MerossMqttConnector(this, scheduler);
+                merossMqttConnector = new MerossMqttConnector(this, credentials, scheduler);
             } else {
                 merossMqttConnector.stopConnection();
             }


### PR DESCRIPTION
Local communication in the Meross binding is working properly, but if local communication fails, it relies on a cloud connection to control the device and receive updates. This cloud MQTT connection is currently not working properly.
The local connection also does not provide timely state updates. A proper connection to the cloud broker gets state updates pushed.

Secondly, the mqtt message builder until now relied on setting an appId in a static field only once for the binding. This effectively makes it impossible to have multiple accounts with devices in separate accounts. The class methods and fields have been made non-static an are now instantiated when creating the connection.