### PR TITLE
[ring] Fix multiple stability issues

### DIFF
--- a/bundles/org.openhab.binding.ring/src/main/java/org/openhab/binding/ring/internal/RestClient.java
+++ b/bundles/org.openhab.binding.ring/src/main/java/org/openhab/binding/ring/internal/RestClient.java
@@ -94,12 +94,13 @@ public class RestClient {
                 throw new AuthenticationException("Bad request");
             case HttpStatus.UNAUTHORIZED_401:
                 throw new AuthenticationException("Invalid username or password");
-            case HttpStatus.PRECONDITION_FAILED_412:
-                if (response.getReason().startsWith("Precondition")
-                        || response.getReason().startsWith("Verification Code")) {
+            case HttpStatus.PRECONDITION_FAILED_412: {
+                String reason = Objects.toString(response.getReason(), "");
+                if (reason.startsWith("Precondition") || reason.startsWith("Verification Code")) {
                     throw new AuthenticationException("Two factor authentication enabled, enter code");
                 }
                 throw new AuthenticationException("Invalid username or password");
+            }
             case HttpStatus.TOO_MANY_REQUESTS_429:
                 throw new AuthenticationException("Account rate-limited");
             default:

--- a/bundles/org.openhab.binding.ring/src/main/java/org/openhab/binding/ring/internal/RestClient.java
+++ b/bundles/org.openhab.binding.ring/src/main/java/org/openhab/binding/ring/internal/RestClient.java
@@ -368,12 +368,12 @@ public class RestClient {
 
                         // Sleep only if the download failed and we are going to retry
                         if (i < 9) {
-                             try {
-                                 Thread.sleep(15000);
-                             } catch (InterruptedException ie) {
-                                 Thread.currentThread().interrupt();
-                                 throw ie;
-                             }
+                            try {
+                                Thread.sleep(15000);
+                            } catch (InterruptedException ie) {
+                                Thread.currentThread().interrupt();
+                                throw ie;
+                            }
                         }
                     }
                 }

--- a/bundles/org.openhab.binding.ring/src/main/java/org/openhab/binding/ring/internal/RestClient.java
+++ b/bundles/org.openhab.binding.ring/src/main/java/org/openhab/binding/ring/internal/RestClient.java
@@ -19,7 +19,6 @@ import java.lang.reflect.Type;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.net.URLConnection;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -345,25 +344,32 @@ public class RestClient {
                     StringBuilder vidUrl = new StringBuilder();
                     vidUrl.append(ApiConstants.URL_RECORDING_START).append(eventId)
                             .append(ApiConstants.URL_RECORDING_END);
+
                     for (int i = 0; i < 10; i++) {
                         try {
                             String jsonResult = getRequest(vidUrl.toString(), Map.of(), tokens);
                             JsonObject obj = JsonParser.parseString(jsonResult).getAsJsonObject();
+
                             if (obj.get("url").getAsString().startsWith("http")) {
                                 URL url = new URI(obj.get("url").getAsString()).toURL();
-                                URLConnection connection = url.openConnection();
+
+                                // Explicit connection with timeouts to prevent thread starvation
+                                java.net.URLConnection connection = url.openConnection();
                                 connection.setConnectTimeout(10000); // 10 seconds
                                 connection.setReadTimeout(30000); // 30 seconds
+
                                 try (InputStream in = connection.getInputStream()) {
-                                    Files.copy(in, Paths.get(fullfilepath), StandardCopyOption.REPLACE_EXISTING);
+                                    Files.copy(in, path, StandardCopyOption.REPLACE_EXISTING);
                                 }
-                                if (!fullfilepath.isEmpty()) {
+
+                                if (Files.exists(path)) {
                                     urlFound = true;
-                                    break;
+                                    break; // Success: instantly exit the loop
                                 }
                             }
-                        } catch (AuthenticationException | URISyntaxException e) {
-                            logger.debug("RingVideo: Error downloading file: {}", e.getMessage());
+                        } catch (AuthenticationException | URISyntaxException | IOException e) {
+                            // Catching IOException here ensures timeouts trigger a retry, not a total abort
+                            logger.debug("RingVideo: Error downloading file on attempt {}: {}", i + 1, e.getMessage());
                         }
 
                         // Sleep only if the download failed and we are going to retry
@@ -404,7 +410,7 @@ public class RestClient {
             } else {
                 return "";
             }
-        } catch (IOException | InterruptedException e) {
+        } catch (InterruptedException e) {
             logger.warn("RingVideo: Unable to process request: {}", e.getMessage());
             return "";
         }

--- a/bundles/org.openhab.binding.ring/src/main/java/org/openhab/binding/ring/internal/RestClient.java
+++ b/bundles/org.openhab.binding.ring/src/main/java/org/openhab/binding/ring/internal/RestClient.java
@@ -21,7 +21,6 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLConnection;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -86,6 +85,29 @@ public class RestClient {
         this.httpClient = httpClient;
     }
 
+    private void validateResponse(ContentResponse response) throws AuthenticationException {
+        int responseCode = response.getStatus();
+        switch (responseCode) {
+            case HttpStatus.OK_200, HttpStatus.CREATED_201:
+                return; // Success
+            case HttpStatus.BAD_REQUEST_400:
+                throw new AuthenticationException("Bad request");
+            case HttpStatus.UNAUTHORIZED_401:
+                throw new AuthenticationException("Invalid username or password");
+            case HttpStatus.PRECONDITION_FAILED_412:
+                if (response.getReason().startsWith("Precondition")
+                        || response.getReason().startsWith("Verification Code")) {
+                    throw new AuthenticationException("Two factor authentication enabled, enter code");
+                }
+                throw new AuthenticationException("Invalid username or password");
+            case HttpStatus.TOO_MANY_REQUESTS_429:
+                throw new AuthenticationException("Account rate-limited");
+            default:
+                throw new AuthenticationException(
+                        "Unhandled HTTP error: " + responseCode + " - " + response.getReason());
+        }
+    }
+
     /**
      * Post data to given url
      *
@@ -113,28 +135,7 @@ public class RestClient {
             additionalHeaders.forEach(request::header);
 
             ContentResponse response = request.send();
-            int responseCode = response.getStatus();
-            switch (responseCode) {
-                case HttpStatus.OK_200, HttpStatus.CREATED_201:
-                    break;
-                case HttpStatus.BAD_REQUEST_400:
-                    throw new AuthenticationException("Bad request");
-                case HttpStatus.UNAUTHORIZED_401:
-                    throw new AuthenticationException("Invalid username or password");
-                case HttpStatus.PRECONDITION_FAILED_412:
-                    if (response.getReason().startsWith("Precondition")
-                            || response.getReason().startsWith("Verification Code")) {
-                        throw new AuthenticationException("Two factor authentication enabled, enter code");
-                    } else {
-                        throw new AuthenticationException("Invalid username or password");
-                    }
-                case HttpStatus.TOO_MANY_REQUESTS_429:
-                    throw new AuthenticationException("Account rate-limited");
-                default:
-                    throw new AuthenticationException(
-                            "Unhandled HTTP error: " + responseCode + " - " + response.getReason());
-            }
-
+            validateResponse(response);
             result = response.getContentAsString();
         } catch (ExecutionException | TimeoutException e) {
             logger.warn("RestApi error in postRequest!", e);
@@ -161,21 +162,7 @@ public class RestClient {
             additionalHeaders.forEach(request::header);
 
             ContentResponse response = request.send();
-            int responseCode = response.getStatus();
-            switch (responseCode) {
-                case HttpStatus.OK_200, HttpStatus.CREATED_201:
-                    break;
-                case HttpStatus.BAD_REQUEST_400:
-                    throw new AuthenticationException("Bad request");
-                case HttpStatus.UNAUTHORIZED_401:
-                    throw new AuthenticationException("Invalid username or password");
-                case HttpStatus.TOO_MANY_REQUESTS_429:
-                    throw new AuthenticationException("Account rate-limited");
-                default:
-                    throw new AuthenticationException(
-                            "Unhandled HTTP error: " + responseCode + " - " + response.getReason());
-            }
-
+            validateResponse(response);
             result = response.getContentAsString();
         } catch (ExecutionException | TimeoutException e) {
             logger.warn("RestApi error in getRequest!", e);
@@ -331,15 +318,27 @@ public class RestClient {
                 return "";
             }
             if (retentionCount > 0 && Files.exists(path)) {
-                // get FileSystem object
-                FileSystem fs = path.getFileSystem();
-                String sep = fs.getSeparator();
+                Path baseDirPath = path.toAbsolutePath().normalize();
+
                 String safeDescription = event.doorbot.description.replaceAll("[^a-zA-Z0-9\\-_]", "");
-                String filename = safeDescription + "-" + event.kind + "-"
+                String safeKind = event.kind != null ? event.kind.replaceAll("[^a-zA-Z0-9\\-_]", "") : "unknown";
+
+                String filename = safeDescription + "-" + safeKind + "-"
                         + event.getCreatedAt().toString().replace(":", "-") + ".mp4";
-                String fullfilepath = filePath + (filePath.endsWith(sep) ? "" : sep) + filename;
+
+                Path targetPath = baseDirPath.resolve(filename).normalize();
+
+                if (!targetPath.startsWith(baseDirPath)) {
+                    logger.error("RingVideo: Path traversal attempt detected! Filename: {}", filename);
+                    return ""; // Abort the download
+                }
+
+                String fullfilepath = targetPath.toString();
                 logger.debug("fullfilepath = {}", fullfilepath);
-                path = Paths.get(fullfilepath);
+
+                // Reassign 'path' to the secure target for the rest of the method
+                path = targetPath;
+
                 boolean urlFound = false;
                 if (Files.notExists(path)) {
                     long eventId = event.id;
@@ -423,21 +422,7 @@ public class RestClient {
                 request.content(new StringContentProvider(payload), "application/json");
             }
             ContentResponse response = request.send();
-            int responseCode = response.getStatus();
-            switch (responseCode) {
-                case HttpStatus.OK_200, HttpStatus.CREATED_201:
-                    break;
-                case HttpStatus.BAD_REQUEST_400:
-                    throw new AuthenticationException("Bad request");
-                case HttpStatus.UNAUTHORIZED_401:
-                    throw new AuthenticationException("Invalid username or password");
-                case HttpStatus.TOO_MANY_REQUESTS_429:
-                    throw new AuthenticationException("Account rate-limited");
-                default:
-                    throw new AuthenticationException(
-                            "Unhandled HTTP error: " + responseCode + " - " + response.getReason());
-            }
-
+            validateResponse(response);
         } catch (InterruptedException e) {
             logger.warn("RestApi error in sendCommand!", e);
             Thread.currentThread().interrupt();

--- a/bundles/org.openhab.binding.ring/src/main/java/org/openhab/binding/ring/internal/RestClient.java
+++ b/bundles/org.openhab.binding.ring/src/main/java/org/openhab/binding/ring/internal/RestClient.java
@@ -368,7 +368,12 @@ public class RestClient {
 
                         // Sleep only if the download failed and we are going to retry
                         if (i < 9) {
-                            Thread.sleep(15000);
+                             try {
+                                 Thread.sleep(15000);
+                             } catch (InterruptedException ie) {
+                                 Thread.currentThread().interrupt();
+                                 throw ie;
+                             }
                         }
                     }
                 }

--- a/bundles/org.openhab.binding.ring/src/main/java/org/openhab/binding/ring/internal/RestClient.java
+++ b/bundles/org.openhab.binding.ring/src/main/java/org/openhab/binding/ring/internal/RestClient.java
@@ -19,6 +19,7 @@ import java.lang.reflect.Type;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.net.URLConnection;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.FileSystem;
 import java.nio.file.Files;
@@ -135,9 +136,13 @@ public class RestClient {
             }
 
             result = response.getContentAsString();
-        } catch (ExecutionException | InterruptedException | TimeoutException e) {
+        } catch (ExecutionException | TimeoutException e) {
+            logger.warn("RestApi error in postRequest!", e);
+            throw new AuthenticationException("Communication error during POST request: " + e.getMessage());
+        } catch (InterruptedException e) {
             logger.warn("RestApi error in postRequest!", e);
             Thread.currentThread().interrupt();
+            throw new AuthenticationException("POST request was interrupted.");
         }
         return result;
     }
@@ -172,9 +177,13 @@ public class RestClient {
             }
 
             result = response.getContentAsString();
-        } catch (ExecutionException | InterruptedException | TimeoutException e) {
+        } catch (ExecutionException | TimeoutException e) {
+            logger.warn("RestApi error in getRequest!", e);
+            throw new AuthenticationException("Communication error during GET request: " + e.getMessage());
+        } catch (InterruptedException e) {
             logger.warn("RestApi error in getRequest!", e);
             Thread.currentThread().interrupt();
+            throw new AuthenticationException("GET request was interrupted.");
         }
         return result;
     }
@@ -325,7 +334,8 @@ public class RestClient {
                 // get FileSystem object
                 FileSystem fs = path.getFileSystem();
                 String sep = fs.getSeparator();
-                String filename = event.doorbot.description.replace(" ", "") + "-" + event.kind + "-"
+                String safeDescription = event.doorbot.description.replaceAll("[^a-zA-Z0-9\\-_]", "");
+                String filename = safeDescription + "-" + event.kind + "-"
                         + event.getCreatedAt().toString().replace(":", "-") + ".mp4";
                 String fullfilepath = filePath + (filePath.endsWith(sep) ? "" : sep) + filename;
                 logger.debug("fullfilepath = {}", fullfilepath);
@@ -342,7 +352,10 @@ public class RestClient {
                             JsonObject obj = JsonParser.parseString(jsonResult).getAsJsonObject();
                             if (obj.get("url").getAsString().startsWith("http")) {
                                 URL url = new URI(obj.get("url").getAsString()).toURL();
-                                try (InputStream in = url.openStream()) {
+                                URLConnection connection = url.openConnection();
+                                connection.setConnectTimeout(10000); // 10 seconds
+                                connection.setReadTimeout(30000); // 30 seconds
+                                try (InputStream in = connection.getInputStream()) {
                                     Files.copy(in, Paths.get(fullfilepath), StandardCopyOption.REPLACE_EXISTING);
                                 }
                                 if (!fullfilepath.isEmpty()) {
@@ -352,7 +365,10 @@ public class RestClient {
                             }
                         } catch (AuthenticationException | URISyntaxException e) {
                             logger.debug("RingVideo: Error downloading file: {}", e.getMessage());
-                        } finally {
+                        }
+
+                        // Sleep only if the download failed and we are going to retry
+                        if (i < 9) {
                             Thread.sleep(15000);
                         }
                     }
@@ -422,10 +438,10 @@ public class RestClient {
                             "Unhandled HTTP error: " + responseCode + " - " + response.getReason());
             }
 
-        } catch (ExecutionException | InterruptedException e) {
+        } catch (InterruptedException e) {
             logger.warn("RestApi error in sendCommand!", e);
             Thread.currentThread().interrupt();
-        } catch (TimeoutException e) {
+        } catch (ExecutionException | TimeoutException e) {
             logger.warn("RestApi error in sendCommand!", e);
         }
     }

--- a/bundles/org.openhab.binding.ring/src/main/java/org/openhab/binding/ring/internal/handler/AccountHandler.java
+++ b/bundles/org.openhab.binding.ring/src/main/java/org/openhab/binding/ring/internal/handler/AccountHandler.java
@@ -134,7 +134,7 @@ public class AccountHandler extends BaseBridgeHandler implements RingAccount {
     @Override
     public void handleCommand(ChannelUID channelUID, Command command) {
         switch (command) {
-            case RefreshType r -> handleRefresh(channelUID);
+            case RefreshType ignored -> handleRefresh(channelUID);
             case OnOffType onOffCommand -> handleOnOff(channelUID, onOffCommand);
             default -> logger.debug("Command {} is not supported for channel: {}", command, channelUID.getId());
         }
@@ -431,7 +431,7 @@ public class AccountHandler extends BaseBridgeHandler implements RingAccount {
                         updateState(CHANNEL_EVENT_EXTENDED_DESCRIPTION, new StringType(message));
                     }
                     RingEventTO latestEvent = lastEvents.getFirst();
-                    Thread.ofVirtual().name("ring-video-dl-" + latestEvent.id).start(() -> getVideo(latestEvent));
+                    scheduler.execute(() -> getVideo(latestEvent));
                 }
             } else {
                 logger.debug("AccountHandler - eventTick - lastEvents null");

--- a/bundles/org.openhab.binding.ring/src/main/java/org/openhab/binding/ring/internal/handler/AccountHandler.java
+++ b/bundles/org.openhab.binding.ring/src/main/java/org/openhab/binding/ring/internal/handler/AccountHandler.java
@@ -16,7 +16,6 @@ import static org.openhab.binding.ring.RingBindingConstants.*;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Collection;
@@ -237,7 +236,7 @@ public class AccountHandler extends BaseBridgeHandler implements RingAccount {
             folder.mkdirs();
         }
         try {
-            Files.write(Paths.get(fileName), refreshToken.getBytes(StandardCharsets.UTF_8));
+            Files.writeString(Paths.get(fileName), refreshToken);
         } catch (IOException ex) {
             logger.debug("IOException when writing refreshToken to file {}", ex.getMessage());
         }
@@ -254,8 +253,7 @@ public class AccountHandler extends BaseBridgeHandler implements RingAccount {
             return refreshToken;
         }
         try {
-            final byte[] contents = Files.readAllBytes(Paths.get(fileName));
-            refreshToken = new String(contents);
+            refreshToken = Files.readString(Paths.get(fileName));
         } catch (IOException ex) {
             logger.debug("IOException when reading refreshToken from file {}", ex.getMessage());
         }
@@ -438,21 +436,16 @@ public class AccountHandler extends BaseBridgeHandler implements RingAccount {
                     if (detectionType == null) {
                         detectionType = "";
                     }
-                    if (lastEvents.getFirst().kind.equals("motion")) {
-                        switch (detectionType) {
-                            case "human":
-                                updateState(CHANNEL_EVENT_EXTENDED_DESCRIPTION, new StringType(
-                                        "There is a Person at your " + lastEvents.getFirst().doorbot.description));
-                                break;
-                            case "vehicle":
-                                updateState(CHANNEL_EVENT_EXTENDED_DESCRIPTION, new StringType(
-                                        "There is a Vehicle at your " + lastEvents.getFirst().doorbot.description));
-                                break;
-                            default:
-                                updateState(CHANNEL_EVENT_EXTENDED_DESCRIPTION, new StringType(
-                                        "There is motion at your " + lastEvents.getFirst().doorbot.description));
-                                break;
-                        }
+                    if ("motion".equals(lastEvents.getFirst().kind)) {
+                        String desc = lastEvents.getFirst().doorbot.description;
+
+                        String message = switch (detectionType) {
+                            case "human" -> "There is a Person at your " + desc;
+                            case "vehicle" -> "There is a Vehicle at your " + desc;
+                            default -> "There is motion at your " + desc;
+                        };
+
+                        updateState(CHANNEL_EVENT_EXTENDED_DESCRIPTION, new StringType(message));
                     }
                     ScheduledExecutorService service = videoExecutorService;
                     if (service != null) {

--- a/bundles/org.openhab.binding.ring/src/main/java/org/openhab/binding/ring/internal/handler/AccountHandler.java
+++ b/bundles/org.openhab.binding.ring/src/main/java/org/openhab/binding/ring/internal/handler/AccountHandler.java
@@ -22,7 +22,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
@@ -44,7 +43,6 @@ import org.openhab.binding.ring.internal.discovery.RingDiscoveryService;
 import org.openhab.binding.ring.internal.errors.AuthenticationException;
 import org.openhab.binding.ring.internal.utils.RingUtils;
 import org.openhab.core.OpenHAB;
-import org.openhab.core.common.ThreadPoolManager;
 import org.openhab.core.config.core.Configuration;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.library.types.StringType;
@@ -106,8 +104,6 @@ public class AccountHandler extends BaseBridgeHandler implements RingAccount {
      */
     private int eventIndex = 0;
 
-    private @Nullable ScheduledExecutorService videoExecutorService;
-
     /*
      * The number of video files to keep when auto-downloading
      */
@@ -133,74 +129,61 @@ public class AccountHandler extends BaseBridgeHandler implements RingAccount {
         this.registry = new RingDeviceRegistry();
         this.restClient = new RestClient(httpClient);
         this.servlet = ringVideoServlet;
-        this.videoExecutorService = ThreadPoolManager.getScheduledPool("ring");
     }
 
     @Override
     public void handleCommand(ChannelUID channelUID, Command command) {
-        if (command instanceof RefreshType) {
-            boolean eventListOk = lastEvents.size() > eventIndex;
-            switch (channelUID.getId()) {
-                case CHANNEL_EVENT_URL:
-                    if (eventListOk) {
-                        String videoFile = restClient.downloadEventVideo(lastEvents.get(eventIndex), tokens,
-                                videoStoragePath, videoRetentionCount);
-                        String localIP = networkAddressService.getPrimaryIpv4HostAddress();
+        switch (command) {
+            case RefreshType r -> handleRefresh(channelUID);
+            case OnOffType onOffCommand -> handleOnOff(channelUID, onOffCommand);
+            default -> logger.debug("Command {} is not supported for channel: {}", command, channelUID.getId());
+        }
+    }
 
-                        if (videoFile.endsWith(".mp4")) {
-                            updateState(channelUID,
-                                    new StringType("http://" + localIP + ":" + httpPort + "/ring/video/" + videoFile));
-                        } else {
-                            updateState(channelUID, new StringType(videoFile));
-                        }
-                    }
-                    break;
-                case CHANNEL_EVENT_CREATED_AT:
-                    if (eventListOk) {
-                        updateState(channelUID, lastEvents.get(eventIndex).getCreatedAt());
-                    }
-                    break;
-                case CHANNEL_EVENT_KIND:
-                    if (eventListOk) {
-                        updateState(channelUID, new StringType(lastEvents.get(eventIndex).kind));
-                    }
-                    break;
-                case CHANNEL_EVENT_DOORBOT_ID:
-                    if (eventListOk) {
-                        updateState(channelUID, new StringType(lastEvents.get(eventIndex).doorbot.id));
-                    }
-                    break;
-                case CHANNEL_EVENT_DOORBOT_DESCRIPTION:
-                    if (eventListOk) {
-                        updateState(channelUID, new StringType(lastEvents.get(eventIndex).doorbot.description));
-                    }
-                    break;
-                case CHANNEL_CONTROL_ENABLED:
+    private void handleRefresh(ChannelUID channelUID) {
+        boolean eventListOk = lastEvents.size() > eventIndex;
+        if (!eventListOk && !channelUID.getId().equals(CHANNEL_CONTROL_ENABLED)) {
+            return;
+        }
+
+        switch (channelUID.getId()) {
+            case CHANNEL_EVENT_URL -> {
+                String videoFile = restClient.downloadEventVideo(lastEvents.get(eventIndex), tokens, videoStoragePath,
+                        videoRetentionCount);
+                String localIP = networkAddressService.getPrimaryIpv4HostAddress();
+
+                if (videoFile.endsWith(".mp4")) {
+                    updateState(channelUID,
+                            new StringType("http://" + localIP + ":" + httpPort + "/ring/video/" + videoFile));
+                } else {
+                    updateState(channelUID, new StringType(videoFile));
+                }
+            }
+            case CHANNEL_EVENT_CREATED_AT -> updateState(channelUID, lastEvents.get(eventIndex).getCreatedAt());
+            case CHANNEL_EVENT_KIND -> updateState(channelUID, new StringType(lastEvents.get(eventIndex).kind));
+            case CHANNEL_EVENT_DOORBOT_ID ->
+                updateState(channelUID, new StringType(lastEvents.get(eventIndex).doorbot.id));
+            case CHANNEL_EVENT_DOORBOT_DESCRIPTION ->
+                updateState(channelUID, new StringType(lastEvents.get(eventIndex).doorbot.description));
+            case CHANNEL_CONTROL_ENABLED -> updateState(channelUID, enabled);
+            default -> logger.debug("Refresh command received for an unknown channel: {}", channelUID.getId());
+        }
+    }
+
+    private void handleOnOff(ChannelUID channelUID, OnOffType xcommand) {
+        switch (channelUID.getId()) {
+            case CHANNEL_CONTROL_ENABLED -> {
+                if (!enabled.equals(xcommand)) {
+                    enabled = xcommand;
                     updateState(channelUID, enabled);
-                    break;
-                default:
-                    logger.debug("Command received for an unknown channel: {}", channelUID.getId());
-                    break;
-            }
-        } else if (command instanceof OnOffType xcommand) {
-            switch (channelUID.getId()) {
-                case CHANNEL_CONTROL_ENABLED:
-                    if (!enabled.equals(xcommand)) {
-                        enabled = xcommand;
-                        updateState(channelUID, enabled);
-                        if (enabled.equals(OnOffType.ON)) {
-                            startAutomaticRefresh(config.refreshInterval);
-                        } else {
-                            stopAutomaticRefresh();
-                        }
+                    if (enabled.equals(OnOffType.ON)) {
+                        startAutomaticRefresh(config.refreshInterval);
+                    } else {
+                        stopAutomaticRefresh();
                     }
-                    break;
-                default:
-                    logger.debug("Command received for an unknown channel: {}", channelUID.getId());
-                    break;
+                }
             }
-        } else {
-            logger.debug("Command {} is not supported for channel: {}", command, channelUID.getId());
+            default -> logger.debug("OnOff command received for an unknown channel: {}", channelUID.getId());
         }
     }
 
@@ -447,10 +430,8 @@ public class AccountHandler extends BaseBridgeHandler implements RingAccount {
 
                         updateState(CHANNEL_EVENT_EXTENDED_DESCRIPTION, new StringType(message));
                     }
-                    ScheduledExecutorService service = videoExecutorService;
-                    if (service != null) {
-                        service.submit(() -> getVideo(lastEvents.getFirst()));
-                    }
+                    RingEventTO latestEvent = lastEvents.getFirst();
+                    Thread.ofVirtual().name("ring-video-dl-" + latestEvent.id).start(() -> getVideo(latestEvent));
                 }
             } else {
                 logger.debug("AccountHandler - eventTick - lastEvents null");

--- a/bundles/org.openhab.binding.ring/src/main/java/org/openhab/binding/ring/internal/handler/AccountHandler.java
+++ b/bundles/org.openhab.binding.ring/src/main/java/org/openhab/binding/ring/internal/handler/AccountHandler.java
@@ -16,8 +16,7 @@ import static org.openhab.binding.ring.RingBindingConstants.*;
 
 import java.io.File;
 import java.io.IOException;
-import java.net.InetAddress;
-import java.net.NetworkInterface;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Collection;
@@ -90,7 +89,7 @@ public class AccountHandler extends BaseBridgeHandler implements RingAccount {
     /**
      * The user profile retrieved when authenticating.
      */
-    private Tokens tokens = new Tokens("", "");
+    private volatile Tokens tokens = new Tokens("", "");
     /**
      * The registry.
      */
@@ -102,7 +101,7 @@ public class AccountHandler extends BaseBridgeHandler implements RingAccount {
     /**
      * The list with events.
      */
-    private List<RingEventTO> lastEvents = List.of();
+    private volatile List<RingEventTO> lastEvents = List.of();
     /**
      * The index to the current event.
      */
@@ -238,7 +237,7 @@ public class AccountHandler extends BaseBridgeHandler implements RingAccount {
             folder.mkdirs();
         }
         try {
-            Files.write(Paths.get(fileName), refreshToken.getBytes());
+            Files.write(Paths.get(fileName), refreshToken.getBytes(StandardCharsets.UTF_8));
         } catch (IOException ex) {
             logger.debug("IOException when writing refreshToken to file {}", ex.getMessage());
         }
@@ -302,24 +301,11 @@ public class AccountHandler extends BaseBridgeHandler implements RingAccount {
         String hardwareId = config.hardwareId;
         logger.debug("getHardwareId H:{}", hardwareId);
         Configuration updatedConfiguration = getThing().getConfiguration();
-        try {
-            if (hardwareId.isBlank()) {
-                hardwareId = getLocalMAC();
-                if (hardwareId.isBlank()) {
-                    updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
-                            "Hardware ID missing, check thing config");
-                    return hardwareId;
-                }
-                logger.debug("getHardwareId getLocalMac H:{}", hardwareId);
-                // write hardwareId to thing config
-                config.hardwareId = hardwareId;
-                updatedConfiguration.put("hardwareId", config.hardwareId);
-                updateConfiguration(updatedConfiguration);
-            }
-        } catch (IOException e) {
-            logger.debug("getHardwareId failed to get local mac address {}", e.getMessage());
-            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
-                    "Initialization failed: " + e.getMessage());
+        if (hardwareId.isBlank()) {
+            hardwareId = java.util.UUID.randomUUID().toString();
+            config.hardwareId = hardwareId;
+            updatedConfiguration.put("hardwareId", config.hardwareId);
+            updateConfiguration(updatedConfiguration);
         }
         return hardwareId;
     }
@@ -445,7 +431,10 @@ public class AccountHandler extends BaseBridgeHandler implements RingAccount {
                     updateState(CHANNEL_EVENT_DOORBOT_ID, new StringType(lastEvents.getFirst().doorbot.id));
                     updateState(CHANNEL_EVENT_DOORBOT_DESCRIPTION,
                             new StringType(lastEvents.getFirst().doorbot.description));
-                    String detectionType = lastEvents.getFirst().cvProperties.detectionType;
+                    String detectionType = null;
+                    if (lastEvents.getFirst().cvProperties != null) {
+                        detectionType = lastEvents.getFirst().cvProperties.detectionType;
+                    }
                     if (detectionType == null) {
                         detectionType = "";
                     }
@@ -530,31 +519,6 @@ public class AccountHandler extends BaseBridgeHandler implements RingAccount {
             job.cancel(true);
         }
         eventRefresh = null;
-    }
-
-    private String getLocalMAC() throws IOException {
-        // get local ip from OH system settings
-        String localIP = networkAddressService.getPrimaryIpv4HostAddress();
-        if ((localIP == null) || (localIP.isBlank())) {
-            logger.debug("No local IP selected in openHAB system configuration");
-            return "";
-        }
-
-        // get MAC address
-        InetAddress ip = InetAddress.getByName(localIP);
-        NetworkInterface network = NetworkInterface.getByInetAddress(ip);
-        if (network != null) {
-            byte[] mac = network.getHardwareAddress();
-
-            StringBuilder sb = new StringBuilder();
-            for (int i = 0; i < mac.length; i++) {
-                sb.append(String.format("%02X%s", mac[i], (i < mac.length - 1) ? "-" : ""));
-            }
-            String localMAC = sb.toString();
-            logger.debug("Local IP address='{}', local MAC address = '{}'", localIP, localMAC);
-            return localMAC;
-        }
-        return "";
     }
 
     /**


### PR DESCRIPTION
Issues addressed:
1. Incorrect Thread Interruption (RestClient.java)
In postRequest, getRequest, and sendCommand, exceptions are caught and the thread is unconditionally interrupted
The Bug: You are interrupting the current thread for all caught exceptions, including TimeoutException and ExecutionException. Because this code is executed by an openHAB shared scheduled thread pool, setting the interrupt flag on a simple HTTP timeout can cascade and disrupt other unrelated jobs running on that thread.

2. NPEs Masked by Empty String Returns (RestClient.java)
In the HTTP methods mentioned above, if an exception occurs, the method catches it, logs it, and returns an empty string "".
The Bug: The calling methods expect a valid JSON response and use Objects.requireNonNull() on the parsed result

3. Missing volatile for Thread Visibility (AccountHandler.java)
The Bug: The variables lastEvents and tokens are accessed and modified across different threads, but they are not marked as volatile.

4. NullPointerException Risk on cvProperties (AccountHandler.java)
In eventTick(), there is an assumption that computer vision properties will always be present:
The Bug: If a Ring event does not have computer vision properties (e.g., an older camera, a standard motion event, or a user without a Ring Protect plan), cvProperties will be parsed as null by Gson. Attempting to access .detectionType will throw a NullPointerException and silently crash the scheduled task.

5. Infinite Loop / Thread Blocking Risk (RestClient.java)
In downloadEventVideo, there is a retry mechanism for video downloads:
The Bug: The Thread.sleep(15000) inside the finally block means this loop will unconditionally sleep for 15 seconds every iteration, even if the video download is successful on the first try! If it succeeds on the first loop, the break statement will be executed, but the finally block runs right before the break exits the loop. This unnecessarily blocks the videoExecutorService thread for 15 seconds every time a video is downloaded.

6. Path Traversal Vulnerability in Video Download (RestClient.java)
The Bug: When saving a video, the filename is generated using event.doorbot.description, which is the user-defined name of the camera returned by the Ring API.
If a user names their camera something malicious like ../../../../etc/cron.d/hack, or if the Ring API is compromised, the Files.copy() method will write the video file outside of the intended videoStoragePath, potentially overwriting critical system files.

7. Infinite Blocking / Thread Starvation Risk (RestClient.java)
The Bug: In downloadEventVideo, the video is downloaded using url.openStream():

url.openStream() relies on the underlying HttpURLConnection, which defaults to an infinite connection and read timeout. If the Ring video CDN server is unresponsive or drops the connection mid-transfer, this thread will hang indefinitely. Because this runs inside a shared scheduled thread pool (videoExecutorService), it will permanently leak threads and eventually break other scheduled tasks.

8. Unreliable Hardware ID Generation (AccountHandler.java)
The Bug: If a hardwareId is missing, the binding generates one using the host machine's MAC address (getLocalMAC()). This causes two major issues:

Docker/VM Instability: If openHAB is running in Docker or a VM, the MAC address can change when the container restarts. This changes the hardwareId, immediately invalidating the refresh token and forcing the user to re-authenticate manually.

Multiple Accounts Conflict: If a user configures two different Ring accounts in openHAB, both Things will use the exact same MAC address as their hardwareId, likely causing the Ring API to aggressively expire sessions due to a perceived conflict.
The Fix: Instead of relying on MAC addresses, generate a random UUID and persist it to the configuration.

9. Platform-Dependent Encoding Bugs (AccountHandler.java)
The Bug: When reading and writing the refresh token to disk, the code relies on the JVM's default character set:
On some older systems or specific Docker images, the JVM default charset is not UTF-8 (e.g., it might be Windows-1252 or US-ASCII). This can subtly corrupt the token or cause issues reading it back.

Addition improvements:
1. Consolidate HTTP Response Handling (RestClient.java)
Both postRequest and getRequest contain the exact same switch statement to evaluate the HttpStatus and throw exceptions. This violates DRY principles and makes it tedious if you ever need to add a new HTTP status handler.
2. Modernize File I/O (AccountHandler.java)
The methods saveRefreshTokenToFile and getRefreshTokenFromFile are using older, more verbose Java concepts (converting strings to byte arrays and back). Since Java 11, java.nio.file.Files includes dedicated methods for reading and writing strings directly, which also handle closing resources automatically.
3. Java 14+ Switch Expressions (AccountHandler.java)
In eventTick(), you are building the CHANNEL_EVENT_EXTENDED_DESCRIPTION string using a traditional switch statement. Using a modern switch expression removes the need for break; statements and allows you to assign the result directly to a variable, making the logic much easier to read.