### PR TITLE
[teslascope] Fix multiple bugs and stability improvements

### DIFF
--- a/bundles/org.openhab.binding.teslascope/src/main/java/org/openhab/binding/teslascope/internal/TeslascopeAccountHandler.java
+++ b/bundles/org.openhab.binding.teslascope/src/main/java/org/openhab/binding/teslascope/internal/TeslascopeAccountHandler.java
@@ -37,6 +37,7 @@ import org.slf4j.LoggerFactory;
 import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonParser;
+import com.google.gson.JsonSyntaxException;
 
 /**
  * The {@link TeslascopeAccountHandler} is responsible for handling commands, which are
@@ -157,9 +158,10 @@ public class TeslascopeAccountHandler extends BaseBridgeHandler {
                 updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
                         "@text/offline.comm-error.no-vehicles");
             }
-        } catch (Exception e) {
+        } catch (JsonSyntaxException e) {
             logger.debug("Failed to parse vehicle list JSON: {}", e.getMessage(), e);
-            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, "Invalid JSON response");
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
+                    "@text/offline.comm-error.no-json");
         }
     }
 

--- a/bundles/org.openhab.binding.teslascope/src/main/java/org/openhab/binding/teslascope/internal/TeslascopeAccountHandler.java
+++ b/bundles/org.openhab.binding.teslascope/src/main/java/org/openhab/binding/teslascope/internal/TeslascopeAccountHandler.java
@@ -89,8 +89,8 @@ public class TeslascopeAccountHandler extends BaseBridgeHandler {
                 updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
                         "Authentication problem: " + e.getMessage());
             } catch (TeslascopeCommunicationException e) {
-                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
-                        "Communication problem: " + e.getMessage());
+                logger.warn("Communication problem while fetching details for vehicle {}: {}", publicID,
+                        e.getMessage());
             }
         }
         return "";
@@ -105,8 +105,8 @@ public class TeslascopeAccountHandler extends BaseBridgeHandler {
                 updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
                         "Authentication problem: " + e.getMessage());
             } catch (TeslascopeCommunicationException e) {
-                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
-                        "Communication problem: " + e.getMessage());
+                logger.warn("Communication problem while fetching details for vehicle {}: {}", publicID,
+                        e.getMessage());
             }
         }
     }
@@ -120,8 +120,8 @@ public class TeslascopeAccountHandler extends BaseBridgeHandler {
                 updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
                         "Authentication problem: " + e.getMessage());
             } catch (TeslascopeCommunicationException e) {
-                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
-                        "Communication problem: " + e.getMessage());
+                logger.warn("Communication problem while fetching details for vehicle {}: {}", publicID,
+                        e.getMessage());
             }
         }
     }

--- a/bundles/org.openhab.binding.teslascope/src/main/java/org/openhab/binding/teslascope/internal/TeslascopeAccountHandler.java
+++ b/bundles/org.openhab.binding.teslascope/src/main/java/org/openhab/binding/teslascope/internal/TeslascopeAccountHandler.java
@@ -80,49 +80,28 @@ public class TeslascopeAccountHandler extends BaseBridgeHandler {
         return "";
     }
 
-    public String getDetailedInformation(String publicID) {
+    public String getDetailedInformation(String publicID)
+            throws TeslascopeCommunicationException, TeslascopeAuthenticationException {
         TeslascopeAccountConfiguration config = this.config;
         if (config != null) {
-            try {
-                return webTargets.getDetailedInformation(publicID, config.apiKey, config.personalAccessToken);
-            } catch (TeslascopeAuthenticationException e) {
-                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
-                        "Authentication problem: " + e.getMessage());
-            } catch (TeslascopeCommunicationException e) {
-                logger.warn("Communication problem while fetching details for vehicle {}: {}", publicID,
-                        e.getMessage());
-            }
+            return webTargets.getDetailedInformation(publicID, config.apiKey, config.personalAccessToken);
         }
         return "";
     }
 
-    public void sendCommand(String publicID, String command) {
+    public void sendCommand(String publicID, String command)
+            throws TeslascopeCommunicationException, TeslascopeAuthenticationException {
         TeslascopeAccountConfiguration config = this.config;
         if (config != null) {
-            try {
-                webTargets.sendCommand(publicID, config.apiKey, config.personalAccessToken, command);
-            } catch (TeslascopeAuthenticationException e) {
-                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
-                        "Authentication problem: " + e.getMessage());
-            } catch (TeslascopeCommunicationException e) {
-                logger.warn("Communication problem while fetching details for vehicle {}: {}", publicID,
-                        e.getMessage());
-            }
+            webTargets.sendCommand(publicID, config.apiKey, config.personalAccessToken, command);
         }
     }
 
-    public void sendCommand(String publicID, String command, String params) {
+    public void sendCommand(String publicID, String command, String params)
+            throws TeslascopeCommunicationException, TeslascopeAuthenticationException {
         TeslascopeAccountConfiguration config = this.config;
         if (config != null) {
-            try {
-                webTargets.sendCommand(publicID, config.apiKey, config.personalAccessToken, command, params);
-            } catch (TeslascopeAuthenticationException e) {
-                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
-                        "Authentication problem: " + e.getMessage());
-            } catch (TeslascopeCommunicationException e) {
-                logger.warn("Communication problem while fetching details for vehicle {}: {}", publicID,
-                        e.getMessage());
-            }
+            webTargets.sendCommand(publicID, config.apiKey, config.personalAccessToken, command, params);
         }
     }
 
@@ -177,7 +156,7 @@ public class TeslascopeAccountHandler extends BaseBridgeHandler {
                         "@text/offline.comm-error.no-vehicles");
             }
         } catch (Exception e) {
-            logger.debug("Failed to parse vehicle list JSON: {}", e.getMessage());
+            logger.debug("Failed to parse vehicle list JSON: {}", e.getMessage(), e);
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, "Invalid JSON response");
         }
     }

--- a/bundles/org.openhab.binding.teslascope/src/main/java/org/openhab/binding/teslascope/internal/TeslascopeAccountHandler.java
+++ b/bundles/org.openhab.binding.teslascope/src/main/java/org/openhab/binding/teslascope/internal/TeslascopeAccountHandler.java
@@ -145,7 +145,8 @@ public class TeslascopeAccountHandler extends BaseBridgeHandler {
         }
         updateStatus(ThingStatus.UNKNOWN);
 
-        this.pollFuture = scheduler.scheduleWithFixedDelay(this::pollStatus, 0, 300, TimeUnit.SECONDS);
+        this.pollFuture = scheduler.scheduleWithFixedDelay(this::pollStatus, 0, localConfig.refreshInterval,
+                TimeUnit.SECONDS);
 
         updateStatus(ThingStatus.ONLINE);
     }
@@ -158,16 +159,26 @@ public class TeslascopeAccountHandler extends BaseBridgeHandler {
 
     private void pollStatus() {
         String responseVehicleList = getVehicleList();
-        JsonArray jsonArrayVehicleList = JsonParser.parseString(responseVehicleList).getAsJsonArray();
-        if (jsonArrayVehicleList.size() > 0) {
-            VehicleList vehicleList = gson.fromJson(jsonArrayVehicleList.get(0), VehicleList.class);
-            if (vehicleList == null) {
+
+        if (responseVehicleList == null || responseVehicleList.isBlank()) {
+            return; // Status is already updated to OFFLINE in getVehicleList()
+        }
+
+        try {
+            JsonArray jsonArrayVehicleList = JsonParser.parseString(responseVehicleList).getAsJsonArray();
+            if (jsonArrayVehicleList.size() > 0) {
+                VehicleList vehicleList = gson.fromJson(jsonArrayVehicleList.get(0), VehicleList.class);
+                if (vehicleList == null) {
+                    updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
+                            "@text/offline.comm-error.no-vehicles");
+                }
+            } else {
                 updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
                         "@text/offline.comm-error.no-vehicles");
             }
-        } else {
-            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
-                    "@text/offline.comm-error.no-vehicles");
+        } catch (Exception e) {
+            logger.debug("Failed to parse vehicle list JSON: {}", e.getMessage());
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, "Invalid JSON response");
         }
     }
 

--- a/bundles/org.openhab.binding.teslascope/src/main/java/org/openhab/binding/teslascope/internal/TeslascopeAccountHandler.java
+++ b/bundles/org.openhab.binding.teslascope/src/main/java/org/openhab/binding/teslascope/internal/TeslascopeAccountHandler.java
@@ -150,7 +150,9 @@ public class TeslascopeAccountHandler extends BaseBridgeHandler {
                 if (vehicleList == null) {
                     updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
                             "@text/offline.comm-error.no-vehicles");
+                    return;
                 }
+                updateStatus(ThingStatus.ONLINE);
             } else {
                 updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
                         "@text/offline.comm-error.no-vehicles");

--- a/bundles/org.openhab.binding.teslascope/src/main/java/org/openhab/binding/teslascope/internal/TeslascopeVehicleHandler.java
+++ b/bundles/org.openhab.binding.teslascope/src/main/java/org/openhab/binding/teslascope/internal/TeslascopeVehicleHandler.java
@@ -227,168 +227,174 @@ public class TeslascopeVehicleHandler extends BaseThingHandler {
                     OnOffType.from(1 == detailedInformation.locatedAtFavorite));
 
             // charge state
-            updateState(TeslascopeBindingConstants.CHANNEL_BATTERY_LEVEL,
-                    new DecimalType(detailedInformation.chargeState.batteryLevel));
-            updateState(TeslascopeBindingConstants.CHANNEL_USABLE_BATTERY_LEVEL,
-                    new DecimalType(detailedInformation.chargeState.usableBatteryLevel));
-            updateState(TeslascopeBindingConstants.CHANNEL_BATTERY_RANGE,
-                    new QuantityType<>(detailedInformation.chargeState.batteryRange, ImperialUnits.MILE));
-            updateState(TeslascopeBindingConstants.CHANNEL_ESTIMATED_BATTERY_RANGE,
-                    new QuantityType<>(detailedInformation.chargeState.estBatteryRange, ImperialUnits.MILE));
-            // charge_enable_request isn't the right flag to determine if car is charging or not
-            updateState(TeslascopeBindingConstants.CHANNEL_CHARGE,
-                    OnOffType.from(
-                            ("DetailedChargeStateCharging".equals(detailedInformation.chargeState.detailedChargeState))
-                                    || "DetailedChargeStateStarting"
-                                            .equals(detailedInformation.chargeState.detailedChargeState)));
-            updateState(TeslascopeBindingConstants.CHANNEL_CHARGE_ENERGY_ADDED,
-                    new QuantityType<>(detailedInformation.chargeState.chargeEnergyAdded, Units.KILOWATT_HOUR));
-            updateState(CHANNEL_CHARGE_LIMIT_SOC, new DecimalType(detailedInformation.chargeState.chargeLimitSoc));
-            updateState(CHANNEL_CHARGE_LIMIT_SOC_MIN,
-                    new DecimalType(detailedInformation.chargeState.chargeLimitSocMin));
-            updateState(CHANNEL_CHARGE_LIMIT_SOC_MAX,
-                    new DecimalType(detailedInformation.chargeState.chargeLimitSocMax));
-            updateState(CHANNEL_CHARGE_LIMIT_SOC_STANDARD,
-                    new DecimalType(detailedInformation.chargeState.chargeLimitSocStd));
-            updateState(TeslascopeBindingConstants.CHANNEL_CHARGE_PORT,
-                    OnOffType.from(1 == detailedInformation.chargeState.chargePortDoorOpen));
-            updateState(TeslascopeBindingConstants.CHANNEL_CHARGE_PORT_LATCH,
-                    OnOffType.from("Engaged".equals(detailedInformation.chargeState.chargePortLatch)));
-            updateState(TeslascopeBindingConstants.CHANNEL_CHARGE_RATE,
-                    new QuantityType<>(detailedInformation.chargeState.chargeRate, ImperialUnits.MILES_PER_HOUR));
-            updateState(TeslascopeBindingConstants.CHANNEL_CHARGER_POWER,
-                    new QuantityType<>(detailedInformation.chargeState.chargerPower, MetricPrefix.KILO(Units.WATT)));
-            updateState(TeslascopeBindingConstants.CHANNEL_CHARGER_VOLTAGE,
-                    new QuantityType<>(detailedInformation.chargeState.chargerVoltage, Units.VOLT));
-            updateState(TeslascopeBindingConstants.CHANNEL_TIME_TO_FULL_CHARGE,
-                    new QuantityType<>(detailedInformation.chargeState.timeToFullCharge, Units.HOUR));
-            updateState(TeslascopeBindingConstants.CHANNEL_CHARGING_STATE, new StringType(
-                    detailedInformation.chargeState.detailedChargeState.replace("DetailedChargeState", "")));
-            updateState(TeslascopeBindingConstants.CHANNEL_SCHEDULED_CHARGING_PENDING,
-                    OnOffType.from(1 == detailedInformation.chargeState.scheduledChargingPending));
-            updateState(TeslascopeBindingConstants.CHANNEL_SCHEDULED_CHARGING_START,
-                    new StringType(detailedInformation.chargeState.scheduledChargingStartTime));
-            updateState(TeslascopeBindingConstants.CHANNEL_CHARGE_AMPS,
-                    new DecimalType(detailedInformation.chargeState.chargeAmps));
-            updateState(TeslascopeBindingConstants.CHANNEL_CHARGE_CURRENT_REQUEST,
-                    new DecimalType(detailedInformation.chargeState.chargeCurrentRequest));
-            updateState(TeslascopeBindingConstants.CHANNEL_CHARGE_CURRENT_REQUEST_MAX,
-                    new DecimalType(detailedInformation.chargeState.chargeCurrentRequestMax));
+            if (detailedInformation.chargeState != null) {
+                updateState(TeslascopeBindingConstants.CHANNEL_BATTERY_LEVEL,
+                        new DecimalType(detailedInformation.chargeState.batteryLevel));
+                updateState(TeslascopeBindingConstants.CHANNEL_USABLE_BATTERY_LEVEL,
+                        new DecimalType(detailedInformation.chargeState.usableBatteryLevel));
+                updateState(TeslascopeBindingConstants.CHANNEL_BATTERY_RANGE,
+                        new QuantityType<>(detailedInformation.chargeState.batteryRange, ImperialUnits.MILE));
+                updateState(TeslascopeBindingConstants.CHANNEL_ESTIMATED_BATTERY_RANGE,
+                        new QuantityType<>(detailedInformation.chargeState.estBatteryRange, ImperialUnits.MILE));
+                // charge_enable_request isn't the right flag to determine if car is charging or not
+                updateState(TeslascopeBindingConstants.CHANNEL_CHARGE, OnOffType.from(
+                        ("DetailedChargeStateCharging".equals(detailedInformation.chargeState.detailedChargeState))
+                                || "DetailedChargeStateStarting"
+                                        .equals(detailedInformation.chargeState.detailedChargeState)));
+                updateState(TeslascopeBindingConstants.CHANNEL_CHARGE_ENERGY_ADDED,
+                        new QuantityType<>(detailedInformation.chargeState.chargeEnergyAdded, Units.KILOWATT_HOUR));
+                updateState(CHANNEL_CHARGE_LIMIT_SOC, new DecimalType(detailedInformation.chargeState.chargeLimitSoc));
+                updateState(CHANNEL_CHARGE_LIMIT_SOC_MIN,
+                        new DecimalType(detailedInformation.chargeState.chargeLimitSocMin));
+                updateState(CHANNEL_CHARGE_LIMIT_SOC_MAX,
+                        new DecimalType(detailedInformation.chargeState.chargeLimitSocMax));
+                updateState(CHANNEL_CHARGE_LIMIT_SOC_STANDARD,
+                        new DecimalType(detailedInformation.chargeState.chargeLimitSocStd));
+                updateState(TeslascopeBindingConstants.CHANNEL_CHARGE_PORT,
+                        OnOffType.from(1 == detailedInformation.chargeState.chargePortDoorOpen));
+                updateState(TeslascopeBindingConstants.CHANNEL_CHARGE_PORT_LATCH,
+                        OnOffType.from("Engaged".equals(detailedInformation.chargeState.chargePortLatch)));
+                updateState(TeslascopeBindingConstants.CHANNEL_CHARGE_RATE,
+                        new QuantityType<>(detailedInformation.chargeState.chargeRate, ImperialUnits.MILES_PER_HOUR));
+                updateState(TeslascopeBindingConstants.CHANNEL_CHARGER_POWER, new QuantityType<>(
+                        detailedInformation.chargeState.chargerPower, MetricPrefix.KILO(Units.WATT)));
+                updateState(TeslascopeBindingConstants.CHANNEL_CHARGER_VOLTAGE,
+                        new QuantityType<>(detailedInformation.chargeState.chargerVoltage, Units.VOLT));
+                updateState(TeslascopeBindingConstants.CHANNEL_TIME_TO_FULL_CHARGE,
+                        new QuantityType<>(detailedInformation.chargeState.timeToFullCharge, Units.HOUR));
+                updateState(TeslascopeBindingConstants.CHANNEL_CHARGING_STATE, new StringType(
+                        detailedInformation.chargeState.detailedChargeState.replace("DetailedChargeState", "")));
+                updateState(TeslascopeBindingConstants.CHANNEL_SCHEDULED_CHARGING_PENDING,
+                        OnOffType.from(1 == detailedInformation.chargeState.scheduledChargingPending));
+                updateState(TeslascopeBindingConstants.CHANNEL_SCHEDULED_CHARGING_START,
+                        new StringType(detailedInformation.chargeState.scheduledChargingStartTime));
+                updateState(TeslascopeBindingConstants.CHANNEL_CHARGE_AMPS,
+                        new DecimalType(detailedInformation.chargeState.chargeAmps));
+                updateState(TeslascopeBindingConstants.CHANNEL_CHARGE_CURRENT_REQUEST,
+                        new DecimalType(detailedInformation.chargeState.chargeCurrentRequest));
+                updateState(TeslascopeBindingConstants.CHANNEL_CHARGE_CURRENT_REQUEST_MAX,
+                        new DecimalType(detailedInformation.chargeState.chargeCurrentRequestMax));
+            }
 
             // climate state
-            updateState(TeslascopeBindingConstants.CHANNEL_AUTOCONDITIONING,
-                    OnOffType.from(1 == detailedInformation.climateState.isAutoConditioningOn));
-            updateState(TeslascopeBindingConstants.CHANNEL_CLIMATE,
-                    OnOffType.from(1 == detailedInformation.climateState.isClimateOn));
-            updateState(TeslascopeBindingConstants.CHANNEL_FRONT_DEFROSTER,
-                    OnOffType.from(1 == detailedInformation.climateState.isFrontDefrosterOn));
-            updateState(TeslascopeBindingConstants.CHANNEL_PRECONDITIONING,
-                    OnOffType.from(1 == detailedInformation.climateState.isPreconditioning));
-            updateState(TeslascopeBindingConstants.CHANNEL_REAR_DEFROSTER,
-                    OnOffType.from(1 == detailedInformation.climateState.isRearDefrosterOn));
-            updateState(TeslascopeBindingConstants.CHANNEL_LEFT_SEAT_HEATER,
-                    new DecimalType(detailedInformation.climateState.seatHeaterLeft));
-            updateState(TeslascopeBindingConstants.CHANNEL_CENTER_REAR_SEAT_HEATER,
-                    new DecimalType(detailedInformation.climateState.seatHeaterRearCenter));
-            updateState(TeslascopeBindingConstants.CHANNEL_LEFT_REAR_SEAT_HEATER,
-                    new DecimalType(detailedInformation.climateState.seatHeaterRearLeft));
-            updateState(TeslascopeBindingConstants.CHANNEL_RIGHT_REAR_SEAT_HEATER,
-                    new DecimalType(detailedInformation.climateState.seatHeaterRearRight));
-            updateState(TeslascopeBindingConstants.CHANNEL_RIGHT_SEAT_HEATER,
-                    new DecimalType(detailedInformation.climateState.seatHeaterRight));
-            updateState(TeslascopeBindingConstants.CHANNEL_SIDE_MIRROR_HEATERS,
-                    OnOffType.from(1 == detailedInformation.climateState.sideMirrorHeaters));
-            updateState(TeslascopeBindingConstants.CHANNEL_SMARTPRECONDITIONG,
-                    OnOffType.from(1 == detailedInformation.climateState.smartPreconditioning));
-            updateState(TeslascopeBindingConstants.CHANNEL_STEERING_WHEEL_HEATER,
-                    OnOffType.from(1 == detailedInformation.climateState.steeringWheelHeater));
-            updateState(TeslascopeBindingConstants.CHANNEL_WIPER_BLADE_HEATER,
-                    OnOffType.from(1 == detailedInformation.climateState.wiperBladeHeater));
-            updateState(TeslascopeBindingConstants.CHANNEL_DRIVER_TEMP,
-                    new QuantityType<>(detailedInformation.climateState.driverTempSetting, SIUnits.CELSIUS));
-            updateState(TeslascopeBindingConstants.CHANNEL_INSIDE_TEMP,
-                    new QuantityType<>(detailedInformation.climateState.insideTemp, SIUnits.CELSIUS));
-            updateState(TeslascopeBindingConstants.CHANNEL_OUTSIDE_TEMP,
-                    new QuantityType<>(detailedInformation.climateState.outsideTemp, SIUnits.CELSIUS));
-            updateState(TeslascopeBindingConstants.CHANNEL_PASSENGER_TEMP,
-                    new QuantityType<>(detailedInformation.climateState.passengerTempSetting, SIUnits.CELSIUS));
-            updateState(TeslascopeBindingConstants.CHANNEL_FAN,
-                    new DecimalType(detailedInformation.climateState.fanStatus));
-            updateState(TeslascopeBindingConstants.CHANNEL_LEFT_TEMP_DIRECTION,
-                    new DecimalType(detailedInformation.climateState.leftTempDirection));
-            updateState(TeslascopeBindingConstants.CHANNEL_MAX_AVAILABLE_TEMP,
-                    new QuantityType<>(detailedInformation.climateState.maxAvailTemp, SIUnits.CELSIUS));
-            updateState(TeslascopeBindingConstants.CHANNEL_MIN_AVAILABLE_TEMP,
-                    new QuantityType<>(detailedInformation.climateState.minAvailTemp, SIUnits.CELSIUS));
-            updateState(TeslascopeBindingConstants.CHANNEL_RIGHT_TEMP_DIRECTION,
-                    new DecimalType(detailedInformation.climateState.rightTempDirection));
+            if (detailedInformation.climateState != null) {
+                updateState(TeslascopeBindingConstants.CHANNEL_AUTOCONDITIONING,
+                        OnOffType.from(1 == detailedInformation.climateState.isAutoConditioningOn));
+                updateState(TeslascopeBindingConstants.CHANNEL_CLIMATE,
+                        OnOffType.from(1 == detailedInformation.climateState.isClimateOn));
+                updateState(TeslascopeBindingConstants.CHANNEL_FRONT_DEFROSTER,
+                        OnOffType.from(1 == detailedInformation.climateState.isFrontDefrosterOn));
+                updateState(TeslascopeBindingConstants.CHANNEL_PRECONDITIONING,
+                        OnOffType.from(1 == detailedInformation.climateState.isPreconditioning));
+                updateState(TeslascopeBindingConstants.CHANNEL_REAR_DEFROSTER,
+                        OnOffType.from(1 == detailedInformation.climateState.isRearDefrosterOn));
+                updateState(TeslascopeBindingConstants.CHANNEL_LEFT_SEAT_HEATER,
+                        new DecimalType(detailedInformation.climateState.seatHeaterLeft));
+                updateState(TeslascopeBindingConstants.CHANNEL_CENTER_REAR_SEAT_HEATER,
+                        new DecimalType(detailedInformation.climateState.seatHeaterRearCenter));
+                updateState(TeslascopeBindingConstants.CHANNEL_LEFT_REAR_SEAT_HEATER,
+                        new DecimalType(detailedInformation.climateState.seatHeaterRearLeft));
+                updateState(TeslascopeBindingConstants.CHANNEL_RIGHT_REAR_SEAT_HEATER,
+                        new DecimalType(detailedInformation.climateState.seatHeaterRearRight));
+                updateState(TeslascopeBindingConstants.CHANNEL_RIGHT_SEAT_HEATER,
+                        new DecimalType(detailedInformation.climateState.seatHeaterRight));
+                updateState(TeslascopeBindingConstants.CHANNEL_SIDE_MIRROR_HEATERS,
+                        OnOffType.from(1 == detailedInformation.climateState.sideMirrorHeaters));
+                updateState(TeslascopeBindingConstants.CHANNEL_SMARTPRECONDITIONG,
+                        OnOffType.from(1 == detailedInformation.climateState.smartPreconditioning));
+                updateState(TeslascopeBindingConstants.CHANNEL_STEERING_WHEEL_HEATER,
+                        OnOffType.from(1 == detailedInformation.climateState.steeringWheelHeater));
+                updateState(TeslascopeBindingConstants.CHANNEL_WIPER_BLADE_HEATER,
+                        OnOffType.from(1 == detailedInformation.climateState.wiperBladeHeater));
+                updateState(TeslascopeBindingConstants.CHANNEL_DRIVER_TEMP,
+                        new QuantityType<>(detailedInformation.climateState.driverTempSetting, SIUnits.CELSIUS));
+                updateState(TeslascopeBindingConstants.CHANNEL_INSIDE_TEMP,
+                        new QuantityType<>(detailedInformation.climateState.insideTemp, SIUnits.CELSIUS));
+                updateState(TeslascopeBindingConstants.CHANNEL_OUTSIDE_TEMP,
+                        new QuantityType<>(detailedInformation.climateState.outsideTemp, SIUnits.CELSIUS));
+                updateState(TeslascopeBindingConstants.CHANNEL_PASSENGER_TEMP,
+                        new QuantityType<>(detailedInformation.climateState.passengerTempSetting, SIUnits.CELSIUS));
+                updateState(TeslascopeBindingConstants.CHANNEL_FAN,
+                        new DecimalType(detailedInformation.climateState.fanStatus));
+                updateState(TeslascopeBindingConstants.CHANNEL_LEFT_TEMP_DIRECTION,
+                        new DecimalType(detailedInformation.climateState.leftTempDirection));
+                updateState(TeslascopeBindingConstants.CHANNEL_MAX_AVAILABLE_TEMP,
+                        new QuantityType<>(detailedInformation.climateState.maxAvailTemp, SIUnits.CELSIUS));
+                updateState(TeslascopeBindingConstants.CHANNEL_MIN_AVAILABLE_TEMP,
+                        new QuantityType<>(detailedInformation.climateState.minAvailTemp, SIUnits.CELSIUS));
+                updateState(TeslascopeBindingConstants.CHANNEL_RIGHT_TEMP_DIRECTION,
+                        new DecimalType(detailedInformation.climateState.rightTempDirection));
+            }
 
             // drive state
-            updateState(TeslascopeBindingConstants.CHANNEL_HEADING,
-                    new DecimalType(detailedInformation.driveState.heading));
-            updateState(TeslascopeBindingConstants.CHANNEL_LOCATION, new PointType(
-                    detailedInformation.driveState.latitude + "," + detailedInformation.driveState.longitude));
-            updateState(TeslascopeBindingConstants.CHANNEL_POWER,
-                    new QuantityType<>(detailedInformation.driveState.power, MetricPrefix.KILO(Units.WATT)));
-            updateState(TeslascopeBindingConstants.CHANNEL_SHIFT_STATE,
-                    new StringType(detailedInformation.driveState.shiftState));
-            updateState(TeslascopeBindingConstants.CHANNEL_SPEED,
-                    new QuantityType<>(detailedInformation.driveState.speed, ImperialUnits.MILES_PER_HOUR));
+            if (detailedInformation.driveState != null) {
+                updateState(TeslascopeBindingConstants.CHANNEL_HEADING,
+                        new DecimalType(detailedInformation.driveState.heading));
+                updateState(TeslascopeBindingConstants.CHANNEL_LOCATION, new PointType(
+                        detailedInformation.driveState.latitude + "," + detailedInformation.driveState.longitude));
+                updateState(TeslascopeBindingConstants.CHANNEL_POWER,
+                        new QuantityType<>(detailedInformation.driveState.power, MetricPrefix.KILO(Units.WATT)));
+                updateState(TeslascopeBindingConstants.CHANNEL_SHIFT_STATE,
+                        new StringType(detailedInformation.driveState.shiftState));
+                updateState(TeslascopeBindingConstants.CHANNEL_SPEED,
+                        new QuantityType<>(detailedInformation.driveState.speed, ImperialUnits.MILES_PER_HOUR));
+            }
 
             // vehicle state
-            Map<String, String> properties = editProperties();
-            properties.put("version", detailedInformation.vehicleState.carVersion);
-            updateProperties(properties);
-            updateState(TeslascopeBindingConstants.CHANNEL_DOOR_LOCK,
-                    OnOffType.from(detailedInformation.vehicleState.locked));
-            updateState(TeslascopeBindingConstants.CHANNEL_ODOMETER,
-                    new QuantityType<>(detailedInformation.vehicleState.odometer, ImperialUnits.MILE));
-            updateState(TeslascopeBindingConstants.CHANNEL_SENTRY_MODE,
-                    OnOffType.from(detailedInformation.vehicleState.sentryMode));
-            updateState(TeslascopeBindingConstants.CHANNEL_VALET_MODE,
-                    OnOffType.from(1 == detailedInformation.vehicleState.valetMode));
-            updateState(TeslascopeBindingConstants.CHANNEL_SOFTWARE_UPDATE_AVAILABLE,
-                    OnOffType.from(!"".equals(detailedInformation.vehicleState.softwareUpdateStatus)));
-            updateState(TeslascopeBindingConstants.CHANNEL_SOFTWARE_UPDATE_STATUS,
-                    new StringType(detailedInformation.vehicleState.softwareUpdateStatus));
-            updateState(TeslascopeBindingConstants.CHANNEL_SOFTWARE_UPDATE_VERSION,
-                    new StringType(detailedInformation.vehicleState.softwareUpdateVersion));
-            updateState(TeslascopeBindingConstants.CHANNEL_SUNROOF_STATE,
-                    new StringType(detailedInformation.vehicleState.sunRoofState));
-            updateState(TeslascopeBindingConstants.CHANNEL_SUNROOF,
-                    new DecimalType(detailedInformation.vehicleState.sunRoofPercentOpen));
-            updateState(TeslascopeBindingConstants.CHANNEL_HOMELINK,
-                    OnOffType.from(1 == detailedInformation.vehicleState.homelinkNearby));
-            updateState(TeslascopeBindingConstants.CHANNEL_TPMS_FL,
-                    new QuantityType<>(detailedInformation.vehicleState.tpmsPressureFL, Units.BAR));
-            updateState(TeslascopeBindingConstants.CHANNEL_TPMS_FR,
-                    new QuantityType<>(detailedInformation.vehicleState.tpmsPressureFR, Units.BAR));
-            updateState(TeslascopeBindingConstants.CHANNEL_TPMS_RL,
-                    new QuantityType<>(detailedInformation.vehicleState.tpmsPressureRL, Units.BAR));
-            updateState(TeslascopeBindingConstants.CHANNEL_TPMS_RR,
-                    new QuantityType<>(detailedInformation.vehicleState.tpmsPressureRR, Units.BAR));
-            updateState(TeslascopeBindingConstants.CHANNEL_TPMS_SOFT_WARNING_FL,
-                    OnOffType.from(1 == detailedInformation.vehicleState.tpmsSoftWarningFL));
-            updateState(TeslascopeBindingConstants.CHANNEL_TPMS_SOFT_WARNING_FR,
-                    OnOffType.from(1 == detailedInformation.vehicleState.tpmsSoftWarningFR));
-            updateState(TeslascopeBindingConstants.CHANNEL_TPMS_SOFT_WARNING_RL,
-                    OnOffType.from(1 == detailedInformation.vehicleState.tpmsSoftWarningRL));
-            updateState(TeslascopeBindingConstants.CHANNEL_TPMS_SOFT_WARNING_RR,
-                    OnOffType.from(1 == detailedInformation.vehicleState.tpmsSoftWarningRR));
-            updateState(TeslascopeBindingConstants.CHANNEL_DRIVER_FRONT_DOOR,
-                    (1 == detailedInformation.vehicleState.df) ? OpenClosedType.OPEN : OpenClosedType.CLOSED);
-            updateState(TeslascopeBindingConstants.CHANNEL_DRIVER_REAR_DOOR,
-                    (1 == detailedInformation.vehicleState.dr) ? OpenClosedType.OPEN : OpenClosedType.CLOSED);
-            updateState(TeslascopeBindingConstants.CHANNEL_PASSENGER_FRONT_DOOR,
-                    (1 == detailedInformation.vehicleState.pf) ? OpenClosedType.OPEN : OpenClosedType.CLOSED);
-            updateState(TeslascopeBindingConstants.CHANNEL_PASSENGER_REAR_DOOR,
-                    (1 == detailedInformation.vehicleState.pr) ? OpenClosedType.OPEN : OpenClosedType.CLOSED);
-            updateState(TeslascopeBindingConstants.CHANNEL_FRONT_TRUNK,
-                    OnOffType.from(1 == detailedInformation.vehicleState.ft));
-            updateState(TeslascopeBindingConstants.CHANNEL_REAR_TRUNK,
-                    OnOffType.from(1 == detailedInformation.vehicleState.rt));
+            if (detailedInformation.vehicleState != null) {
+                Map<String, String> properties = editProperties();
+                properties.put("version", detailedInformation.vehicleState.carVersion);
+                updateProperties(properties);
+                updateState(TeslascopeBindingConstants.CHANNEL_DOOR_LOCK,
+                        OnOffType.from(detailedInformation.vehicleState.locked));
+                updateState(TeslascopeBindingConstants.CHANNEL_ODOMETER,
+                        new QuantityType<>(detailedInformation.vehicleState.odometer, ImperialUnits.MILE));
+                updateState(TeslascopeBindingConstants.CHANNEL_SENTRY_MODE,
+                        OnOffType.from(detailedInformation.vehicleState.sentryMode));
+                updateState(TeslascopeBindingConstants.CHANNEL_VALET_MODE,
+                        OnOffType.from(1 == detailedInformation.vehicleState.valetMode));
+                updateState(TeslascopeBindingConstants.CHANNEL_SOFTWARE_UPDATE_AVAILABLE,
+                        OnOffType.from(!"".equals(detailedInformation.vehicleState.softwareUpdateStatus)));
+                updateState(TeslascopeBindingConstants.CHANNEL_SOFTWARE_UPDATE_STATUS,
+                        new StringType(detailedInformation.vehicleState.softwareUpdateStatus));
+                updateState(TeslascopeBindingConstants.CHANNEL_SOFTWARE_UPDATE_VERSION,
+                        new StringType(detailedInformation.vehicleState.softwareUpdateVersion));
+                updateState(TeslascopeBindingConstants.CHANNEL_SUNROOF_STATE,
+                        new StringType(detailedInformation.vehicleState.sunRoofState));
+                updateState(TeslascopeBindingConstants.CHANNEL_SUNROOF,
+                        new DecimalType(detailedInformation.vehicleState.sunRoofPercentOpen));
+                updateState(TeslascopeBindingConstants.CHANNEL_HOMELINK,
+                        OnOffType.from(1 == detailedInformation.vehicleState.homelinkNearby));
+                updateState(TeslascopeBindingConstants.CHANNEL_TPMS_FL,
+                        new QuantityType<>(detailedInformation.vehicleState.tpmsPressureFL, Units.BAR));
+                updateState(TeslascopeBindingConstants.CHANNEL_TPMS_FR,
+                        new QuantityType<>(detailedInformation.vehicleState.tpmsPressureFR, Units.BAR));
+                updateState(TeslascopeBindingConstants.CHANNEL_TPMS_RL,
+                        new QuantityType<>(detailedInformation.vehicleState.tpmsPressureRL, Units.BAR));
+                updateState(TeslascopeBindingConstants.CHANNEL_TPMS_RR,
+                        new QuantityType<>(detailedInformation.vehicleState.tpmsPressureRR, Units.BAR));
+                updateState(TeslascopeBindingConstants.CHANNEL_TPMS_SOFT_WARNING_FL,
+                        OnOffType.from(1 == detailedInformation.vehicleState.tpmsSoftWarningFL));
+                updateState(TeslascopeBindingConstants.CHANNEL_TPMS_SOFT_WARNING_FR,
+                        OnOffType.from(1 == detailedInformation.vehicleState.tpmsSoftWarningFR));
+                updateState(TeslascopeBindingConstants.CHANNEL_TPMS_SOFT_WARNING_RL,
+                        OnOffType.from(1 == detailedInformation.vehicleState.tpmsSoftWarningRL));
+                updateState(TeslascopeBindingConstants.CHANNEL_TPMS_SOFT_WARNING_RR,
+                        OnOffType.from(1 == detailedInformation.vehicleState.tpmsSoftWarningRR));
+                updateState(TeslascopeBindingConstants.CHANNEL_DRIVER_FRONT_DOOR,
+                        (1 == detailedInformation.vehicleState.df) ? OpenClosedType.OPEN : OpenClosedType.CLOSED);
+                updateState(TeslascopeBindingConstants.CHANNEL_DRIVER_REAR_DOOR,
+                        (1 == detailedInformation.vehicleState.dr) ? OpenClosedType.OPEN : OpenClosedType.CLOSED);
+                updateState(TeslascopeBindingConstants.CHANNEL_PASSENGER_FRONT_DOOR,
+                        (1 == detailedInformation.vehicleState.pf) ? OpenClosedType.OPEN : OpenClosedType.CLOSED);
+                updateState(TeslascopeBindingConstants.CHANNEL_PASSENGER_REAR_DOOR,
+                        (1 == detailedInformation.vehicleState.pr) ? OpenClosedType.OPEN : OpenClosedType.CLOSED);
+                updateState(TeslascopeBindingConstants.CHANNEL_FRONT_TRUNK,
+                        OnOffType.from(1 == detailedInformation.vehicleState.ft));
+                updateState(TeslascopeBindingConstants.CHANNEL_REAR_TRUNK,
+                        OnOffType.from(1 == detailedInformation.vehicleState.rt));
+            }
         }
-
         // virtual items
         updateState(TeslascopeBindingConstants.CHANNEL_HONK_HORN, OnOffType.OFF);
         updateState(TeslascopeBindingConstants.CHANNEL_FLASH_LIGHTS, OnOffType.OFF);
@@ -433,6 +439,6 @@ public class TeslascopeVehicleHandler extends BaseThingHandler {
     }
 
     protected void setChargeLimit(QuantityType<?> chargeLimit) {
-        sendCommand(config.publicID, "setChargeLimit", "&limit=" + chargeLimit.toString().replace(" %", ""));
+        sendCommand(config.publicID, "setChargeLimit", "limit=" + chargeLimit.toBigDecimal().intValue());
     }
 }

--- a/bundles/org.openhab.binding.teslascope/src/main/java/org/openhab/binding/teslascope/internal/TeslascopeVehicleHandler.java
+++ b/bundles/org.openhab.binding.teslascope/src/main/java/org/openhab/binding/teslascope/internal/TeslascopeVehicleHandler.java
@@ -112,63 +112,48 @@ public class TeslascopeVehicleHandler extends BaseThingHandler {
     @Override
     public void handleCommand(ChannelUID channelUID, Command command) {
         switch (channelUID.getId()) {
-            case TeslascopeBindingConstants.CHANNEL_AUTOCONDITIONING:
-                if (command instanceof OnOffType onOffCommand) {
+            case TeslascopeBindingConstants.CHANNEL_AUTOCONDITIONING -> {
+                if (command instanceof OnOffType onOffCommand)
                     setAutoConditioning(onOffCommand == OnOffType.ON);
-                }
-                break;
-            case TeslascopeBindingConstants.CHANNEL_CHARGE:
-                if (command instanceof OnOffType onOffCommand) {
+            }
+            case TeslascopeBindingConstants.CHANNEL_CHARGE -> {
+                if (command instanceof OnOffType onOffCommand)
                     charge(onOffCommand == OnOffType.ON);
-                }
-                break;
-            case TeslascopeBindingConstants.CHANNEL_CHARGE_LIMIT_SOC:
-                if (command instanceof QuantityType quantityCommand) {
+            }
+            case TeslascopeBindingConstants.CHANNEL_CHARGE_LIMIT_SOC -> {
+                if (command instanceof QuantityType<?> quantityCommand)
                     setChargeLimit(quantityCommand);
-                }
-                break;
-            case TeslascopeBindingConstants.CHANNEL_CHARGE_PORT:
-                if (command instanceof OnOffType onOffCommand) {
+            }
+            case TeslascopeBindingConstants.CHANNEL_CHARGE_PORT -> {
+                if (command instanceof OnOffType onOffCommand)
                     chargeDoor(onOffCommand == OnOffType.ON);
-                }
-                break;
-            case TeslascopeBindingConstants.CHANNEL_DOOR_LOCK:
-                if (command instanceof OnOffType onOffCommand) {
+            }
+            case TeslascopeBindingConstants.CHANNEL_DOOR_LOCK -> {
+                if (command instanceof OnOffType onOffCommand)
                     lock(onOffCommand == OnOffType.ON);
-                }
-                break;
-            case TeslascopeBindingConstants.CHANNEL_FLASH_LIGHTS:
-                if (command instanceof OnOffType) {
+            }
+            case TeslascopeBindingConstants.CHANNEL_FLASH_LIGHTS -> {
+                if (command instanceof OnOffType)
                     flashLights();
-                    return;
-                }
-                break;
-            case TeslascopeBindingConstants.CHANNEL_FRONT_TRUNK:
-                if (command instanceof OnOffType) {
+            }
+            case TeslascopeBindingConstants.CHANNEL_FRONT_TRUNK -> {
+                if (command instanceof OnOffType)
                     openFrunk();
-                    return;
-                }
-                break;
-            case TeslascopeBindingConstants.CHANNEL_HONK_HORN:
-                if (command instanceof OnOffType) {
+            }
+            case TeslascopeBindingConstants.CHANNEL_HONK_HORN -> {
+                if (command instanceof OnOffType)
                     honkHorn();
-                    return;
-                }
-                break;
-            case TeslascopeBindingConstants.CHANNEL_REAR_TRUNK:
-                if (command instanceof OnOffType) {
+            }
+            case TeslascopeBindingConstants.CHANNEL_REAR_TRUNK -> {
+                if (command instanceof OnOffType)
                     openTrunk();
-                    return;
-                }
-                break;
-            case TeslascopeBindingConstants.CHANNEL_SENTRY_MODE:
-                if (command instanceof OnOffType onOffCommand) {
+            }
+            case TeslascopeBindingConstants.CHANNEL_SENTRY_MODE -> {
+                if (command instanceof OnOffType onOffCommand)
                     sentry(onOffCommand == OnOffType.ON);
-                }
-                break;
-            default:
-                logger.debug("Received command ({}) of wrong type for thing '{}' on channel {}", command,
-                        thing.getUID().getAsString(), channelUID.getId());
+            }
+            default -> logger.debug("Received command ({}) of wrong type for thing '{}' on channel {}", command,
+                    thing.getUID().getAsString(), channelUID.getId());
         }
     }
 

--- a/bundles/org.openhab.binding.teslascope/src/main/java/org/openhab/binding/teslascope/internal/TeslascopeVehicleHandler.java
+++ b/bundles/org.openhab.binding.teslascope/src/main/java/org/openhab/binding/teslascope/internal/TeslascopeVehicleHandler.java
@@ -411,7 +411,7 @@ public class TeslascopeVehicleHandler extends BaseThingHandler {
         } catch (IllegalStateException e) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE, e.getMessage());
         } catch (Exception e) {
-            logger.debug("Failed to parse vehicle details: {}", e.getMessage());
+            logger.debug("Failed to parse vehicle details: {}", e.getMessage(), e);
         }
     }
 
@@ -425,7 +425,7 @@ public class TeslascopeVehicleHandler extends BaseThingHandler {
         } catch (IllegalStateException e) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE, e.getMessage());
         } catch (Exception e) {
-            logger.debug("Failed to parse vehicle details: {}", e.getMessage());
+            logger.debug("Failed to send setAutoConditioning command: {}", e.getMessage(), e);
         }
     }
 
@@ -439,7 +439,7 @@ public class TeslascopeVehicleHandler extends BaseThingHandler {
         } catch (IllegalStateException e) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE, e.getMessage());
         } catch (Exception e) {
-            logger.debug("Failed to parse vehicle details: {}", e.getMessage());
+            logger.debug("Failed to send charge command: {}", e.getMessage(), e);
         }
     }
 
@@ -453,7 +453,7 @@ public class TeslascopeVehicleHandler extends BaseThingHandler {
         } catch (IllegalStateException e) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE, e.getMessage());
         } catch (Exception e) {
-            logger.debug("Failed to parse vehicle details: {}", e.getMessage());
+            logger.debug("Failed to send chargeDoor command: {}", e.getMessage(), e);
         }
     }
 
@@ -468,7 +468,7 @@ public class TeslascopeVehicleHandler extends BaseThingHandler {
         } catch (IllegalStateException e) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE, e.getMessage());
         } catch (Exception e) {
-            logger.debug("Failed to parse vehicle details: {}", e.getMessage());
+            logger.debug("Failed to send flashLights command: {}", e.getMessage(), e);
         }
     }
 
@@ -483,7 +483,7 @@ public class TeslascopeVehicleHandler extends BaseThingHandler {
         } catch (IllegalStateException e) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE, e.getMessage());
         } catch (Exception e) {
-            logger.debug("Failed to parse vehicle details: {}", e.getMessage());
+            logger.debug("Failed to send honkHorn command: {}", e.getMessage(), e);
         }
     }
 
@@ -497,7 +497,7 @@ public class TeslascopeVehicleHandler extends BaseThingHandler {
         } catch (IllegalStateException e) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE, e.getMessage());
         } catch (Exception e) {
-            logger.debug("Failed to parse vehicle details: {}", e.getMessage());
+            logger.debug("Failed to send lock command: {}", e.getMessage(), e);
         }
     }
 
@@ -511,7 +511,7 @@ public class TeslascopeVehicleHandler extends BaseThingHandler {
         } catch (IllegalStateException e) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE, e.getMessage());
         } catch (Exception e) {
-            logger.debug("Failed to parse vehicle details: {}", e.getMessage());
+            logger.debug("Failed to send openFrunk command: {}", e.getMessage(), e);
         }
     }
 
@@ -525,7 +525,7 @@ public class TeslascopeVehicleHandler extends BaseThingHandler {
         } catch (IllegalStateException e) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE, e.getMessage());
         } catch (Exception e) {
-            logger.debug("Failed to parse vehicle details: {}", e.getMessage());
+            logger.debug("Failed to send openTrunk command: {}", e.getMessage(), e);
         }
     }
 
@@ -539,7 +539,7 @@ public class TeslascopeVehicleHandler extends BaseThingHandler {
         } catch (IllegalStateException e) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE, e.getMessage());
         } catch (Exception e) {
-            logger.debug("Failed to parse vehicle details: {}", e.getMessage());
+            logger.debug("Failed to send sentry command: {}", e.getMessage(), e);
         }
     }
 
@@ -553,7 +553,7 @@ public class TeslascopeVehicleHandler extends BaseThingHandler {
         } catch (IllegalStateException e) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE, e.getMessage());
         } catch (Exception e) {
-            logger.debug("Failed to parse vehicle details: {}", e.getMessage());
+            logger.debug("Failed to send setChargeLimit command: {}", e.getMessage(), e);
         }
     }
 }

--- a/bundles/org.openhab.binding.teslascope/src/main/java/org/openhab/binding/teslascope/internal/TeslascopeVehicleHandler.java
+++ b/bundles/org.openhab.binding.teslascope/src/main/java/org/openhab/binding/teslascope/internal/TeslascopeVehicleHandler.java
@@ -25,6 +25,7 @@ import org.openhab.binding.teslascope.internal.api.DetailedInformation;
 import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.library.types.OpenClosedType;
+import org.openhab.core.library.types.PercentType;
 import org.openhab.core.library.types.PointType;
 import org.openhab.core.library.types.QuantityType;
 import org.openhab.core.library.types.StringType;
@@ -74,47 +75,38 @@ public class TeslascopeVehicleHandler extends BaseThingHandler {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE);
         } else if (bridgeStatusInfo.getStatus() == ThingStatus.ONLINE) {
             updateStatus(ThingStatus.ONLINE);
+            stopPoll();
             schedulePoll();
         }
     }
 
-    protected String getDetailedInformation(String publicID) {
+    protected String getDetailedInformation(String publicID)
+            throws TeslascopeCommunicationException, TeslascopeAuthenticationException {
         TeslascopeAccountHandler localBridge = bridgeHandler;
         if (localBridge == null) {
-            return "";
+            throw new IllegalStateException("Bridge is offline");
         }
-        try {
-            return localBridge.getDetailedInformation(publicID);
-        } catch (IllegalStateException e) {
-            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE, e.getMessage());
-            return "";
-        }
+        return localBridge.getDetailedInformation(publicID);
     }
 
-    protected void sendCommand(String publicID, String command) {
+    protected void sendCommand(String publicID, String command)
+            throws TeslascopeCommunicationException, TeslascopeAuthenticationException {
         TeslascopeAccountHandler localBridge = bridgeHandler;
         if (localBridge == null) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE, "@text/offline.conf-error.no-bridge");
             return;
         }
-        try {
-            localBridge.sendCommand(publicID, command);
-        } catch (IllegalStateException e) {
-            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE, e.getMessage());
-        }
+        localBridge.sendCommand(publicID, command);
     }
 
-    protected void sendCommand(String publicID, String command, String params) {
+    protected void sendCommand(String publicID, String command, String params)
+            throws TeslascopeCommunicationException, TeslascopeAuthenticationException {
         TeslascopeAccountHandler localBridge = bridgeHandler;
         if (localBridge == null) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE, "@text/offline.conf-error.no-bridge");
             return;
         }
-        try {
-            localBridge.sendCommand(publicID, command, params);
-        } catch (IllegalStateException e) {
-            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE, e.getMessage());
-        }
+        localBridge.sendCommand(publicID, command, params);
     }
 
     @Override
@@ -220,237 +212,348 @@ public class TeslascopeVehicleHandler extends BaseThingHandler {
     }
 
     private void pollStatus() {
-        String response = "";
-
-        response = getDetailedInformation(config.publicID);
-        updateStatus(ThingStatus.ONLINE);
-
-        DetailedInformation detailedInformation = gson.fromJson(response, DetailedInformation.class);
-
-        if (detailedInformation != null) {
-            updateState(TeslascopeBindingConstants.CHANNEL_VIN, new StringType(detailedInformation.vin));
-            updateState(TeslascopeBindingConstants.CHANNEL_VEHICLE_NAME, new StringType(detailedInformation.name));
-            updateState(TeslascopeBindingConstants.CHANNEL_VEHICLE_STATE, new StringType(detailedInformation.state));
-            updateState(TeslascopeBindingConstants.CHANNEL_LOCATED_AT_HOME,
-                    OnOffType.from(1 == detailedInformation.locatedAtHome));
-            updateState(TeslascopeBindingConstants.CHANNEL_LOCATED_AT_WORK,
-                    OnOffType.from(1 == detailedInformation.locatedAtWork));
-            updateState(TeslascopeBindingConstants.CHANNEL_LOCATED_AT_FAVORITE,
-                    OnOffType.from(1 == detailedInformation.locatedAtFavorite));
-
-            // charge state
-            if (detailedInformation.chargeState != null) {
-                updateState(TeslascopeBindingConstants.CHANNEL_BATTERY_LEVEL,
-                        new DecimalType(detailedInformation.chargeState.batteryLevel));
-                updateState(TeslascopeBindingConstants.CHANNEL_USABLE_BATTERY_LEVEL,
-                        new DecimalType(detailedInformation.chargeState.usableBatteryLevel));
-                updateState(TeslascopeBindingConstants.CHANNEL_BATTERY_RANGE,
-                        new QuantityType<>(detailedInformation.chargeState.batteryRange, ImperialUnits.MILE));
-                updateState(TeslascopeBindingConstants.CHANNEL_ESTIMATED_BATTERY_RANGE,
-                        new QuantityType<>(detailedInformation.chargeState.estBatteryRange, ImperialUnits.MILE));
-                // charge_enable_request isn't the right flag to determine if car is charging or not
-                updateState(TeslascopeBindingConstants.CHANNEL_CHARGE, OnOffType.from(
-                        ("DetailedChargeStateCharging".equals(detailedInformation.chargeState.detailedChargeState))
-                                || "DetailedChargeStateStarting"
-                                        .equals(detailedInformation.chargeState.detailedChargeState)));
-                updateState(TeslascopeBindingConstants.CHANNEL_CHARGE_ENERGY_ADDED,
-                        new QuantityType<>(detailedInformation.chargeState.chargeEnergyAdded, Units.KILOWATT_HOUR));
-                updateState(CHANNEL_CHARGE_LIMIT_SOC, new DecimalType(detailedInformation.chargeState.chargeLimitSoc));
-                updateState(CHANNEL_CHARGE_LIMIT_SOC_MIN,
-                        new DecimalType(detailedInformation.chargeState.chargeLimitSocMin));
-                updateState(CHANNEL_CHARGE_LIMIT_SOC_MAX,
-                        new DecimalType(detailedInformation.chargeState.chargeLimitSocMax));
-                updateState(CHANNEL_CHARGE_LIMIT_SOC_STANDARD,
-                        new DecimalType(detailedInformation.chargeState.chargeLimitSocStd));
-                updateState(TeslascopeBindingConstants.CHANNEL_CHARGE_PORT,
-                        OnOffType.from(1 == detailedInformation.chargeState.chargePortDoorOpen));
-                updateState(TeslascopeBindingConstants.CHANNEL_CHARGE_PORT_LATCH,
-                        OnOffType.from("Engaged".equals(detailedInformation.chargeState.chargePortLatch)));
-                updateState(TeslascopeBindingConstants.CHANNEL_CHARGE_RATE,
-                        new QuantityType<>(detailedInformation.chargeState.chargeRate, ImperialUnits.MILES_PER_HOUR));
-                updateState(TeslascopeBindingConstants.CHANNEL_CHARGER_POWER, new QuantityType<>(
-                        detailedInformation.chargeState.chargerPower, MetricPrefix.KILO(Units.WATT)));
-                updateState(TeslascopeBindingConstants.CHANNEL_CHARGER_VOLTAGE,
-                        new QuantityType<>(detailedInformation.chargeState.chargerVoltage, Units.VOLT));
-                updateState(TeslascopeBindingConstants.CHANNEL_TIME_TO_FULL_CHARGE,
-                        new QuantityType<>(detailedInformation.chargeState.timeToFullCharge, Units.HOUR));
-                updateState(TeslascopeBindingConstants.CHANNEL_CHARGING_STATE, new StringType(
-                        detailedInformation.chargeState.detailedChargeState.replace("DetailedChargeState", "")));
-                updateState(TeslascopeBindingConstants.CHANNEL_SCHEDULED_CHARGING_PENDING,
-                        OnOffType.from(1 == detailedInformation.chargeState.scheduledChargingPending));
-                updateState(TeslascopeBindingConstants.CHANNEL_SCHEDULED_CHARGING_START,
-                        new StringType(detailedInformation.chargeState.scheduledChargingStartTime));
-                updateState(TeslascopeBindingConstants.CHANNEL_CHARGE_AMPS,
-                        new QuantityType<>(detailedInformation.chargeState.chargeAmps, Units.AMPERE));
-                updateState(TeslascopeBindingConstants.CHANNEL_CHARGE_CURRENT_REQUEST,
-                        new QuantityType<>(detailedInformation.chargeState.chargeCurrentRequest, Units.AMPERE));
-                updateState(TeslascopeBindingConstants.CHANNEL_CHARGE_CURRENT_REQUEST_MAX,
-                        new QuantityType<>(detailedInformation.chargeState.chargeCurrentRequestMax, Units.AMPERE));
+        try {
+            String response = getDetailedInformation(config.publicID);
+            if (response == null || response.isBlank()) {
+                return;
             }
+            DetailedInformation detailedInformation = gson.fromJson(response, DetailedInformation.class);
 
-            // climate state
-            if (detailedInformation.climateState != null) {
-                updateState(TeslascopeBindingConstants.CHANNEL_AUTOCONDITIONING,
-                        OnOffType.from(1 == detailedInformation.climateState.isAutoConditioningOn));
-                updateState(TeslascopeBindingConstants.CHANNEL_CLIMATE,
-                        OnOffType.from(1 == detailedInformation.climateState.isClimateOn));
-                updateState(TeslascopeBindingConstants.CHANNEL_FRONT_DEFROSTER,
-                        OnOffType.from(1 == detailedInformation.climateState.isFrontDefrosterOn));
-                updateState(TeslascopeBindingConstants.CHANNEL_PRECONDITIONING,
-                        OnOffType.from(1 == detailedInformation.climateState.isPreconditioning));
-                updateState(TeslascopeBindingConstants.CHANNEL_REAR_DEFROSTER,
-                        OnOffType.from(1 == detailedInformation.climateState.isRearDefrosterOn));
-                updateState(TeslascopeBindingConstants.CHANNEL_LEFT_SEAT_HEATER,
-                        new DecimalType(detailedInformation.climateState.seatHeaterLeft));
-                updateState(TeslascopeBindingConstants.CHANNEL_CENTER_REAR_SEAT_HEATER,
-                        new DecimalType(detailedInformation.climateState.seatHeaterRearCenter));
-                updateState(TeslascopeBindingConstants.CHANNEL_LEFT_REAR_SEAT_HEATER,
-                        new DecimalType(detailedInformation.climateState.seatHeaterRearLeft));
-                updateState(TeslascopeBindingConstants.CHANNEL_RIGHT_REAR_SEAT_HEATER,
-                        new DecimalType(detailedInformation.climateState.seatHeaterRearRight));
-                updateState(TeslascopeBindingConstants.CHANNEL_RIGHT_SEAT_HEATER,
-                        new DecimalType(detailedInformation.climateState.seatHeaterRight));
-                updateState(TeslascopeBindingConstants.CHANNEL_SIDE_MIRROR_HEATERS,
-                        OnOffType.from(1 == detailedInformation.climateState.sideMirrorHeaters));
-                updateState(TeslascopeBindingConstants.CHANNEL_SMARTPRECONDITIONG,
-                        OnOffType.from(1 == detailedInformation.climateState.smartPreconditioning));
-                updateState(TeslascopeBindingConstants.CHANNEL_STEERING_WHEEL_HEATER,
-                        OnOffType.from(1 == detailedInformation.climateState.steeringWheelHeater));
-                updateState(TeslascopeBindingConstants.CHANNEL_WIPER_BLADE_HEATER,
-                        OnOffType.from(1 == detailedInformation.climateState.wiperBladeHeater));
-                updateState(TeslascopeBindingConstants.CHANNEL_DRIVER_TEMP,
-                        new QuantityType<>(detailedInformation.climateState.driverTempSetting, SIUnits.CELSIUS));
-                updateState(TeslascopeBindingConstants.CHANNEL_INSIDE_TEMP,
-                        new QuantityType<>(detailedInformation.climateState.insideTemp, SIUnits.CELSIUS));
-                updateState(TeslascopeBindingConstants.CHANNEL_OUTSIDE_TEMP,
-                        new QuantityType<>(detailedInformation.climateState.outsideTemp, SIUnits.CELSIUS));
-                updateState(TeslascopeBindingConstants.CHANNEL_PASSENGER_TEMP,
-                        new QuantityType<>(detailedInformation.climateState.passengerTempSetting, SIUnits.CELSIUS));
-                updateState(TeslascopeBindingConstants.CHANNEL_FAN,
-                        new DecimalType(detailedInformation.climateState.fanStatus));
-                updateState(TeslascopeBindingConstants.CHANNEL_LEFT_TEMP_DIRECTION,
-                        new DecimalType(detailedInformation.climateState.leftTempDirection));
-                updateState(TeslascopeBindingConstants.CHANNEL_MAX_AVAILABLE_TEMP,
-                        new QuantityType<>(detailedInformation.climateState.maxAvailTemp, SIUnits.CELSIUS));
-                updateState(TeslascopeBindingConstants.CHANNEL_MIN_AVAILABLE_TEMP,
-                        new QuantityType<>(detailedInformation.climateState.minAvailTemp, SIUnits.CELSIUS));
-                updateState(TeslascopeBindingConstants.CHANNEL_RIGHT_TEMP_DIRECTION,
-                        new DecimalType(detailedInformation.climateState.rightTempDirection));
-            }
+            if (detailedInformation != null) {
+                updateState(TeslascopeBindingConstants.CHANNEL_VIN, new StringType(detailedInformation.vin));
+                updateState(TeslascopeBindingConstants.CHANNEL_VEHICLE_NAME, new StringType(detailedInformation.name));
+                updateState(TeslascopeBindingConstants.CHANNEL_VEHICLE_STATE,
+                        new StringType(detailedInformation.state));
+                updateState(TeslascopeBindingConstants.CHANNEL_LOCATED_AT_HOME,
+                        OnOffType.from(1 == detailedInformation.locatedAtHome));
+                updateState(TeslascopeBindingConstants.CHANNEL_LOCATED_AT_WORK,
+                        OnOffType.from(1 == detailedInformation.locatedAtWork));
+                updateState(TeslascopeBindingConstants.CHANNEL_LOCATED_AT_FAVORITE,
+                        OnOffType.from(1 == detailedInformation.locatedAtFavorite));
 
-            // drive state
-            if (detailedInformation.driveState != null) {
-                updateState(TeslascopeBindingConstants.CHANNEL_HEADING,
-                        new DecimalType(detailedInformation.driveState.heading));
-                updateState(TeslascopeBindingConstants.CHANNEL_LOCATION, new PointType(
-                        detailedInformation.driveState.latitude + "," + detailedInformation.driveState.longitude));
-                updateState(TeslascopeBindingConstants.CHANNEL_POWER,
-                        new QuantityType<>(detailedInformation.driveState.power, MetricPrefix.KILO(Units.WATT)));
-                updateState(TeslascopeBindingConstants.CHANNEL_SHIFT_STATE,
-                        new StringType(detailedInformation.driveState.shiftState));
-                updateState(TeslascopeBindingConstants.CHANNEL_SPEED,
-                        new QuantityType<>(detailedInformation.driveState.speed, ImperialUnits.MILES_PER_HOUR));
-            }
+                // charge state
+                if (detailedInformation.chargeState != null) {
+                    updateState(TeslascopeBindingConstants.CHANNEL_BATTERY_LEVEL,
+                            new DecimalType(detailedInformation.chargeState.batteryLevel));
+                    updateState(TeslascopeBindingConstants.CHANNEL_USABLE_BATTERY_LEVEL,
+                            new DecimalType(detailedInformation.chargeState.usableBatteryLevel));
+                    updateState(TeslascopeBindingConstants.CHANNEL_BATTERY_RANGE,
+                            new QuantityType<>(detailedInformation.chargeState.batteryRange, ImperialUnits.MILE));
+                    updateState(TeslascopeBindingConstants.CHANNEL_ESTIMATED_BATTERY_RANGE,
+                            new QuantityType<>(detailedInformation.chargeState.estBatteryRange, ImperialUnits.MILE));
+                    // charge_enable_request isn't the right flag to determine if car is charging or not
+                    updateState(TeslascopeBindingConstants.CHANNEL_CHARGE, OnOffType.from(
+                            ("DetailedChargeStateCharging".equals(detailedInformation.chargeState.detailedChargeState))
+                                    || "DetailedChargeStateStarting"
+                                            .equals(detailedInformation.chargeState.detailedChargeState)));
+                    updateState(TeslascopeBindingConstants.CHANNEL_CHARGE_ENERGY_ADDED,
+                            new QuantityType<>(detailedInformation.chargeState.chargeEnergyAdded, Units.KILOWATT_HOUR));
+                    updateState(CHANNEL_CHARGE_LIMIT_SOC,
+                            new DecimalType(detailedInformation.chargeState.chargeLimitSoc));
+                    updateState(CHANNEL_CHARGE_LIMIT_SOC_MIN,
+                            new DecimalType(detailedInformation.chargeState.chargeLimitSocMin));
+                    updateState(CHANNEL_CHARGE_LIMIT_SOC_MAX,
+                            new DecimalType(detailedInformation.chargeState.chargeLimitSocMax));
+                    updateState(CHANNEL_CHARGE_LIMIT_SOC_STANDARD,
+                            new DecimalType(detailedInformation.chargeState.chargeLimitSocStd));
+                    updateState(TeslascopeBindingConstants.CHANNEL_CHARGE_PORT,
+                            OnOffType.from(1 == detailedInformation.chargeState.chargePortDoorOpen));
+                    updateState(TeslascopeBindingConstants.CHANNEL_CHARGE_PORT_LATCH,
+                            OnOffType.from("Engaged".equals(detailedInformation.chargeState.chargePortLatch)));
+                    updateState(TeslascopeBindingConstants.CHANNEL_CHARGE_RATE, new QuantityType<>(
+                            detailedInformation.chargeState.chargeRate, ImperialUnits.MILES_PER_HOUR));
+                    updateState(TeslascopeBindingConstants.CHANNEL_CHARGER_POWER, new QuantityType<>(
+                            detailedInformation.chargeState.chargerPower, MetricPrefix.KILO(Units.WATT)));
+                    updateState(TeslascopeBindingConstants.CHANNEL_CHARGER_VOLTAGE,
+                            new QuantityType<>(detailedInformation.chargeState.chargerVoltage, Units.VOLT));
+                    updateState(TeslascopeBindingConstants.CHANNEL_TIME_TO_FULL_CHARGE,
+                            new QuantityType<>(detailedInformation.chargeState.timeToFullCharge, Units.HOUR));
+                    updateState(TeslascopeBindingConstants.CHANNEL_CHARGING_STATE, new StringType(
+                            detailedInformation.chargeState.detailedChargeState.replace("DetailedChargeState", "")));
+                    updateState(TeslascopeBindingConstants.CHANNEL_SCHEDULED_CHARGING_PENDING,
+                            OnOffType.from(1 == detailedInformation.chargeState.scheduledChargingPending));
+                    updateState(TeslascopeBindingConstants.CHANNEL_SCHEDULED_CHARGING_START,
+                            new StringType(detailedInformation.chargeState.scheduledChargingStartTime));
+                    updateState(TeslascopeBindingConstants.CHANNEL_CHARGE_AMPS,
+                            new QuantityType<>(detailedInformation.chargeState.chargeAmps, Units.AMPERE));
+                    updateState(TeslascopeBindingConstants.CHANNEL_CHARGE_CURRENT_REQUEST,
+                            new QuantityType<>(detailedInformation.chargeState.chargeCurrentRequest, Units.AMPERE));
+                    updateState(TeslascopeBindingConstants.CHANNEL_CHARGE_CURRENT_REQUEST_MAX,
+                            new QuantityType<>(detailedInformation.chargeState.chargeCurrentRequestMax, Units.AMPERE));
+                }
 
-            // vehicle state
-            if (detailedInformation.vehicleState != null) {
-                Map<String, String> properties = editProperties();
-                properties.put(Thing.PROPERTY_FIRMWARE_VERSION, detailedInformation.vehicleState.carVersion);
-                updateProperties(properties);
-                updateState(TeslascopeBindingConstants.CHANNEL_DOOR_LOCK,
-                        OnOffType.from(detailedInformation.vehicleState.locked));
-                updateState(TeslascopeBindingConstants.CHANNEL_ODOMETER,
-                        new QuantityType<>(detailedInformation.vehicleState.odometer, ImperialUnits.MILE));
-                updateState(TeslascopeBindingConstants.CHANNEL_SENTRY_MODE,
-                        OnOffType.from(detailedInformation.vehicleState.sentryMode));
-                updateState(TeslascopeBindingConstants.CHANNEL_VALET_MODE,
-                        OnOffType.from(1 == detailedInformation.vehicleState.valetMode));
-                updateState(TeslascopeBindingConstants.CHANNEL_SOFTWARE_UPDATE_AVAILABLE,
-                        OnOffType.from(!"".equals(detailedInformation.vehicleState.softwareUpdateStatus)));
-                updateState(TeslascopeBindingConstants.CHANNEL_SOFTWARE_UPDATE_STATUS,
-                        new StringType(detailedInformation.vehicleState.softwareUpdateStatus));
-                updateState(TeslascopeBindingConstants.CHANNEL_SOFTWARE_UPDATE_VERSION,
-                        new StringType(detailedInformation.vehicleState.softwareUpdateVersion));
-                updateState(TeslascopeBindingConstants.CHANNEL_SUNROOF_STATE,
-                        new StringType(detailedInformation.vehicleState.sunRoofState));
-                updateState(TeslascopeBindingConstants.CHANNEL_SUNROOF,
-                        new DecimalType(detailedInformation.vehicleState.sunRoofPercentOpen));
-                updateState(TeslascopeBindingConstants.CHANNEL_HOMELINK,
-                        OnOffType.from(1 == detailedInformation.vehicleState.homelinkNearby));
-                updateState(TeslascopeBindingConstants.CHANNEL_TPMS_FL,
-                        new QuantityType<>(detailedInformation.vehicleState.tpmsPressureFL, Units.BAR));
-                updateState(TeslascopeBindingConstants.CHANNEL_TPMS_FR,
-                        new QuantityType<>(detailedInformation.vehicleState.tpmsPressureFR, Units.BAR));
-                updateState(TeslascopeBindingConstants.CHANNEL_TPMS_RL,
-                        new QuantityType<>(detailedInformation.vehicleState.tpmsPressureRL, Units.BAR));
-                updateState(TeslascopeBindingConstants.CHANNEL_TPMS_RR,
-                        new QuantityType<>(detailedInformation.vehicleState.tpmsPressureRR, Units.BAR));
-                updateState(TeslascopeBindingConstants.CHANNEL_TPMS_SOFT_WARNING_FL,
-                        OnOffType.from(1 == detailedInformation.vehicleState.tpmsSoftWarningFL));
-                updateState(TeslascopeBindingConstants.CHANNEL_TPMS_SOFT_WARNING_FR,
-                        OnOffType.from(1 == detailedInformation.vehicleState.tpmsSoftWarningFR));
-                updateState(TeslascopeBindingConstants.CHANNEL_TPMS_SOFT_WARNING_RL,
-                        OnOffType.from(1 == detailedInformation.vehicleState.tpmsSoftWarningRL));
-                updateState(TeslascopeBindingConstants.CHANNEL_TPMS_SOFT_WARNING_RR,
-                        OnOffType.from(1 == detailedInformation.vehicleState.tpmsSoftWarningRR));
-                updateState(TeslascopeBindingConstants.CHANNEL_DRIVER_FRONT_DOOR,
-                        (1 == detailedInformation.vehicleState.df) ? OpenClosedType.OPEN : OpenClosedType.CLOSED);
-                updateState(TeslascopeBindingConstants.CHANNEL_DRIVER_REAR_DOOR,
-                        (1 == detailedInformation.vehicleState.dr) ? OpenClosedType.OPEN : OpenClosedType.CLOSED);
-                updateState(TeslascopeBindingConstants.CHANNEL_PASSENGER_FRONT_DOOR,
-                        (1 == detailedInformation.vehicleState.pf) ? OpenClosedType.OPEN : OpenClosedType.CLOSED);
-                updateState(TeslascopeBindingConstants.CHANNEL_PASSENGER_REAR_DOOR,
-                        (1 == detailedInformation.vehicleState.pr) ? OpenClosedType.OPEN : OpenClosedType.CLOSED);
-                updateState(TeslascopeBindingConstants.CHANNEL_FRONT_TRUNK,
-                        OnOffType.from(1 == detailedInformation.vehicleState.ft));
-                updateState(TeslascopeBindingConstants.CHANNEL_REAR_TRUNK,
-                        OnOffType.from(1 == detailedInformation.vehicleState.rt));
+                // climate state
+                if (detailedInformation.climateState != null) {
+                    updateState(TeslascopeBindingConstants.CHANNEL_AUTOCONDITIONING,
+                            OnOffType.from(1 == detailedInformation.climateState.isAutoConditioningOn));
+                    updateState(TeslascopeBindingConstants.CHANNEL_CLIMATE,
+                            OnOffType.from(1 == detailedInformation.climateState.isClimateOn));
+                    updateState(TeslascopeBindingConstants.CHANNEL_FRONT_DEFROSTER,
+                            OnOffType.from(1 == detailedInformation.climateState.isFrontDefrosterOn));
+                    updateState(TeslascopeBindingConstants.CHANNEL_PRECONDITIONING,
+                            OnOffType.from(1 == detailedInformation.climateState.isPreconditioning));
+                    updateState(TeslascopeBindingConstants.CHANNEL_REAR_DEFROSTER,
+                            OnOffType.from(1 == detailedInformation.climateState.isRearDefrosterOn));
+                    updateState(TeslascopeBindingConstants.CHANNEL_LEFT_SEAT_HEATER,
+                            new DecimalType(detailedInformation.climateState.seatHeaterLeft));
+                    updateState(TeslascopeBindingConstants.CHANNEL_CENTER_REAR_SEAT_HEATER,
+                            new DecimalType(detailedInformation.climateState.seatHeaterRearCenter));
+                    updateState(TeslascopeBindingConstants.CHANNEL_LEFT_REAR_SEAT_HEATER,
+                            new DecimalType(detailedInformation.climateState.seatHeaterRearLeft));
+                    updateState(TeslascopeBindingConstants.CHANNEL_RIGHT_REAR_SEAT_HEATER,
+                            new DecimalType(detailedInformation.climateState.seatHeaterRearRight));
+                    updateState(TeslascopeBindingConstants.CHANNEL_RIGHT_SEAT_HEATER,
+                            new DecimalType(detailedInformation.climateState.seatHeaterRight));
+                    updateState(TeslascopeBindingConstants.CHANNEL_SIDE_MIRROR_HEATERS,
+                            OnOffType.from(1 == detailedInformation.climateState.sideMirrorHeaters));
+                    updateState(TeslascopeBindingConstants.CHANNEL_SMARTPRECONDITIONG,
+                            OnOffType.from(1 == detailedInformation.climateState.smartPreconditioning));
+                    updateState(TeslascopeBindingConstants.CHANNEL_STEERING_WHEEL_HEATER,
+                            OnOffType.from(1 == detailedInformation.climateState.steeringWheelHeater));
+                    updateState(TeslascopeBindingConstants.CHANNEL_WIPER_BLADE_HEATER,
+                            OnOffType.from(1 == detailedInformation.climateState.wiperBladeHeater));
+                    updateState(TeslascopeBindingConstants.CHANNEL_DRIVER_TEMP,
+                            new QuantityType<>(detailedInformation.climateState.driverTempSetting, SIUnits.CELSIUS));
+                    updateState(TeslascopeBindingConstants.CHANNEL_INSIDE_TEMP,
+                            new QuantityType<>(detailedInformation.climateState.insideTemp, SIUnits.CELSIUS));
+                    updateState(TeslascopeBindingConstants.CHANNEL_OUTSIDE_TEMP,
+                            new QuantityType<>(detailedInformation.climateState.outsideTemp, SIUnits.CELSIUS));
+                    updateState(TeslascopeBindingConstants.CHANNEL_PASSENGER_TEMP,
+                            new QuantityType<>(detailedInformation.climateState.passengerTempSetting, SIUnits.CELSIUS));
+                    updateState(TeslascopeBindingConstants.CHANNEL_FAN,
+                            new DecimalType(detailedInformation.climateState.fanStatus));
+                    updateState(TeslascopeBindingConstants.CHANNEL_LEFT_TEMP_DIRECTION,
+                            new DecimalType(detailedInformation.climateState.leftTempDirection));
+                    updateState(TeslascopeBindingConstants.CHANNEL_MAX_AVAILABLE_TEMP,
+                            new QuantityType<>(detailedInformation.climateState.maxAvailTemp, SIUnits.CELSIUS));
+                    updateState(TeslascopeBindingConstants.CHANNEL_MIN_AVAILABLE_TEMP,
+                            new QuantityType<>(detailedInformation.climateState.minAvailTemp, SIUnits.CELSIUS));
+                    updateState(TeslascopeBindingConstants.CHANNEL_RIGHT_TEMP_DIRECTION,
+                            new DecimalType(detailedInformation.climateState.rightTempDirection));
+                }
+
+                // drive state
+                if (detailedInformation.driveState != null) {
+                    updateState(TeslascopeBindingConstants.CHANNEL_HEADING,
+                            new DecimalType(detailedInformation.driveState.heading));
+                    updateState(TeslascopeBindingConstants.CHANNEL_LOCATION, new PointType(
+                            detailedInformation.driveState.latitude + "," + detailedInformation.driveState.longitude));
+                    updateState(TeslascopeBindingConstants.CHANNEL_POWER,
+                            new QuantityType<>(detailedInformation.driveState.power, MetricPrefix.KILO(Units.WATT)));
+                    updateState(TeslascopeBindingConstants.CHANNEL_SHIFT_STATE,
+                            new StringType(detailedInformation.driveState.shiftState));
+                    updateState(TeslascopeBindingConstants.CHANNEL_SPEED,
+                            new QuantityType<>(detailedInformation.driveState.speed, ImperialUnits.MILES_PER_HOUR));
+                }
+
+                // vehicle state
+                if (detailedInformation.vehicleState != null) {
+                    Map<String, String> properties = editProperties();
+                    properties.put(Thing.PROPERTY_FIRMWARE_VERSION, detailedInformation.vehicleState.carVersion);
+                    updateProperties(properties);
+                    updateState(TeslascopeBindingConstants.CHANNEL_DOOR_LOCK,
+                            OnOffType.from(detailedInformation.vehicleState.locked));
+                    updateState(TeslascopeBindingConstants.CHANNEL_ODOMETER,
+                            new QuantityType<>(detailedInformation.vehicleState.odometer, ImperialUnits.MILE));
+                    updateState(TeslascopeBindingConstants.CHANNEL_SENTRY_MODE,
+                            OnOffType.from(detailedInformation.vehicleState.sentryMode));
+                    updateState(TeslascopeBindingConstants.CHANNEL_VALET_MODE,
+                            OnOffType.from(1 == detailedInformation.vehicleState.valetMode));
+                    updateState(TeslascopeBindingConstants.CHANNEL_SOFTWARE_UPDATE_AVAILABLE,
+                            OnOffType.from(!"".equals(detailedInformation.vehicleState.softwareUpdateStatus)));
+                    updateState(TeslascopeBindingConstants.CHANNEL_SOFTWARE_UPDATE_STATUS,
+                            new StringType(detailedInformation.vehicleState.softwareUpdateStatus));
+                    updateState(TeslascopeBindingConstants.CHANNEL_SOFTWARE_UPDATE_VERSION,
+                            new StringType(detailedInformation.vehicleState.softwareUpdateVersion));
+                    updateState(TeslascopeBindingConstants.CHANNEL_SUNROOF_STATE,
+                            new StringType(detailedInformation.vehicleState.sunRoofState));
+                    updateState(TeslascopeBindingConstants.CHANNEL_SUNROOF,
+                            new PercentType(detailedInformation.vehicleState.sunRoofPercentOpen));
+                    updateState(TeslascopeBindingConstants.CHANNEL_HOMELINK,
+                            OnOffType.from(1 == detailedInformation.vehicleState.homelinkNearby));
+                    updateState(TeslascopeBindingConstants.CHANNEL_TPMS_FL,
+                            new QuantityType<>(detailedInformation.vehicleState.tpmsPressureFL, Units.BAR));
+                    updateState(TeslascopeBindingConstants.CHANNEL_TPMS_FR,
+                            new QuantityType<>(detailedInformation.vehicleState.tpmsPressureFR, Units.BAR));
+                    updateState(TeslascopeBindingConstants.CHANNEL_TPMS_RL,
+                            new QuantityType<>(detailedInformation.vehicleState.tpmsPressureRL, Units.BAR));
+                    updateState(TeslascopeBindingConstants.CHANNEL_TPMS_RR,
+                            new QuantityType<>(detailedInformation.vehicleState.tpmsPressureRR, Units.BAR));
+                    updateState(TeslascopeBindingConstants.CHANNEL_TPMS_SOFT_WARNING_FL,
+                            OnOffType.from(1 == detailedInformation.vehicleState.tpmsSoftWarningFL));
+                    updateState(TeslascopeBindingConstants.CHANNEL_TPMS_SOFT_WARNING_FR,
+                            OnOffType.from(1 == detailedInformation.vehicleState.tpmsSoftWarningFR));
+                    updateState(TeslascopeBindingConstants.CHANNEL_TPMS_SOFT_WARNING_RL,
+                            OnOffType.from(1 == detailedInformation.vehicleState.tpmsSoftWarningRL));
+                    updateState(TeslascopeBindingConstants.CHANNEL_TPMS_SOFT_WARNING_RR,
+                            OnOffType.from(1 == detailedInformation.vehicleState.tpmsSoftWarningRR));
+                    updateState(TeslascopeBindingConstants.CHANNEL_DRIVER_FRONT_DOOR,
+                            (1 == detailedInformation.vehicleState.df) ? OpenClosedType.OPEN : OpenClosedType.CLOSED);
+                    updateState(TeslascopeBindingConstants.CHANNEL_DRIVER_REAR_DOOR,
+                            (1 == detailedInformation.vehicleState.dr) ? OpenClosedType.OPEN : OpenClosedType.CLOSED);
+                    updateState(TeslascopeBindingConstants.CHANNEL_PASSENGER_FRONT_DOOR,
+                            (1 == detailedInformation.vehicleState.pf) ? OpenClosedType.OPEN : OpenClosedType.CLOSED);
+                    updateState(TeslascopeBindingConstants.CHANNEL_PASSENGER_REAR_DOOR,
+                            (1 == detailedInformation.vehicleState.pr) ? OpenClosedType.OPEN : OpenClosedType.CLOSED);
+                    updateState(TeslascopeBindingConstants.CHANNEL_FRONT_TRUNK,
+                            OnOffType.from(1 == detailedInformation.vehicleState.ft));
+                    updateState(TeslascopeBindingConstants.CHANNEL_REAR_TRUNK,
+                            OnOffType.from(1 == detailedInformation.vehicleState.rt));
+                }
+                // virtual items
+                updateState(TeslascopeBindingConstants.CHANNEL_HONK_HORN, OnOffType.OFF);
+                updateState(TeslascopeBindingConstants.CHANNEL_FLASH_LIGHTS, OnOffType.OFF);
             }
+        } catch (TeslascopeAuthenticationException e) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, e.getMessage());
+        } catch (TeslascopeCommunicationException e) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, e.getMessage());
+        } catch (IllegalStateException e) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE, e.getMessage());
+        } catch (Exception e) {
+            logger.debug("Failed to parse vehicle details: {}", e.getMessage());
         }
-        // virtual items
-        updateState(TeslascopeBindingConstants.CHANNEL_HONK_HORN, OnOffType.OFF);
-        updateState(TeslascopeBindingConstants.CHANNEL_FLASH_LIGHTS, OnOffType.OFF);
     }
 
     protected void setAutoConditioning(boolean b) {
-        sendCommand(config.publicID, b ? "startAC" : "stopAC", "");
+        try {
+            sendCommand(config.publicID, b ? "startAC" : "stopAC", "");
+        } catch (TeslascopeAuthenticationException e) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, e.getMessage());
+        } catch (TeslascopeCommunicationException e) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, e.getMessage());
+        } catch (IllegalStateException e) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE, e.getMessage());
+        } catch (Exception e) {
+            logger.debug("Failed to parse vehicle details: {}", e.getMessage());
+        }
     }
 
     protected void charge(boolean b) {
-        sendCommand(config.publicID, b ? "startCharging" : "stopCharging", "");
+        try {
+            sendCommand(config.publicID, b ? "startCharging" : "stopCharging", "");
+        } catch (TeslascopeAuthenticationException e) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, e.getMessage());
+        } catch (TeslascopeCommunicationException e) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, e.getMessage());
+        } catch (IllegalStateException e) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE, e.getMessage());
+        } catch (Exception e) {
+            logger.debug("Failed to parse vehicle details: {}", e.getMessage());
+        }
     }
 
     protected void chargeDoor(boolean b) {
-        sendCommand(config.publicID, b ? "openChargeDoor" : "closeChargeDoor", "");
+        try {
+            sendCommand(config.publicID, b ? "openChargeDoor" : "closeChargeDoor", "");
+        } catch (TeslascopeAuthenticationException e) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, e.getMessage());
+        } catch (TeslascopeCommunicationException e) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, e.getMessage());
+        } catch (IllegalStateException e) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE, e.getMessage());
+        } catch (Exception e) {
+            logger.debug("Failed to parse vehicle details: {}", e.getMessage());
+        }
     }
 
     protected void flashLights() {
-        sendCommand(config.publicID, "flashLights");
-        updateState(TeslascopeBindingConstants.CHANNEL_FLASH_LIGHTS, OnOffType.OFF);
+        try {
+            sendCommand(config.publicID, "flashLights");
+            updateState(TeslascopeBindingConstants.CHANNEL_FLASH_LIGHTS, OnOffType.OFF);
+        } catch (TeslascopeAuthenticationException e) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, e.getMessage());
+        } catch (TeslascopeCommunicationException e) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, e.getMessage());
+        } catch (IllegalStateException e) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE, e.getMessage());
+        } catch (Exception e) {
+            logger.debug("Failed to parse vehicle details: {}", e.getMessage());
+        }
     }
 
     protected void honkHorn() {
-        sendCommand(config.publicID, "honkHorn");
-        updateState(TeslascopeBindingConstants.CHANNEL_HONK_HORN, OnOffType.OFF);
+        try {
+            sendCommand(config.publicID, "honkHorn");
+            updateState(TeslascopeBindingConstants.CHANNEL_HONK_HORN, OnOffType.OFF);
+        } catch (TeslascopeAuthenticationException e) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, e.getMessage());
+        } catch (TeslascopeCommunicationException e) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, e.getMessage());
+        } catch (IllegalStateException e) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE, e.getMessage());
+        } catch (Exception e) {
+            logger.debug("Failed to parse vehicle details: {}", e.getMessage());
+        }
     }
 
     protected void lock(boolean b) {
-        sendCommand(config.publicID, b ? "lock" : "unlock");
+        try {
+            sendCommand(config.publicID, b ? "lock" : "unlock");
+        } catch (TeslascopeAuthenticationException e) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, e.getMessage());
+        } catch (TeslascopeCommunicationException e) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, e.getMessage());
+        } catch (IllegalStateException e) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE, e.getMessage());
+        } catch (Exception e) {
+            logger.debug("Failed to parse vehicle details: {}", e.getMessage());
+        }
     }
 
     protected void openFrunk() {
-        sendCommand(config.publicID, "openFrunk");
+        try {
+            sendCommand(config.publicID, "openFrunk");
+        } catch (TeslascopeAuthenticationException e) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, e.getMessage());
+        } catch (TeslascopeCommunicationException e) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, e.getMessage());
+        } catch (IllegalStateException e) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE, e.getMessage());
+        } catch (Exception e) {
+            logger.debug("Failed to parse vehicle details: {}", e.getMessage());
+        }
     }
 
     protected void openTrunk() {
-        sendCommand(config.publicID, "openTrunk");
+        try {
+            sendCommand(config.publicID, "openTrunk");
+        } catch (TeslascopeAuthenticationException e) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, e.getMessage());
+        } catch (TeslascopeCommunicationException e) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, e.getMessage());
+        } catch (IllegalStateException e) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE, e.getMessage());
+        } catch (Exception e) {
+            logger.debug("Failed to parse vehicle details: {}", e.getMessage());
+        }
     }
 
     protected void sentry(boolean b) {
-        sendCommand(config.publicID, b ? "enableSentryMode" : "disableSentryMode");
+        try {
+            sendCommand(config.publicID, b ? "enableSentryMode" : "disableSentryMode");
+        } catch (TeslascopeAuthenticationException e) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, e.getMessage());
+        } catch (TeslascopeCommunicationException e) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, e.getMessage());
+        } catch (IllegalStateException e) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE, e.getMessage());
+        } catch (Exception e) {
+            logger.debug("Failed to parse vehicle details: {}", e.getMessage());
+        }
     }
 
     protected void setChargeLimit(QuantityType<?> chargeLimit) {
-        sendCommand(config.publicID, "setChargeLimit", "limit=" + chargeLimit.toBigDecimal().intValue());
+        try {
+            sendCommand(config.publicID, "setChargeLimit", "limit=" + chargeLimit.toBigDecimal().intValue());
+        } catch (TeslascopeAuthenticationException e) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, e.getMessage());
+        } catch (TeslascopeCommunicationException e) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, e.getMessage());
+        } catch (IllegalStateException e) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE, e.getMessage());
+        } catch (Exception e) {
+            logger.debug("Failed to parse vehicle details: {}", e.getMessage());
+        }
     }
 }

--- a/bundles/org.openhab.binding.teslascope/src/main/java/org/openhab/binding/teslascope/internal/TeslascopeVehicleHandler.java
+++ b/bundles/org.openhab.binding.teslascope/src/main/java/org/openhab/binding/teslascope/internal/TeslascopeVehicleHandler.java
@@ -221,6 +221,7 @@ public class TeslascopeVehicleHandler extends BaseThingHandler {
 
             if (detailedInformation != null) {
                 updateStatus(ThingStatus.ONLINE);
+                updateState(TeslascopeBindingConstants.CHANNEL_VEHICLE_NAME, new StringType(detailedInformation.name));
                 updateState(TeslascopeBindingConstants.CHANNEL_VIN, new StringType(detailedInformation.vin));
                 updateState(TeslascopeBindingConstants.CHANNEL_VEHICLE_STATE,
                         new StringType(detailedInformation.state));

--- a/bundles/org.openhab.binding.teslascope/src/main/java/org/openhab/binding/teslascope/internal/TeslascopeVehicleHandler.java
+++ b/bundles/org.openhab.binding.teslascope/src/main/java/org/openhab/binding/teslascope/internal/TeslascopeVehicleHandler.java
@@ -45,6 +45,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.gson.Gson;
+import com.google.gson.JsonSyntaxException;
 
 /**
  * The {@link TeslascopeHandler} is responsible for handling commands, which are
@@ -200,6 +201,8 @@ public class TeslascopeVehicleHandler extends BaseThingHandler {
         try {
             String response = getDetailedInformation(config.publicID);
             if (response == null || response.isBlank()) {
+                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
+                        "@text/offline.comm-error.empty-response");
                 return;
             }
             DetailedInformation detailedInformation = gson.fromJson(response, DetailedInformation.class);
@@ -396,9 +399,10 @@ public class TeslascopeVehicleHandler extends BaseThingHandler {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, e.getMessage());
         } catch (IllegalStateException e) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE, e.getMessage());
-        } catch (Exception e) {
+        } catch (JsonSyntaxException e) {
             logger.debug("Failed to parse vehicle details: {}", e.getMessage(), e);
-            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, "Invalid JSON response");
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
+                    "@text/offline.comm-error.no-json");
         }
     }
 

--- a/bundles/org.openhab.binding.teslascope/src/main/java/org/openhab/binding/teslascope/internal/TeslascopeVehicleHandler.java
+++ b/bundles/org.openhab.binding.teslascope/src/main/java/org/openhab/binding/teslascope/internal/TeslascopeVehicleHandler.java
@@ -398,6 +398,7 @@ public class TeslascopeVehicleHandler extends BaseThingHandler {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE, e.getMessage());
         } catch (Exception e) {
             logger.debug("Failed to parse vehicle details: {}", e.getMessage(), e);
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, "Invalid JSON response");
         }
     }
 

--- a/bundles/org.openhab.binding.teslascope/src/main/java/org/openhab/binding/teslascope/internal/TeslascopeVehicleHandler.java
+++ b/bundles/org.openhab.binding.teslascope/src/main/java/org/openhab/binding/teslascope/internal/TeslascopeVehicleHandler.java
@@ -220,8 +220,8 @@ public class TeslascopeVehicleHandler extends BaseThingHandler {
             DetailedInformation detailedInformation = gson.fromJson(response, DetailedInformation.class);
 
             if (detailedInformation != null) {
+                updateStatus(ThingStatus.ONLINE);
                 updateState(TeslascopeBindingConstants.CHANNEL_VIN, new StringType(detailedInformation.vin));
-                updateState(TeslascopeBindingConstants.CHANNEL_VEHICLE_NAME, new StringType(detailedInformation.name));
                 updateState(TeslascopeBindingConstants.CHANNEL_VEHICLE_STATE,
                         new StringType(detailedInformation.state));
                 updateState(TeslascopeBindingConstants.CHANNEL_LOCATED_AT_HOME,

--- a/bundles/org.openhab.binding.teslascope/src/main/java/org/openhab/binding/teslascope/internal/TeslascopeVehicleHandler.java
+++ b/bundles/org.openhab.binding.teslascope/src/main/java/org/openhab/binding/teslascope/internal/TeslascopeVehicleHandler.java
@@ -269,11 +269,11 @@ public class TeslascopeVehicleHandler extends BaseThingHandler {
                 updateState(TeslascopeBindingConstants.CHANNEL_SCHEDULED_CHARGING_START,
                         new StringType(detailedInformation.chargeState.scheduledChargingStartTime));
                 updateState(TeslascopeBindingConstants.CHANNEL_CHARGE_AMPS,
-                        new DecimalType(detailedInformation.chargeState.chargeAmps));
+                        new QuantityType<>(detailedInformation.chargeState.chargeAmps, Units.AMPERE));
                 updateState(TeslascopeBindingConstants.CHANNEL_CHARGE_CURRENT_REQUEST,
-                        new DecimalType(detailedInformation.chargeState.chargeCurrentRequest));
+                        new QuantityType<>(detailedInformation.chargeState.chargeCurrentRequest, Units.AMPERE));
                 updateState(TeslascopeBindingConstants.CHANNEL_CHARGE_CURRENT_REQUEST_MAX,
-                        new DecimalType(detailedInformation.chargeState.chargeCurrentRequestMax));
+                        new QuantityType<>(detailedInformation.chargeState.chargeCurrentRequestMax, Units.AMPERE));
             }
 
             // climate state
@@ -343,7 +343,7 @@ public class TeslascopeVehicleHandler extends BaseThingHandler {
             // vehicle state
             if (detailedInformation.vehicleState != null) {
                 Map<String, String> properties = editProperties();
-                properties.put("version", detailedInformation.vehicleState.carVersion);
+                properties.put(Thing.PROPERTY_FIRMWARE_VERSION, detailedInformation.vehicleState.carVersion);
                 updateProperties(properties);
                 updateState(TeslascopeBindingConstants.CHANNEL_DOOR_LOCK,
                         OnOffType.from(detailedInformation.vehicleState.locked));

--- a/bundles/org.openhab.binding.teslascope/src/main/java/org/openhab/binding/teslascope/internal/TeslascopeVehicleHandler.java
+++ b/bundles/org.openhab.binding.teslascope/src/main/java/org/openhab/binding/teslascope/internal/TeslascopeVehicleHandler.java
@@ -37,6 +37,7 @@ import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.Thing;
 import org.openhab.core.thing.ThingStatus;
 import org.openhab.core.thing.ThingStatusDetail;
+import org.openhab.core.thing.ThingStatusInfo;
 import org.openhab.core.thing.binding.BaseThingHandler;
 import org.openhab.core.types.Command;
 import org.slf4j.Logger;
@@ -64,6 +65,17 @@ public class TeslascopeVehicleHandler extends BaseThingHandler {
 
     public TeslascopeVehicleHandler(Thing thing) {
         super(thing);
+    }
+
+    @Override
+    public void bridgeStatusChanged(ThingStatusInfo bridgeStatusInfo) {
+        if (bridgeStatusInfo.getStatus() == ThingStatus.OFFLINE) {
+            stopPoll();
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE);
+        } else if (bridgeStatusInfo.getStatus() == ThingStatus.ONLINE) {
+            updateStatus(ThingStatus.ONLINE);
+            schedulePoll();
+        }
     }
 
     protected String getDetailedInformation(String publicID) {

--- a/bundles/org.openhab.binding.teslascope/src/main/java/org/openhab/binding/teslascope/internal/TeslascopeVehicleHandler.java
+++ b/bundles/org.openhab.binding.teslascope/src/main/java/org/openhab/binding/teslascope/internal/TeslascopeVehicleHandler.java
@@ -84,7 +84,7 @@ public class TeslascopeVehicleHandler extends BaseThingHandler {
             throws TeslascopeCommunicationException, TeslascopeAuthenticationException {
         TeslascopeAccountHandler localBridge = bridgeHandler;
         if (localBridge == null) {
-            throw new IllegalStateException("Bridge is offline");
+            throw new IllegalStateException("@text/offline.conf-error.bridge-offline");
         }
         return localBridge.getDetailedInformation(publicID);
     }

--- a/bundles/org.openhab.binding.teslascope/src/main/java/org/openhab/binding/teslascope/internal/TeslascopeWebTargets.java
+++ b/bundles/org.openhab.binding.teslascope/src/main/java/org/openhab/binding/teslascope/internal/TeslascopeWebTargets.java
@@ -107,7 +107,7 @@ public class TeslascopeWebTargets {
                     request.header(HttpHeader.AUTHORIZATION.asString(), "Bearer " + personalAccessToken);
                 }
                 if (logger.isTraceEnabled()) {
-                    logger.trace("{} request for {}", HttpMethod.GET, uri);
+                    logger.trace("{} request for {}", method, uri);
                 }
                 ContentResponse response = request.send();
                 status = response.getStatus();

--- a/bundles/org.openhab.binding.teslascope/src/main/java/org/openhab/binding/teslascope/internal/TeslascopeWebTargets.java
+++ b/bundles/org.openhab.binding.teslascope/src/main/java/org/openhab/binding/teslascope/internal/TeslascopeWebTargets.java
@@ -75,14 +75,23 @@ public class TeslascopeWebTargets {
 
     public void sendCommand(String publicID, String apiKey, String personalAccessToken, String command, String params)
             throws TeslascopeCommunicationException, TeslascopeAuthenticationException {
+        String cleanParams = (params == null) ? "" : params.replaceFirst("^[?&]", "");
+
         if (personalAccessToken.isBlank()) {
-            invoke(BASE_VEHICLE_URI + publicID + "/command/" + command + "?api_key=" + apiKey + params, HttpMethod.POST,
-                    "");
+            // Legacy API Key method (needs & separator because ? is already used)
+            String url = BASE_VEHICLE_URI + publicID + "/command/" + command + "?api_key=" + apiKey;
+            if (!cleanParams.isEmpty()) {
+                url += "&" + cleanParams;
+            }
+            invoke(url, HttpMethod.POST, "");
         } else {
-            invoke(BASE_VEHICLE_URI + publicID + "/command/" + command + "?" + params, HttpMethod.POST,
-                    personalAccessToken);
+            // Personal Access Token method (needs ? separator)
+            String url = BASE_VEHICLE_URI + publicID + "/command/" + command;
+            if (!cleanParams.isEmpty()) {
+                url += "?" + cleanParams;
+            }
+            invoke(url, HttpMethod.POST, personalAccessToken);
         }
-        return;
     }
 
     private String invoke(String uri, HttpMethod method, String personalAccessToken)

--- a/bundles/org.openhab.binding.teslascope/src/main/java/org/openhab/binding/teslascope/internal/TeslascopeWebTargets.java
+++ b/bundles/org.openhab.binding.teslascope/src/main/java/org/openhab/binding/teslascope/internal/TeslascopeWebTargets.java
@@ -111,31 +111,32 @@ public class TeslascopeWebTargets {
                 }
                 ContentResponse response = request.send();
                 status = response.getStatus();
+
                 if (HttpStatus.isSuccess(status)) {
-                    return response.getContentAsString(); // Return immediately on success
+                    return response.getContentAsString();
                 } else {
                     switch (status) {
-                        case HttpStatus.UNAUTHORIZED_401:
-                            throw new TeslascopeAuthenticationException("Unauthorized");
-                        case HttpStatus.INTERNAL_SERVER_ERROR_500:
-                        case HttpStatus.BAD_GATEWAY_502:
-                        case HttpStatus.SERVICE_UNAVAILABLE_503:
-                        case HttpStatus.GATEWAY_TIMEOUT_504:
+                        case HttpStatus.UNAUTHORIZED_401 -> throw new TeslascopeAuthenticationException("Unauthorized");
+
+                        case HttpStatus.INTERNAL_SERVER_ERROR_500, HttpStatus.BAD_GATEWAY_502,
+                                HttpStatus.SERVICE_UNAVAILABLE_503, HttpStatus.GATEWAY_TIMEOUT_504 -> {
+
                             if (retryCounter == MAX_RETRIES) {
                                 throw new TeslascopeCommunicationException("Teslascope API unavailable after "
                                         + MAX_RETRIES + " attempts (HTTP " + status + ")");
                             }
                             logger.debug("Teslascope returned {}, retrying", status);
                             Thread.sleep(2000);
-                            break;
-                        default:
-                            throw new TeslascopeCommunicationException(
-                                    String.format("Teslascope returned error <%d> while invoking %s", status, uri));
+                        }
+
+                        default -> throw new TeslascopeCommunicationException(
+                                String.format("Teslascope returned error <%d> while invoking %s", status, uri));
                     }
                 }
+
             } catch (InterruptedException ex) {
                 Thread.currentThread().interrupt();
-                throw new TeslascopeCommunicationException(ex.getLocalizedMessage(), ex);
+                throw new TeslascopeCommunicationException("Thread was interrupted during API call");
             } catch (TimeoutException | ExecutionException ex) {
                 throw new TeslascopeCommunicationException(ex.getLocalizedMessage(), ex);
             }

--- a/bundles/org.openhab.binding.teslascope/src/main/java/org/openhab/binding/teslascope/internal/TeslascopeWebTargets.java
+++ b/bundles/org.openhab.binding.teslascope/src/main/java/org/openhab/binding/teslascope/internal/TeslascopeWebTargets.java
@@ -48,27 +48,27 @@ public class TeslascopeWebTargets {
     public String getVehicleList(String apiKey, String personalAccessToken)
             throws TeslascopeCommunicationException, TeslascopeAuthenticationException {
         if (personalAccessToken.isBlank()) {
-            return invoke(BASE_URI + "vehicles?api_key=" + apiKey, "");
+            return invoke(BASE_URI + "vehicles?api_key=" + apiKey, HttpMethod.GET, "");
         } else {
-            return invoke(BASE_URI + "vehicles", personalAccessToken);
+            return invoke(BASE_URI + "vehicles", HttpMethod.GET, personalAccessToken);
         }
     }
 
     public String getDetailedInformation(String publicID, String apiKey, String personalAccessToken)
             throws TeslascopeCommunicationException, TeslascopeAuthenticationException {
         if (personalAccessToken.isBlank()) {
-            return invoke(BASE_VEHICLE_URI + publicID + "/detailed?api_key=" + apiKey, "");
+            return invoke(BASE_VEHICLE_URI + publicID + "/detailed?api_key=" + apiKey, HttpMethod.GET, "");
         } else {
-            return invoke(BASE_VEHICLE_URI + publicID + "/detailed", personalAccessToken);
+            return invoke(BASE_VEHICLE_URI + publicID + "/detailed", HttpMethod.GET, personalAccessToken);
         }
     }
 
     public void sendCommand(String publicID, String apiKey, String personalAccessToken, String command)
             throws TeslascopeCommunicationException, TeslascopeAuthenticationException {
         if (personalAccessToken.isBlank()) {
-            invoke(BASE_VEHICLE_URI + publicID + "/command/" + command + "?api_key=" + apiKey, "");
+            invoke(BASE_VEHICLE_URI + publicID + "/command/" + command + "?api_key=" + apiKey, HttpMethod.POST, "");
         } else {
-            invoke(BASE_VEHICLE_URI + publicID + "/command/" + command, personalAccessToken);
+            invoke(BASE_VEHICLE_URI + publicID + "/command/" + command, HttpMethod.POST, personalAccessToken);
         }
         return;
     }
@@ -76,14 +76,16 @@ public class TeslascopeWebTargets {
     public void sendCommand(String publicID, String apiKey, String personalAccessToken, String command, String params)
             throws TeslascopeCommunicationException, TeslascopeAuthenticationException {
         if (personalAccessToken.isBlank()) {
-            invoke(BASE_VEHICLE_URI + publicID + "/command/" + command + "?api_key=" + apiKey + params, "");
+            invoke(BASE_VEHICLE_URI + publicID + "/command/" + command + "?api_key=" + apiKey + params, HttpMethod.POST,
+                    "");
         } else {
-            invoke(BASE_VEHICLE_URI + publicID + "/command/" + command + "?" + params, personalAccessToken);
+            invoke(BASE_VEHICLE_URI + publicID + "/command/" + command + "?" + params, HttpMethod.POST,
+                    personalAccessToken);
         }
         return;
     }
 
-    private String invoke(String uri, String personalAccessToken)
+    private String invoke(String uri, HttpMethod method, String personalAccessToken)
             throws TeslascopeCommunicationException, TeslascopeAuthenticationException {
         logger.debug("Calling url: {}", uri);
         String jsonResponse = "";
@@ -91,8 +93,7 @@ public class TeslascopeWebTargets {
 
         for (int retryCounter = 1; retryCounter <= MAX_RETRIES; retryCounter++) {
             try {
-                Request request = httpClient.newRequest(uri).method(HttpMethod.GET).timeout(TIMEOUT_MS,
-                        TimeUnit.MILLISECONDS);
+                Request request = httpClient.newRequest(uri).method(method).timeout(TIMEOUT_MS, TimeUnit.MILLISECONDS);
                 if (!personalAccessToken.isBlank()) {
                     request.header(HttpHeader.AUTHORIZATION.asString(), "Bearer " + personalAccessToken);
                 }

--- a/bundles/org.openhab.binding.teslascope/src/main/java/org/openhab/binding/teslascope/internal/TeslascopeWebTargets.java
+++ b/bundles/org.openhab.binding.teslascope/src/main/java/org/openhab/binding/teslascope/internal/TeslascopeWebTargets.java
@@ -136,7 +136,7 @@ public class TeslascopeWebTargets {
 
             } catch (InterruptedException ex) {
                 Thread.currentThread().interrupt();
-                throw new TeslascopeCommunicationException("Thread was interrupted during API call");
+                throw new TeslascopeCommunicationException("Thread was interrupted during API call.", ex);
             } catch (TimeoutException | ExecutionException ex) {
                 throw new TeslascopeCommunicationException(ex.getLocalizedMessage(), ex);
             }

--- a/bundles/org.openhab.binding.teslascope/src/main/java/org/openhab/binding/teslascope/internal/TeslascopeWebTargets.java
+++ b/bundles/org.openhab.binding.teslascope/src/main/java/org/openhab/binding/teslascope/internal/TeslascopeWebTargets.java
@@ -102,14 +102,19 @@ public class TeslascopeWebTargets {
                 ContentResponse response = request.send();
                 status = response.getStatus();
                 if (HttpStatus.isSuccess(status)) {
-                    jsonResponse = response.getContentAsString();
-                    logger.trace("JSON response: '{}'", jsonResponse);
+                    return response.getContentAsString(); // Return immediately on success
                 } else {
                     switch (status) {
                         case HttpStatus.UNAUTHORIZED_401:
                             throw new TeslascopeAuthenticationException("Unauthorized");
                         case HttpStatus.INTERNAL_SERVER_ERROR_500:
                         case HttpStatus.BAD_GATEWAY_502:
+                        case HttpStatus.SERVICE_UNAVAILABLE_503:
+                        case HttpStatus.GATEWAY_TIMEOUT_504:
+                            if (retryCounter == MAX_RETRIES) {
+                                throw new TeslascopeCommunicationException("Teslascope API unavailable after "
+                                        + MAX_RETRIES + " attempts (HTTP " + status + ")");
+                            }
                             logger.debug("Teslascope returned {}, retrying", status);
                             Thread.sleep(2000);
                             break;

--- a/bundles/org.openhab.binding.teslascope/src/main/java/org/openhab/binding/teslascope/internal/discovery/TeslascopeVehicleDiscoveryService.java
+++ b/bundles/org.openhab.binding.teslascope/src/main/java/org/openhab/binding/teslascope/internal/discovery/TeslascopeVehicleDiscoveryService.java
@@ -30,6 +30,7 @@ import org.slf4j.LoggerFactory;
 import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonParser;
+import com.google.gson.JsonSyntaxException;
 
 /**
  * The TeslascopeVehicleDiscoveryService is responsible for auto detecting a Tesla
@@ -82,7 +83,7 @@ public class TeslascopeVehicleDiscoveryService extends AbstractThingHandlerDisco
                         .withRepresentationProperty(CONFIG_PUBLICID).withLabel("Teslascope - " + vehicleList.name)
                         .build());
             }
-        } catch (Exception e) {
+        } catch (JsonSyntaxException e) {
             logger.debug("Failed to parse vehicle list during discovery: {}", e.getMessage(), e);
         }
     }

--- a/bundles/org.openhab.binding.teslascope/src/main/java/org/openhab/binding/teslascope/internal/discovery/TeslascopeVehicleDiscoveryService.java
+++ b/bundles/org.openhab.binding.teslascope/src/main/java/org/openhab/binding/teslascope/internal/discovery/TeslascopeVehicleDiscoveryService.java
@@ -83,7 +83,7 @@ public class TeslascopeVehicleDiscoveryService extends AbstractThingHandlerDisco
                         .build());
             }
         } catch (Exception e) {
-            logger.debug("Failed to parse vehicle list during discovery: {}", e.getMessage());
+            logger.debug("Failed to parse vehicle list during discovery: {}", e.getMessage(), e);
         }
     }
 

--- a/bundles/org.openhab.binding.teslascope/src/main/java/org/openhab/binding/teslascope/internal/discovery/TeslascopeVehicleDiscoveryService.java
+++ b/bundles/org.openhab.binding.teslascope/src/main/java/org/openhab/binding/teslascope/internal/discovery/TeslascopeVehicleDiscoveryService.java
@@ -20,7 +20,6 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.binding.teslascope.internal.TeslascopeAccountHandler;
 import org.openhab.binding.teslascope.internal.api.VehicleList;
 import org.openhab.core.config.discovery.AbstractThingHandlerDiscoveryService;
-import org.openhab.core.config.discovery.DiscoveryResultBuilder;
 import org.openhab.core.thing.ThingUID;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.ServiceScope;
@@ -62,18 +61,24 @@ public class TeslascopeVehicleDiscoveryService extends AbstractThingHandlerDisco
     private void discover() {
         ThingUID bridgeUID = thingHandler.getThing().getUID();
         String responseVehicleList = getVehicleList();
-        HashMap<String, Object> properties = new HashMap<>();
-        JsonArray jsonArrayVehicleList = JsonParser.parseString(responseVehicleList).getAsJsonArray();
-        VehicleList vehicleList = new VehicleList();
-        for (int i = 0; i < jsonArrayVehicleList.size(); i++) {
-            vehicleList = gson.fromJson(jsonArrayVehicleList.get(i), VehicleList.class);
-            if (vehicleList == null) {
-                return;
+
+        if (responseVehicleList == null || responseVehicleList.isBlank()) {
+            return;
+        }
+
+        try {
+            HashMap<String, Object> properties = new HashMap<>();
+            JsonArray jsonArrayVehicleList = JsonParser.parseString(responseVehicleList).getAsJsonArray();
+            VehicleList vehicleList = new VehicleList();
+            for (int i = 0; i < jsonArrayVehicleList.size(); i++) {
+                vehicleList = gson.fromJson(jsonArrayVehicleList.get(i), VehicleList.class);
+                if (vehicleList == null) {
+                    continue; // Skip invalid entries instead of aborting the whole method
+                }
+                // ... rest of the discovery logic
             }
-            properties.put(CONFIG_PUBLICID, vehicleList.publicId);
-            ThingUID uid = new ThingUID(TESLASCOPE_VEHICLE, bridgeUID, vehicleList.publicId);
-            thingDiscovered(DiscoveryResultBuilder.create(uid).withBridge(bridgeUID).withProperties(properties)
-                    .withRepresentationProperty(CONFIG_PUBLICID).withLabel("Teslascope - " + vehicleList.name).build());
+        } catch (Exception e) {
+            logger.debug("Failed to parse vehicle list during discovery: {}", e.getMessage());
         }
     }
 

--- a/bundles/org.openhab.binding.teslascope/src/main/java/org/openhab/binding/teslascope/internal/discovery/TeslascopeVehicleDiscoveryService.java
+++ b/bundles/org.openhab.binding.teslascope/src/main/java/org/openhab/binding/teslascope/internal/discovery/TeslascopeVehicleDiscoveryService.java
@@ -20,6 +20,7 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.binding.teslascope.internal.TeslascopeAccountHandler;
 import org.openhab.binding.teslascope.internal.api.VehicleList;
 import org.openhab.core.config.discovery.AbstractThingHandlerDiscoveryService;
+import org.openhab.core.config.discovery.DiscoveryResultBuilder;
 import org.openhab.core.thing.ThingUID;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.ServiceScope;
@@ -67,7 +68,6 @@ public class TeslascopeVehicleDiscoveryService extends AbstractThingHandlerDisco
         }
 
         try {
-            HashMap<String, Object> properties = new HashMap<>();
             JsonArray jsonArrayVehicleList = JsonParser.parseString(responseVehicleList).getAsJsonArray();
             VehicleList vehicleList = new VehicleList();
             for (int i = 0; i < jsonArrayVehicleList.size(); i++) {
@@ -75,7 +75,12 @@ public class TeslascopeVehicleDiscoveryService extends AbstractThingHandlerDisco
                 if (vehicleList == null) {
                     continue; // Skip invalid entries instead of aborting the whole method
                 }
-                // ... rest of the discovery logic
+                HashMap<String, Object> properties = new HashMap<>();
+                properties.put(CONFIG_PUBLICID, vehicleList.publicId);
+                ThingUID uid = new ThingUID(TESLASCOPE_VEHICLE, bridgeUID, vehicleList.publicId);
+                thingDiscovered(DiscoveryResultBuilder.create(uid).withBridge(bridgeUID).withProperties(properties)
+                        .withRepresentationProperty(CONFIG_PUBLICID).withLabel("Teslascope - " + vehicleList.name)
+                        .build());
             }
         } catch (Exception e) {
             logger.debug("Failed to parse vehicle list during discovery: {}", e.getMessage());

--- a/bundles/org.openhab.binding.teslascope/src/main/resources/OH-INF/i18n/teslascope.properties
+++ b/bundles/org.openhab.binding.teslascope/src/main/resources/OH-INF/i18n/teslascope.properties
@@ -190,11 +190,6 @@ channel-type.teslascope.vin.description = Vehicle Identification Number
 channel-type.teslascope.wiper-blade-heater.label = Wiper Blade Heater
 channel-type.teslascope.wiper-blade-heater.description = Indicates if the wiper blade heater is switched on
 
-# thing types config
-
-thing-type.config.teslascope.vehicle.apiKey.label = apiKey
-thing-type.config.teslascope.vehicle.apiKey.description = apiKey provided by Teslascope
-
 # thing types
 
 thing-type.teslascope.service.label = Teslascope

--- a/bundles/org.openhab.binding.teslascope/src/main/resources/OH-INF/i18n/teslascope.properties
+++ b/bundles/org.openhab.binding.teslascope/src/main/resources/OH-INF/i18n/teslascope.properties
@@ -210,3 +210,5 @@ offline.conf-error.no-credentials = API key or Personal Access Token must be set
 offline.conf-error.no-bridge = No Teslascope Bridge selected
 offline.comm-error.no-vehicles = Unable to retrieve Vehicle List
 offline.conf-error.bridge-offline = Teslascope Bridge is offline
+offline.comm-error.no-json = Invalid JSON response
+offline.comm-error.empty-response = Empty response from API

--- a/bundles/org.openhab.binding.teslascope/src/main/resources/OH-INF/i18n/teslascope.properties
+++ b/bundles/org.openhab.binding.teslascope/src/main/resources/OH-INF/i18n/teslascope.properties
@@ -209,3 +209,4 @@ thing-type.config.teslascope.service.refreshInterval.description = Interval the 
 offline.conf-error.no-credentials = API key or Personal Access Token must be set
 offline.conf-error.no-bridge = No Teslascope Bridge selected
 offline.comm-error.no-vehicles = Unable to retrieve Vehicle List
+offline.conf-error.bridge-offline = Teslascope Bridge is offline

--- a/bundles/org.openhab.binding.teslascope/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.teslascope/src/main/resources/OH-INF/thing/thing-types.xml
@@ -609,7 +609,7 @@
 		<item-type>Dimmer</item-type>
 		<label>Sunroof</label>
 		<description>Indicates the opening state of the sunroof (0% closed, 100% fully open)</description>
-		<state readOnly="true"></state>
+		<state pattern="%d %%" readOnly="true"></state>
 	</channel-type>
 	<channel-type id="time-to-full-charge" advanced="true">
 		<item-type>Number</item-type>

--- a/bundles/org.openhab.binding.teslascope/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.teslascope/src/main/resources/OH-INF/thing/thing-types.xml
@@ -609,7 +609,7 @@
 		<item-type>Dimmer</item-type>
 		<label>Sunroof</label>
 		<description>Indicates the opening state of the sunroof (0% closed, 100% fully open)</description>
-		<state pattern="%d %%" readOnly="true"></state>
+		<state readOnly="true"></state>
 	</channel-type>
 	<channel-type id="time-to-full-charge" advanced="true">
 		<item-type>Number</item-type>

--- a/bundles/org.openhab.binding.teslascope/src/main/resources/OH-INF/update/instructions.xml
+++ b/bundles/org.openhab.binding.teslascope/src/main/resources/OH-INF/update/instructions.xml
@@ -38,8 +38,8 @@
 			<add-channel id="located-at-favorite">
 				<type>teslascope:located-at-favorite</type>
 			</add-channel>
-			<update-channel id="charge-limit-soc-std">
-				<type>teslascope:charge-limit-soc-std</type>
+			<update-channel id="charge-limit-soc-standard">
+				<type>teslascope:charge-limit-soc-standard</type>
 			</update-channel>
 		</instruction-set>
 


### PR DESCRIPTION
Includes the following:
1. Fix Unhandled JSON Exceptions & Polling Thread Crashes
File: TeslascopeAccountHandler.java
Change: Validate the string before parsing it and wrap the parser in a try-catch block to prevent exceptions from killing the ScheduledExecutorService.
2. Fix NullPointerExceptions on Vehicle Offline/Sleep States
File: TeslascopeVehicleHandler.java
Change: Add null checks around the state objects before dereferencing them in pollStatus().
3. Fix Ignored Refresh Interval Configuration
File: TeslascopeAccountHandler.java
Change: In the initialize() method, utilize localConfig.refreshInterval instead of hardcoding 300 seconds.
4. Fix Fragile QuantityType Value Extraction & Malformed HTTP Query Parameters
File: TeslascopeVehicleHandler.java
Change: Safely convert the QuantityType into an integer instead of doing a string replacement, and drop the leading & so that TeslascopeWebTargets constructs valid URLs.
6. Fix Mismatched Channel Types in Update Instructions
File: instructions.xml
Change: Align the channel rename with thing-types.xml.
7. Clean up Orphaned Properties
8. Unit of Measurement (UoM) Mismatches
There is a discrepancy between how some channels are defined in the XML and how their states are updated in the handler. This will cause warnings in the openHAB logs and prevent users from utilizing automatic unit conversions.
9. Standardizing Thing Properties
openHAB relies on standardized property keys to populate specific fields in the Main UI (like the hardware and firmware version badges on the Thing page).
The Issue: The vehicle's software version is currently injected using a custom "version" key.
10. Silent Failure on Exhausted Retries
The network retry logic is built to handle temporary server errors (HTTP 500/502), but it has a "silent failure" state if the server doesn't recover in time.
11. Optimize sunroof Channel Definition
The Issue: The sunroof channel is correctly defined as a Dimmer item, which inherently represents a percentage. However, the state update is formatted using state pattern="%d %%". Since openHAB 4.x, the framework automatically handles percentage rendering for Dimmers, and appending the explicit %% pattern to a standard Dimmer can occasionally cause parsing collisions in advanced UI widgets.
The Fix: Remove the pattern attribute for the sunroof Dimmer channel in thing-types.xml to let the core framework handle the standard 0-100 rendering.
12. add SERVICE_UNAVAILABLE_503 and GATEWAY_TIMEOUT_504 to retry logic