### PR TITLE
[bluetooth] Fix BlueZ events stopping after reconnect (no SERVICES_DISCOVERED)

### DIFF
--- a/bundles/org.openhab.binding.bluetooth.bluez/src/main/java/org/openhab/binding/bluetooth/bluez/internal/BlueZBluetoothDevice.java
+++ b/bundles/org.openhab.binding.bluetooth.bluez/src/main/java/org/openhab/binding/bluetooth/bluez/internal/BlueZBluetoothDevice.java
@@ -386,13 +386,13 @@ public class BlueZBluetoothDevice extends BaseBluetoothDevice implements BlueZEv
     @Override
     public void onServicesResolved(ServicesResolvedEvent event) {
         if (event.isResolved()) {
-            // Populate our service/characteristic list from the now-resolved GATT before notifying
+            // Populate our service/characteristic list from the now-resolved GATT and notify
             // listeners. BlueZ can deliver ServicesResolved=true while our own supportedServices list
             // is still empty (e.g. right after a reconnect, before discoverServices() has run); firing
             // SERVICES_DISCOVERED then makes listeners (e.g. the generic handler's channel builder) run
             // against an empty list and miss every characteristic. discoverServices() populates the
-            // list and fires SERVICES_DISCOVERED itself once it has added services, so it is the
-            // correct trigger here. If the services are already known it is a cheap no-op.
+            // list and fires SERVICES_DISCOVERED once the GATT is resolved with services present -
+            // including on a reconnect where the list is unchanged - so it is the correct trigger here.
             discoverServices();
         }
     }
@@ -505,6 +505,14 @@ public class BlueZBluetoothDevice extends BaseBluetoothDevice implements BlueZEv
                 }
                 addService(service);
             }
+        }
+        // Notify whenever the GATT is resolved with services present, not only when our list just
+        // grew. On a reconnect BlueZ re-fires ServicesResolved=true while our supportedServices map
+        // is already fully populated from the previous connection (it is only cleared on object
+        // removal), so the "grew" check above is false. Consumers such as ConnectedBluetoothHandler
+        // re-arm their notifications/polling off SERVICES_DISCOVERED, so swallowing it here leaves the
+        // Thing online but silent after every reconnect. The notification is idempotent for listeners.
+        if (!getServices().isEmpty()) {
             notifyListeners(BluetoothEventType.SERVICES_DISCOVERED);
         }
         return true;


### PR DESCRIPTION
## Description

Fixes #20947 — a regression introduced by #20903 where a BlueZ device stays **ONLINE but receives no events after a reconnect** (reported by @jlaur with a Grundfos Alpha3, but it affects every binding built on `ConnectedBluetoothHandler`).

### Root cause

#20903 changed `BlueZBluetoothDevice.onServicesResolved()` from firing `SERVICES_DISCOVERED` unconditionally to calling `discoverServices()`. That was correct in intent (populate our list before notifying, so listeners don't run against an empty service list), but `discoverServices()` only fires `SERVICES_DISCOVERED` when the openHAB-side list **grows**:

```java
if (dev.getGattServices().size() > getServices().size()) {
    ...
    notifyListeners(BluetoothEventType.SERVICES_DISCOVERED);
}
```

`supportedServices` is only cleared on BlueZ object removal (`resetForRemoval()`), so on a normal reconnect BlueZ re-fires `ServicesResolved=true` while the list is **already fully populated** → the `>` check is `false` → `SERVICES_DISCOVERED` is never re-fired.

Consumers re-arm their notifications/polling off `onServicesDiscovered()`:
- `grundfosalpha` calls `enableNotifications(...)` and schedules its 30s read loop there;
- the generic binding rebuilds its channels there.

So swallowing the event leaves the Thing online but silent. @jlaur diagnosed it to exactly this line, and confirmed that manually invoking `onServicesDiscovered()` immediately restores the event stream.

### Fix

Fire `SERVICES_DISCOVERED` whenever the GATT is resolved with services present, not only when the list just grew. Population still only happens when the list grows, but the notification now reliably reaches listeners on every resolve (including reconnects).

The event is idempotent for all consumers:
- `GenericBluetoothHandler.updateThingChannels()` only adds channels that don't already exist;
- `ConnectedBluetoothHandler` / `grundfosalpha` re-enabling notifications is a no-op when already notifying ("Already notifying" is swallowed).

### Testing

- Compiles; `spotless:check` passes.
- Logic verified against the trace in #20947.

cc @jlaur @lsiepel