### PR TITLE
[amplipi] Use AmpliPi's normalized vol_f for zone volume

### DIFF
--- a/bundles/org.openhab.binding.amplipi/amplipi-api.yml
+++ b/bundles/org.openhab.binding.amplipi/amplipi-api.yml
@@ -5794,6 +5794,12 @@ components:
           type: integer
           description: Output volume in dB
           default: -79
+        vol_f:
+          title: Vol F
+          maximum: 1.0
+          minimum: 0.0
+          type: number
+          description: Output volume as a fraction of the volume range (0.0 - 1.0)
         disabled:
           title: Disabled
           type: boolean
@@ -5840,6 +5846,18 @@ components:
           minimum: -79.0
           type: integer
           description: Output volume in dB
+        vol_f:
+          title: Vol F
+          maximum: 1.0
+          minimum: 0.0
+          type: number
+          description: Output volume as a fraction of the volume range (0.0 - 1.0)
+        vol_delta_f:
+          title: Vol Delta F
+          maximum: 1.0
+          minimum: -1.0
+          type: number
+          description: Change in output volume as a fraction of the volume range (-1.0 - 1.0)
         disabled:
           title: Disabled
           type: boolean

--- a/bundles/org.openhab.binding.amplipi/src/gen/java/org/openhab/binding/amplipi/internal/model/Zone.java
+++ b/bundles/org.openhab.binding.amplipi/src/gen/java/org/openhab/binding/amplipi/internal/model/Zone.java
@@ -54,6 +54,13 @@ public class Zone {
     private Integer vol = -79;
 
     @Schema
+    @SerializedName("vol_f")
+    /**
+     * Output volume as a fraction of the volume range (0.0 - 1.0)
+     **/
+    private Double volF;
+
+    @Schema
     /**
      * Set to true if not connected to a speaker
      **/
@@ -154,6 +161,26 @@ public class Zone {
     }
 
     /**
+     * Output volume as a fraction of the volume range
+     * minimum: 0.0
+     * maximum: 1.0
+     *
+     * @return volF
+     **/
+    public Double getVolF() {
+        return volF;
+    }
+
+    public void setVolF(Double volF) {
+        this.volF = volF;
+    }
+
+    public Zone volF(Double volF) {
+        this.volF = volF;
+        return this;
+    }
+
+    /**
      * Set to true if not connected to a speaker
      *
      * @return disabled
@@ -181,6 +208,7 @@ public class Zone {
         sb.append("    sourceId: ").append(toIndentedString(sourceId)).append("\n");
         sb.append("    mute: ").append(toIndentedString(mute)).append("\n");
         sb.append("    vol: ").append(toIndentedString(vol)).append("\n");
+        sb.append("    volF: ").append(toIndentedString(volF)).append("\n");
         sb.append("    disabled: ").append(toIndentedString(disabled)).append("\n");
         sb.append("}");
         return sb.toString();

--- a/bundles/org.openhab.binding.amplipi/src/gen/java/org/openhab/binding/amplipi/internal/model/ZoneUpdate.java
+++ b/bundles/org.openhab.binding.amplipi/src/gen/java/org/openhab/binding/amplipi/internal/model/ZoneUpdate.java
@@ -48,6 +48,13 @@ public class ZoneUpdate {
     private Integer vol;
 
     @Schema
+    @SerializedName("vol_f")
+    /**
+     * Output volume as a fraction of the volume range (0.0 - 1.0)
+     **/
+    private Double volF;
+
+    @Schema
     /**
      * Set to true if not connected to a speaker
      **/
@@ -130,6 +137,26 @@ public class ZoneUpdate {
     }
 
     /**
+     * Output volume as a fraction of the volume range
+     * minimum: 0.0
+     * maximum: 1.0
+     *
+     * @return volF
+     **/
+    public Double getVolF() {
+        return volF;
+    }
+
+    public void setVolF(Double volF) {
+        this.volF = volF;
+    }
+
+    public ZoneUpdate volF(Double volF) {
+        this.volF = volF;
+        return this;
+    }
+
+    /**
      * Set to true if not connected to a speaker
      *
      * @return disabled
@@ -156,6 +183,7 @@ public class ZoneUpdate {
         sb.append("    sourceId: ").append(toIndentedString(sourceId)).append("\n");
         sb.append("    mute: ").append(toIndentedString(mute)).append("\n");
         sb.append("    vol: ").append(toIndentedString(vol)).append("\n");
+        sb.append("    volF: ").append(toIndentedString(volF)).append("\n");
         sb.append("    disabled: ").append(toIndentedString(disabled)).append("\n");
         sb.append("}");
         return sb.toString();

--- a/bundles/org.openhab.binding.amplipi/src/gen/java/org/openhab/binding/amplipi/internal/model/ZoneUpdate.java
+++ b/bundles/org.openhab.binding.amplipi/src/gen/java/org/openhab/binding/amplipi/internal/model/ZoneUpdate.java
@@ -55,6 +55,13 @@ public class ZoneUpdate {
     private Double volF;
 
     @Schema
+    @SerializedName("vol_delta_f")
+    /**
+     * Change in output volume as a fraction of the volume range (-1.0 - 1.0)
+     **/
+    private Double volDeltaF;
+
+    @Schema
     /**
      * Set to true if not connected to a speaker
      **/
@@ -157,6 +164,26 @@ public class ZoneUpdate {
     }
 
     /**
+     * Change in output volume as a fraction of the volume range
+     * minimum: -1.0
+     * maximum: 1.0
+     *
+     * @return volDeltaF
+     **/
+    public Double getVolDeltaF() {
+        return volDeltaF;
+    }
+
+    public void setVolDeltaF(Double volDeltaF) {
+        this.volDeltaF = volDeltaF;
+    }
+
+    public ZoneUpdate volDeltaF(Double volDeltaF) {
+        this.volDeltaF = volDeltaF;
+        return this;
+    }
+
+    /**
      * Set to true if not connected to a speaker
      *
      * @return disabled
@@ -184,6 +211,7 @@ public class ZoneUpdate {
         sb.append("    mute: ").append(toIndentedString(mute)).append("\n");
         sb.append("    vol: ").append(toIndentedString(vol)).append("\n");
         sb.append("    volF: ").append(toIndentedString(volF)).append("\n");
+        sb.append("    volDeltaF: ").append(toIndentedString(volDeltaF)).append("\n");
         sb.append("    disabled: ").append(toIndentedString(disabled)).append("\n");
         sb.append("}");
         return sb.toString();

--- a/bundles/org.openhab.binding.amplipi/src/main/java/org/openhab/binding/amplipi/internal/AmpliPiUtils.java
+++ b/bundles/org.openhab.binding.amplipi/src/main/java/org/openhab/binding/amplipi/internal/AmpliPiUtils.java
@@ -24,25 +24,52 @@ import org.openhab.core.library.types.PercentType;
 @NonNullByDefault
 public class AmpliPiUtils {
     /**
-     * The supported volume range in decibels for the AmpliPi
+     * The supported volume range in decibels for the AmpliPi (used for the
+     * legacy dB-based group volume delta).
      */
     public static final int MIN_VOLUME_DB = -79;
     public static final int MAX_VOLUME_DB = 0;
 
     /**
-     * Converts a volume from AmpliPi to an openHAB PercentType
+     * Converts a normalized AmpliPi volume fraction (0.0 - 1.0) to an openHAB
+     * PercentType. Using the firmware-provided fraction avoids assuming a fixed
+     * dB range, which differs between firmware versions (e.g. -79 vs -80 dB).
      *
-     * @param volume volume from AmpliPi
+     * @param volumeFraction volume fraction from AmpliPi (0.0 - 1.0)
      * @return according PercentType for openHAB
      */
-    public static PercentType volumeToPercentType(Integer volume) {
-        // AmpliPi volumes range from -79..0
-        return new PercentType((volume + 79) * 100 / 79);
+    public static PercentType volumeFractionToPercentType(double volumeFraction) {
+        long percent = Math.round(volumeFraction * 100);
+        return new PercentType((int) Math.max(0, Math.min(100, percent)));
     }
 
     /**
-     * Converts a volume as PercentType from openHAB to an integer for AmpliPi
-     * 
+     * Converts an openHAB PercentType to a normalized AmpliPi volume fraction
+     * (0.0 - 1.0).
+     *
+     * @param volume volume as PercentType
+     * @return according volume fraction for AmpliPi
+     */
+    public static double percentTypeToVolumeFraction(PercentType volume) {
+        return volume.doubleValue() / 100.0;
+    }
+
+    /**
+     * Converts a dB volume from AmpliPi to an openHAB PercentType. Only used for
+     * the group volume delta; the result is clamped so an out-of-range value can
+     * never throw.
+     *
+     * @param volume volume from AmpliPi in dB
+     * @return according PercentType for openHAB
+     */
+    public static PercentType volumeToPercentType(Integer volume) {
+        int percent = (volume + 79) * 100 / 79;
+        return new PercentType(Math.max(0, Math.min(100, percent)));
+    }
+
+    /**
+     * Converts a volume as PercentType from openHAB to a dB integer for AmpliPi.
+     *
      * @param volume volume as PercentType
      * @return according volume as int for AmpliPi
      */

--- a/bundles/org.openhab.binding.amplipi/src/main/java/org/openhab/binding/amplipi/internal/AmpliPiUtils.java
+++ b/bundles/org.openhab.binding.amplipi/src/main/java/org/openhab/binding/amplipi/internal/AmpliPiUtils.java
@@ -24,8 +24,8 @@ import org.openhab.core.library.types.PercentType;
 @NonNullByDefault
 public class AmpliPiUtils {
     /**
-     * The supported volume range in decibels for the AmpliPi (used for the
-     * legacy dB-based group volume delta).
+     * The supported volume range in decibels for the AmpliPi, used for group volumes
+     * and for zones on firmware that predates vol_f.
      */
     public static final int MIN_VOLUME_DB = -79;
     public static final int MAX_VOLUME_DB = 0;
@@ -55,9 +55,9 @@ public class AmpliPiUtils {
     }
 
     /**
-     * Converts a dB volume from AmpliPi to an openHAB PercentType. Only used for
-     * the group volume delta; the result is clamped so an out-of-range value can
-     * never throw.
+     * Converts a dB volume from AmpliPi to an openHAB PercentType. Used for group
+     * volumes and as the zone fallback on firmware that predates vol_f; the result
+     * is clamped so an out-of-range value can never throw.
      *
      * @param volume volume from AmpliPi in dB
      * @return according PercentType for openHAB

--- a/bundles/org.openhab.binding.amplipi/src/main/java/org/openhab/binding/amplipi/internal/AmpliPiZoneHandler.java
+++ b/bundles/org.openhab.binding.amplipi/src/main/java/org/openhab/binding/amplipi/internal/AmpliPiZoneHandler.java
@@ -115,17 +115,16 @@ public class AmpliPiZoneHandler extends BaseThingHandler implements AmpliPiStatu
                 break;
             case AmpliPiBindingConstants.CHANNEL_VOLUME:
                 if (command instanceof PercentType percentCommand) {
-                    update.setVol(AmpliPiUtils.percentTypeToVolume(percentCommand));
+                    update.setVolF(AmpliPiUtils.percentTypeToVolumeFraction(percentCommand));
                 } else if (command instanceof IncreaseDecreaseType) {
-                    if (zoneState != null) {
-                        if (IncreaseDecreaseType.INCREASE.equals(command)) {
-                            zoneState.setVol(
-                                    Math.min(zoneState.getVol() + getVolumeDelta(thing), AmpliPiUtils.MAX_VOLUME_DB));
-                        } else {
-                            zoneState.setVol(
-                                    Math.max(zoneState.getVol() - getVolumeDelta(thing), AmpliPiUtils.MIN_VOLUME_DB));
-                        }
-                        update.setVol(zoneState.getVol());
+                    Zone state = zoneState;
+                    if (state != null && state.getVolF() != null) {
+                        double step = getVolumeDelta(thing) / 100.0;
+                        double current = state.getVolF();
+                        double newVolF = IncreaseDecreaseType.INCREASE.equals(command) ? Math.min(current + step, 1.0)
+                                : Math.max(current - step, 0.0);
+                        state.setVolF(newVolF);
+                        update.setVolF(newVolF);
                     }
                 }
                 break;
@@ -166,12 +165,16 @@ public class AmpliPiZoneHandler extends BaseThingHandler implements AmpliPiStatu
 
         Boolean power = !zoneState.getMute();
         Boolean mute = zoneState.getMute();
-        Integer vol = zoneState.getVol();
         Integer sourceId = zoneState.getSourceId();
 
         updateState(AmpliPiBindingConstants.CHANNEL_POWER, OnOffType.from(power));
         updateState(AmpliPiBindingConstants.CHANNEL_MUTE, OnOffType.from(mute));
-        updateState(AmpliPiBindingConstants.CHANNEL_VOLUME, AmpliPiUtils.volumeToPercentType(vol));
+        // Prefer the firmware-provided volume fraction; fall back to the dB value
+        // for older firmware that does not report vol_f.
+        Double volF = zoneState.getVolF();
+        PercentType volume = volF != null ? AmpliPiUtils.volumeFractionToPercentType(volF)
+                : AmpliPiUtils.volumeToPercentType(zoneState.getVol());
+        updateState(AmpliPiBindingConstants.CHANNEL_VOLUME, volume);
         updateState(AmpliPiBindingConstants.CHANNEL_SOURCE, new DecimalType(sourceId));
     }
 }

--- a/bundles/org.openhab.binding.amplipi/src/main/java/org/openhab/binding/amplipi/internal/AmpliPiZoneHandler.java
+++ b/bundles/org.openhab.binding.amplipi/src/main/java/org/openhab/binding/amplipi/internal/AmpliPiZoneHandler.java
@@ -114,17 +114,36 @@ public class AmpliPiZoneHandler extends BaseThingHandler implements AmpliPiStatu
                 }
                 break;
             case AmpliPiBindingConstants.CHANNEL_VOLUME:
+                Zone state = zoneState;
+                // vol_f only exists from AmpliPi 0.1.8 on. A device whose status does not report it
+                // cannot understand it when PATCHing either, so writes have to use the dB field too.
+                boolean supportsVolumeFraction = state != null && state.getVolF() != null;
+                int volumeDelta = getVolumeDelta(thing);
                 if (command instanceof PercentType percentCommand) {
-                    update.setVolF(AmpliPiUtils.percentTypeToVolumeFraction(percentCommand));
+                    if (supportsVolumeFraction) {
+                        update.setVolF(AmpliPiUtils.percentTypeToVolumeFraction(percentCommand));
+                    } else {
+                        update.setVol(AmpliPiUtils.percentTypeToVolume(percentCommand));
+                    }
                 } else if (command instanceof IncreaseDecreaseType) {
-                    Zone state = zoneState;
-                    if (state != null && state.getVolF() != null) {
-                        double step = getVolumeDelta(thing) / 100.0;
-                        double current = state.getVolF();
-                        double newVolF = IncreaseDecreaseType.INCREASE.equals(command) ? Math.min(current + step, 1.0)
-                                : Math.max(current - step, 0.0);
-                        state.setVolF(newVolF);
-                        update.setVolF(newVolF);
+                    if (supportsVolumeFraction) {
+                        // Send the step itself and let AmpliPi apply it to its own current volume.
+                        // The cached zone state can be stale when the volume was changed through the
+                        // AmpliPi UI or another client since the last poll, and this also leaves the
+                        // bounds and overflow handling to the device.
+                        double step = volumeDelta / 100.0;
+                        update.setVolDeltaF(IncreaseDecreaseType.INCREASE.equals(command) ? step : -step);
+                    } else if (state != null && state.getVol() != null) {
+                        // Older firmware: keep adjusting the dB value against the cached state. The
+                        // configured step is a percentage, so scale it over the dB range.
+                        int stepDb = Math.max(1, (int) Math.round(
+                                volumeDelta / 100.0 * (AmpliPiUtils.MAX_VOLUME_DB - AmpliPiUtils.MIN_VOLUME_DB)));
+                        int current = state.getVol();
+                        int newVol = IncreaseDecreaseType.INCREASE.equals(command)
+                                ? Math.min(current + stepDb, AmpliPiUtils.MAX_VOLUME_DB)
+                                : Math.max(current - stepDb, AmpliPiUtils.MIN_VOLUME_DB);
+                        state.setVol(newVol);
+                        update.setVol(newVol);
                     }
                 }
                 break;

--- a/bundles/org.openhab.binding.amplipi/src/main/java/org/openhab/binding/amplipi/internal/AmpliPiZoneHandler.java
+++ b/bundles/org.openhab.binding.amplipi/src/main/java/org/openhab/binding/amplipi/internal/AmpliPiZoneHandler.java
@@ -15,6 +15,8 @@ package org.openhab.binding.amplipi.internal;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
@@ -23,6 +25,7 @@ import org.eclipse.jetty.client.api.ContentResponse;
 import org.eclipse.jetty.client.util.StringContentProvider;
 import org.eclipse.jetty.http.HttpMethod;
 import org.eclipse.jetty.http.HttpStatus;
+import org.openhab.binding.amplipi.internal.model.Info;
 import org.openhab.binding.amplipi.internal.model.Status;
 import org.openhab.binding.amplipi.internal.model.Zone;
 import org.openhab.binding.amplipi.internal.model.ZoneUpdate;
@@ -60,6 +63,15 @@ public class AmpliPiZoneHandler extends BaseThingHandler implements AmpliPiStatu
     private @Nullable AmpliPiHandler bridgeHandler;
 
     private @Nullable Zone zoneState;
+
+    // vol_delta_f only exists from AmpliPi 0.4.6, four releases after vol_f, so the presence of
+    // vol_f says nothing about it.
+    private static final Pattern VERSION_PATTERN = Pattern.compile("(\\d+)\\.(\\d+)\\.(\\d+)");
+    private static final int VOL_DELTA_F_MAJOR = 0;
+    private static final int VOL_DELTA_F_MINOR = 4;
+    private static final int VOL_DELTA_F_PATCH = 6;
+
+    private volatile boolean supportsVolumeDelta = false;
 
     public AmpliPiZoneHandler(Thing thing, HttpClient httpClient) {
         super(thing);
@@ -126,13 +138,23 @@ public class AmpliPiZoneHandler extends BaseThingHandler implements AmpliPiStatu
                         update.setVol(AmpliPiUtils.percentTypeToVolume(percentCommand));
                     }
                 } else if (command instanceof IncreaseDecreaseType) {
-                    if (supportsVolumeFraction) {
+                    if (supportsVolumeDelta) {
                         // Send the step itself and let AmpliPi apply it to its own current volume.
                         // The cached zone state can be stale when the volume was changed through the
                         // AmpliPi UI or another client since the last poll, and this also leaves the
-                        // bounds and overflow handling to the device.
+                        // bounds and overflow handling to the device. Gated on the reported version,
+                        // not on vol_f: vol_delta_f only arrived in 0.4.6, four releases later.
                         double step = volumeDelta / 100.0;
                         update.setVolDeltaF(IncreaseDecreaseType.INCREASE.equals(command) ? step : -step);
+                    } else if (supportsVolumeFraction && state != null && state.getVolF() != null) {
+                        // Knows vol_f but not vol_delta_f: adjust the fraction against the cached
+                        // state, which is still better than falling all the way back to dB.
+                        double step = volumeDelta / 100.0;
+                        double current = state.getVolF();
+                        double newVolF = IncreaseDecreaseType.INCREASE.equals(command) ? Math.min(current + step, 1.0)
+                                : Math.max(current - step, 0.0);
+                        state.setVolF(newVolF);
+                        update.setVolF(newVolF);
                     } else if (state != null && state.getVol() != null) {
                         // Older firmware: keep adjusting the dB value against the cached state. The
                         // configured step is a percentage, so scale it over the dB range.
@@ -175,8 +197,39 @@ public class AmpliPiZoneHandler extends BaseThingHandler implements AmpliPiStatu
     @Override
     public void receive(Status status) {
         int id = getId(thing);
+        supportsVolumeDelta = supportsVolumeDelta(status);
         Optional<Zone> zone = status.getZones().stream().filter(z -> z.getId().equals(id)).findFirst();
         zone.ifPresent(this::updateZoneState);
+    }
+
+    /**
+     * Whether this AmpliPi understands {@code vol_delta_f}, which it only does from 0.4.6 on.
+     *
+     * It cannot be probed from the zone status: {@code vol_delta_f} is write-only, and the status
+     * is identical in 0.4.5 and 0.4.6, so the reported software version is the only signal. Anything
+     * unparseable is treated as too old, which costs nothing -- the caller then adjusts the dB value
+     * itself, exactly as the binding did before.
+     */
+    private static boolean supportsVolumeDelta(Status status) {
+        Info info = status.getInfo();
+        String version = info != null ? info.getVersion() : null;
+        if (version == null) {
+            return false;
+        }
+        Matcher matcher = VERSION_PATTERN.matcher(version.trim());
+        if (!matcher.lookingAt()) {
+            return false;
+        }
+        int major = Integer.parseInt(matcher.group(1));
+        int minor = Integer.parseInt(matcher.group(2));
+        int patch = Integer.parseInt(matcher.group(3));
+        if (major != VOL_DELTA_F_MAJOR) {
+            return major > VOL_DELTA_F_MAJOR;
+        }
+        if (minor != VOL_DELTA_F_MINOR) {
+            return minor > VOL_DELTA_F_MINOR;
+        }
+        return patch >= VOL_DELTA_F_PATCH;
     }
 
     private void updateZoneState(Zone state) {

--- a/bundles/org.openhab.binding.amplipi/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.amplipi/src/main/resources/OH-INF/thing/thing-types.xml
@@ -70,7 +70,7 @@
 			</parameter>
 			<parameter name="volumeDelta" type="integer" min="1" max="10">
 				<label>Volume Delta</label>
-				<description>How much to change the zone volume for each INCREASE/DECREASE command (in dB)</description>
+				<description>How much to change the zone volume for each INCREASE/DECREASE command (in %)</description>
 				<default>1</default>
 				<advanced>true</advanced>
 			</parameter>


### PR DESCRIPTION
AmpliPi exposes a normalized volume value (`vol_f`, 0.0–1.0) alongside the dB `vol` field. The binding currently derives the zone volume percentage from the dB value, assuming a fixed -79..0 dB range.

This switches zone volume read/write to `vol_f`, so the binding no longer assumes a particular dB range. Reading falls back to the (now clamped) dB value when `vol_f` is absent. As a side benefit it avoids producing an out-of-range `PercentType` (which throws "Value must be between 0 and 100") if a zone's minimum volume ever differs from -79 dB.

The zone increase/decrease step is expressed in percent accordingly.
