### PR TITLE
[shelly] Detail power meter description

### DIFF
--- a/bundles/org.openhab.binding.shelly/README.md
+++ b/bundles/org.openhab.binding.shelly/README.md
@@ -326,13 +326,13 @@ The binding sets the following Thing status depending on the device status:
 | DUTY_CYCLE            | The device is re-initializing and reported a restart event, e.g. after a firmware update or manual reboot.                                                                                                                   |
 
 `Note:`
-For more details see  [Thing Concept](https://www.openhab.org/docs/concepts/things.html#status-details) in openHAB documentation.
+For more details see [Thing Concept](https://www.openhab.org/docs/concepts/things.html#status-details) in openHAB documentation.
 
 `Battery powered devices:`
 If the device is in sleep mode and can't be reached by the binding, the Thing will change into CONFIG_PENDING.
 Once the device wakes up, the Thing will perform initialization and the state will change to ONLINE.
 
-The first time a device is discovered and initialized successfully, the binding will be able to perform auto-initialization when OH is restarted.  Waking up the device triggers the a status report (CoIoT packet for event url for Gen1 and WebSocket call for Gen2), which is processed by the binding and triggers initialization. Once a device is initialized, it is no longer necessary to manually wake it up after an openHAB restart unless you change the battery. In this case press the button and run the discovery again.
+The first time a device is discovered and initialized successfully, the binding will be able to perform auto-initialization when OH is restarted. Waking up the device triggers the a status report (CoIoT packet for event url for Gen1 and WebSocket call for Gen2), which is processed by the binding and triggers initialization. Once a device is initialized, it is no longer necessary to manually wake it up after an openHAB restart unless you change the battery. In this case press the button and run the discovery again.
 
 ### Device Watchdog
 
@@ -346,7 +346,7 @@ Communication errors are handled depending on the device type:
 The binding also monitors that the device is responding at least once within a given time period.
 The period is computed depending on the device type and configuration:
 
-- battery  powered devices: &lt;sleepPeriod from device config&gt; + 10min, usually 12h+10min=730min
+- battery powered devices: &lt;sleepPeriod from device config&gt; + 10min, usually 12h+10min=730min
 - else, if CoIoT or WebSocket is enabled: 3*&lt;update Period from device settings&gt;+10sec, usually3*15+10=45sec
 - else 2*60+10sec = 130sec
 

--- a/bundles/org.openhab.binding.shelly/README.md
+++ b/bundles/org.openhab.binding.shelly/README.md
@@ -332,7 +332,7 @@ For more details see [Thing Concept](https://www.openhab.org/docs/concepts/thing
 If the device is in sleep mode and can't be reached by the binding, the Thing will change into CONFIG_PENDING.
 Once the device wakes up, the Thing will perform initialization and the state will change to ONLINE.
 
-The first time a device is discovered and initialized successfully, the binding will be able to perform auto-initialization when OH is restarted. Waking up the device triggers the a status report (CoIoT packet for event url for Gen1 and WebSocket call for Gen2), which is processed by the binding and triggers initialization. Once a device is initialized, it is no longer necessary to manually wake it up after an openHAB restart unless you change the battery. In this case press the button and run the discovery again.
+The first time a device is discovered and initialized successfully, the binding will be able to perform auto-initialization when OH is restarted. Waking up the device triggers a status report (CoIoT packet for event url for Gen1 and WebSocket call for Gen2), which is processed by the binding and triggers initialization. Once a device is initialized, it is no longer necessary to manually wake it up after an openHAB restart unless you change the battery. In this case press the button and run the discovery again.
 
 ### Device Watchdog
 
@@ -514,7 +514,7 @@ Refer to section [Full Example](#full-example) for examples how to catch alarm t
 ### Power Meter
 
 Many Shelly devices include one or more power meters.
-The binding exposes meter data through channel groups named `meter` (single-meter devices) or `meter1` / `meter2` / `meter3` (multi-meter devices).
+The binding exposes meter data through channel groups named `meter` (single-meter devices) or `meter1`, `meter2`, … `meter4` (multi-meter devices).
 Dedicated energy-meter devices (EM, 3EM, Pro EM-50, Plus EM, …) use the same group naming.
 
 **Common per-meter channels:**
@@ -524,8 +524,7 @@ Dedicated energy-meter devices (EM, 3EM, Pro EM-50, Plus EM, …) use the same g
 | `currentWatts`  | W    | Active power                                            |
 | `totalKWH`      | kWh  | Consumed energy (see note on persistence below)         |
 | `returnedKWH`   | kWh  | Returned / feed-in energy (EM devices only)             |
-| `reactivePower` | VAR  | Reactive power (Gen1 EM/3EM only)                       |
-| `apparentPower` | VA   | Apparent power (Gen2+ EM devices)                       |
+| `reactiveWatts` | VAR  | Reactive power (Gen1 EM/3EM only)                       |
 | `powerFactor`   | −    | Power factor, range −1.0 … +1.0                         |
 | `voltage`       | V    | RMS voltage                                             |
 | `current`       | A    | RMS current                                             |
@@ -536,7 +535,7 @@ Dedicated energy-meter devices (EM, 3EM, Pro EM-50, Plus EM, …) use the same g
 | Channel               | Description                                     |
 | --------------------- | ----------------------------------------------- |
 | `accumulatedWatts`    | Sum of active power across all meters           |
-| `accumulatedTotal`    | Sum of consumed energy in kWh                   |
+| `accumulatedWTotal`   | Sum of consumed energy in kWh                   |
 | `accumulatedReturned` | Sum of returned energy in kWh (EM devices only) |
 
 **Energy counter persistence:**
@@ -612,7 +611,6 @@ In this case the is no real measurement based on power consumption, but the Shel
 |         | lastPower1   | Number   | yes       | Average power consumption during the previous minute                            |
 |         | totalKWH     | Number   | yes       | Total energy consumption in kWh since the device powered up (resets on restart) |
 |         | frequency    | Number   | yes       | Grid frequency (Hz) - Gen4 only                                                 |
-| ------- | ------------ | -------- | --------- | ------------------------------------------------------------------------------- |
 |         | lastUpdate   | DateTime | yes       | Timestamp of the last measurement                                               |
 | sensors | temperature1 | Number   | yes       | Temperature value of external sensor #1 (if connected to temp/hum addon)        |
 |         | temperature2 | Number   | yes       | Temperature value of external sensor #2 (if connected to temp/hum addon)        |
@@ -1358,9 +1356,9 @@ Refer to [Smartify Roller Shutters with openHAB and Shelly](doc/UseCaseSmartRoll
 | relay3 |         |      | r/w       | Relay #3 with control options and status values |
 | relay4 |         |      | r/w       | Relay #4 with control options and status values |
 | meter1 |         |      | r/w       | Power Meter #1 with measurement values          |
-| meter2 |         |      | r/w       | Power Meter #1 with measurement values          |
-| meter3 |         |      | r/w       | Power Meter #1 with measurement values          |
-| meter4 |         |      | r/w       | Power Meter #1 with measurement values          |
+| meter2 |         |      | r/w       | Power Meter #2 with measurement values          |
+| meter3 |         |      | r/w       | Power Meter #3 with measurement values          |
+| meter4 |         |      | r/w       | Power Meter #4 with measurement values          |
 
 ### Shelly Plus EM (thing-type: shellyplusem)
 

--- a/bundles/org.openhab.binding.shelly/README.md
+++ b/bundles/org.openhab.binding.shelly/README.md
@@ -14,6 +14,8 @@ The binding gets in sync with the next status refresh.
 
 Refer to [Advanced Users](doc/AdvancedUsers.md) for more information on openHAB Shelly integration, e.g. firmware update, network communication or log filtering.
 
+Refer to [Power Meter Devices](doc/PowerMeterDevices.md) for a reference of all Shelly devices with power measurement capability, including per-device channel lists, energy counter persistence behaviour, and known restrictions.
+
 Also check out the [Shelly Manager](doc/ShellyManager.md), which
 
 - provides detailed information on your Shellys
@@ -508,6 +510,42 @@ A new alarm will be triggered on a new condition or every 5 minutes if the condi
 | VIBRATION  | A vibration/tamper was detected (DW2 only)                                                       |
 
 Refer to section [Full Example](#full-example) for examples how to catch alarm triggers in openHAB rules.
+
+### Power Meter
+
+Many Shelly devices include one or more power meters.
+The binding exposes meter data through channel groups named `meter` (single-meter devices) or `meter1` / `meter2` / `meter3` (multi-meter devices).
+Dedicated energy-meter devices (EM, 3EM, Pro EM-50, Plus EM, …) use the same group naming.
+
+**Common per-meter channels:**
+
+| Channel         | Unit | Description                                             |
+| --------------- | ---- | ------------------------------------------------------- |
+| `currentWatts`  | W    | Active power                                            |
+| `totalKWH`      | kWh  | Consumed energy (see note on persistence below)         |
+| `returnedKWH`   | kWh  | Returned / feed-in energy (EM devices only)             |
+| `reactivePower` | VAR  | Reactive power (Gen1 EM/3EM only)                       |
+| `apparentPower` | VA   | Apparent power (Gen2+ EM devices)                       |
+| `powerFactor`   | −    | Power factor, range −1.0 … +1.0                         |
+| `voltage`       | V    | RMS voltage                                             |
+| `current`       | A    | RMS current                                             |
+| `frequency`     | Hz   | Line frequency (data-driven; Gen4+ on relay-PM devices) |
+
+**Device-level accumulated channels** (group `device`) aggregate values across all meters:
+
+| Channel               | Description                                     |
+| --------------------- | ----------------------------------------------- |
+| `accumulatedWatts`    | Sum of active power across all meters           |
+| `accumulatedTotal`    | Sum of consumed energy in kWh                   |
+| `accumulatedReturned` | Sum of returned energy in kWh (EM devices only) |
+
+**Energy counter persistence:**
+
+- **Gen1 relay-PM devices** (1PM, Plug S, 2.5): counters are stored in RAM and **reset on every device restart**.
+  Use openHAB persistence to track long-term consumption.
+- **Gen1 EM/3EM and all Gen2+ devices**: counters are stored in device NVM and **preserved across restarts**.
+
+See [Power Meter Devices](doc/PowerMeterDevices.md) for a full device-by-device reference including per-device channel availability and known restrictions.
 
 ## Channels
 

--- a/bundles/org.openhab.binding.shelly/README.md
+++ b/bundles/org.openhab.binding.shelly/README.md
@@ -42,49 +42,49 @@ See section [Discovery](#discovery) for details.
 
 ### Generation 1
 
-| thing-type        | Model                                                  | Vendor ID           |
-| ----------------- | ------------------------------------------------------ | ------------------- |
-| shelly1           | Shelly 1 Single Relay Switch                           | SHSW-1              |
-| shelly1l          | Shelly 1L Single Relay Switch                          | SHSW-L              |
-| shelly1pm         | Shelly Single Relay Switch with integrated Power Meter | SHSW-PM             |
-| shelly2-relay     | Shelly Double Relay Switch in relay mode               | SHSW-21             |
-| shelly2-roller    | Shelly2 in Roller Mode                                 | SHSW-21             |
-| shelly25-relay    | Shelly 2.5 in Relay Switch                             | SHSW-25             |
-| shelly25-roller   | Shelly 2.5 in Roller Mode                              | SHSW-25             |
-| shelly4pro        | Shelly 4x Relay Switch                                 | SHSW-44             |
-| shellydimmer      | Shelly Dimmer                                          | SHDM-1              |
-| shellydimmer2     | Shelly Dimmer2                                         | SHDM-2              |
-| shellyix3         | Shelly ix3                                             | SHIX3-1             |
-| shellyuni         | Shelly UNI, Shelly Plus UNI                            | SHUNI-1             |
-| shellyplug        | Shelly Plug                                            | SHPLG2-1            |
-| shellyplugs       | Shelly Plug-S                                          | SHPLG-S             |
-| shellyem          | Shelly EM with integrated Power Meters                 | SHEM                |
-| shellyem3         | Shelly 3EM with 3 integrated Power Meter               | SHEM-3              |
-| shellyrgbw2-color | Shelly RGBW2 Controller in Color Mode                  | SHRGBW2             |
-| shellyrgbw2-white | Shelly RGBW2 Controller in White Mode                  | SHRGBW2             |
-| shellybulb-color  | Shelly Bulb in Color Mode                              | SHBLB-1             |
-| shellybulb-white  | Shelly Bulb in White Mode                              | SHBLB-1             |
-| shellybulbduo     | Shelly Duo White                                       | SHBDUO-1            |
-| shellybulbduo     | Shelly Duo White G10                                   | SHBDUO-1            |
-| shellycolorbulb   | Shelly Duo Color G10                                   | SHCB-1              |
-| shellyvintage     | Shelly Vintage (White Mode)                            | SHVIN-1             |
-| shellyht          | Shelly Sensor (temperature+humidity)                   | SHHT-1              |
-| shellyflood       | Shelly Flood Sensor                                    | SHWT-1              |
-| shellysmoke       | Shelly Smoke Sensor                                    | SHSM-1              |
-| shellymotion      | Shelly Motion Sensor                                   | SHMOS-01            |
-| shellymotion2     | Shelly Motion Sensor 2                                 | SHMOS-02            |
-| shellygas         | Shelly Gas Sensor                                      | SHGS-1              |
-| shellydw          | Shelly Door/Window                                     | SHDW-1              |
-| shellydw2         | Shelly Door/Window 2                                   | SHDW-2              |
-| shellybutton1     | Shelly Button 1                                        | SHBTN-1             |
-| shellybutton2     | Shelly Button 2                                        | SHBTN-2             |
-| shellysense       | Shelly Motion and IR Controller                        | SHSEN-1             |
-| shellytrv         | Shelly TRV                                             | SHTRV-01            |
+| thing-type        | Model                                                  | Vendor ID |
+| ----------------- | ------------------------------------------------------ | --------- |
+| shelly1           | Shelly 1 Single Relay Switch                           | SHSW-1    |
+| shelly1l          | Shelly 1L Single Relay Switch                          | SHSW-L    |
+| shelly1pm         | Shelly Single Relay Switch with integrated Power Meter | SHSW-PM   |
+| shelly2-relay     | Shelly Double Relay Switch in relay mode               | SHSW-21   |
+| shelly2-roller    | Shelly2 in Roller Mode                                 | SHSW-21   |
+| shelly25-relay    | Shelly 2.5 in Relay Switch                             | SHSW-25   |
+| shelly25-roller   | Shelly 2.5 in Roller Mode                              | SHSW-25   |
+| shelly4pro        | Shelly 4x Relay Switch                                 | SHSW-44   |
+| shellydimmer      | Shelly Dimmer                                          | SHDM-1    |
+| shellydimmer2     | Shelly Dimmer2                                         | SHDM-2    |
+| shellyix3         | Shelly ix3                                             | SHIX3-1   |
+| shellyuni         | Shelly UNI, Shelly Plus UNI                            | SHUNI-1   |
+| shellyplug        | Shelly Plug                                            | SHPLG2-1  |
+| shellyplugs       | Shelly Plug-S                                          | SHPLG-S   |
+| shellyem          | Shelly EM with integrated Power Meters                 | SHEM      |
+| shellyem3         | Shelly 3EM with 3 integrated Power Meter               | SHEM-3    |
+| shellyrgbw2-color | Shelly RGBW2 Controller in Color Mode                  | SHRGBW2   |
+| shellyrgbw2-white | Shelly RGBW2 Controller in White Mode                  | SHRGBW2   |
+| shellybulb-color  | Shelly Bulb in Color Mode                              | SHBLB-1   |
+| shellybulb-white  | Shelly Bulb in White Mode                              | SHBLB-1   |
+| shellybulbduo     | Shelly Duo White                                       | SHBDUO-1  |
+| shellybulbduo     | Shelly Duo White G10                                   | SHBDUO-1  |
+| shellycolorbulb   | Shelly Duo Color G10                                   | SHCB-1    |
+| shellyvintage     | Shelly Vintage (White Mode)                            | SHVIN-1   |
+| shellyht          | Shelly Sensor (temperature+humidity)                   | SHHT-1    |
+| shellyflood       | Shelly Flood Sensor                                    | SHWT-1    |
+| shellysmoke       | Shelly Smoke Sensor                                    | SHSM-1    |
+| shellymotion      | Shelly Motion Sensor                                   | SHMOS-01  |
+| shellymotion2     | Shelly Motion Sensor 2                                 | SHMOS-02  |
+| shellygas         | Shelly Gas Sensor                                      | SHGS-1    |
+| shellydw          | Shelly Door/Window                                     | SHDW-1    |
+| shellydw2         | Shelly Door/Window 2                                   | SHDW-2    |
+| shellybutton1     | Shelly Button 1                                        | SHBTN-1   |
+| shellybutton2     | Shelly Button 2                                        | SHBTN-2   |
+| shellysense       | Shelly Motion and IR Controller                        | SHSEN-1   |
+| shellytrv         | Shelly TRV                                             | SHTRV-01  |
 
 ### Shelly Plus series (Generation 2+3+4)
 
 | thing-type           | Model                                                    | Vendor ID                                                                 |
-|----------------------|----------------------------------------------------------|---------------------------------------------------------------------------|
+| -------------------- | -------------------------------------------------------- | ------------------------------------------------------------------------- |
 | shellyplus1          | Shelly Plus 1 with 1x relay                              | SNSW-001X16EU, S3SW-001X16EU, S3SW-001X16EU, S4SW-001X16EU                |
 | shellyplus1l         | Shelly Plus 1L with 1x relay                             | S3SW-0A1X1EUL                                                             |
 | shellyplus1pm        | Shelly Plus 1PM with 1x relay + power meter              | SNSW-001P16EU, S3SW-001P16EU, S4SW-001P16EU                               |
@@ -121,51 +121,51 @@ See section [Discovery](#discovery) for details.
 
 ### Shelly Plus Mini series (Generation 2+3+4)
 
-| thing-type           | Model                                                    | Vendor ID                                     |
-| -------------------- | -------------------------------------------------------- | --------------------------------------------- |
-| shelly1mini          | Shelly Plus 1 Mini with 1x relay                         | SNSW-001X8EU, S3SW-001X8EU, S4SW-001X8EU      |
-| shelly1pmmini        | Shelly Plus 1PM Mini with 1x relay + power meter         | SNSW-001P8EU, S3SW-001P8EU, S4SW-001P8EU      |
-| shellypmmini         | Shelly Plus PM Mini with 1x power meter                  | SNPM-001PCEU16, S3PM-001PCEU16                |
-| shellyemmini         | Shelly Plus EM Mini with 1x power meter                  | S4EM-001PXCEU16                               |
+| thing-type    | Model                                            | Vendor ID                                |
+| ------------- | ------------------------------------------------ | ---------------------------------------- |
+| shelly1mini   | Shelly Plus 1 Mini with 1x relay                 | SNSW-001X8EU, S3SW-001X8EU, S4SW-001X8EU |
+| shelly1pmmini | Shelly Plus 1PM Mini with 1x relay + power meter | SNSW-001P8EU, S3SW-001P8EU, S4SW-001P8EU |
+| shellypmmini  | Shelly Plus PM Mini with 1x power meter          | SNPM-001PCEU16, S3PM-001PCEU16           |
+| shellyemmini  | Shelly Plus EM Mini with 1x power meter          | S4EM-001PXCEU16                          |
 
 ### Shelly Pro Series (Generation 2+3)
 
-| thing-type          | Model                                                    | Vendor ID                                      |
-| ------------------- | -------------------------------------------------------- | ---------------------------------------------- |
-| shellypro1          | Shelly Pro 1 with 1x relay                               | SPSW-001XE16EU, SPSW-101XE16EU, SPSW-201XE16EU |
-| shellypro1pm        | Shelly Pro 1 PM with 1x relay + power meter              | SPSW-001PE16EU, SPSW-101PE16EU, SPSW-201PE16EU |
-| shellypro1cb        | Shelly Pro 1 Circuit Breaker with 1x relay + volt meter  | SPCB-01VENEU                                   |
-| shellypro2-relay    | Shelly Pro 2 with 2x relay, relay mode                   | SPSW-002XE16EU, SPSW-102XE16EU, SPSW-202XE16EU |
-| shellypro2pm-relay  | Shelly Pro 2 PM with 2x relay + power meter, relay mode  | SPSW-002PE16EU, SPSW-102PE16EU, SPSW-202PE16EU |
-| shellypro2pm-roller | Shelly Pro 2 PM with 2x relay + power meter, roller mode | SPSW-002PE16EU, SPSW-102PE16EU, SPSW-202PE16EU |
-| shellypro3          | Shelly Pro 3 with 3x relay (dry contacts)                | SPSW-003XE16EU                                 |
-| shellypro4pm        | Shelly Pro 4 PM with 4x relay + power meter              | SHPSW04P, SPSW-004PE16EU, SPSW-104PE16EU       |
-| shellyproem50       | Shelly Pro EM-50 - 2 channel, single phase energy meter  | SPEM-002CEBEU50                                |
-| shellypro3em        | Shelly Pro 3EM - 3-phase energy meter                    | SPEM-003CEBEU, SPEM-003CEBEU120                |
-| shellypro3em3ct63   | Shelly Pro 3EM-3CT63 - single or three-phase energy meter| SPEM-003CEBEU63                                |
-| shellypro3em400     | Shelly Pro 3EM-400 - 3-phase energy meter                | SPEM-003CEBEU400                               |
+| thing-type          | Model                                                     | Vendor ID                                      |
+| ------------------- | --------------------------------------------------------- | ---------------------------------------------- |
+| shellypro1          | Shelly Pro 1 with 1x relay                                | SPSW-001XE16EU, SPSW-101XE16EU, SPSW-201XE16EU |
+| shellypro1pm        | Shelly Pro 1 PM with 1x relay + power meter               | SPSW-001PE16EU, SPSW-101PE16EU, SPSW-201PE16EU |
+| shellypro1cb        | Shelly Pro 1 Circuit Breaker with 1x relay + volt meter   | SPCB-01VENEU                                   |
+| shellypro2-relay    | Shelly Pro 2 with 2x relay, relay mode                    | SPSW-002XE16EU, SPSW-102XE16EU, SPSW-202XE16EU |
+| shellypro2pm-relay  | Shelly Pro 2 PM with 2x relay + power meter, relay mode   | SPSW-002PE16EU, SPSW-102PE16EU, SPSW-202PE16EU |
+| shellypro2pm-roller | Shelly Pro 2 PM with 2x relay + power meter, roller mode  | SPSW-002PE16EU, SPSW-102PE16EU, SPSW-202PE16EU |
+| shellypro3          | Shelly Pro 3 with 3x relay (dry contacts)                 | SPSW-003XE16EU                                 |
+| shellypro4pm        | Shelly Pro 4 PM with 4x relay + power meter               | SHPSW04P, SPSW-004PE16EU, SPSW-104PE16EU       |
+| shellyproem50       | Shelly Pro EM-50 - 2 channel, single phase energy meter   | SPEM-002CEBEU50                                |
+| shellypro3em        | Shelly Pro 3EM - 3-phase energy meter                     | SPEM-003CEBEU, SPEM-003CEBEU120                |
+| shellypro3em3ct63   | Shelly Pro 3EM-3CT63 - single or three-phase energy meter | SPEM-003CEBEU63                                |
+| shellypro3em400     | Shelly Pro 3EM-400 - 3-phase energy meter                 | SPEM-003CEBEU400                               |
 
 ### Shelly BLU
 
-| thing-type           | Model                                                  | Vendor ID               |
-| -------------------- | ------------------------------------------------------ | ----------------------- |
-| shellyblubutton      | Shelly BLU Button 1, Shelly BLU Tough                  | SBBT-002C               |
-| shellyblubutton      | Shelly BLU Tough ZB                                    | SBBT-102C               |
-| shellybluwallswitch4 | Shelly BLU Wallswitch 4                                | SBBT-EU5027             |
-| shellyblurcbutton4   | Shelly BLU RC Button 4                                 | SBBT-004CUS             |
-| shellybluht          | Shelly BLU H&T                                         | SBHT-003C               |
-| shellybluht          | Shelly BLU H&T ZB                                      | SBHT-203C               |
-| shellybludw          | Shelly BLU Door/Windows                                | SBDW-002C               |
-| shellyblumotion      | Shelly BLU Motion                                      | SBMO-003Z               |
-| shellybludistance    | Shelly BLU Distance                                    | SBDI-003E               |
-| shellybluremote      | Shelly BLU Remote Control                              | SBRC-005B               |
+| thing-type           | Model                                 | Vendor ID   |
+| -------------------- | ------------------------------------- | ----------- |
+| shellyblubutton      | Shelly BLU Button 1, Shelly BLU Tough | SBBT-002C   |
+| shellyblubutton      | Shelly BLU Tough ZB                   | SBBT-102C   |
+| shellybluwallswitch4 | Shelly BLU Wallswitch 4               | SBBT-EU5027 |
+| shellyblurcbutton4   | Shelly BLU RC Button 4                | SBBT-004CUS |
+| shellybluht          | Shelly BLU H&T                        | SBHT-003C   |
+| shellybluht          | Shelly BLU H&T ZB                     | SBHT-203C   |
+| shellybludw          | Shelly BLU Door/Windows               | SBDW-002C   |
+| shellyblumotion      | Shelly BLU Motion                     | SBMO-003Z   |
+| shellybludistance    | Shelly BLU Distance                   | SBDI-003E   |
+| shellybluremote      | Shelly BLU Remote Control             | SBRC-005B   |
 
 ### Special Thing Types
 
-| thing-type        | Model                                                  | Vendor ID |
-| ----------------- | ------------------------------------------------------ | --------- |
-| shellydevice      | A password protected Shelly device or an unknown type  |           |
-| shellyunknown     | An unknown Shelly device / model has been detected     |           |
+| thing-type    | Model                                                 | Vendor ID |
+| ------------- | ----------------------------------------------------- | --------- |
+| shellydevice  | A password protected Shelly device or an unknown type |           |
+| shellyunknown | An unknown Shelly device / model has been detected    |           |
 
 ## Binding Configuration
 
@@ -315,7 +315,7 @@ Values 1-4 are selecting the corresponding favorite id in the Shelly App, 0 mean
 The binding sets the following Thing status depending on the device status:
 
 | Status                | Description                                                                                                                                                                                                                  |
-|-----------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| --------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | INITIALIZING          | This is the default status while initializing the Thing. Once the initialization is triggered the Thing switches to Status ONLINE.CONFIGURATION_PENDING.                                                                     |
 | UNKNOWN               | Indicates that the status is currently unknown, which must not show a problem. Once the device is reachable and was initialized the Thing switches to status ONLINE.                                                         |
 | CONFIGURATION_PENDING | Device initialization in progress or pending (e.g., waiting for device wake-up).                                                                                                                                             |
@@ -612,7 +612,7 @@ In this case the is no real measurement based on power consumption, but the Shel
 |         | lastPower1   | Number   | yes       | Average power consumption during the previous minute                            |
 |         | totalKWH     | Number   | yes       | Total energy consumption in kWh since the device powered up (resets on restart) |
 |         | frequency    | Number   | yes       | Grid frequency (Hz) - Gen4 only                                                 |
-|         |              |          |           |                                                                                 |
+| ------- | ------------ | -------- | --------- | ------------------------------------------------------------------------------- |
 |         | lastUpdate   | DateTime | yes       | Timestamp of the last measurement                                               |
 | sensors | temperature1 | Number   | yes       | Temperature value of external sensor #1 (if connected to temp/hum addon)        |
 |         | temperature2 | Number   | yes       | Temperature value of external sensor #2 (if connected to temp/hum addon)        |
@@ -723,7 +723,7 @@ Check the Shelly documentation for details.
 |        | lastPower1   | Number   | yes       | Average power consumption during the previous minute                              |
 |        | totalKWH     | Number   | yes       | Total energy consumption in kWh since the device powered up (resets on restart)   |
 |        | lastUpdate   | DateTime | yes       | Timestamp of the last measurement                                                 |
-|        | returnedKWH   | Number   | yes       | Total returned energy, kWh                                                       |
+|        | returnedKWH  | Number   | yes       | Total returned energy, kWh                                                        |
 
 | Group  | Channel      | Type          | read-only | Description                                                                           |
 | ------ | ------------ | ------------- | --------- | ------------------------------------------------------------------------------------- |
@@ -1284,22 +1284,22 @@ If the Shelly Add-On is installed:
 
 ### Shelly Plus 2L (thing-type: shellyplus2l)
 
-| Group  | Channel      | Type     | read-only | Description                                                                       |
-| ------ | ------------ | -------- | --------- | --------------------------------------------------------------------------------- |
-| relay1 | output       | Switch   | r/w       | Relay #1: Controls the relay's output channel (on/off)                            |
-|        | outputName   | String   | yes       | Logical name of this relay output as configured in the Shelly App                 |
-|        | input        | Switch   | yes       | ON: Input/Button is powered, see General Notes on Channels                        |
-|        | autoOn       | Number   | r/w       | Relay #1: Sets a  timer to turn the device ON after every OFF command; in seconds |
-|        | autoOff      | Number   | r/w       | Relay #1: Sets a  timer to turn the device OFF after every ON command; in seconds |
-|        | timerActive  | Switch   | yes       | Relay #1: ON: An auto-on/off timer is active                                      |
-|        | button       | Trigger  | yes       | Event trigger, see section Button Events                                          |
-| relay2 | output       | Switch   | r/w       | Relay #2: Controls the relay's output channel (on/off)                            |
-|        | outputName   | String   | yes       | Logical name of this relay output as configured in the Shelly App                 |
-|        | input        | Switch   | yes       | ON: Input/Button is powered, see General Notes on Channels                        |
-|        | autoOn       | Number   | r/w       | Relay #2: Sets a  timer to turn the device ON after every OFF command; in seconds |
-|        | autoOff      | Number   | r/w       | Relay #2: Sets a  timer to turn the device OFF after every ON command; in seconds |
-|        | timerActive  | Switch   | yes       | Relay #2: ON: An auto-on/off timer is active                                      |
-|        | button       | Trigger  | yes       | Event trigger, see section Button Events                                          |
+| Group  | Channel     | Type    | read-only | Description                                                                       |
+| ------ | ----------- | ------- | --------- | --------------------------------------------------------------------------------- |
+| relay1 | output      | Switch  | r/w       | Relay #1: Controls the relay's output channel (on/off)                            |
+|        | outputName  | String  | yes       | Logical name of this relay output as configured in the Shelly App                 |
+|        | input       | Switch  | yes       | ON: Input/Button is powered, see General Notes on Channels                        |
+|        | autoOn      | Number  | r/w       | Relay #1: Sets a  timer to turn the device ON after every OFF command; in seconds |
+|        | autoOff     | Number  | r/w       | Relay #1: Sets a  timer to turn the device OFF after every ON command; in seconds |
+|        | timerActive | Switch  | yes       | Relay #1: ON: An auto-on/off timer is active                                      |
+|        | button      | Trigger | yes       | Event trigger, see section Button Events                                          |
+| relay2 | output      | Switch  | r/w       | Relay #2: Controls the relay's output channel (on/off)                            |
+|        | outputName  | String  | yes       | Logical name of this relay output as configured in the Shelly App                 |
+|        | input       | Switch  | yes       | ON: Input/Button is powered, see General Notes on Channels                        |
+|        | autoOn      | Number  | r/w       | Relay #2: Sets a  timer to turn the device ON after every OFF command; in seconds |
+|        | autoOff     | Number  | r/w       | Relay #2: Sets a  timer to turn the device OFF after every ON command; in seconds |
+|        | timerActive | Switch  | yes       | Relay #2: ON: An auto-on/off timer is active                                      |
+|        | button      | Trigger | yes       | Event trigger, see section Button Events                                          |
 
 ### Shelly Plus 2PM - roller mode (thing-type: shellyplus2pm-roller)
 
@@ -1335,32 +1335,32 @@ Refer to [Smartify Roller Shutters with openHAB and Shelly](doc/UseCaseSmartRoll
 
 ### Shelly Plus Plug-S/IT/UK/US/CPM/USG4 (thing-type: shellyplusplug, shellyplusplugus, shellyplusplugcpm, shellyplugusg4)
 
-| Group | Channel      | Type     | read-only | Description                                                                       |
-| ----- | ------------ | -------- | --------- | --------------------------------------------------------------------------------- |
-| relay | output       | Switch   | r/w       | Controls the relay's output channel (on/off)                                      |
-|       | outputName   | String   | yes       | Logical name of this relay output as configured in the Shelly App                 |
-|       | input        | Switch   | yes       | ON: Input/Button is powered, see General Notes on Channels                        |
-|       | autoOn       | Number   | r/w       | Sets a  timer to turn the device ON after every OFF command; in seconds           |
-|       | autoOff      | Number   | r/w       | Sets a  timer to turn the device OFF after every ON command; in seconds           |
-|       | timerActive  | Switch   | yes       | ON: An auto-on/off timer is active                                                |
-|       | button       | Trigger  | yes       | Event trigger, see section Button Events                                          |
-| meter | currentWatts | Number   | yes       | Current power consumption in Watts                                                |
-|       | lastPower1   | Number   | yes       | Average power consumption during the previous minute                              |
-|       | totalKWH     | Number   | yes       | Total energy consumption in kWh since the device powered up (resets on restart)   |
-|       | lastUpdate   | DateTime | yes       | Timestamp of the last measurement                                                 |
+| Group | Channel      | Type     | read-only | Description                                                                     |
+| ----- | ------------ | -------- | --------- | ------------------------------------------------------------------------------- |
+| relay | output       | Switch   | r/w       | Controls the relay's output channel (on/off)                                    |
+|       | outputName   | String   | yes       | Logical name of this relay output as configured in the Shelly App               |
+|       | input        | Switch   | yes       | ON: Input/Button is powered, see General Notes on Channels                      |
+|       | autoOn       | Number   | r/w       | Sets a  timer to turn the device ON after every OFF command; in seconds         |
+|       | autoOff      | Number   | r/w       | Sets a  timer to turn the device OFF after every ON command; in seconds         |
+|       | timerActive  | Switch   | yes       | ON: An auto-on/off timer is active                                              |
+|       | button       | Trigger  | yes       | Event trigger, see section Button Events                                        |
+| meter | currentWatts | Number   | yes       | Current power consumption in Watts                                              |
+|       | lastPower1   | Number   | yes       | Average power consumption during the previous minute                            |
+|       | totalKWH     | Number   | yes       | Total energy consumption in kWh since the device powered up (resets on restart) |
+|       | lastUpdate   | DateTime | yes       | Timestamp of the last measurement                                               |
 
 ### Shelly Plus Power Strip 4 (thing-type: shellyplusstrip)
 
-| Group  | Channel     | Type    | read-only | Description                                                                         |
-| ------ | ----------- | ------- | --------- | ----------------------------------------------------------------------------------- |
-| relay1 |             |         | r/w       | Relay #1 with control options and status values                                     |
-| relay2 |             |         | r/w       | Relay #2 with control options and status values                                     |
-| relay3 |             |         | r/w       | Relay #3 with control options and status values                                     |
-| relay4 |             |         | r/w       | Relay #4 with control options and status values                                     |
-| meter1 |             |         | r/w       | Power Meter #1 with measurement values                                              |
-| meter2 |             |         | r/w       | Power Meter #1 with measurement values                                              |
-| meter3 |             |         | r/w       | Power Meter #1 with measurement values                                              |
-| meter4 |             |         | r/w       | Power Meter #1 with measurement values                                              |
+| Group  | Channel | Type | read-only | Description                                     |
+| ------ | ------- | ---- | --------- | ----------------------------------------------- |
+| relay1 |         |      | r/w       | Relay #1 with control options and status values |
+| relay2 |         |      | r/w       | Relay #2 with control options and status values |
+| relay3 |         |      | r/w       | Relay #3 with control options and status values |
+| relay4 |         |      | r/w       | Relay #4 with control options and status values |
+| meter1 |         |      | r/w       | Power Meter #1 with measurement values          |
+| meter2 |         |      | r/w       | Power Meter #1 with measurement values          |
+| meter3 |         |      | r/w       | Power Meter #1 with measurement values          |
+| meter4 |         |      | r/w       | Power Meter #1 with measurement values          |
 
 ### Shelly Plus EM (thing-type: shellyplusem)
 
@@ -1501,13 +1501,13 @@ Channels lastEvent and eventCount are only available if input type is set to mom
 
 ### Shelly Plus Wall Dimmer US (thing-type: shellypluswdus)
 
-|Group  | Channel     |Type     |read-only  |Description                                                                        |
-|-------|-------------|---------|-----------|-----------------------------------------------------------------------------------|
-| relay | brightness  | Dimmer  | r/w       | Currently selected brightness.                                                    |
-|       | outputName  | String  | yes       | Logical name of this relay output as configured in the Shelly App                 |
-|       | autoOn      | Number  | r/w       | Relay #1: Sets a  timer to turn the device ON after every OFF command; in seconds |
-|       | autoOff     | Number  | r/w       | Relay #1: Sets a  timer to turn the device OFF after every ON command; in seconds |
-|       | timerActive | Switch  | yes       | Relay #1: ON: An auto-on/off timer is active                                      |
+| Group | Channel     | Type   | read-only | Description                                                                       |
+| ----- | ----------- | ------ | --------- | --------------------------------------------------------------------------------- |
+| relay | brightness  | Dimmer | r/w       | Currently selected brightness.                                                    |
+|       | outputName  | String | yes       | Logical name of this relay output as configured in the Shelly App                 |
+|       | autoOn      | Number | r/w       | Relay #1: Sets a  timer to turn the device ON after every OFF command; in seconds |
+|       | autoOff     | Number | r/w       | Relay #1: Sets a  timer to turn the device OFF after every ON command; in seconds |
+|       | timerActive | Switch | yes       | Relay #1: ON: An auto-on/off timer is active                                      |
 
 ## Shelly Plus Mini Series
 
@@ -1542,13 +1542,13 @@ Channels lastEvent and eventCount are only available if input type is set to mom
 
 ### Shelly Plus PM Mini (thing-type: shellypmmini)
 
-| Group | Channel      | Type     | read-only | Description                                                                       |
-| ----- | ------------ | -------- | --------- | --------------------------------------------------------------------------------- |
-| meter | currentWatts | Number   | yes       | Current power consumption in Watts                                                |
-|       | lastPower1   | Number   | yes       | Average power consumption during the previous minute                              |
-|       | totalKWH     | Number   | yes       | Total energy consumption in kWh since the device powered up (resets on restart)   |
-|       | lastUpdate   | DateTime | yes       | Timestamp of the last measurement                                                 |
-|       | frequency    | Number   | yes       | Grid frequency in Hertz (Hz)                                                      |
+| Group | Channel      | Type     | read-only | Description                                                                     |
+| ----- | ------------ | -------- | --------- | ------------------------------------------------------------------------------- |
+| meter | currentWatts | Number   | yes       | Current power consumption in Watts                                              |
+|       | lastPower1   | Number   | yes       | Average power consumption during the previous minute                            |
+|       | totalKWH     | Number   | yes       | Total energy consumption in kWh since the device powered up (resets on restart) |
+|       | lastUpdate   | DateTime | yes       | Timestamp of the last measurement                                               |
+|       | frequency    | Number   | yes       | Grid frequency in Hertz (Hz)                                                    |
 
 ### Shelly Plus EM (thing-type: shellyemmini)
 
@@ -1628,11 +1628,11 @@ There are no additional channels besides the device group.
 
 ### Shelly Pro 1CB (thing-type: shellypro1cb)
 
-| Group | Channel      | Type     | read-only | Description                                                                      |
-| ----- | ------------ | -------- | --------- | -------------------------------------------------------------------------------- |
-| relay | output       | Switch   | r/w       | Controls the relay's output channel (on/off)                                     |
-|       | outputName   | String   | yes       | Logical name of this relay output as configured in the Shelly App                |
-| meter | voltage      | Number   | yes       | RMS voltage, Volts                                                               |
+| Group | Channel    | Type   | read-only | Description                                                       |
+| ----- | ---------- | ------ | --------- | ----------------------------------------------------------------- |
+| relay | output     | Switch | r/w       | Controls the relay's output channel (on/off)                      |
+|       | outputName | String | yes       | Logical name of this relay output as configured in the Shelly App |
+| meter | voltage    | Number | yes       | RMS voltage, Volts                                                |
 
 ### Shelly Pro 2 (thing-type: shellypro2-relay)
 
@@ -1720,35 +1720,35 @@ There are no additional channels besides the device group.
 
 ### Shelly Pro 3EM (thing-type: shellypro3em)
 
-| Group  | Channel       | Type     | read-only | Description                                                                       |
-| ------ | ------------- | -------- | --------- | --------------------------------------------------------------------------------- |
-| meter1 | currentWatts  | Number   | yes       | Current power consumption in Watts                                                |
-|        | totalKWH      | Number   | yes       | Total energy consumption in kWh since the device powered up (resets on restart)   |
-|        | returnedKWH   | Number   | yes       | Total returned energy, kWh                                                        |
-|        | reactiveWatts | Number   | yes       | Instantaneous reactive power, Watts                                               |
-|        | voltage       | Number   | yes       | RMS voltage, Volts                                                                |
-|        | current       | Number   | yes       | Current in A                                                                      |
-|        | powerFactor   | Number   | yes       | Power factor in percent (ratio of real to apparent power)                         |
-|        | resetTotals   | Switch   | no        | ON: Resets total values for the power meter                                       |
-|        | lastUpdate    | DateTime | yes       | Timestamp of the last measurement                                                 |
-| meter2 | currentWatts  | Number   | yes       | Current power consumption in Watts                                                |
-|        | totalKWH      | Number   | yes       | Total energy consumption in kWh since the device powered up (resets on restart)   |
-|        | returnedKWH   | Number   | yes       | Total returned energy, kWh                                                        |
-|        | reactiveWatts | Number   | yes       | Instantaneous reactive power, Watts                                               |
-|        | voltage       | Number   | yes       | RMS voltage, Volts                                                                |
-|        | current       | Number   | yes       | Current in A                                                                      |
-|        | powerFactor   | Number   | yes       | Power factor in percent (ratio of real to apparent power)                         |
-|        | resetTotals   | Switch   | no        | ON: Resets total values for the power meter                                       |
-|        | lastUpdate    | DateTime | yes       | Timestamp of the last measurement                                                 |
-| meter3 | currentWatts  | Number   | yes       | Current power consumption in Watts                                                |
-|        | totalKWH      | Number   | yes       | Total energy consumption in kWh since the device powered up (resets on restart)   |
-|        | returnedKWH   | Number   | yes       | Total returned energy, kWh                                                        |
-|        | reactiveWatts | Number   | yes       | Instantaneous reactive power, Watts                                               |
-|        | voltage       | Number   | yes       | RMS voltage, Volts                                                                |
-|        | current       | Number   | yes       | Current in A                                                                      |
-|        | powerFactor   | Number   | yes       | Power factor in percent (ratio of real to apparent power)                         |
-|        | resetTotals   | Switch   | no        | ON: Resets total values for the power meter                                       |
-|        | lastUpdate    | DateTime | yes       | Timestamp of the last measurement                                                 |
+| Group  | Channel       | Type     | read-only | Description                                                                     |
+| ------ | ------------- | -------- | --------- | ------------------------------------------------------------------------------- |
+| meter1 | currentWatts  | Number   | yes       | Current power consumption in Watts                                              |
+|        | totalKWH      | Number   | yes       | Total energy consumption in kWh since the device powered up (resets on restart) |
+|        | returnedKWH   | Number   | yes       | Total returned energy, kWh                                                      |
+|        | reactiveWatts | Number   | yes       | Instantaneous reactive power, Watts                                             |
+|        | voltage       | Number   | yes       | RMS voltage, Volts                                                              |
+|        | current       | Number   | yes       | Current in A                                                                    |
+|        | powerFactor   | Number   | yes       | Power factor in percent (ratio of real to apparent power)                       |
+|        | resetTotals   | Switch   | no        | ON: Resets total values for the power meter                                     |
+|        | lastUpdate    | DateTime | yes       | Timestamp of the last measurement                                               |
+| meter2 | currentWatts  | Number   | yes       | Current power consumption in Watts                                              |
+|        | totalKWH      | Number   | yes       | Total energy consumption in kWh since the device powered up (resets on restart) |
+|        | returnedKWH   | Number   | yes       | Total returned energy, kWh                                                      |
+|        | reactiveWatts | Number   | yes       | Instantaneous reactive power, Watts                                             |
+|        | voltage       | Number   | yes       | RMS voltage, Volts                                                              |
+|        | current       | Number   | yes       | Current in A                                                                    |
+|        | powerFactor   | Number   | yes       | Power factor in percent (ratio of real to apparent power)                       |
+|        | resetTotals   | Switch   | no        | ON: Resets total values for the power meter                                     |
+|        | lastUpdate    | DateTime | yes       | Timestamp of the last measurement                                               |
+| meter3 | currentWatts  | Number   | yes       | Current power consumption in Watts                                              |
+|        | totalKWH      | Number   | yes       | Total energy consumption in kWh since the device powered up (resets on restart) |
+|        | returnedKWH   | Number   | yes       | Total returned energy, kWh                                                      |
+|        | reactiveWatts | Number   | yes       | Instantaneous reactive power, Watts                                             |
+|        | voltage       | Number   | yes       | RMS voltage, Volts                                                              |
+|        | current       | Number   | yes       | Current in A                                                                    |
+|        | powerFactor   | Number   | yes       | Power factor in percent (ratio of real to apparent power)                       |
+|        | resetTotals   | Switch   | no        | ON: Resets total values for the power meter                                     |
+|        | lastUpdate    | DateTime | yes       | Timestamp of the last measurement                                               |
 
 ### Shelly Pro EM-50 (thing-type: shellyproem50)
 
@@ -1782,16 +1782,16 @@ There are no additional channels besides the device group.
 
 ## Shelly Pro 4PM (thing-type: shelly4pro)
 
-| Group  | Channel     | Type    | read-only | Description                                                                         |
-| ------ | ----------- | ------- | --------- | ----------------------------------------------------------------------------------- |
-| relay1 |             |         | r/w       | Relay #1 with control options and status values                                     |
-| relay2 |             |         | r/w       | Relay #2 with control options and status values                                     |
-| relay3 |             |         | r/w       | Relay #3 with control options and status values                                     |
-| relay4 |             |         | r/w       | Relay #4 with control options and status values                                     |
-| meter1 |             |         | r/w       | Power Meter #1 with measurement values                                              |
-| meter2 |             |         | r/w       | Power Meter #2 with measurement values                                              |
-| meter3 |             |         | r/w       | Power Meter #3 with measurement values                                              |
-| meter4 |             |         | r/w       | Power Meter #4 with measurement values                                              |
+| Group  | Channel | Type | read-only | Description                                     |
+| ------ | ------- | ---- | --------- | ----------------------------------------------- |
+| relay1 |         |      | r/w       | Relay #1 with control options and status values |
+| relay2 |         |      | r/w       | Relay #2 with control options and status values |
+| relay3 |         |      | r/w       | Relay #3 with control options and status values |
+| relay4 |         |      | r/w       | Relay #4 with control options and status values |
+| meter1 |         |      | r/w       | Power Meter #1 with measurement values          |
+| meter2 |         |      | r/w       | Power Meter #2 with measurement values          |
+| meter3 |         |      | r/w       | Power Meter #3 with measurement values          |
+| meter4 |         |      | r/w       | Power Meter #4 with measurement values          |
 
 ## Shelly BLU Devices
 
@@ -1881,19 +1881,19 @@ See notes on discovery of Shelly BLU devices above.
 
 See notes on discovery of Shelly BLU devices above.
 
-| Group   | Channel       | Type     | read-only | Description                                                                         |
-| ------- | ------------- | -------- | --------- | ----------------------------------------------------------------------------------- |
-| sensors | motion        | Switch   | yes       | ON: Motion detected                                                                 |
-| battery | batteryLevel  | Number   | yes       | Battery Level in %                                                                  |
-|         | lowBattery    | Switch   | yes       | Low battery alert (< 20%)                                                           |
-| device  | gatewayDevice | String   | yes       | Shelly forwarded last status update (BLU gateway), could vary from packet to packet |
+| Group   | Channel       | Type   | read-only | Description                                                                         |
+| ------- | ------------- | ------ | --------- | ----------------------------------------------------------------------------------- |
+| sensors | motion        | Switch | yes       | ON: Motion detected                                                                 |
+| battery | batteryLevel  | Number | yes       | Battery Level in %                                                                  |
+|         | lowBattery    | Switch | yes       | Low battery alert (< 20%)                                                           |
+| device  | gatewayDevice | String | yes       | Shelly forwarded last status update (BLU gateway), could vary from packet to packet |
 
 ### Shelly BLU H&T(thing-type: shellybluht)
 
 See notes on discovery of Shelly BLU devices above.
 
 | Group   | Channel      | Type     | read-only | Description                                                           |
-|---------|--------------|----------|-----------|-----------------------------------------------------------------------|
+| ------- | ------------ | -------- | --------- | --------------------------------------------------------------------- |
 | sensors | temperature  | Number   | yes       | Temperature, unit is reported by tempUnit                             |
 |         | humidity     | Number   | yes       | Relative humidity in %                                                |
 |         | eventCount   | Number   | yes       | Counter gets incremented every time the device issues a button event. |
@@ -1906,13 +1906,13 @@ See notes on discovery of Shelly BLU devices above.
 
 See notes on discovery of Shelly BLU devices above.
 
-| Group   | Channel       | Type     | read-only | Description                                                                         |
-| ------- | ------------- | -------- | --------- | ----------------------------------------------------------------------------------- |
-| sensors | distance      | Number   | yes       | Distance in mm                                                                      |
-|         | vibration     | Switch   | yes       | ON: Vibration detected                                                              |
-| battery | batteryLevel  | Number   | yes       | Battery Level in %                                                                  |
-|         | lowBattery    | Switch   | yes       | Low battery alert (< 20%)                                                           |
-| device  | gatewayDevice | String   | yes       | Shelly forwarded last status update (BLU gateway), could vary from packet to packet |
+| Group   | Channel       | Type   | read-only | Description                                                                         |
+| ------- | ------------- | ------ | --------- | ----------------------------------------------------------------------------------- |
+| sensors | distance      | Number | yes       | Distance in mm                                                                      |
+|         | vibration     | Switch | yes       | ON: Vibration detected                                                              |
+| battery | batteryLevel  | Number | yes       | Battery Level in %                                                                  |
+|         | lowBattery    | Switch | yes       | Low battery alert (< 20%)                                                           |
+| device  | gatewayDevice | String | yes       | Shelly forwarded last status update (BLU gateway), could vary from packet to packet |
 
 ### Shelly BLU Remote (thing-type: shellybluremote)
 

--- a/bundles/org.openhab.binding.shelly/doc/PowerMeterDevices.md
+++ b/bundles/org.openhab.binding.shelly/doc/PowerMeterDevices.md
@@ -1,0 +1,136 @@
+# Shelly Power Meter Devices
+
+Reference for all Shelly devices with power measurement capability.
+
+## Channel Abbreviations
+
+**Per-meter channels** (groups `meter1`, `meter2`, …):
+
+| ID   | Channel         | Unit                            |
+| ---- | --------------- | ------------------------------- |
+| W    | `currentWatts`  | W — active power                |
+| kWh  | `totalKWH`      | kWh — consumed energy           |
+| kWh← | `returnedKWH`   | kWh — returned / feed-in energy |
+| VAR  | `reactivePower` | VAR — reactive power            |
+| VA   | `apparentPower` | VA — apparent power             |
+| PF   | `powerFactor`   | − (−1.0 … +1.0)                 |
+| V    | `voltage`       | V                               |
+| A    | `current`       | A                               |
+| Hz   | `frequency`     | Hz — line frequency             |
+
+**Device-level channels** (group `devstatus`):
+
+| ID      | Channel                   | Notes                                                                     |
+| ------- | ------------------------- | ------------------------------------------------------------------------- |
+| ΣW      | `accuWatts`               | Total active power; device-reported when available                        |
+| ΣkWh    | `accuKWH`                 | Sum of per-meter kWh; only when device has no hardware total              |
+| ΣkWh-hw | `totalKWH` (devstatus)    | Hardware total from `emdata:0` / `em1data:x`; Gen2 EM only                |
+| ΣkWh←   | `returnedKWH` (devstatus) | Device-level returned energy                                              |
+| ΣVA     | `accuApparent`            | Total apparent power; device-reported (`total_aprt_power`) when available |
+
+---
+
+## Gen1 — Simple Relay PM
+
+Energy counters stored in **RAM** → **lost on device restart**. Use openHAB persistence for long-term tracking.
+
+| Device                | Thing type                           | # Meters | Per-meter channels | Device-level channels | Counter on restart | Notes                                   |
+| --------------------- | ------------------------------------ | -------- | ------------------ | --------------------- | ------------------ | --------------------------------------- |
+| Shelly 1PM            | `shelly1pm`                          | 1        | W, kWh             | —                     | **Lost**           | No V/A/PF/Hz                            |
+| Shelly Plug S         | `shellyplugs`                        | 1        | W, kWh             | —                     | **Lost**           | No V/A/PF/Hz                            |
+| Shelly Plug US (Gen1) | `shellyplugu1`                       | 1        | W, kWh             | —                     | **Lost**           | No V/A/PF/Hz                            |
+| Shelly 2.5            | `shelly25-relay` / `shelly25-roller` | 2        | W, kWh             | ΣW, ΣkWh              | **Lost**           | 2 relay+PM; roller mode shares channels |
+
+---
+
+## Gen1 — Energy Meters (EM)
+
+Energy counters stored in device **NVM** → **preserved on restart**.
+
+| Device     | Thing type  | # Meters | Per-meter channels          | Device-level channels      | Counter on restart | Notes                                                                  |
+| ---------- | ----------- | -------- | --------------------------- | -------------------------- | ------------------ | ---------------------------------------------------------------------- |
+| Shelly EM  | `shellyem`  | 2        | W, kWh, kWh←, VAR, PF, V, A | ΣW, ΣkWh, ΣkWh←            | Preserved          | 2 CT clamps + 1 relay output; relay not separately metered             |
+| Shelly 3EM | `shellyem3` | 3        | W, kWh, kWh←, VAR, PF, V, A | ΣW, ΣkWh, ΣkWh←, neutral-I | Preserved          | 3-phase; neutral-current channel (group `nmeter`); no controlled relay |
+
+---
+
+## Gen2 / Gen3 / Gen4 — Relay with PM (switch:x)
+
+Energy counters in device **NVM** → **preserved on restart**.
+`frequency` channel created data-driven (`emeter.frequency != null`): only Gen4+ firmware exposes `freq` in `switch:x` / `pm1:x` status.
+No reactive power and no apparent power on switch:x interface.
+
+| Device                 | Thing type             | Gen   | # Meters | Per-meter channels   | Device-level channels | Counter on restart | Notes                           |
+| ---------------------- | ---------------------- | ----- | -------- | -------------------- | --------------------- | ------------------ | ------------------------------- |
+| Plus 1PM / G3 / G4     | `shellyplus1pm`        | 2/3/4 | 1        | W, kWh, V, A, PF     | —                     | Preserved          | Hz on Gen4+ only                |
+| Plus 2PM (relay)       | `shellyplus2pm-relay`  | 2/3/4 | 2        | W, kWh, V, A, PF     | ΣW, ΣkWh              | Preserved          | Hz on Gen4+ only                |
+| Plus 2PM (roller)      | `shellyplus2pm-roller` | 2/3/4 | 2        | W, kWh, V, A, PF     | ΣW, ΣkWh              | Preserved          | Roller: single virtual channel  |
+| Plus Plug C PM (UK/CH) | `shellyplusplugcpm`    | 2     | 1        | W, kWh, V, A, PF     | —                     | Preserved          |                                 |
+| Plus Plug US G4        | `shellyplugusg4`       | 4     | 1        | W, kWh, V, A, PF, Hz | —                     | Preserved          | Gen4: Hz always present         |
+| PM Mini / G3           | `shellypmmini`         | 2/3   | 1        | W, kWh, V, A, PF     | —                     | Preserved          | No relay                        |
+| 1PM Mini / G3 / G4     | `shelly1pmmini`        | 2/3/4 | 1        | W, kWh, V, A, PF     | —                     | Preserved          | Hz on Gen4+ only                |
+| Pro 1PM                | `shellypro1pm`         | 2     | 1        | W, kWh, V, A, PF     | —                     | Preserved          |                                 |
+| Pro 2PM (relay)        | `shellypro2pm-relay`   | 2     | 2        | W, kWh, V, A, PF     | ΣW, ΣkWh              | Preserved          |                                 |
+| Pro 2PM (roller)       | `shellypro2pm-roller`  | 2     | 2        | W, kWh, V, A, PF     | ΣW, ΣkWh              | Preserved          | Roller: single virtual channel  |
+| Pro 4PM                | `shellypro4pm`         | 2     | 4        | W, kWh, V, A, PF     | ΣW, ΣkWh              | Preserved          | 4 independent relay+PM channels |
+
+---
+
+## Gen2 / Gen3 / Gen4 — Single-Clamp EM (em1:x)
+
+Energy counters in device **NVM** → **preserved on restart**.
+`reactivePower` channel **not available** (em1:x API does not expose reactive power).
+
+| Device          | Thing type     | Gen | # Meters | Per-meter channels              | Device-level channels   | Counter on restart | Notes                                                                         |
+| --------------- | -------------- | --- | -------- | ------------------------------- | ----------------------- | ------------------ | ----------------------------------------------------------------------------- |
+| EM Mini / G4    | `shellyemmini` | 2/4 | 1        | W, kWh, kWh←¹, VA, PF, V, A, Hz | —                       | Preserved          | ¹`returnedKWH` data-driven; single CT clamp                                   |
+| Plus EM / EM G3 | `shellyplusem` | 3   | 2        | W, kWh, kWh←, VA, PF, V, A, Hz  | ΣW, ΣkWh-hw, ΣkWh←, ΣVA | Preserved          | 2 CT clamps; has 1 relay (switch:0) — relay **not yet exposed** in thing type |
+
+---
+
+## Gen2 / Gen3 — 3-Phase EM (em:x)
+
+Energy counters in device **NVM** → **preserved on restart**.
+`reactivePower` channel **not available** — em:x API exposes only active, apparent, and PF per phase.
+Device reports `total_aprt_power` → bound to `devstatus#accuApparent`.
+Neutral-current channel (group `nmeter`) where hardware supports it.
+
+| Device               | Thing type        | Gen | # Meters | Per-meter channels             | Device-level channels              | Counter on restart | Notes                                                                                               |
+| -------------------- | ----------------- | --- | -------- | ------------------------------ | ---------------------------------- | ------------------ | --------------------------------------------------------------------------------------------------- |
+| Plus 3EM-63 / 3EM G3 | `shellyplus3em63` | 3   | 3        | W, kWh, kWh←, VA, PF, V, A, Hz | ΣW, ΣkWh-hw, ΣkWh←, ΣVA, neutral-I | Preserved          | 3-phase 63A; no relay                                                                               |
+| Pro EM-50            | `shellyproem50`   | 2   | 2        | W, kWh, kWh←, VA, PF, V, A, Hz | ΣW, ΣkWh-hw, ΣkWh←, ΣVA            | Preserved          | 2×50A CT clamps; has 1 relay (switch:0) — relay **not yet exposed**; `resetTotal` channel per meter |
+| Pro 3EM              | `shellypro3em`    | 2   | 3        | W, kWh, kWh←, VA, PF, V, A, Hz | ΣW, ΣkWh-hw, ΣkWh←, ΣVA, neutral-I | Preserved          | 3-phase                                                                                             |
+| Pro 3EM-63           | `shellypro3em63`  | 2   | 3        | W, kWh, kWh←, VA, PF, V, A, Hz | ΣW, ΣkWh-hw, ΣkWh←, ΣVA, neutral-I | Preserved          | 3-phase 63A CT clamps                                                                               |
+| Pro 3EM-400          | `shellypro3em400` | 2   | 3        | W, kWh, kWh←, VA, PF, V, A, Hz | ΣW, ΣkWh-hw, ΣkWh←, ΣVA, neutral-I | Preserved          | 3-phase 400A CT clamps                                                                              |
+
+---
+
+## Channel Creation Rules
+
+| Channel                    | Created when                                                                       |
+| -------------------------- | ---------------------------------------------------------------------------------- |
+| `returnedKWH` (per meter)  | `emeter.totalReturned != null` OR device is 3EM or EM50                            |
+| `reactivePower`            | `emeter.reactive != null` — Gen1 EM/3EM only                                       |
+| `apparentPower`            | Gen2+ devices always (em:x and em1:x)                                              |
+| `powerFactor`              | Gen2+: always. Gen1: data-driven (`emeter.pf != null`)                             |
+| `frequency`                | Data-driven (`emeter.frequency != null`). em:x/em1:x: always. switch:x: Gen4+ only |
+| `accuKWH` (devstatus)      | `numMeters > 1 && status.totalKWH == null` — device has no hardware total          |
+| `totalKWH` (devstatus)     | Gen2+ EM with `emdata:0`/`em1data:x` in HTTP poll payload                          |
+| `returnedKWH` (devstatus)  | `status.totalReturned != null` OR `accumulatedReturned != 0`                       |
+| `accuApparent` (devstatus) | `status.totalApparent != null` OR `accumulatedApparent != 0`                       |
+
+---
+
+## Known Restrictions and Issues
+
+| Issue                                                 | Devices                                                                | Status                                                                         |
+| ----------------------------------------------------- | ---------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
+| Energy counter reset on restart                       | Gen1 1PM, Plug S, Plug US, 2.5                                         | By design — use OH persistence                                                 |
+| No reactive power                                     | All Gen2+ EM (em:x, em1:x)                                             | API limitation — not in em:x protocol                                          |
+| Relay not exposed                                     | Plus EM (`shellyplusem`), Pro EM-50 (`shellyproem50`)                  | Deferred — relay is present in HW but not mapped to a thing channel            |
+| `reactivePower` channel rename                        | All (was `reactiveWatts`)                                              | Breaking change in OH 5.x — update item definitions                            |
+| `frequency` Gen1 EM/3EM                               | `shellyem`, `shellyem3`                                                | Data-driven; channel absent if device doesn't report it                        |
+| `returnedKWH` (emdata) was always null                | `shellypro3em`, `shellypro3em63`, `shellypro3em400`, `shellyplus3em63` | **Fixed in `shelly_fixmeters`** — wrong `@SerializedName` (`_act_ret_` keys)   |
+| Per-phase frequency always null                       | Same 3-phase EM devices                                                | **Fixed in `shelly_fixmeters`** — `a_freq`/`b_freq`/`c_freq` mapping corrected |
+| `accuApparent` used accumulated sum, not device total | Same 3-phase EM devices                                                | **Fixed in `shelly_fixmeters`** — now prefers `total_aprt_power`               |
+| Pro EM-50 slot routing (clamp assignment)             | `shellyproem50`                                                        | Deferred to separate PR                                                        |

--- a/bundles/org.openhab.binding.shelly/doc/PowerMeterDevices.md
+++ b/bundles/org.openhab.binding.shelly/doc/PowerMeterDevices.md
@@ -28,8 +28,6 @@ Reference for all Shelly devices with power measurement capability.
 | ΣkWh←   | `returnedKWH` (devstatus) | Device-level returned energy                                              |
 | ΣVA     | `accuApparent`            | Total apparent power; device-reported (`total_aprt_power`) when available |
 
----
-
 ## Gen1 — Simple Relay PM
 
 Energy counters stored in **RAM** → **lost on device restart**. Use openHAB persistence for long-term tracking.
@@ -41,8 +39,6 @@ Energy counters stored in **RAM** → **lost on device restart**. Use openHAB pe
 | Shelly Plug US (Gen1) | `shellyplugu1`                       | 1        | W, kWh             | —                     | **Lost**           | No V/A/PF/Hz                            |
 | Shelly 2.5            | `shelly25-relay` / `shelly25-roller` | 2        | W, kWh             | ΣW, ΣkWh              | **Lost**           | 2 relay+PM; roller mode shares channels |
 
----
-
 ## Gen1 — Energy Meters (EM)
 
 Energy counters stored in device **NVM** → **preserved on restart**.
@@ -51,8 +47,6 @@ Energy counters stored in device **NVM** → **preserved on restart**.
 | ---------- | ----------- | -------- | --------------------------- | -------------------------- | ------------------ | ---------------------------------------------------------------------- |
 | Shelly EM  | `shellyem`  | 2        | W, kWh, kWh←, VAR, PF, V, A | ΣW, ΣkWh, ΣkWh←            | Preserved          | 2 CT clamps + 1 relay output; relay not separately metered             |
 | Shelly 3EM | `shellyem3` | 3        | W, kWh, kWh←, VAR, PF, V, A | ΣW, ΣkWh, ΣkWh←, neutral-I | Preserved          | 3-phase; neutral-current channel (group `nmeter`); no controlled relay |
-
----
 
 ## Gen2 / Gen3 / Gen4 — Relay with PM (switch:x)
 
@@ -74,8 +68,6 @@ No reactive power and no apparent power on switch:x interface.
 | Pro 2PM (roller)       | `shellypro2pm-roller`  | 2     | 2        | W, kWh, V, A, PF     | ΣW, ΣkWh              | Preserved          | Roller: single virtual channel  |
 | Pro 4PM                | `shellypro4pm`         | 2     | 4        | W, kWh, V, A, PF     | ΣW, ΣkWh              | Preserved          | 4 independent relay+PM channels |
 
----
-
 ## Gen2 / Gen3 / Gen4 — Single-Clamp EM (em1:x)
 
 Energy counters in device **NVM** → **preserved on restart**.
@@ -85,8 +77,6 @@ Energy counters in device **NVM** → **preserved on restart**.
 | --------------- | -------------- | --- | -------- | ------------------------------- | ----------------------- | ------------------ | ----------------------------------------------------------------------------- |
 | EM Mini / G4    | `shellyemmini` | 2/4 | 1        | W, kWh, kWh←¹, VA, PF, V, A, Hz | —                       | Preserved          | ¹`returnedKWH` data-driven; single CT clamp                                   |
 | Plus EM / EM G3 | `shellyplusem` | 3   | 2        | W, kWh, kWh←, VA, PF, V, A, Hz  | ΣW, ΣkWh-hw, ΣkWh←, ΣVA | Preserved          | 2 CT clamps; has 1 relay (switch:0) — relay **not yet exposed** in thing type |
-
----
 
 ## Gen2 / Gen3 — 3-Phase EM (em:x)
 
@@ -103,8 +93,6 @@ Neutral-current channel (group `nmeter`) where hardware supports it.
 | Pro 3EM-63           | `shellypro3em63`  | 2   | 3        | W, kWh, kWh←, VA, PF, V, A, Hz | ΣW, ΣkWh-hw, ΣkWh←, ΣVA, neutral-I | Preserved          | 3-phase 63A CT clamps                                                                               |
 | Pro 3EM-400          | `shellypro3em400` | 2   | 3        | W, kWh, kWh←, VA, PF, V, A, Hz | ΣW, ΣkWh-hw, ΣkWh←, ΣVA, neutral-I | Preserved          | 3-phase 400A CT clamps                                                                              |
 
----
-
 ## Channel Creation Rules
 
 | Channel                    | Created when                                                                       |
@@ -118,8 +106,6 @@ Neutral-current channel (group `nmeter`) where hardware supports it.
 | `totalKWH` (devstatus)     | Gen2+ EM with `emdata:0`/`em1data:x` in HTTP poll payload                          |
 | `returnedKWH` (devstatus)  | `status.totalReturned != null` OR `accumulatedReturned != 0`                       |
 | `accuApparent` (devstatus) | `status.totalApparent != null` OR `accumulatedApparent != 0`                       |
-
----
 
 ## Known Restrictions and Issues
 

--- a/bundles/org.openhab.binding.shelly/doc/PowerMeterDevices.md
+++ b/bundles/org.openhab.binding.shelly/doc/PowerMeterDevices.md
@@ -4,29 +4,27 @@ Reference for all Shelly devices with power measurement capability.
 
 ## Channel Abbreviations
 
-**Per-meter channels** (groups `meter1`, `meter2`, …):
+**Per-meter channels** (group `meter` for single-meter devices, `meter1`, `meter2`, … for multi-meter devices):
 
 | ID   | Channel         | Unit                            |
 | ---- | --------------- | ------------------------------- |
 | W    | `currentWatts`  | W — active power                |
 | kWh  | `totalKWH`      | kWh — consumed energy           |
 | kWh← | `returnedKWH`   | kWh — returned / feed-in energy |
-| VAR  | `reactivePower` | VAR — reactive power            |
-| VA   | `apparentPower` | VA — apparent power             |
+| VAR  | `reactiveWatts` | VAR — reactive power            |
 | PF   | `powerFactor`   | − (−1.0 … +1.0)                 |
 | V    | `voltage`       | V                               |
 | A    | `current`       | A                               |
 | Hz   | `frequency`     | Hz — line frequency             |
 
-**Device-level channels** (group `devstatus`):
+**Device-level channels** (group `device`):
 
-| ID      | Channel                   | Notes                                                                     |
-| ------- | ------------------------- | ------------------------------------------------------------------------- |
-| ΣW      | `accuWatts`               | Total active power; device-reported when available                        |
-| ΣkWh    | `accuKWH`                 | Sum of per-meter kWh; only when device has no hardware total              |
-| ΣkWh-hw | `totalKWH` (devstatus)    | Hardware total from `emdata:0` / `em1data:x`; Gen2 EM only                |
-| ΣkWh←   | `returnedKWH` (devstatus) | Device-level returned energy                                              |
-| ΣVA     | `accuApparent`            | Total apparent power; device-reported (`total_aprt_power`) when available |
+| ID      | Channel                | Notes                                                                     |
+| ------- | ---------------------- | ------------------------------------------------------------------------- |
+| ΣW      | `accumulatedWatts`     | Total active power; device-reported when available                        |
+| ΣkWh    | `accumulatedWTotal`    | Sum of per-meter kWh; only when device has no hardware total              |
+| ΣkWh-hw | `totalKWH` (device)    | Hardware total from `emdata:0` / `em1data:x`; Gen2 EM only                |
+| ΣkWh←   | `accumulatedReturned`  | Device-level returned energy                                              |
 
 ## Gen1 — Simple Relay PM
 
@@ -71,52 +69,36 @@ No reactive power and no apparent power on switch:x interface.
 ## Gen2 / Gen3 / Gen4 — Single-Clamp EM (em1:x)
 
 Energy counters in device **NVM** → **preserved on restart**.
-`reactivePower` channel **not available** (em1:x API does not expose reactive power).
+`reactiveWatts` channel **not available** (em1:x API does not expose reactive power).
 
 | Device          | Thing type     | Gen | # Meters | Per-meter channels              | Device-level channels   | Counter on restart | Notes                                                                         |
 | --------------- | -------------- | --- | -------- | ------------------------------- | ----------------------- | ------------------ | ----------------------------------------------------------------------------- |
 | EM Mini / G4    | `shellyemmini` | 2/4 | 1        | W, kWh, kWh←¹, VA, PF, V, A, Hz | —                       | Preserved          | ¹`returnedKWH` data-driven; single CT clamp                                   |
-| Plus EM / EM G3 | `shellyplusem` | 3   | 2        | W, kWh, kWh←, VA, PF, V, A, Hz  | ΣW, ΣkWh-hw, ΣkWh←, ΣVA | Preserved          | 2 CT clamps; has 1 relay (switch:0) — relay **not yet exposed** in thing type |
+| Plus EM / EM G3 | `shellyplusem` | 3   | 2        | W, kWh, kWh←, PF, V, A, Hz     | ΣW, ΣkWh-hw, ΣkWh←        | Preserved          | 2 CT clamps; 1 relay (group `relay`); no reactive power                        |
 
 ## Gen2 / Gen3 — 3-Phase EM (em:x)
 
 Energy counters in device **NVM** → **preserved on restart**.
-`reactivePower` channel **not available** — em:x API exposes only active, apparent, and PF per phase.
-Device reports `total_aprt_power` → bound to `devstatus#accuApparent`.
+`reactiveWatts` channel **not available** — em:x API exposes only active, apparent, and PF per phase.
 Neutral-current channel (group `nmeter`) where hardware supports it.
 
 | Device               | Thing type        | Gen | # Meters | Per-meter channels             | Device-level channels              | Counter on restart | Notes                                                                                               |
 | -------------------- | ----------------- | --- | -------- | ------------------------------ | ---------------------------------- | ------------------ | --------------------------------------------------------------------------------------------------- |
-| Plus 3EM-63 / 3EM G3 | `shellyplus3em63` | 3   | 3        | W, kWh, kWh←, VA, PF, V, A, Hz | ΣW, ΣkWh-hw, ΣkWh←, ΣVA, neutral-I | Preserved          | 3-phase 63A; no relay                                                                               |
-| Pro EM-50            | `shellyproem50`   | 2   | 2        | W, kWh, kWh←, VA, PF, V, A, Hz | ΣW, ΣkWh-hw, ΣkWh←, ΣVA            | Preserved          | 2×50A CT clamps; has 1 relay (switch:0) — relay **not yet exposed**; `resetTotal` channel per meter |
-| Pro 3EM              | `shellypro3em`    | 2   | 3        | W, kWh, kWh←, VA, PF, V, A, Hz | ΣW, ΣkWh-hw, ΣkWh←, ΣVA, neutral-I | Preserved          | 3-phase                                                                                             |
-| Pro 3EM-63           | `shellypro3em63`  | 2   | 3        | W, kWh, kWh←, VA, PF, V, A, Hz | ΣW, ΣkWh-hw, ΣkWh←, ΣVA, neutral-I | Preserved          | 3-phase 63A CT clamps                                                                               |
-| Pro 3EM-400          | `shellypro3em400` | 2   | 3        | W, kWh, kWh←, VA, PF, V, A, Hz | ΣW, ΣkWh-hw, ΣkWh←, ΣVA, neutral-I | Preserved          | 3-phase 400A CT clamps                                                                              |
-
-## Channel Creation Rules
-
-| Channel                    | Created when                                                                       |
-| -------------------------- | ---------------------------------------------------------------------------------- |
-| `returnedKWH` (per meter)  | `emeter.totalReturned != null` OR device is 3EM or EM50                            |
-| `reactivePower`            | `emeter.reactive != null` — Gen1 EM/3EM only                                       |
-| `apparentPower`            | Gen2+ devices always (em:x and em1:x)                                              |
-| `powerFactor`              | Gen2+: always. Gen1: data-driven (`emeter.pf != null`)                             |
-| `frequency`                | Data-driven (`emeter.frequency != null`). em:x/em1:x: always. switch:x: Gen4+ only |
-| `accuKWH` (devstatus)      | `numMeters > 1 && status.totalKWH == null` — device has no hardware total          |
-| `totalKWH` (devstatus)     | Gen2+ EM with `emdata:0`/`em1data:x` in HTTP poll payload                          |
-| `returnedKWH` (devstatus)  | `status.totalReturned != null` OR `accumulatedReturned != 0`                       |
-| `accuApparent` (devstatus) | `status.totalApparent != null` OR `accumulatedApparent != 0`                       |
+| Plus 3EM-63 / 3EM G3 | `shellyplus3em63` | 3   | 3        | W, kWh, kWh←, VA, PF, V, A, Hz | ΣW, ΣkWh-hw, ΣkWh←, neutral-I | Preserved          | 3-phase 63A; no relay                                                                               |
+| Pro EM-50            | `shellyproem50`   | 2   | 2        | W, kWh, kWh←, PF, V, A, Hz     | ΣW, ΣkWh-hw, ΣkWh←            | Preserved          | 2×50A CT clamps; 1 relay (group `relay`); `resetTotals` channel per meter; no reactive power        |
+| Pro 3EM              | `shellypro3em`    | 2   | 3        | W, kWh, kWh←, VA, PF, V, A, Hz | ΣW, ΣkWh-hw, ΣkWh←, neutral-I | Preserved          | 3-phase                                                                                             |
+| Pro 3EM-63           | `shellypro3em63`  | 2   | 3        | W, kWh, kWh←, VA, PF, V, A, Hz | ΣW, ΣkWh-hw, ΣkWh←, neutral-I | Preserved          | 3-phase 63A CT clamps                                                                               |
+| Pro 3EM-400          | `shellypro3em400` | 2   | 3        | W, kWh, kWh←, VA, PF, V, A, Hz | ΣW, ΣkWh-hw, ΣkWh←, neutral-I | Preserved          | 3-phase 400A CT clamps                                                                              |
 
 ## Known Restrictions and Issues
 
-| Issue                                                 | Devices                                                                | Status                                                                         |
-| ----------------------------------------------------- | ---------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
-| Energy counter reset on restart                       | Gen1 1PM, Plug S, Plug US, 2.5                                         | By design — use OH persistence                                                 |
-| No reactive power                                     | All Gen2+ EM (em:x, em1:x)                                             | API limitation — not in em:x protocol                                          |
-| Relay not exposed                                     | Plus EM (`shellyplusem`), Pro EM-50 (`shellyproem50`)                  | Deferred — relay is present in HW but not mapped to a thing channel            |
-| `reactivePower` channel rename                        | All (was `reactiveWatts`)                                              | Breaking change in OH 5.x — update item definitions                            |
-| `frequency` Gen1 EM/3EM                               | `shellyem`, `shellyem3`                                                | Data-driven; channel absent if device doesn't report it                        |
-| `returnedKWH` (emdata) was always null                | `shellypro3em`, `shellypro3em63`, `shellypro3em400`, `shellyplus3em63` | **Fixed in `shelly_fixmeters`** — wrong `@SerializedName` (`_act_ret_` keys)   |
-| Per-phase frequency always null                       | Same 3-phase EM devices                                                | **Fixed in `shelly_fixmeters`** — `a_freq`/`b_freq`/`c_freq` mapping corrected |
-| `accuApparent` used accumulated sum, not device total | Same 3-phase EM devices                                                | **Fixed in `shelly_fixmeters`** — now prefers `total_aprt_power`               |
-| Pro EM-50 slot routing (clamp assignment)             | `shellyproem50`                                                        | Deferred to separate PR                                                        |
+| Issue                                     | Devices                                                                | Status                                                                              |
+| ----------------------------------------- | ---------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
+| Energy counter reset on restart           | Gen1 1PM, Plug S, Plug US, 2.5                                         | By design — use OH persistence                                                      |
+| No reactive power                         | All Gen2+ EM (em:x, em1:x)                                             | API limitation — not in em:x protocol                                               |
+| `frequency` Gen1 EM/3EM                   | `shellyem`, `shellyem3`                                                | Data-driven; channel absent if device doesn't report it                             |
+| `returnedKWH` (emdata) always null        | `shellypro3em`, `shellypro3em63`, `shellypro3em400`, `shellyplus3em63` | Wrong `@SerializedName` (`_act_ret_` keys) — fixed in PR [#20805][pr-fixmeters]     |
+| Per-phase frequency always null           | Same 3-phase EM devices                                                | `a_freq`/`b_freq`/`c_freq` mapping missing — fixed in PR [#20805][pr-fixmeters]    |
+| Pro EM-50 slot routing (clamp assignment) | `shellyproem50`                                                        | Deferred to separate PR                                                             |
+
+[pr-fixmeters]: https://github.com/openhab/openhab-addons/pull/20805


### PR DESCRIPTION
# Description

Documentation / Improvement.

Adds `doc/PowerMeterDevices.md` — a device-by-device reference for all Shelly power-meter-capable devices.
Covers meter counts, per-meter channel availability, device-level accumulated channels, counter persistence behaviour, and known restrictions per device class (Gen1 relay-PM, Gen1 EM, Gen2+ switch:x, Gen2+ em1:x, Gen2+ em:x).
Extends `README.md` with a Power Meter overview section linking to the new document.

References:
- PR [#20805](https://github.com/openhab/openhab-addons/pull/20805) — meter channel fixes for 3-phase EM devices

# Testing

Markdownlint clean (0 errors).
Channel names, group names, and device-level channel IDs verified against binding source (`ShellyBindingConstants.java`, thing type XML).

## Acceptance criteria

- [x] Implementation done
- [ ] Verified by Community
- [x] Documentation is up-to-date

## Backport assessment

Documentation-only PR — no code changes, no cherry-pick needed.