### PR TITLE
[shelly] Add Gen4 support for Shelly Plus 1L, 2L and 2PM

### DIFF
--- a/bundles/org.openhab.binding.shelly/README.md
+++ b/bundles/org.openhab.binding.shelly/README.md
@@ -85,10 +85,10 @@ See section [Discovery](#discovery) for details.
 
 | thing-type           | Model                                                    | Vendor ID                                                                 |
 | -------------------- | -------------------------------------------------------- | ------------------------------------------------------------------------- |
-| shellyplus1          | Shelly Plus 1 with 1x relay                              | SNSW-001X16EU, S3SW-001X16EU, S3SW-001X16EU, S4SW-001X16EU                |
-| shellyplus1l         | Shelly Plus 1L with 1x relay                             | S3SW-0A1X1EUL                                                             |
+| shellyplus1          | Shelly Plus 1 with 1x relay                              | SNSW-001X16EU, S3SW-001X16EU, S4SW-001X16EU                               |
+| shellyplus1l         | Shelly Plus 1L with 1x relay                             | S3SW-0A1X1EUL, S4SW-0A1X1EUL                                              |
 | shellyplus1pm        | Shelly Plus 1PM with 1x relay + power meter              | SNSW-001P16EU, S3SW-001P16EU, S4SW-001P16EU                               |
-| shellyplus2l         | Shelly Plus 2L with 2x relay                             | S3SW-0A2X4EUL                                                             |
+| shellyplus2l         | Shelly Plus 2L with 2x relay                             | S3SW-0A2X4EUL, S4SW-0A2X4EUL                                              |
 | shellyplus2pm-relay  | Shelly Plus 2PM with 2x relay + power meter, relay mode  | SNSW-002P16EU, SNSW-102P16EU, S3SW-002P16EU, SNSW-002P15UL, S4SW-002P16EU |
 | shellyplus2pm-roller | Shelly Plus 2PM with 2x relay + power meter, roller mode | SNSW-002P16EU, SNSW-102P16EU, S3SW-002P16EU, SNSW-002P15UL, S4SW-002P16EU |
 | shellyplusshutter    | Shelly Plus Shutter for 1x roller                        | S3SH-0A2P4EU                                                              |

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/ShellyDevices.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/ShellyDevices.java
@@ -78,7 +78,9 @@ public class ShellyDevices {
     public static final String SHELLYDT_PLUS1UL = "SNSW-001X15UL";
     public static final String SHELLYDT_PLUS1PMUL = "SNSW-001P15UL";
     public static final String SHELLYDT_PLUS1L = "S3SW-0A1X1EUL";
+    public static final String SHELLYDT_PLUS1LG4 = "S4SW-0A1X1EUL";
     public static final String SHELLYDT_PLUS2L = "S3SW-0A2X4EUL";
+    public static final String SHELLYDT_PLUS2LG4 = "S4SW-0A2X4EUL";
     public static final String SHELLYDT_PLUS2PM = "SNSW-002P16EU";
     public static final String SHELLYDT_PLUS2PM_2 = "SNSW-102P16EU";
     public static final String SHELLYDT_PLUS2PMG3 = "S3SW-002P16EU";
@@ -425,7 +427,9 @@ public class ShellyDevices {
             Map.entry(SHELLYDT_PLUS1PMG4, THING_TYPE_SHELLYPLUS1PM),
             Map.entry(SHELLYDT_PLUS1PMUL, THING_TYPE_SHELLYPLUS1PM),
             Map.entry(SHELLYDT_PLUS1L, THING_TYPE_SHELLYPLUS1L), //
-            Map.entry(SHELLYDT_PLUS2L, THING_TYPE_SHELLYPLUS2L),
+            Map.entry(SHELLYDT_PLUS1LG4, THING_TYPE_SHELLYPLUS1L), //
+            Map.entry(SHELLYDT_PLUS2L, THING_TYPE_SHELLYPLUS2L), //
+            Map.entry(SHELLYDT_PLUS2LG4, THING_TYPE_SHELLYPLUS2L),
             Map.entry(SHELLYDT_PLUSSHUTTER, THING_TYPE_SHELLYPLUSSHUTTER),
             Map.entry(SHELLYDT_PLUSPLUGS, THING_TYPE_SHELLYPLUSPLUGS),
             Map.entry(SHELLYDT_PLUSPLUGS_2, THING_TYPE_SHELLYPLUSPLUGS),
@@ -609,10 +613,13 @@ public class ShellyDevices {
             Map.entry("shelly1pmg3", THING_TYPE_SHELLYPLUS1PM), //
             Map.entry("shelly1pmg4", THING_TYPE_SHELLYPLUS1PM), //
             Map.entry("shellyplus1l", THING_TYPE_SHELLYPLUS1L), //
+            Map.entry("shelly1lg4", THING_TYPE_SHELLYPLUS1L), //
             Map.entry("shellyplus2pm-relay", THING_TYPE_SHELLYPLUS2PM_RELAY),
             Map.entry("shellyplus2pm-roller", THING_TYPE_SHELLYPLUS2PM_ROLLER),
+            Map.entry("shelly2pmg4", THING_TYPE_SHELLYPLUS2PM_RELAY),
             Map.entry("shellyplusshutter", THING_TYPE_SHELLYPLUSSHUTTER),
             Map.entry("shellyplus2l", THING_TYPE_SHELLYPLUS2L), //
+            Map.entry("shelly2lg4", THING_TYPE_SHELLYPLUS2L), //
             Map.entry("shellyplugu1", THING_TYPE_SHELLYPLUGU1), //
             Map.entry("shellyplugus", THING_TYPE_SHELLYPLUSPLUGUS),
             Map.entry("shellyplusplug", THING_TYPE_SHELLYPLUSPLUGS), //

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/ShellyDevices.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/ShellyDevices.java
@@ -700,8 +700,8 @@ public class ShellyDevices {
     public static final Map<ThingTypeUID, Integer> THING_TYPE_CAP_NUM_METERS = Map.ofEntries( //
             Map.entry(THING_TYPE_SHELLYPRO2, 0), //
             Map.entry(THING_TYPE_SHELLYPRO3, 0), //
-            Map.entry(THING_TYPE_SHELLYPLUS1L, 0), //
-            Map.entry(THING_TYPE_SHELLYPLUS2L, 0), //
+            Map.entry(THING_TYPE_SHELLYPLUS1L, 0), // no power metering
+            Map.entry(THING_TYPE_SHELLYPLUS2L, 0), // no power metering
             Map.entry(THING_TYPE_SHELLYPROEM50, 2), //
             Map.entry(THING_TYPE_SHELLY3EM, 3), //
             Map.entry(THING_TYPE_SHELLYPLUS3EM63, 3), //

--- a/bundles/org.openhab.binding.shelly/src/test/java/org/openhab/binding/shelly/internal/ShellyDevicesTest.java
+++ b/bundles/org.openhab.binding.shelly/src/test/java/org/openhab/binding/shelly/internal/ShellyDevicesTest.java
@@ -76,6 +76,25 @@ public class ShellyDevicesTest {
     }
 
     @ParameterizedTest
+    @MethodSource("provideTestCasesForNumMetersByThingType")
+    void numMetersByThingType(ThingTypeUID thingTypeUid, int expectedMeters) {
+        Integer numMeters = THING_TYPE_CAP_NUM_METERS.get(thingTypeUid);
+        assertThat("THING_TYPE_CAP_NUM_METERS for " + thingTypeUid.getId(), numMeters, is(equalTo(expectedMeters)));
+    }
+
+    private static Stream<Arguments> provideTestCasesForNumMetersByThingType() {
+        return Stream.of( //
+                Arguments.of(THING_TYPE_SHELLYPLUS1L, 0), // no PM — relay-count fallback must be suppressed
+                Arguments.of(THING_TYPE_SHELLYPLUS2L, 0), // no PM — relay-count fallback must be suppressed
+                Arguments.of(THING_TYPE_SHELLYPRO2, 0), //
+                Arguments.of(THING_TYPE_SHELLYPRO3, 0), //
+                Arguments.of(THING_TYPE_SHELLYPROEM50, 2), //
+                Arguments.of(THING_TYPE_SHELLY3EM, 3), //
+                Arguments.of(THING_TYPE_SHELLYPLUS3EM63, 3), //
+                Arguments.of(THING_TYPE_SHELLYPRO3EM, 3)); //
+    }
+
+    @ParameterizedTest
     @MethodSource("provideTestCasesFornNumberInputsByBluThingType")
     void numberInputsByBluThingType(ThingTypeUID thingTypeUid, int expectedInputs) {
         Integer numberInputs = THING_TYPE_CAP_NUM_INPUTS.get(thingTypeUid);

--- a/bundles/org.openhab.binding.shelly/src/test/java/org/openhab/binding/shelly/internal/discovery/ShellyThingCreatorTest.java
+++ b/bundles/org.openhab.binding.shelly/src/test/java/org/openhab/binding/shelly/internal/discovery/ShellyThingCreatorTest.java
@@ -109,6 +109,9 @@ public class ShellyThingCreatorTest {
 
                 // Shelly Plus
                 Arguments.of("shelly3em63g3-" + DEVICE_ID, "", THING_TYPE_SHELLYPLUS3EM63),
+                Arguments.of("shelly2pmg4-" + DEVICE_ID, "", THING_TYPE_SHELLYPLUS2PM_RELAY),
+                Arguments.of("shelly1lg4-" + DEVICE_ID, "", THING_TYPE_SHELLYPLUS1L),
+                Arguments.of("shelly2lg4-" + DEVICE_ID, "", THING_TYPE_SHELLYPLUS2L),
 
                 // Shelly Pro
                 Arguments.of("shellypro3em-" + DEVICE_ID, "", THING_TYPE_SHELLYPRO3EM),
@@ -182,6 +185,7 @@ public class ShellyThingCreatorTest {
                 Arguments.of(SHELLYDT_PLUS1UL, "", THING_TYPE_SHELLYPLUS1), //
                 Arguments.of(SHELLYDT_PLUS1PMUL, "", THING_TYPE_SHELLYPLUS1PM), //
                 Arguments.of(SHELLYDT_PLUS1L, "", THING_TYPE_SHELLYPLUS1L), //
+                Arguments.of(SHELLYDT_PLUS1LG4, "", THING_TYPE_SHELLYPLUS1L), //
                 Arguments.of(SHELLYDT_PLUS2PM, "relay", THING_TYPE_SHELLYPLUS2PM_RELAY), //
                 Arguments.of(SHELLYDT_PLUS2PM, "roller", THING_TYPE_SHELLYPLUS2PM_ROLLER), //
                 Arguments.of(SHELLYDT_PLUS2PM_2, "relay", THING_TYPE_SHELLYPLUS2PM_RELAY), //
@@ -191,6 +195,7 @@ public class ShellyThingCreatorTest {
                 Arguments.of(SHELLYDT_PLUS2PMG4, "relay", THING_TYPE_SHELLYPLUS2PM_RELAY), //
                 Arguments.of(SHELLYDT_PLUS2PMG4, "roller", THING_TYPE_SHELLYPLUS2PM_ROLLER), //
                 Arguments.of(SHELLYDT_PLUS2L, "", THING_TYPE_SHELLYPLUS2L), //
+                Arguments.of(SHELLYDT_PLUS2LG4, "", THING_TYPE_SHELLYPLUS2L), //
                 Arguments.of(SHELLYDT_PLUSSHUTTER, "", THING_TYPE_SHELLYPLUSSHUTTER), //
                 Arguments.of(SHELLYDT_PLUSPLUGS, "", THING_TYPE_SHELLYPLUSPLUGS), //
                 Arguments.of(SHELLYDT_PLUSPLUGSG3, "", THING_TYPE_SHELLYPLUSPLUGS), //
@@ -299,6 +304,24 @@ public class ShellyThingCreatorTest {
         return Stream.of( //
                 Arguments.of("shellyplusshutter-" + DEVICE_ID, SHELLYDT_PLUSSMOKE, THING_TYPE_SHELLYPLUSSMOKE), //
                 Arguments.of("notfound-" + DEVICE_ID, SHELLYDT_PLUSSMOKE, THING_TYPE_SHELLYPLUSSMOKE));
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideTestCasesForGetThingUIDReturnsThingUidByServiceNameDeviceTypeAndMode")
+    void getThingUIDReturnsThingUidByServiceNameDeviceTypeAndMode(String serviceName, String deviceType, String mode,
+            ThingTypeUID expectedThingTypeUid) {
+        ThingUID actual = ShellyThingCreator.getThingUID(serviceName, deviceType, mode);
+        ThingUID expected = new ThingUID(expectedThingTypeUid, DEVICE_ID);
+
+        assertThat("serviceName: " + serviceName + "; deviceType: " + deviceType + "; mode: " + mode, actual,
+                is(equalTo(expected)));
+    }
+
+    private static Stream<Arguments> provideTestCasesForGetThingUIDReturnsThingUidByServiceNameDeviceTypeAndMode() {
+        return Stream.of( //
+                Arguments.of("shelly2pmg4-" + DEVICE_ID, SHELLYDT_PLUS2PMG4, "relay", THING_TYPE_SHELLYPLUS2PM_RELAY), //
+                Arguments.of("shelly2pmg4-" + DEVICE_ID, SHELLYDT_PLUS2PMG4, "roller",
+                        THING_TYPE_SHELLYPLUS2PM_ROLLER)); //
     }
 
     @Test


### PR DESCRIPTION
# Description

New Device Support

Adds support for the Gen4 hardware revision of the Shelly Plus 1L, 2L, and 2PM.
These map to the already-supported `shellyplus1l`, `shellyplus2l`, and `shellyplus2pm-relay`/`shellyplus2pm-roller` Things, so no new channels, Thing types, or configuration options are introduced.
Existing Things and rules are unaffected.

**New devices**

- Shelly Plus 1L Gen4 is now discovered and mapped to its existing Thing type.
- Shelly Plus 2L Gen4 is now discovered and mapped to its existing Thing type.
- Shelly Plus 2PM Gen4 is now discovered and mapped to its existing Thing type, in both relay and roller mode.

# Testing

- Verified discovery and Thing creation for all three Gen4 models.
- Verified no unrelated channels are created on models without power metering.

Test build: https://github.com/markus7017/myfiles/blob/master/shelly/org.openhab.binding.shelly-5.3.0-SNAPSHOT-relayg4.jar

**How to verify on hardware**

- 1L Gen4: after discovery, only the relay channel should be created — no accumulated-energy channels.
- 2L Gen4: after discovery, both relay channels should be created — no accumulated-energy channels.
- 2PM Gen4: the Thing type and channels (including power metering) should match whatever mode (relay or roller) the device is set to.

## Acceptance criteria

- [x] Implementation done
- [x] Documentation is up-to-date
- [x] Verified by Community

## Closing

- Closes #20972
- Closes #20973
- Closes #20974

## Backport assessment

Pure new-hardware-revision registration with no behavior change for existing devices — no backport needed.

