### PR TITLE
[govee] Fix `NullPointerException` in discovery for non-scan and malformed packets

### DIFF
--- a/bundles/org.openhab.binding.govee/src/main/java/org/openhab/binding/govee/internal/GoveeDiscoveryService.java
+++ b/bundles/org.openhab.binding.govee/src/main/java/org/openhab/binding/govee/internal/GoveeDiscoveryService.java
@@ -117,17 +117,12 @@ public class GoveeDiscoveryService extends AbstractDiscoveryService implements G
 
     public @Nullable DiscoveryResult responseToResult(DiscoveryResponse response) {
         final DiscoveryMsg msg = response.msg();
-        // The discovery socket receives data on the same port that is used for device status updates
-        // (see class documentation). Ignore anything that is not a scan response so that status packets,
-        // which do not carry the device information expected below, do not reach the parsing code.
         if (!"scan".equals(msg.cmd())) {
             logger.trace("Ignoring non-scan message received during discovery - {}", response);
             return null;
         }
 
         final DiscoveryData data = msg.data();
-        // Although the model is annotated @NonNullByDefault, the fields are populated by Gson from network
-        // input and may be null when the corresponding JSON field is absent or the packet is malformed.
         final String macAddress = data.device();
         if (macAddress == null || macAddress.isEmpty()) {
             logger.warn("Missing Mac address received during discovery - ignoring {}", response);

--- a/bundles/org.openhab.binding.govee/src/main/java/org/openhab/binding/govee/internal/GoveeDiscoveryService.java
+++ b/bundles/org.openhab.binding.govee/src/main/java/org/openhab/binding/govee/internal/GoveeDiscoveryService.java
@@ -25,6 +25,7 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.govee.internal.CommunicationManager.GoveeDiscoveryListener;
 import org.openhab.binding.govee.internal.model.DiscoveryData;
+import org.openhab.binding.govee.internal.model.DiscoveryMsg;
 import org.openhab.binding.govee.internal.model.DiscoveryResponse;
 import org.openhab.core.config.discovery.AbstractDiscoveryService;
 import org.openhab.core.config.discovery.DiscoveryResult;
@@ -115,22 +116,33 @@ public class GoveeDiscoveryService extends AbstractDiscoveryService implements G
     }
 
     public @Nullable DiscoveryResult responseToResult(DiscoveryResponse response) {
-        final DiscoveryData data = response.msg().data();
+        final DiscoveryMsg msg = response.msg();
+        // The discovery socket receives data on the same port that is used for device status updates
+        // (see class documentation). Ignore anything that is not a scan response so that status packets,
+        // which do not carry the device information expected below, do not reach the parsing code.
+        if (!"scan".equals(msg.cmd())) {
+            logger.trace("Ignoring non-scan message received during discovery - {}", response);
+            return null;
+        }
+
+        final DiscoveryData data = msg.data();
+        // Although the model is annotated @NonNullByDefault, the fields are populated by Gson from network
+        // input and may be null when the corresponding JSON field is absent or the packet is malformed.
         final String macAddress = data.device();
-        if (macAddress.isEmpty()) {
-            logger.warn("Empty Mac address received during discovery - ignoring {}", response);
+        if (macAddress == null || macAddress.isEmpty()) {
+            logger.warn("Missing Mac address received during discovery - ignoring {}", response);
             return null;
         }
 
         final String ipAddress = data.ip();
-        if (ipAddress.isEmpty()) {
-            logger.warn("Empty IP address received during discovery - ignoring {}", response);
+        if (ipAddress == null || ipAddress.isEmpty()) {
+            logger.warn("Missing IP address received during discovery - ignoring {}", response);
             return null;
         }
 
         final String sku = data.sku();
-        if (sku.isEmpty()) {
-            logger.warn("Empty SKU (product name) received during discovery - ignoring {}", response);
+        if (sku == null || sku.isEmpty()) {
+            logger.warn("Missing SKU (product name) received during discovery - ignoring {}", response);
             return null;
         }
 
@@ -157,11 +169,11 @@ public class GoveeDiscoveryService extends AbstractDiscoveryService implements G
         }
 
         String hwVersion = data.wifiVersionHard();
-        if (!hwVersion.isEmpty()) {
+        if (hwVersion != null && !hwVersion.isEmpty()) {
             builder.withProperty(GoveeBindingConstants.HW_VERSION, hwVersion);
         }
         String swVersion = data.wifiVersionSoft();
-        if (!swVersion.isEmpty()) {
+        if (swVersion != null && !swVersion.isEmpty()) {
             builder.withProperty(GoveeBindingConstants.SW_VERSION, swVersion);
         }
 

--- a/bundles/org.openhab.binding.govee/src/main/java/org/openhab/binding/govee/internal/model/DiscoveryData.java
+++ b/bundles/org.openhab.binding.govee/src/main/java/org/openhab/binding/govee/internal/model/DiscoveryData.java
@@ -13,9 +13,14 @@
 package org.openhab.binding.govee.internal.model;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 
 /**
  * Govee Message - Device information
+ *
+ * The fields are populated from JSON received over the network using Gson, which does not honor
+ * {@link NonNullByDefault} and leaves absent fields {@code null}. They are therefore marked
+ * {@link Nullable} and must be null-checked by consumers.
  *
  * @param ip IP address of the device
  * @param device mac Address
@@ -28,8 +33,9 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
  * @author Stefan Höhn - Initial contribution
  */
 @NonNullByDefault
-public record DiscoveryData(String ip, String device, String sku, String bleVersionHard, String bleVersionSoft,
-        String wifiVersionHard, String wifiVersionSoft) {
+public record DiscoveryData(@Nullable String ip, @Nullable String device, @Nullable String sku,
+        @Nullable String bleVersionHard, @Nullable String bleVersionSoft, @Nullable String wifiVersionHard,
+        @Nullable String wifiVersionSoft) {
     public DiscoveryData() {
         this("", "", "", "", "", "", "");
     }

--- a/bundles/org.openhab.binding.govee/src/main/java/org/openhab/binding/govee/internal/model/DiscoveryData.java
+++ b/bundles/org.openhab.binding.govee/src/main/java/org/openhab/binding/govee/internal/model/DiscoveryData.java
@@ -18,10 +18,6 @@ import org.eclipse.jdt.annotation.Nullable;
 /**
  * Govee Message - Device information
  *
- * The fields are populated from JSON received over the network using Gson, which does not honor
- * {@link NonNullByDefault} and leaves absent fields {@code null}. They are therefore marked
- * {@link Nullable} and must be null-checked by consumers.
- *
  * @param ip IP address of the device
  * @param device mac Address
  * @param sku article number

--- a/bundles/org.openhab.binding.govee/src/test/java/org/openhab/binding/govee/internal/GoveeDiscoveryTest.java
+++ b/bundles/org.openhab.binding.govee/src/test/java/org/openhab/binding/govee/internal/GoveeDiscoveryTest.java
@@ -48,6 +48,35 @@ public class GoveeDiscoveryTest {
             }
              """;
 
+    // A status update is received on the same port as discovery responses. Its "data" object does not
+    // contain the device information expected by discovery, so Gson leaves those fields null.
+    String statusResponse = """
+             {
+                "msg":{
+                   "cmd":"devStatus",
+                   "data":{
+                      "onOff":1,
+                      "brightness":100,
+                      "color":{ "r":255, "g":255, "b":255 },
+                      "colorTemInKelvin":7200
+                   }
+                }
+            }
+             """;
+
+    // A malformed scan response that is missing the "ip" field.
+    String scanResponseWithoutIp = """
+             {
+                "msg":{
+                   "cmd":"scan",
+                   "data":{
+                      "device":"7D:31:C3:35:33:33:44:15",
+                      "sku":"H6076"
+                   }
+                }
+            }
+             """;
+
     @Test
     public void testProcessScanMessage() {
         GoveeDiscoveryService service = new GoveeDiscoveryService(new CommunicationManager());
@@ -60,5 +89,23 @@ public class GoveeDiscoveryTest {
         assertEquals(deviceProperties.get(GoveeBindingConstants.DEVICE_TYPE), "H6076");
         assertEquals(deviceProperties.get(GoveeBindingConstants.IP_ADDRESS), "192.168.178.171");
         assertEquals(deviceProperties.get(GoveeBindingConstants.MAC_ADDRESS), "7D:31:C3:35:33:33:44:15");
+    }
+
+    @Test
+    public void testStatusMessageIsIgnored() {
+        GoveeDiscoveryService service = new GoveeDiscoveryService(new CommunicationManager());
+        DiscoveryResponse resp = new Gson().fromJson(statusResponse, DiscoveryResponse.class);
+        Objects.requireNonNull(resp);
+        // Must not throw and must not be discovered as a Thing.
+        assertNull(service.responseToResult(resp));
+    }
+
+    @Test
+    public void testScanMessageWithoutIpIsIgnored() {
+        GoveeDiscoveryService service = new GoveeDiscoveryService(new CommunicationManager());
+        DiscoveryResponse resp = new Gson().fromJson(scanResponseWithoutIp, DiscoveryResponse.class);
+        Objects.requireNonNull(resp);
+        // Must not throw a NullPointerException when the IP field is absent.
+        assertNull(service.responseToResult(resp));
     }
 }


### PR DESCRIPTION
## Description
The Govee discovery socket receives data on the same UDP port used for device status updates (as noted in the discovery service's own class documentation). Status packets — and any malformed packet — are deserialized by Gson into a `DiscoveryResponse` whose `data` fields are left `null`, because Gson does not honor `@NonNullByDefault`. `responseToResult()` then called `String.isEmpty()` on those values, throwing a `NullPointerException` that repeats continuously on the `OH-binding-govee` thread and floods the log (observed tens of thousands of times shortly after startup on a normal LAN).

```
Exception in thread "OH-binding-govee" java.lang.NullPointerException: Cannot invoke "String.isEmpty()" because "ipAddress" is null
	at org.openhab.binding.govee.internal.GoveeDiscoveryService.responseToResult(GoveeDiscoveryService.java:126)
	at org.openhab.binding.govee.internal.GoveeDiscoveryService.onDiscoveryResponse(GoveeDiscoveryService.java:203)
	at org.openhab.binding.govee.internal.CommunicationManager.serverThreadTask(CommunicationManager.java:225)
```

## Fix
- Ignore messages whose command is not `scan`, so status packets no longer reach the discovery parser.
- Null-check the device-information fields before use; mark `DiscoveryData` fields `@Nullable` to reflect that they originate from untrusted network input.

## Testing
- Added unit tests covering a `devStatus` status packet and a `scan` response missing the `ip` field; both must be ignored without throwing.
- Existing `testProcessScanMessage` still passes.
