### PR TITLE
[bluetooth.bluez] Improve stability of BlueZ adapter and align with interface

### DIFF
--- a/bundles/org.openhab.binding.bluetooth.bluez/src/main/java/org/openhab/binding/bluetooth/bluez/internal/BlueZBluetoothDevice.java
+++ b/bundles/org.openhab.binding.bluetooth.bluez/src/main/java/org/openhab/binding/bluetooth/bluez/internal/BlueZBluetoothDevice.java
@@ -17,12 +17,14 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
-import org.freedesktop.dbus.errors.NoReply;
 import org.freedesktop.dbus.errors.UnknownObject;
 import org.freedesktop.dbus.exceptions.DBusException;
 import org.freedesktop.dbus.exceptions.DBusExecutionException;
@@ -71,6 +73,8 @@ public class BlueZBluetoothDevice extends BaseBluetoothDevice implements BlueZEv
     private final Logger logger = LoggerFactory.getLogger(BlueZBluetoothDevice.class);
 
     private final ScheduledExecutorService scheduler = ThreadPoolManager.getScheduledPool("bluetooth");
+
+    private final AtomicBoolean connectionStartRunning = new AtomicBoolean();
 
     // Device from native lib
     private @Nullable BluetoothDevice device = null;
@@ -170,6 +174,7 @@ public class BlueZBluetoothDevice extends BaseBluetoothDevice implements BlueZEv
     }
 
     private void setConnectionState(ConnectionState state) {
+        logger.debug("Update connection state for {} to {}", address, state);
         if (this.connectionState != state) {
             this.connectionState = state;
             notifyListeners(BluetoothEventType.CONNECTION_STATE, new BluetoothConnectionStatusNotification(state));
@@ -207,42 +212,47 @@ public class BlueZBluetoothDevice extends BaseBluetoothDevice implements BlueZEv
 
     @Override
     public boolean connect() {
-        logger.debug("Connect({})", device);
-
         BluetoothDevice dev = device;
-        if (dev != null) {
-            if (Boolean.FALSE.equals(dev.isConnected())) {
-                // BlueZ Device.Connect() is unreliable while the adapter is actively discovering
-                // (the call blocks / does not complete). Pause discovery first; the bridge's periodic
-                // refresh job resumes it shortly after.
-                bridgeHandler.stopDiscovery();
-                try {
+
+        if (dev == null) {
+            return false;
+        }
+
+        logger.debug("Connect({})", dev);
+
+        if (Boolean.FALSE.equals(dev.isConnected())) {
+            if (connectionStartRunning.compareAndSet(false, true)) {
+                CompletableFuture.runAsync(() -> {
+                    setConnectionState(ConnectionState.CONNECTING);
+                    // BlueZ Device.Connect() is unreliable while the adapter is actively discovering
+                    // (the call blocks / does not complete). Pause discovery first; the bridge's periodic
+                    // refresh job resumes it shortly after.
+                    bridgeHandler.stopDiscovery();
+                    // This method does not block at most until the dbus-java
+                    // method timeout is reached.
                     boolean ret = dev.connect();
                     logger.debug("Connect result: {}", ret);
-                    return ret;
-                } catch (NoReply e) {
-                    // Have to double check because sometimes, exception but still worked
-                    logger.debug("Got a timeout - but sometimes happen. Is Connected ? {}", dev.isConnected());
-                    if (Boolean.FALSE.equals(dev.isConnected())) {
-                        notifyListeners(BluetoothEventType.CONNECTION_STATE,
-                                new BluetoothConnectionStatusNotification(ConnectionState.DISCONNECTED));
-                        return false;
-                    } else {
-                        return true;
+                    ConnectionState cs1 = ret ? ConnectionState.CONNECTED : ConnectionState.DISCONNECTED;
+                    logger.debug("Updating connection state after connect: {}", cs1);
+                    setConnectionState(cs1);
+                }, scheduler).handle((voidResult, th) -> {
+                    if (th != null) {
+                        logger.debug("Failed to connect", th);
+                        setConnectionState(ConnectionState.DISCONNECTED);
                     }
-                } catch (DBusExecutionException e) {
-                    // Catch "software caused connection abort"
-                    return false;
-                } catch (Exception e) {
-                    logger.warn("error occurred while trying to connect", e);
-                }
+                    connectionStartRunning.set(false);
+                    return null;
+                });
             } else {
-                logger.debug("Device was already connected");
-                // we might be stuck in another state atm so we need to trigger a connected in this case
-                setConnectionState(ConnectionState.CONNECTED);
-                return true;
+                logger.debug("Connection already in progress for {}", address);
             }
+            return true;
+        } else {
+            logger.debug("Device was already connected");
+            // we might be stuck in another state atm so we need to trigger a connected in this case
+            setConnectionState(ConnectionState.CONNECTED);
         }
+
         return false;
     }
 
@@ -283,19 +293,29 @@ public class BlueZBluetoothDevice extends BaseBluetoothDevice implements BlueZEv
         return services;
     }
 
-    private @Nullable BluetoothGattCharacteristic getDBusBlueZCharacteristicByUUID(String uuid) {
+    private @Nullable CompletableFuture<BluetoothGattCharacteristic> getDBusBlueZCharacteristicByUUID(String uuid) {
         BluetoothDevice dev = device;
         if (dev == null) {
             return null;
         }
-        for (BluetoothGattService service : getGattServicesRefreshed(dev)) {
-            for (BluetoothGattCharacteristic characteristic : service.getGattCharacteristics()) {
-                if (characteristic != null && uuid.equalsIgnoreCase(characteristic.getUuid())) {
-                    return characteristic;
+        AtomicInteger atomicInteger = new AtomicInteger();
+        return RetryFuture.callWithRetry(() -> {
+            if (Boolean.TRUE.equals(dev.isServicesResolved())) {
+                for (BluetoothGattService service : getGattServicesRefreshed(dev)) {
+                    for (BluetoothGattCharacteristic characteristic : service.getGattCharacteristics()) {
+                        if (characteristic != null && uuid.equalsIgnoreCase(characteristic.getUuid())) {
+                            return characteristic;
+                        }
+                    }
                 }
             }
-        }
-        return null;
+
+            if (atomicInteger.incrementAndGet() < 100) { // 100 iterations 50ms each => 5s
+                throw new RetryException(50, TimeUnit.MILLISECONDS);
+            }
+
+            throw new IllegalStateException("Characteristic " + uuid + " is missing on device");
+        }, scheduler);
     }
 
     private @Nullable BluetoothGattCharacteristic getDBusBlueZCharacteristicByDBusPath(String dBusPath) {
@@ -323,30 +343,25 @@ public class BlueZBluetoothDevice extends BaseBluetoothDevice implements BlueZEv
                     .failedFuture(new IllegalStateException("DBusBlueZ device is not set or not connected"));
         }
 
-        BluetoothGattCharacteristic c = getDBusBlueZCharacteristicByUUID(characteristic.getUuid().toString());
-        if (c == null) {
-            logger.warn("Characteristic '{}' is missing on device '{}'.", characteristic.getUuid(), address);
-            return CompletableFuture.failedFuture(
-                    new IllegalStateException("Characteristic " + characteristic.getUuid() + " is missing on device"));
-        }
-
-        return RetryFuture.callWithRetry(() -> {
-            try {
-                c.startNotify();
-            } catch (DBusException e) {
-                String exceptionMessage = e.getMessage();
-                if (exceptionMessage != null && exceptionMessage.contains("Already notifying")) {
+        return getDBusBlueZCharacteristicByUUID(characteristic.getUuid().toString())
+                .thenCompose(c -> RetryFuture.callWithRetry(() -> {
+                    try {
+                        c.startNotify();
+                    } catch (DBusExecutionException e) {
+                        String exceptionMessage = e.getMessage();
+                        if (exceptionMessage != null && exceptionMessage.contains("Already notifying")) {
+                            return null;
+                        } else if (exceptionMessage != null && exceptionMessage.contains("In Progress")) {
+                            // let's retry in half a second
+                            throw new RetryException(500, TimeUnit.MILLISECONDS);
+                        } else {
+                            logger.warn("Exception occurred while activating notifications on '{}'", address, e);
+                            throw e;
+                        }
+                    }
+                    ;
                     return null;
-                } else if (exceptionMessage != null && exceptionMessage.contains("In Progress")) {
-                    // let's retry in half a second
-                    throw new RetryException(500, TimeUnit.MILLISECONDS);
-                } else {
-                    logger.warn("Exception occurred while activating notifications on '{}'", address, e);
-                    throw e;
-                }
-            }
-            return null;
-        }, scheduler);
+                }, scheduler));
     }
 
     @Override
@@ -359,23 +374,17 @@ public class BlueZBluetoothDevice extends BaseBluetoothDevice implements BlueZEv
                     .failedFuture(new IllegalStateException("DBusBlueZ device is not set or not connected"));
         }
 
-        BluetoothGattCharacteristic c = getDBusBlueZCharacteristicByUUID(characteristic.getUuid().toString());
-        if (c == null) {
-            logger.warn("Characteristic '{}' is missing on device '{}'.", characteristic.getUuid(), address);
-            return CompletableFuture.failedFuture(
-                    new IllegalStateException("Characteristic " + characteristic.getUuid() + " is missing on device"));
-        }
-
-        return RetryFuture.callWithRetry(() -> {
-            try {
-                c.writeValue(value, null);
-                return null;
-            } catch (DBusException e) {
-                logger.debug("Exception occurred when trying to write characteristic '{}': {}",
-                        characteristic.getUuid(), e.getMessage());
-                throw e;
-            }
-        }, scheduler);
+        return getDBusBlueZCharacteristicByUUID(characteristic.getUuid().toString())
+                .thenCompose(c -> RetryFuture.callWithRetry(() -> {
+                    try {
+                        c.writeValue(value, null);
+                        return null;
+                    } catch (DBusException e) {
+                        logger.debug("Exception occurred when trying to write characteristic '{}': {}",
+                                characteristic.getUuid(), e.getMessage());
+                        throw e;
+                    }
+                }, scheduler));
     }
 
     @Override
@@ -385,6 +394,7 @@ public class BlueZBluetoothDevice extends BaseBluetoothDevice implements BlueZEv
 
     @Override
     public void onServicesResolved(ServicesResolvedEvent event) {
+        logger.debug("onServicesResolved: {}", event.isResolved());
         if (event.isResolved()) {
             // Populate our service/characteristic list from the now-resolved GATT and notify
             // listeners. BlueZ can deliver ServicesResolved=true while our own supportedServices list
@@ -461,9 +471,7 @@ public class BlueZBluetoothDevice extends BaseBluetoothDevice implements BlueZEv
 
     @Override
     public void onConnectedStatusUpdate(ConnectedEvent event) {
-        this.connectionState = event.isConnected() ? ConnectionState.CONNECTED : ConnectionState.DISCONNECTED;
-        notifyListeners(BluetoothEventType.CONNECTION_STATE,
-                new BluetoothConnectionStatusNotification(connectionState));
+        setConnectionState(event.isConnected() ? ConnectionState.CONNECTED : ConnectionState.DISCONNECTED);
     }
 
     @Override
@@ -562,33 +570,32 @@ public class BlueZBluetoothDevice extends BaseBluetoothDevice implements BlueZEv
                     .failedFuture(new IllegalStateException("DBusBlueZ device is not set or not connected"));
         }
 
-        BluetoothGattCharacteristic c = getDBusBlueZCharacteristicByUUID(characteristic.getUuid().toString());
-        if (c == null) {
-            logger.warn("Characteristic '{}' is missing on device '{}'.", characteristic.getUuid(), address);
-            return CompletableFuture.failedFuture(
-                    new IllegalStateException("Characteristic " + characteristic.getUuid() + " is missing on device"));
-        }
-
-        return RetryFuture.callWithRetry(() -> {
-            try {
-                return c.readValue(null);
-            } catch (DBusException | DBusExecutionException e) {
-                // DBusExecutionException is thrown if the value cannot be read
-                logger.debug("Exception occurred when trying to read characteristic '{}': {}", characteristic.getUuid(),
-                        e.getMessage());
-                throw e;
-            }
-        }, scheduler);
+        return getDBusBlueZCharacteristicByUUID(characteristic.getUuid().toString())
+                .thenCompose(c -> RetryFuture.callWithRetry(() -> {
+                    try {
+                        return c.readValue(null);
+                    } catch (DBusException | DBusExecutionException e) {
+                        // DBusExecutionException is thrown if the value cannot be read
+                        logger.debug("Exception occurred when trying to read characteristic '{}': {}",
+                                characteristic.getUuid(), e.getMessage());
+                        throw e;
+                    }
+                }, scheduler));
     }
 
     @Override
     public boolean isNotifying(BluetoothCharacteristic characteristic) {
-        BluetoothGattCharacteristic c = getDBusBlueZCharacteristicByUUID(characteristic.getUuid().toString());
-        if (c != null) {
-            Boolean isNotifying = c.isNotifying();
-            return Objects.requireNonNullElse(isNotifying, false);
-        } else {
-            logger.warn("Characteristic '{}' is missing on device '{}'.", characteristic.getUuid(), address);
+        try {
+            BluetoothGattCharacteristic c = getDBusBlueZCharacteristicByUUID(characteristic.getUuid().toString()).get();
+            if (c != null) {
+                Boolean isNotifying = c.isNotifying();
+                return Objects.requireNonNullElse(isNotifying, false);
+            } else {
+                logger.warn("Characteristic '{}' is missing on device '{}'.", characteristic.getUuid(), address);
+                return false;
+            }
+        } catch (InterruptedException | ExecutionException ex) {
+            logger.warn("Fetchig characteristic '{}' for device '{}'.", characteristic.getUuid(), address, ex);
             return false;
         }
     }
@@ -597,33 +604,32 @@ public class BlueZBluetoothDevice extends BaseBluetoothDevice implements BlueZEv
     public CompletableFuture<@Nullable Void> disableNotifications(BluetoothCharacteristic characteristic) {
         BluetoothDevice dev = device;
         if (dev == null || Boolean.FALSE.equals(dev.isConnected())) {
-            return CompletableFuture
-                    .failedFuture(new IllegalStateException("DBusBlueZ device is not set or not connected"));
-        }
-        BluetoothGattCharacteristic c = getDBusBlueZCharacteristicByUUID(characteristic.getUuid().toString());
-        if (c == null) {
-            logger.warn("Characteristic '{}' is missing on device '{}'.", characteristic.getUuid(), address);
-            return CompletableFuture.failedFuture(
-                    new IllegalStateException("Characteristic " + characteristic.getUuid() + " is missing on device"));
-        }
-
-        return RetryFuture.callWithRetry(() -> {
-            try {
-                c.stopNotify();
-            } catch (DBusException e) {
-                String exceptionMessage = e.getMessage();
-                if (exceptionMessage != null && exceptionMessage.contains("Already notifying")) {
-                    return null;
-                } else if (exceptionMessage != null && exceptionMessage.contains("In Progress")) {
-                    // let's retry in half a second
-                    throw new RetryException(500, TimeUnit.MILLISECONDS);
-                } else {
-                    logger.warn("Exception occurred while deactivating notifications on '{}'", address, e);
-                    throw e;
-                }
+            String message;
+            if (dev == null) {
+                message = "DBusBlueZ device is not set";
+            } else {
+                message = "DBusBlueZ device is not not connected";
             }
-            return null;
-        }, scheduler);
+            return CompletableFuture.failedFuture(new IllegalStateException(message));
+        }
+        return getDBusBlueZCharacteristicByUUID(characteristic.getUuid().toString())
+                .thenCompose(c -> RetryFuture.callWithRetry(() -> {
+                    try {
+                        c.stopNotify();
+                    } catch (DBusExecutionException e) {
+                        String exceptionMessage = e.getMessage();
+                        if (exceptionMessage != null && exceptionMessage.contains("Already notifying")) {
+                            return null;
+                        } else if (exceptionMessage != null && exceptionMessage.contains("In Progress")) {
+                            // let's retry in half a second
+                            throw new RetryException(500, TimeUnit.MILLISECONDS);
+                        } else {
+                            logger.warn("Exception occurred while deactivating notifications on '{}'", address, e);
+                            throw e;
+                        }
+                    }
+                    return null;
+                }, scheduler));
     }
 
     @Override

--- a/bundles/org.openhab.binding.bluetooth.bluez/src/main/java/org/openhab/binding/bluetooth/bluez/internal/BlueZBridgeHandler.java
+++ b/bundles/org.openhab.binding.bluetooth.bluez/src/main/java/org/openhab/binding/bluetooth/bluez/internal/BlueZBridgeHandler.java
@@ -27,6 +27,7 @@ import org.bluez.exceptions.BluezNotSupportedException;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.freedesktop.dbus.exceptions.DBusExecutionException;
+import org.freedesktop.dbus.messages.MethodCall;
 import org.freedesktop.dbus.types.Variant;
 import org.openhab.binding.bluetooth.AbstractBluetoothBridgeHandler;
 import org.openhab.binding.bluetooth.BluetoothAddress;
@@ -60,6 +61,10 @@ import com.github.hypfvieh.bluetooth.wrapper.BluetoothDevice;
 @NonNullByDefault
 public class BlueZBridgeHandler extends AbstractBluetoothBridgeHandler<BlueZBluetoothDevice>
         implements BlueZEventListener {
+
+    static {
+        MethodCall.setDefaultTimeout(60_000);
+    }
 
     private final Logger logger = LoggerFactory.getLogger(BlueZBridgeHandler.class);
 

--- a/bundles/org.openhab.binding.bluetooth/src/main/java/org/openhab/binding/bluetooth/ConnectedBluetoothHandler.java
+++ b/bundles/org.openhab.binding.bluetooth/src/main/java/org/openhab/binding/bluetooth/ConnectedBluetoothHandler.java
@@ -93,7 +93,8 @@ public abstract class ConnectedBluetoothHandler extends BeaconBluetoothHandler {
             reconnectJob = connectionTaskExecutor.scheduleWithFixedDelay(() -> {
                 try {
                     if (device.getConnectionState() != ConnectionState.CONNECTED) {
-                        if (device.connect()) {
+                        device.connect();
+                        if (device.awaitConnection(30, TimeUnit.SECONDS)) {
                             if (!alwaysConnected) {
                                 cancel(reconnectJob, false);
                                 reconnectJob = null;
@@ -110,7 +111,7 @@ public abstract class ConnectedBluetoothHandler extends BeaconBluetoothHandler {
                             logger.debug("Error while discovering services");
                         }
                     }
-                } catch (RuntimeException ex) {
+                } catch (RuntimeException | InterruptedException ex) {
                     logger.warn("Unexpected error occurred", ex);
                 }
             }, 0, 30, TimeUnit.SECONDS);
@@ -166,7 +167,7 @@ public abstract class ConnectedBluetoothHandler extends BeaconBluetoothHandler {
                 throw new ConnectionException("Failed to start connecting");
             }
         }
-        if (!device.awaitConnection(1, TimeUnit.SECONDS)) {
+        if (!device.awaitConnection(30, TimeUnit.SECONDS)) {
             throw new TimeoutException("Connection attempt timeout.");
         }
         if (!device.isServicesDiscovered()) {


### PR DESCRIPTION
Wrong method implementation/assumption
--------------------------------------

`BluetoothDevice#connect` is documented as: "[...] Connects to a device. This is an asynchronous method. [...]" and there is a companion method `BluetoothDevice#awaitConnection`. While documentation on the latter method is missing, it only makes sense if `connect` is indeed implemented asynchronously and `awaitConnection` allows to issue a bounded wait for the connection to be established.

There are two issues:

- ConnectedBluetoothHandler assumes that BluetoothDevice#connect indeed connects and returns `true` on successful connection in the `reconnectJob`. The problem is that `true` only means, that the connection process started. This is rectified by issuing a `connect` called followd by an `awaitConnection` call. The latter assumes that connection is established after not more than 30s.

- `BlueZBluetoothDevice#connect` directly calls into the bluez adapter `Connect` method which is blocking. To work around this the call is dispatched into an asynchronous call and parallel invocation is prevented using an AtomicBoolean as lock/indicator.

`BluetoothDevice#discoverServices` is documented as: "[...] Starts a discovery on a device. This will iterate through all services and characteristics to build up a view of the device. This method should be called before attempting to read or write characteristics.[...]"

The current code assumes that the GATT services are immediately available for BlueZ, but that is not the case. `discoverServices` can be NO-OP for BlueZ as service discovery automatically runs after a connection is established. What is crucial is, that BlueZ signals once service discovery is done. At that point we can reread the GATT services and populate the OpenHAB view of the services.

Timeouts
--------

While working with Govee Bluetooth LE devices it was noted, that these devices take a long time to connect. The observed numbers were:

| Scanning | Discovery |
| -------- | --------- |
|    12,5s |      0,3s |
|    16,2s |      0,8s |
|    14,9s |      0,3s |
|    15,1s |      0,3s |
|     8,0s |      0,8s |
|    11,1s |      0,3s |
|    14,6s |      0,3s |
|    28,0s |      0,3s |
|     4,6s |      0,3s |
|    17,3s |      0,3s |
|    19,5s |      0,3s |
|    15,9s |      0,3s |
|     4,0s |      0,8s |
|    13,6s |      0,3s |
|    19,2s |      0,3s |

This causes problems as that might exceed the default limit of 20s dbus-java sets for replies for dbus calls.

The timeouts for connection and discovery were thus bumped to 30s to account for slow devices.

The call timeout for dbus-java was bumped to 60s. It is assumed, that the dbus connection can be assumed to be stable in general and thus calls that take long are not broken at the connection level, but are indeed just slow.

<!--
Thanks for contributing to the openHAB project!
Please describe the goal and effect of your PR here.
Pay attention to the below notes and to *the guidelines* for this repository.
Feel free to delete any comment sections in the template (starting with "<!--").

ATTENTION: Don't use "git merge" when working with your pull request branch!
This can clutter your Git history and make your PR unusable.
Use "git rebase" instead. See this forum post for further details:
https://community.openhab.org/t/rebase-your-code-or-how-to-fix-your-git-history-before-requesting-a-pull/129358

All PRs should be created using the "main" branch as base.
Important bugfixes are cherry-picked by maintainers to the patch release branch after a PR has been merged.

Add one or more appropriate labels to make your PR show up in the release notes.
E.g. enhancement, bug, documentation, new binding
This can only be done by yourself if you already contributed to this repo.

If your PR's code is not backward compatible with previous releases (which
should be avoided), add a message to the release notes by filing another PR:
https://github.com/openhab/openhab-distro/blob/main/distributions/openhab/src/main/resources/bin/update.lst

# Title

Provide a short summary in the *Title* above. It will show up in the release notes.
For example:
- [homematic] Improve communication with weak signal devices
- [timemachine][WIP] Initial contribution

# Description

Please give a few sentences describing the overall goals of the pull request.
Give enough details to make the improvement and changes of the PR understandable
to both developers and tech-savy users.

Please keep the following in mind:
- What is the classification of the PR, e.g. Bugfix, Improvement, Novel Addition, ... ?
- Did you describe the PRs motivation and goal?
- Did you provide a link to any prior discussion, e.g. an issue or community forum thread?
- Did you describe new features for the end user?
- Did you describe any noteworthy changes in usage for the end user?
- Was the documentation updated accordingly, e.g. the add-on README?
- Does your contribution follow the coding guidelines:
  https://www.openhab.org/docs/developer/guidelines.html
- Did you check for any (relevant) issues from the static code analysis:
  https://www.openhab.org/docs/developer/bindings/#include-the-binding-in-the-build
- Did you sign-off your work:
  https://www.openhab.org/docs/developer/contributing.html#sign-your-work

# Testing

Your pull request will automatically be built and available under the following folder:
https://openhab.jfrog.io/ui/native/libs-pullrequest-local/org/openhab/addons/bundles/

It is a good practice to add a URL to your built JAR in this pull request description,
so it is easier for the community to test your Add-on.
If your pull request contains a new binding, it will likely take some time
before it is reviewed and processed by maintainers.
That said, consider submitting your Add-on in the Marketplace:
https://community.openhab.org/c/marketplace/69

Don't forget to submit a thread about your Add-on in the openHAB community:
https://community.openhab.org/c/add-ons 
-->
