### PR TITLE
[homeconnect] Fix bridge access after handler disposal

### DIFF
--- a/bundles/org.openhab.binding.homeconnect/src/main/java/org/openhab/binding/homeconnect/internal/handler/AbstractHomeConnectThingHandler.java
+++ b/bundles/org.openhab.binding.homeconnect/src/main/java/org/openhab/binding/homeconnect/internal/handler/AbstractHomeConnectThingHandler.java
@@ -31,6 +31,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -104,9 +105,9 @@ public abstract class AbstractHomeConnectThingHandler extends BaseThingHandler i
     private @Nullable ScheduledFuture<?> reinitializationFuture1;
     private @Nullable ScheduledFuture<?> reinitializationFuture2;
     private @Nullable ScheduledFuture<?> reinitializationFuture3;
-    private @Nullable Future<?> initializationFuture;
+    private final AtomicReference<@Nullable Future<?>> initializationFuture = new AtomicReference<>();
+    private volatile long initializationGeneration;
     private boolean ignoreEventSourceClosedEvent;
-    private volatile boolean disposed;
     private @Nullable String programOptionsDelayedUpdate;
 
     private final ConcurrentHashMap<String, EventHandler> eventHandlers;
@@ -138,7 +139,8 @@ public abstract class AbstractHomeConnectThingHandler extends BaseThingHandler i
 
     @Override
     public void initialize() {
-        disposed = false;
+        // Mark a new initialization generation; any previously scheduled or running init task becomes stale.
+        final long generation = ++initializationGeneration;
         if (getBridgeHandler().isEmpty()) {
             updateStatus(OFFLINE, ThingStatusDetail.BRIDGE_UNINITIALIZED);
             accessible.set(false);
@@ -147,18 +149,39 @@ public abstract class AbstractHomeConnectThingHandler extends BaseThingHandler i
             accessible.set(false);
         } else {
             updateStatus(UNKNOWN);
-            initializationFuture = scheduler.submit(() -> {
-                if (disposed) {
+            initializationFuture.set(scheduler.submit(() -> {
+                if (isStaleInitialization(generation)) {
                     return;
                 }
                 refreshThingStatus(); // set ONLINE / OFFLINE
+                if (isStaleInitialization(generation)) {
+                    return;
+                }
                 updateSelectedProgramStateDescription();
+                if (isStaleInitialization(generation)) {
+                    return;
+                }
                 updateChannels();
+                if (isStaleInitialization(generation)) {
+                    return;
+                }
                 registerEventListener();
+                if (isStaleInitialization(generation)) {
+                    return;
+                }
                 scheduleOfflineMonitor1();
                 scheduleOfflineMonitor2();
-            });
+            }));
         }
+    }
+
+    /**
+     * Returns {@code true} if the init task that captured {@code generation} has been superseded by a later
+     * {@link #initialize()} or stopped by {@link #teardown(boolean)}. Used to skip work and rescheduling after
+     * the handler was disposed or reinitialized.
+     */
+    private boolean isStaleInitialization(long generation) {
+        return generation != initializationGeneration;
     }
 
     @Override
@@ -186,7 +209,8 @@ public abstract class AbstractHomeConnectThingHandler extends BaseThingHandler i
      *            during {@link #reinitialize()}).
      */
     private void teardown(boolean immediate) {
-        disposed = true;
+        // Invalidate the current init generation so a running/queued init task stops at its next checkpoint.
+        initializationGeneration++;
         cancelInitialization();
         stopRetryRegistering();
         stopOfflineMonitor1();
@@ -195,11 +219,10 @@ public abstract class AbstractHomeConnectThingHandler extends BaseThingHandler i
     }
 
     private void cancelInitialization() {
-        Future<?> future = initializationFuture;
+        Future<?> future = initializationFuture.getAndSet(null);
         if (future != null) {
             // graceful cancel: do not interrupt a running task, only prevent a queued one from starting
             future.cancel(false);
-            initializationFuture = null;
         }
     }
 

--- a/bundles/org.openhab.binding.homeconnect/src/main/java/org/openhab/binding/homeconnect/internal/handler/AbstractHomeConnectThingHandler.java
+++ b/bundles/org.openhab.binding.homeconnect/src/main/java/org/openhab/binding/homeconnect/internal/handler/AbstractHomeConnectThingHandler.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -103,7 +104,9 @@ public abstract class AbstractHomeConnectThingHandler extends BaseThingHandler i
     private @Nullable ScheduledFuture<?> reinitializationFuture1;
     private @Nullable ScheduledFuture<?> reinitializationFuture2;
     private @Nullable ScheduledFuture<?> reinitializationFuture3;
+    private @Nullable Future<?> initializationFuture;
     private boolean ignoreEventSourceClosedEvent;
+    private volatile boolean disposed;
     private @Nullable String programOptionsDelayedUpdate;
 
     private final ConcurrentHashMap<String, EventHandler> eventHandlers;
@@ -135,6 +138,7 @@ public abstract class AbstractHomeConnectThingHandler extends BaseThingHandler i
 
     @Override
     public void initialize() {
+        disposed = false;
         if (getBridgeHandler().isEmpty()) {
             updateStatus(OFFLINE, ThingStatusDetail.BRIDGE_UNINITIALIZED);
             accessible.set(false);
@@ -143,7 +147,10 @@ public abstract class AbstractHomeConnectThingHandler extends BaseThingHandler i
             accessible.set(false);
         } else {
             updateStatus(UNKNOWN);
-            scheduler.submit(() -> {
+            initializationFuture = scheduler.submit(() -> {
+                if (disposed) {
+                    return;
+                }
                 refreshThingStatus(); // set ONLINE / OFFLINE
                 updateSelectedProgramStateDescription();
                 updateChannels();
@@ -156,10 +163,7 @@ public abstract class AbstractHomeConnectThingHandler extends BaseThingHandler i
 
     @Override
     public void dispose() {
-        stopRetryRegistering();
-        stopOfflineMonitor1();
-        stopOfflineMonitor2();
-        unregisterEventListener(true);
+        teardown(true);
     }
 
     @Override
@@ -170,11 +174,33 @@ public abstract class AbstractHomeConnectThingHandler extends BaseThingHandler i
 
     private void reinitialize() {
         logger.debug("Reinitialize thing handler ({}). haId={}", getThingLabel(), getThingHaId());
+        teardown(false);
+        initialize();
+    }
+
+    /**
+     * Stop all asynchronous work performed by this handler.
+     *
+     * @param immediate if {@code true} the event listener is unregistered immediately (used during
+     *            {@link #dispose()}); if {@code false} a graceful unregistration is performed (used
+     *            during {@link #reinitialize()}).
+     */
+    private void teardown(boolean immediate) {
+        disposed = true;
+        cancelInitialization();
         stopRetryRegistering();
         stopOfflineMonitor1();
         stopOfflineMonitor2();
-        unregisterEventListener();
-        initialize();
+        unregisterEventListener(immediate);
+    }
+
+    private void cancelInitialization() {
+        Future<?> future = initializationFuture;
+        if (future != null) {
+            // graceful cancel: do not interrupt a running task, only prevent a queued one from starting
+            future.cancel(false);
+            initializationFuture = null;
+        }
     }
 
     /**


### PR DESCRIPTION
## Description

The asynchronous task submitted in `initialize()` could run after `dispose()` or `reinitialize()` had already been called, causing the framework to log a spurious warning:

```
Handler ... tried accessing its bridge although the handler was already disposed.
```

In addition, a re-initialization while a previous init task was still queued could lead to duplicate scheduling of the offline monitors.

This fix combines two complementary measures:

- Store the `Future` returned by `scheduler.submit(...)` and cancel it gracefully (`cancel(false)`, i.e. without interrupting an already running task) in both `dispose()` and `reinitialize()`. This removes a queued task before it ever starts.
- A `volatile boolean disposed` flag, set to `true` at the start of `dispose()`/`reinitialize()` and reset at the start of `initialize()`, acts as a safety net for the narrow race where the runnable has just been picked up by the executor before `cancel()` could take effect.

The teardown logic shared by `dispose()` and `reinitialize()` is extracted into a `teardown(boolean immediate)` helper.

### Notes on the chosen approach

- I deliberately use `cancel(false)` instead of `cancel(true)`: the init task should be allowed to finish cleanly if it is already running, rather than being interrupted mid-way. The `disposed` guard at the top of the runnable prevents it from doing any work once teardown has started.
- The `disposed` flag is not redundant with the cancel: `cancel(false)` returns `false` and does not stop a task that the executor has already started but which has not yet reached the guard. The flag closes exactly that window.

This supersedes #20767. Thanks to @jpg0 for the original report and analysis.