### PR TITLE
[gpio] Add notes about RPi5 incompatibility and Trixie installation

### DIFF
--- a/bundles/org.openhab.binding.gpio/README.md
+++ b/bundles/org.openhab.binding.gpio/README.md
@@ -3,6 +3,8 @@
 This binding adds GPIO support via the pigpiod daemon to openHAB.
 It requires the pigpiod daemon (<http://abyz.me.uk/rpi/pigpio/>) to be installed on the pi that should be controlled.
 
+**This binding does not work with RPi 5 due to a different GPIO hardware implementation that is not supported by pigpio.**
+
 ## Supported Things
 
 ### pigpio-remote
@@ -11,9 +13,13 @@ This thing represents a remote pigpiod instance running as daemon on a raspberry
 
 ## Thing Configuration
 
-### Pigpio Remote  (`pigpio-remote`)
+### Pigpio Remote (`pigpio-remote`)
 
 On a raspberry (or a compatible device) you have to install pigpiod.
+
+**Beginning with Raspberry Pi OS Trixie, manually downloading and compiling the pigpio package is required as it has been removed from the distribution. Instructions here:** <https://github.com/joan2937/pigpio/issues/632#issuecomment-3379034242>
+
+Prior versions of Raspberry Pi OS should use the following instructions to install and configure pigpiod:
 
 ```shell
 sudo apt-get install pigpiod
@@ -72,8 +78,6 @@ This action only occurs once after binding startup.
 - **Do Nothing:** The default, do nothing. Input channels will retain their default value (UNDEF).
 - **Refresh Channel:** Issues a refresh command on the input channels. This will refresh the channels from pigpiod causing the gpio pin state to reflect on the channel state.
 
-Input Channel Disconnect Connect Action:
-
 ### Input Channel Disconnect Connect Action
 
 Input Channel Disconnect Connect Action determines what happens when the binding disconnects from pigpiod.
@@ -97,8 +101,8 @@ Output Channel Connect Action determines what happens when the binding initially
 This action only occurs once after binding startup.
 
 - **Do Nothing:** The default, do nothing. Output channels will retain their default value (UNDEF).
-- **All On:** Issues a ON command to all configured output channels.
-- **All Off:** Issues a OFF command to all configured output channels.
+- **All On:** Issues an ON command to all configured output channels.
+- **All Off:** Issues an OFF command to all configured output channels.
 - **Refresh Channel:** Issues a refresh command on the output channels. This will refresh the channels from
                     pigpiod causing the gpio pin state to reflect on the channel state. NOTE: This does
                     not update the gpio pin state on the Pi itself. It only updates the channel state
@@ -108,7 +112,7 @@ This action only occurs once after binding startup.
 
 Output Channel Disconnect Connect Action determines what happens when the binding disconnects from pigpiod.
 
-- **Do Nothing:** he default, do nothing. Input channels will retain their current value.
+- **Do Nothing:** The default, do nothing. Input channels will retain their current value.
 - **Set Undef:** Sets the output channel states to UNDEF to indicate that pigpiod has disconnected.
 
 ### Output Channel Reconnect Connect Action
@@ -192,7 +196,7 @@ of time.
 - **On:** When the OFF command is issued to the channel. The Pulse feature will send an
                     ON command after the Pulse duration.
 - **Blink:** Cycles the channel ON, OFF, ON indefinitely with a 50% duty cycle. The Blink
-                    operation continues regardless of the commanded channel state. This was originaly
+                    operation continues regardless of the commanded channel state. This was originally
                     developed as a way to flash a status LED to visually confirm that a remote pigpiod
                     instance has connectivity to openHAB.
 
@@ -200,7 +204,7 @@ of time.
 
 Example for users who still prefer configuration files.
 
-demo.things:
+gpio.things:
 
 ```java
 Thing gpio:pigpio-remote:mypi "MyPi GPIO" [ host="192.168.1.5", port=8888,
@@ -234,7 +238,7 @@ Thing gpio:pigpio-remote:mypi "MyPi GPIO" [ host="192.168.1.5", port=8888,
     }
 ```
 
-demo.items:
+gpio.items:
 
 ```java
 Switch SampleInput1 {channel="gpio:pigpio-remote:mypi:GPI23"}

--- a/bundles/org.openhab.binding.gpio/README.md
+++ b/bundles/org.openhab.binding.gpio/README.md
@@ -112,7 +112,7 @@ This action only occurs once after binding startup.
 
 Output Channel Disconnect Connect Action determines what happens when the binding disconnects from pigpiod.
 
-- **Do Nothing:** The default, do nothing. Input channels will retain their current value.
+- **Do Nothing:** The default, do nothing. Output channels will retain their current value.
 - **Set Undef:** Sets the output channel states to UNDEF to indicate that pigpiod has disconnected.
 
 ### Output Channel Reconnect Connect Action

--- a/bundles/org.openhab.binding.gpio/README.md
+++ b/bundles/org.openhab.binding.gpio/README.md
@@ -15,7 +15,7 @@ This thing represents a remote pigpiod instance running as daemon on a raspberry
 
 ### Pigpio Remote (`pigpio-remote`)
 
-On a raspberry (or a compatible device) you have to install pigpiod.
+On a Raspberry Pi (or compatible device) you have to install pigpiod.
 
 **Beginning with Raspberry Pi OS Trixie, manually downloading and compiling the pigpio package is required as it has been removed from the distribution. Instructions here:** <https://github.com/joan2937/pigpio/issues/632#issuecomment-3379034242>
 


### PR DESCRIPTION
Add notes about RPi5 incompatibility and manual installation of `pigpio` under Raspberry Pi OS Trixie.

Closes #20141 by providing instructions for manual installation of `pigpio`.
