### PR TITLE
[fineoffsetweatherstation] Fix false low battery for voltage sensors on HTTP API

### DIFF
--- a/bundles/org.openhab.binding.fineoffsetweatherstation/src/main/java/org/openhab/binding/fineoffsetweatherstation/internal/domain/Sensor.java
+++ b/bundles/org.openhab.binding.fineoffsetweatherstation/src/main/java/org/openhab/binding/fineoffsetweatherstation/internal/domain/Sensor.java
@@ -59,4 +59,17 @@ public enum Sensor {
     public BatteryStatus getBatteryStatus(byte data) {
         return new BatteryStatus(batteryStatusTpe, data);
     }
+
+    /**
+     * Interprets the battery field as reported by the Ecowitt HTTP API. Unlike the binary protocol, the HTTP API
+     * reports the battery of voltage-based sensors already as a 0-5 level (5 = full) rather than a raw voltage, so
+     * those are read as {@link BatteryStatus.Type#LEVEL}; all other sensor types share the binary encoding.
+     */
+    public BatteryStatus getHttpBatteryStatus(byte data) {
+        BatteryStatus.Type type = switch (batteryStatusTpe) {
+            case VOLTAGE_BROAD_STEPS, VOLTAGE_FINE_STEPS -> LEVEL;
+            default -> batteryStatusTpe;
+        };
+        return new BatteryStatus(type, data);
+    }
 }

--- a/bundles/org.openhab.binding.fineoffsetweatherstation/src/main/java/org/openhab/binding/fineoffsetweatherstation/internal/domain/Sensor.java
+++ b/bundles/org.openhab.binding.fineoffsetweatherstation/src/main/java/org/openhab/binding/fineoffsetweatherstation/internal/domain/Sensor.java
@@ -50,14 +50,14 @@ public enum Sensor {
     WN20(LOW_HIGH),
     WN38(VOLTAGE_FINE_STEPS);
 
-    private final BatteryStatus.Type batteryStatusTpe;
+    private final BatteryStatus.Type batteryStatusType;
 
-    Sensor(BatteryStatus.Type batteryStatusTpe) {
-        this.batteryStatusTpe = batteryStatusTpe;
+    Sensor(BatteryStatus.Type batteryStatusType) {
+        this.batteryStatusType = batteryStatusType;
     }
 
     public BatteryStatus getBatteryStatus(byte data) {
-        return new BatteryStatus(batteryStatusTpe, data);
+        return new BatteryStatus(batteryStatusType, data);
     }
 
     /**
@@ -66,9 +66,9 @@ public enum Sensor {
      * those are read as {@link BatteryStatus.Type#LEVEL}; all other sensor types share the binary encoding.
      */
     public BatteryStatus getHttpBatteryStatus(byte data) {
-        BatteryStatus.Type type = switch (batteryStatusTpe) {
+        BatteryStatus.Type type = switch (batteryStatusType) {
             case VOLTAGE_BROAD_STEPS, VOLTAGE_FINE_STEPS -> LEVEL;
-            default -> batteryStatusTpe;
+            default -> batteryStatusType;
         };
         return new BatteryStatus(type, data);
     }

--- a/bundles/org.openhab.binding.fineoffsetweatherstation/src/main/java/org/openhab/binding/fineoffsetweatherstation/internal/domain/SensorGatewayBinding.java
+++ b/bundles/org.openhab.binding.fineoffsetweatherstation/src/main/java/org/openhab/binding/fineoffsetweatherstation/internal/domain/SensorGatewayBinding.java
@@ -138,6 +138,10 @@ public enum SensorGatewayBinding {
         return sensor.getBatteryStatus(data);
     }
 
+    public BatteryStatus getHttpBatteryStatus(byte data) {
+        return sensor.getHttpBatteryStatus(data);
+    }
+
     public Sensor getSensor() {
         return sensor;
     }

--- a/bundles/org.openhab.binding.fineoffsetweatherstation/src/main/java/org/openhab/binding/fineoffsetweatherstation/internal/service/EcowittDataParser.java
+++ b/bundles/org.openhab.binding.fineoffsetweatherstation/src/main/java/org/openhab/binding/fineoffsetweatherstation/internal/service/EcowittDataParser.java
@@ -191,7 +191,7 @@ public class EcowittDataParser {
         } catch (NumberFormatException e) {
             return;
         }
-        BatteryStatus batteryStatus = sensorGatewayBinding.getBatteryStatus((byte) parseInt(asString(obj, "batt")));
+        BatteryStatus batteryStatus = sensorGatewayBinding.getHttpBatteryStatus((byte) parseInt(asString(obj, "batt")));
         int signal = parseInt(asString(obj, "signal"));
         result.put(sensorGatewayBinding, new SensorDevice(id, sensorGatewayBinding, batteryStatus, signal));
     }

--- a/bundles/org.openhab.binding.fineoffsetweatherstation/src/test/java/org/openhab/binding/fineoffsetweatherstation/internal/service/EcowittDataParserTest.java
+++ b/bundles/org.openhab.binding.fineoffsetweatherstation/src/test/java/org/openhab/binding/fineoffsetweatherstation/internal/service/EcowittDataParserTest.java
@@ -131,6 +131,19 @@ class EcowittDataParserTest {
     }
 
     @Test
+    void testVoltageSensorBatteryReportedAsLevel() {
+        // unlike the binary protocol, where the WH51 battery field is a raw voltage (val * 0.1 V), the Ecowitt HTTP
+        // API reports it already as a 0-5 level (5 = full). It must therefore not be misread as 0.5 V and flagged low.
+        Map<SensorGatewayBinding, SensorDevice> sensors = parser.parseSensors(List.of("[{\"img\":\"wh51\","
+                + "\"type\":\"14\",\"name\":\"Soil moisture CH1\",\"id\":\"FBF08\",\"batt\":\"5\",\"rssi\":\"-85\","
+                + "\"signal\":\"4\",\"idst\":\"1\"}]"), false);
+        Assertions.assertThat(sensors.values())
+                .extracting(device -> device.getSensorGatewayBinding().getSensor().name(),
+                        device -> device.getBatteryStatus().isLow(), device -> device.getBatteryStatus().getLevel())
+                .containsExactly(new Tuple("WH51", false, 5));
+    }
+
+    @Test
     void testSystemInfo() {
         @Nullable
         SystemInfo systemInfo = parser.parseSystemInfo(resource("device_info.json"));


### PR DESCRIPTION
## Description

The Ecowitt HTTP API (`get_sensors_info`) reports the battery of voltage-based sensors — e.g. the WH51 soil moisture sensor — already as a **0–5 level** (5 = full), whereas the binary protocol reports the same field as a **raw voltage** (`val * 0.1 V`).

The HTTP parser reused the binary interpretation, so a healthy WH51 reporting `"batt":"5"` was read as `0.5 V` and incorrectly flagged as **low battery**.

Example payload from `get_sensors_info?page=3`:

```json
{"img":"wh51","type":"14","name":"Soil moisture CH1","id":"FBF08","batt":"5","rssi":"-85","signal":"4","idst":"1"}
```

## Fix

Add `Sensor#getHttpBatteryStatus`, which reads the battery of `VOLTAGE_BROAD_STEPS` and `VOLTAGE_FINE_STEPS` sensors as a 0–5 level for the HTTP API, while keeping the binary encoding for all other sensor types (low/high and level sensors are unchanged). `EcowittDataParser` now uses it when parsing the registered sensors.

After the fix the WH51 reads as level 5 → low-battery `OFF`, battery-level `100 %`, and the spurious `0.5 V` voltage channel is no longer created.

## Testing

Added `EcowittDataParserTest#testVoltageSensorBatteryReportedAsLevel`. Full binding test suite passes (23 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)