### PR TITLE
[lgthinq] Enforce uppercase `manualCountry` being send

### DIFF
--- a/bundles/org.openhab.binding.lgthinq/src/main/java/org/openhab/binding/lgthinq/internal/LGThinQBridgeConfiguration.java
+++ b/bundles/org.openhab.binding.lgthinq/src/main/java/org/openhab/binding/lgthinq/internal/LGThinQBridgeConfiguration.java
@@ -12,6 +12,8 @@
  */
 package org.openhab.binding.lgthinq.internal;
 
+import java.util.Locale;
+
 import org.eclipse.jdt.annotation.NonNullByDefault;
 
 /**
@@ -56,7 +58,7 @@ public class LGThinQBridgeConfiguration {
 
     public String getCountry() {
         if ("--".equals(country)) {
-            return manualCountry;
+            return manualCountry.toUpperCase(Locale.ROOT);
         }
         return country;
     }


### PR DESCRIPTION
Fixes: https://github.com/openhab/openhab-addons/issues/20983