### PR TITLE
[linkplay] Stability fixes

### DIFF
--- a/bundles/org.openhab.binding.linkplay/src/main/java/org/openhab/binding/linkplay/internal/LinkPlayHandlerFactory.java
+++ b/bundles/org.openhab.binding.linkplay/src/main/java/org/openhab/binding/linkplay/internal/LinkPlayHandlerFactory.java
@@ -25,6 +25,8 @@ import java.util.concurrent.ScheduledExecutorService;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.api.Request;
+import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.jupnp.UpnpService;
 import org.jupnp.model.meta.LocalDevice;
@@ -94,6 +96,18 @@ public class LinkPlayHandlerFactory extends BaseThingHandlerFactory implements R
         this.networkAddressService = networkAddressService;
         upnpService.getRegistry().addListener(this);
         httpClient = httpClientFactory.createHttpClient("linkplay", new SslContextFactory.Client(true));
+        // LinkPlay devices aggressively close idle keep-alive connections, so a pooled connection is frequently already
+        // dead when reused and the next request fails with an EOFException before it reaches the device. Requests are
+        // infrequent (user commands plus periodic polling), so disable connection reuse entirely by sending
+        // "Connection: close" on every request; Jetty then closes the socket after each exchange instead of pooling it.
+        httpClient.getRequestListeners().add(new Request.Listener.Adapter() {
+            @Override
+            public void onBegin(@Nullable Request request) {
+                if (request != null) {
+                    request.header(HttpHeader.CONNECTION, "close");
+                }
+            }
+        });
         try {
             httpClient.start();
         } catch (Exception e) {

--- a/bundles/org.openhab.binding.linkplay/src/main/java/org/openhab/binding/linkplay/internal/LinkPlayHandlerFactory.java
+++ b/bundles/org.openhab.binding.linkplay/src/main/java/org/openhab/binding/linkplay/internal/LinkPlayHandlerFactory.java
@@ -96,10 +96,10 @@ public class LinkPlayHandlerFactory extends BaseThingHandlerFactory implements R
         this.networkAddressService = networkAddressService;
         upnpService.getRegistry().addListener(this);
         httpClient = httpClientFactory.createHttpClient("linkplay", new SslContextFactory.Client(true));
-        // LinkPlay devices aggressively close idle keep-alive connections, so a pooled connection is frequently already
-        // dead when reused and the next request fails with an EOFException before it reaches the device. Requests are
-        // infrequent (user commands plus periodic polling), so disable connection reuse entirely by sending
-        // "Connection: close" on every request; Jetty then closes the socket after each exchange instead of pooling it.
+        // LinkPlay devices aggressively close idle keep alive connections after a few seconds, so a pooled connection
+        // is frequently already dead when reused and the next request fails with an EOFException before it reaches the
+        // device. HTTP requests are infrequent (user commands plus periodic polling), so disable connection reuse
+        // entirely.
         httpClient.getRequestListeners().add(new Request.Listener.Adapter() {
             @Override
             public void onBegin(@Nullable Request request) {

--- a/bundles/org.openhab.binding.linkplay/src/main/java/org/openhab/binding/linkplay/internal/client/upnp/LinkPlayUpnpClient.java
+++ b/bundles/org.openhab.binding.linkplay/src/main/java/org/openhab/binding/linkplay/internal/client/upnp/LinkPlayUpnpClient.java
@@ -69,8 +69,6 @@ public class LinkPlayUpnpClient implements UpnpIOParticipant, LinkPlayUpnpComman
     private @Nullable RemoteDevice remoteDevice;
     private String udn = "";
     private volatile boolean disposed;
-    // Monotonic timestamp of the last UPnP value (GENA event) received, used by the handler's event watchdog to detect
-    // silently dead subscriptions.
     private volatile long lastValueNanos = System.nanoTime();
 
     public LinkPlayUpnpClient(LinkPlayUpnpClientHandler handler, UpnpIOService upnpIOService, UpnpService upnpService,
@@ -106,9 +104,7 @@ public class LinkPlayUpnpClient implements UpnpIOParticipant, LinkPlayUpnpComman
     }
 
     /**
-     * Looks up the current {@link RemoteDevice} for this UDN directly from the jUPnP registry. This returns a fresh
-     * device reference (for example after the device re-advertised at a new IP) rather than the possibly stale one
-     * cached via {@link #setRemoteDevice(RemoteDevice)}.
+     * Looks up the current {@link RemoteDevice} for this UDN directly from the jUPnP registry.
      *
      * @return the registered device, or {@code null} if the device is not currently in the registry
      */
@@ -135,8 +131,6 @@ public class LinkPlayUpnpClient implements UpnpIOParticipant, LinkPlayUpnpComman
 
     @Override
     public void onValueReceived(@Nullable String variable, @Nullable String value, @Nullable String service) {
-        // Stamp the time on every received value (including high-frequency position updates): any value proves the GENA
-        // subscription is still delivering, which is what the event watchdog checks for.
         lastValueNanos = System.nanoTime();
         if (!handler.shouldProcessUpnpEvents()) {
             logger.debug("{}: onValueReceived: handler is not ready to process UPnP events", udn);
@@ -280,10 +274,8 @@ public class LinkPlayUpnpClient implements UpnpIOParticipant, LinkPlayUpnpComman
     }
 
     /**
-     * Forces a clean GENA resubscription cycle by tearing down the current subscriptions and creating fresh ones. This
-     * sidesteps jUPnP's in-place renewal (which LinkPlay devices frequently fail to honor) by obtaining a brand new
-     * subscription id, and is used by the handler's event watchdog to recover a silently dead subscription.
-     * ({@link #removeSubscriptions()} already clears the subscription state.)
+     * Forces a resubscription by removing the current subscriptions and creating fresh ones. This
+     * works around jUPnP's renewal issues which LinkPlay devices frequently fail to honor
      */
     public void resubscribe() {
         removeSubscriptions();
@@ -291,7 +283,7 @@ public class LinkPlayUpnpClient implements UpnpIOParticipant, LinkPlayUpnpComman
     }
 
     /**
-     * @return the number of seconds since the last UPnP value (GENA event) was received, based on a monotonic clock
+     * @return the number of seconds since the last UPnP value (GENA event) was received
      */
     public long secondsSinceLastValue() {
         return TimeUnit.NANOSECONDS.toSeconds(System.nanoTime() - lastValueNanos);

--- a/bundles/org.openhab.binding.linkplay/src/main/java/org/openhab/binding/linkplay/internal/client/upnp/LinkPlayUpnpClient.java
+++ b/bundles/org.openhab.binding.linkplay/src/main/java/org/openhab/binding/linkplay/internal/client/upnp/LinkPlayUpnpClient.java
@@ -101,6 +101,17 @@ public class LinkPlayUpnpClient implements UpnpIOParticipant, LinkPlayUpnpComman
         return remoteDevice;
     }
 
+    /**
+     * Looks up the current {@link RemoteDevice} for this UDN directly from the jUPnP registry. This returns a fresh
+     * device reference (for example after the device re-advertised at a new IP) rather than the possibly stale one
+     * cached via {@link #setRemoteDevice(RemoteDevice)}.
+     *
+     * @return the registered device, or {@code null} if the device is not currently in the registry
+     */
+    public @Nullable RemoteDevice findRegisteredDevice() {
+        return upnpService.getRegistry().getRemoteDevice(new UDN(udn), false);
+    }
+
     public boolean needsUpnpInitialization() {
         return needsUpnpInitialization.get();
     }

--- a/bundles/org.openhab.binding.linkplay/src/main/java/org/openhab/binding/linkplay/internal/client/upnp/LinkPlayUpnpClient.java
+++ b/bundles/org.openhab.binding.linkplay/src/main/java/org/openhab/binding/linkplay/internal/client/upnp/LinkPlayUpnpClient.java
@@ -23,6 +23,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -68,6 +69,9 @@ public class LinkPlayUpnpClient implements UpnpIOParticipant, LinkPlayUpnpComman
     private @Nullable RemoteDevice remoteDevice;
     private String udn = "";
     private volatile boolean disposed;
+    // Monotonic timestamp of the last UPnP value (GENA event) received, used by the handler's event watchdog to detect
+    // silently dead subscriptions.
+    private volatile long lastValueNanos = System.nanoTime();
 
     public LinkPlayUpnpClient(LinkPlayUpnpClientHandler handler, UpnpIOService upnpIOService, UpnpService upnpService,
             ScheduledExecutorService scheduler) {
@@ -131,6 +135,9 @@ public class LinkPlayUpnpClient implements UpnpIOParticipant, LinkPlayUpnpComman
 
     @Override
     public void onValueReceived(@Nullable String variable, @Nullable String value, @Nullable String service) {
+        // Stamp the time on every received value (including high-frequency position updates): any value proves the GENA
+        // subscription is still delivering, which is what the event watchdog checks for.
+        lastValueNanos = System.nanoTime();
         if (!handler.shouldProcessUpnpEvents()) {
             logger.debug("{}: onValueReceived: handler is not ready to process UPnP events", udn);
             return;
@@ -270,6 +277,24 @@ public class LinkPlayUpnpClient implements UpnpIOParticipant, LinkPlayUpnpComman
 
     public void clearSubscriptionState() {
         subscriptionState.clear();
+    }
+
+    /**
+     * Forces a clean GENA resubscription cycle by tearing down the current subscriptions and creating fresh ones. This
+     * sidesteps jUPnP's in-place renewal (which LinkPlay devices frequently fail to honor) by obtaining a brand new
+     * subscription id, and is used by the handler's event watchdog to recover a silently dead subscription.
+     * ({@link #removeSubscriptions()} already clears the subscription state.)
+     */
+    public void resubscribe() {
+        removeSubscriptions();
+        addSubscriptions();
+    }
+
+    /**
+     * @return the number of seconds since the last UPnP value (GENA event) was received, based on a monotonic clock
+     */
+    public long secondsSinceLastValue() {
+        return TimeUnit.NANOSECONDS.toSeconds(System.nanoTime() - lastValueNanos);
     }
 
     public boolean isFullySubscribed() {

--- a/bundles/org.openhab.binding.linkplay/src/main/java/org/openhab/binding/linkplay/internal/handler/LinkPlayHandler.java
+++ b/bundles/org.openhab.binding.linkplay/src/main/java/org/openhab/binding/linkplay/internal/handler/LinkPlayHandler.java
@@ -587,6 +587,8 @@ public class LinkPlayHandler extends BaseThingHandler
         if (getThing().getStatus() != ThingStatus.ONLINE) {
             updateStatus(ThingStatus.ONLINE);
         }
+        // we are fully subscribed and online, stop any active reconnect loop
+        cancelReconnectJob();
     }
 
     @Override
@@ -814,15 +816,58 @@ public class LinkPlayHandler extends BaseThingHandler
 
     public void setOffline(String reason) {
         updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, reason);
-        RemoteDevice device = upnpClient.getRemoteDevice();
         upnpClient.clearSubscriptionState();
-        if (device != null) {
-            cancelReconnectJob();
-            if (!disposed) {
-                reconnectJob = scheduler.schedule(() -> initFromUpnp(device), RECONNECT_DELAY, TimeUnit.SECONDS);
-            }
-        }
         upnpClient.sendDeviceSearchRequest();
+        scheduleReconnect();
+    }
+
+    /**
+     * Ensures a repeating reconnect job is running while the device is offline. The job keeps retrying until the device
+     * is back ONLINE, at which point it cancels itself. Calling this while a reconnect job is already running is a
+     * no-op so the retry cadence is not reset on every offline notification.
+     */
+    private void scheduleReconnect() {
+        if (disposed) {
+            return;
+        }
+        ScheduledFuture<?> job = reconnectJob;
+        if (job != null && !job.isDone()) {
+            return;
+        }
+        reconnectJob = scheduler.scheduleWithFixedDelay(this::reconnect, RECONNECT_DELAY, RECONNECT_DELAY,
+                TimeUnit.SECONDS);
+    }
+
+    /**
+     * Actively attempts to bring an offline device back ONLINE. This mirrors what the initialize/dispose
+     * (pause/unpause) cycle does: it re-issues a UPnP search, looks up a fresh device reference from the registry (the
+     * device may have re-advertised at a new IP) and drives initialization itself rather than waiting for a push
+     * callback from the registry that may never arrive. Once the device is ONLINE the reconnect job cancels itself.
+     */
+    private void reconnect() {
+        if (disposed || getThing().getStatus() == ThingStatus.ONLINE) {
+            cancelReconnectJob();
+            return;
+        }
+        if (isInitializing.get()) {
+            return;
+        }
+        logger.debug("{}: Attempting to reconnect", udn);
+        upnpClient.sendDeviceSearchRequest();
+        Slave slave = linkPlayGroupService.findSlaveByUDN(udn);
+        if (slave != null) {
+            initFromGroup(slave);
+            return;
+        }
+        RemoteDevice device = upnpClient.findRegisteredDevice();
+        if (device == null) {
+            device = upnpClient.getRemoteDevice();
+        }
+        if (device != null) {
+            upnpClient.setRemoteDevice(device);
+            upnpClient.setNeedsUpnpInitialization(true);
+            initFromUpnp(device);
+        }
     }
 
     // Derives the host and port from the Upnp device and attempts to connect to the api

--- a/bundles/org.openhab.binding.linkplay/src/main/java/org/openhab/binding/linkplay/internal/handler/LinkPlayHandler.java
+++ b/bundles/org.openhab.binding.linkplay/src/main/java/org/openhab/binding/linkplay/internal/handler/LinkPlayHandler.java
@@ -1471,7 +1471,7 @@ public class LinkPlayHandler extends BaseThingHandler
 
         if (staleSeconds > sinceResubscribe && sinceResubscribe >= UPNP_EVENT_GRACE_SECONDS) {
             logger.debug("{}: No UPnP events {}s after resubscribe; reconnecting", udn, sinceResubscribe);
-            setOffline("No UPnP events received for " + staleSeconds + "s");
+            setOffline("No UPnP events received " + sinceResubscribe + "s after resubscribing");
             return;
         }
 

--- a/bundles/org.openhab.binding.linkplay/src/main/java/org/openhab/binding/linkplay/internal/handler/LinkPlayHandler.java
+++ b/bundles/org.openhab.binding.linkplay/src/main/java/org/openhab/binding/linkplay/internal/handler/LinkPlayHandler.java
@@ -102,13 +102,6 @@ public class LinkPlayHandler extends BaseThingHandler
     private final Logger logger = LoggerFactory.getLogger(LinkPlayHandler.class);
 
     private static final int RECONNECT_DELAY = 30;
-    // UPnP event watchdog. jUPnP renews GENA subscriptions in-place at half of the 1800s duration (~15 min), but
-    // LinkPlay devices frequently fail to honor that renewal and openHAB core does not reliably tell us when it is
-    // dropped, leaving us unable to control playback. Rather than wait for that, we proactively tear down and recreate
-    // the subscriptions on a much faster cadence (defeating the flaky in-place renewal), and because a successful
-    // (re)subscribe always yields an initial event dump we treat "no event shortly after a refresh" as a dead
-    // subscription and fully reconnect. Lower UPNP_RESUBSCRIBE_INTERVAL_SECONDS for even more aggressive recovery at
-    // the cost of more subscribe traffic. See upnpEventWatchdog.
     private static final int UPNP_WATCHDOG_INTERVAL_SECONDS = 30;
     private static final int UPNP_RESUBSCRIBE_INTERVAL_SECONDS = 180;
     private static final int UPNP_EVENT_GRACE_SECONDS = 60;
@@ -117,8 +110,6 @@ public class LinkPlayHandler extends BaseThingHandler
     private @Nullable ScheduledFuture<?> upnpWatchdogJob;
     private @Nullable ScheduledFuture<?> reconnectJob;
     private @Nullable ScheduledFuture<?> positionJob;
-    // Monotonic timestamp of the last (re)subscribe, used to time the watchdog's grace/refresh windows. Written from
-    // both the scheduler thread (watchdog) and the jUPnP callback thread (onUpnpSubscriptionStateChanged), so volatile.
     private volatile long lastResubscribeNanos = System.nanoTime();
     // Are we currently initializing the device?
     private final AtomicBoolean isInitializing = new AtomicBoolean(false);
@@ -182,7 +173,7 @@ public class LinkPlayHandler extends BaseThingHandler
         cancelUpnpServiceCheckJob();
         upnpServiceCheck = scheduler.scheduleWithFixedDelay(this::initializationCheck, 0, 15, TimeUnit.SECONDS);
 
-        // Watchdog that detects and recovers silently dead UPnP subscriptions (it self-guards on thing status).
+        // Watchdog that detects and recovers dead UPnP subscriptions.
         cancelUpnpWatchdogJob();
         upnpWatchdogJob = scheduler.scheduleWithFixedDelay(this::upnpEventWatchdog, UPNP_WATCHDOG_INTERVAL_SECONDS,
                 UPNP_WATCHDOG_INTERVAL_SECONDS, TimeUnit.SECONDS);
@@ -601,9 +592,6 @@ public class LinkPlayHandler extends BaseThingHandler
             return;
         }
         if (!allSubscriptionsSuccessful) {
-            // Only report "waiting" before we are ONLINE. While ONLINE this is normally just the transient gap during a
-            // proactive resubscribe (one service confirmed before the other), so don't flap the thing status; the
-            // watchdog handles genuinely dead subscriptions.
             if (getThing().getStatus() != ThingStatus.ONLINE) {
                 updateStatus(ThingStatus.UNKNOWN, ThingStatusDetail.NONE, "Waiting for UPnP subscriptions");
             }
@@ -612,10 +600,6 @@ public class LinkPlayHandler extends BaseThingHandler
         if (getThing().getStatus() != ThingStatus.ONLINE) {
             updateStatus(ThingStatus.ONLINE);
         }
-        // fully subscribed: stop any active reconnect loop and start a fresh refresh window. Note we deliberately do
-        // NOT touch the last-event clock here: this fires on the SUBSCRIBE acknowledgement, not on an actual GENA
-        // event, so resetting it would mask a device that ACKs the subscribe but never delivers events. The grace
-        // window measured from lastResubscribeNanos gives the initial event dump time to arrive.
         cancelReconnectJob();
         lastResubscribeNanos = System.nanoTime();
     }
@@ -850,11 +834,6 @@ public class LinkPlayHandler extends BaseThingHandler
         scheduleReconnect();
     }
 
-    /**
-     * Ensures a repeating reconnect job is running while the device is offline. The job keeps retrying until the device
-     * is back ONLINE, at which point it cancels itself. Calling this while a reconnect job is already running is a
-     * no-op so the retry cadence is not reset on every offline notification.
-     */
     private void scheduleReconnect() {
         if (disposed) {
             return;
@@ -867,12 +846,6 @@ public class LinkPlayHandler extends BaseThingHandler
                 TimeUnit.SECONDS);
     }
 
-    /**
-     * Actively attempts to bring an offline device back ONLINE. This mirrors what the initialize/dispose
-     * (pause/unpause) cycle does: it re-issues a UPnP search, looks up a fresh device reference from the registry (the
-     * device may have re-advertised at a new IP) and drives initialization itself rather than waiting for a push
-     * callback from the registry that may never arrive. Once the device is ONLINE the reconnect job cancels itself.
-     */
     private void reconnect() {
         if (disposed || getThing().getStatus() == ThingStatus.ONLINE) {
             cancelReconnectJob();
@@ -1481,12 +1454,6 @@ public class LinkPlayHandler extends BaseThingHandler
         }
     }
 
-    /**
-     * Keeps UPnP event delivery alive. LinkPlay devices frequently drop GENA subscriptions silently, so instead of
-     * relying on jUPnP's flaky in-place renewal this proactively recreates the subscriptions on a fast cadence (each
-     * refresh gets a fresh subscription id and an initial event dump). If a refresh produces no event within the grace
-     * period the subscription is dead, so the thing is dropped OFFLINE to run the full reconnect cycle.
-     */
     private void upnpEventWatchdog() {
         if (disposed || getThing().getStatus() != ThingStatus.ONLINE) {
             return;
@@ -1502,15 +1469,12 @@ public class LinkPlayHandler extends BaseThingHandler
         long staleSeconds = upnpClient.secondsSinceLastValue();
         long sinceResubscribe = TimeUnit.NANOSECONDS.toSeconds(System.nanoTime() - lastResubscribeNanos);
 
-        // A successful (re)subscribe always yields an initial event dump, so if our most recent refresh produced no
-        // event within the grace period the subscription is dead -> fully reconnect.
         if (staleSeconds > sinceResubscribe && sinceResubscribe >= UPNP_EVENT_GRACE_SECONDS) {
             logger.debug("{}: No UPnP events {}s after resubscribe; reconnecting", udn, sinceResubscribe);
             setOffline("No UPnP events received for " + staleSeconds + "s");
             return;
         }
 
-        // Proactively refresh well ahead of jUPnP's ~15 min in-place renewal so we keep control of playback.
         if (sinceResubscribe >= UPNP_RESUBSCRIBE_INTERVAL_SECONDS) {
             logger.debug("{}: Proactively refreshing UPnP subscription ({}s since last event)", udn, staleSeconds);
             upnpClient.resubscribe();

--- a/bundles/org.openhab.binding.linkplay/src/main/java/org/openhab/binding/linkplay/internal/handler/LinkPlayHandler.java
+++ b/bundles/org.openhab.binding.linkplay/src/main/java/org/openhab/binding/linkplay/internal/handler/LinkPlayHandler.java
@@ -1462,7 +1462,7 @@ public class LinkPlayHandler extends BaseThingHandler
         if (inGroup && !isLeader) {
             return;
         }
-        // don't tear down the subscription mid-notification; notifications are short-lived
+        // don't tear down the subscription mid-notification as notifications are short-lived
         if (notificationHandler.isInNotification()) {
             return;
         }

--- a/bundles/org.openhab.binding.linkplay/src/main/java/org/openhab/binding/linkplay/internal/handler/LinkPlayHandler.java
+++ b/bundles/org.openhab.binding.linkplay/src/main/java/org/openhab/binding/linkplay/internal/handler/LinkPlayHandler.java
@@ -102,10 +102,24 @@ public class LinkPlayHandler extends BaseThingHandler
     private final Logger logger = LoggerFactory.getLogger(LinkPlayHandler.class);
 
     private static final int RECONNECT_DELAY = 30;
+    // UPnP event watchdog. jUPnP renews GENA subscriptions in-place at half of the 1800s duration (~15 min), but
+    // LinkPlay devices frequently fail to honor that renewal and openHAB core does not reliably tell us when it is
+    // dropped, leaving us unable to control playback. Rather than wait for that, we proactively tear down and recreate
+    // the subscriptions on a much faster cadence (defeating the flaky in-place renewal), and because a successful
+    // (re)subscribe always yields an initial event dump we treat "no event shortly after a refresh" as a dead
+    // subscription and fully reconnect. Lower UPNP_RESUBSCRIBE_INTERVAL_SECONDS for even more aggressive recovery at
+    // the cost of more subscribe traffic. See upnpEventWatchdog.
+    private static final int UPNP_WATCHDOG_INTERVAL_SECONDS = 30;
+    private static final int UPNP_RESUBSCRIBE_INTERVAL_SECONDS = 180;
+    private static final int UPNP_EVENT_GRACE_SECONDS = 60;
     private final HttpClient httpClient;
     private @Nullable ScheduledFuture<?> upnpServiceCheck;
+    private @Nullable ScheduledFuture<?> upnpWatchdogJob;
     private @Nullable ScheduledFuture<?> reconnectJob;
     private @Nullable ScheduledFuture<?> positionJob;
+    // Monotonic timestamp of the last (re)subscribe, used to time the watchdog's grace/refresh windows. Written from
+    // both the scheduler thread (watchdog) and the jUPnP callback thread (onUpnpSubscriptionStateChanged), so volatile.
+    private volatile long lastResubscribeNanos = System.nanoTime();
     // Are we currently initializing the device?
     private final AtomicBoolean isInitializing = new AtomicBoolean(false);
     // Have we been disposed, prevent further calls to the device when shutting down
@@ -167,6 +181,11 @@ public class LinkPlayHandler extends BaseThingHandler
          */
         cancelUpnpServiceCheckJob();
         upnpServiceCheck = scheduler.scheduleWithFixedDelay(this::initializationCheck, 0, 15, TimeUnit.SECONDS);
+
+        // Watchdog that detects and recovers silently dead UPnP subscriptions (it self-guards on thing status).
+        cancelUpnpWatchdogJob();
+        upnpWatchdogJob = scheduler.scheduleWithFixedDelay(this::upnpEventWatchdog, UPNP_WATCHDOG_INTERVAL_SECONDS,
+                UPNP_WATCHDOG_INTERVAL_SECONDS, TimeUnit.SECONDS);
     }
 
     @Override
@@ -176,6 +195,7 @@ public class LinkPlayHandler extends BaseThingHandler
         linkPlayGroupService.unregisterParticipant(this);
         cancelReconnectJob();
         cancelUpnpServiceCheckJob();
+        cancelUpnpWatchdogJob();
         cancelPositionJob();
         notificationHandler.dispose();
         upnpClient.dispose();
@@ -581,14 +601,23 @@ public class LinkPlayHandler extends BaseThingHandler
             return;
         }
         if (!allSubscriptionsSuccessful) {
-            updateStatus(ThingStatus.UNKNOWN, ThingStatusDetail.NONE, "Waiting for UPnP subscriptions");
+            // Only report "waiting" before we are ONLINE. While ONLINE this is normally just the transient gap during a
+            // proactive resubscribe (one service confirmed before the other), so don't flap the thing status; the
+            // watchdog handles genuinely dead subscriptions.
+            if (getThing().getStatus() != ThingStatus.ONLINE) {
+                updateStatus(ThingStatus.UNKNOWN, ThingStatusDetail.NONE, "Waiting for UPnP subscriptions");
+            }
             return;
         }
         if (getThing().getStatus() != ThingStatus.ONLINE) {
             updateStatus(ThingStatus.ONLINE);
         }
-        // we are fully subscribed and online, stop any active reconnect loop
+        // fully subscribed: stop any active reconnect loop and start a fresh refresh window. Note we deliberately do
+        // NOT touch the last-event clock here: this fires on the SUBSCRIBE acknowledgement, not on an actual GENA
+        // event, so resetting it would mask a device that ACKs the subscribe but never delivers events. The grace
+        // window measured from lastResubscribeNanos gives the initial event dump time to arrive.
         cancelReconnectJob();
+        lastResubscribeNanos = System.nanoTime();
     }
 
     @Override
@@ -1452,6 +1481,44 @@ public class LinkPlayHandler extends BaseThingHandler
         }
     }
 
+    /**
+     * Keeps UPnP event delivery alive. LinkPlay devices frequently drop GENA subscriptions silently, so instead of
+     * relying on jUPnP's flaky in-place renewal this proactively recreates the subscriptions on a fast cadence (each
+     * refresh gets a fresh subscription id and an initial event dump). If a refresh produces no event within the grace
+     * period the subscription is dead, so the thing is dropped OFFLINE to run the full reconnect cycle.
+     */
+    private void upnpEventWatchdog() {
+        if (disposed || getThing().getStatus() != ThingStatus.ONLINE) {
+            return;
+        }
+        // non-leader group members intentionally have UPnP turned off, so silence is expected
+        if (inGroup && !isLeader) {
+            return;
+        }
+        // don't tear down the subscription mid-notification; notifications are short-lived
+        if (notificationHandler.isInNotification()) {
+            return;
+        }
+        long staleSeconds = upnpClient.secondsSinceLastValue();
+        long sinceResubscribe = TimeUnit.NANOSECONDS.toSeconds(System.nanoTime() - lastResubscribeNanos);
+
+        // A successful (re)subscribe always yields an initial event dump, so if our most recent refresh produced no
+        // event within the grace period the subscription is dead -> fully reconnect.
+        if (staleSeconds > sinceResubscribe && sinceResubscribe >= UPNP_EVENT_GRACE_SECONDS) {
+            logger.debug("{}: No UPnP events {}s after resubscribe; reconnecting", udn, sinceResubscribe);
+            setOffline("No UPnP events received for " + staleSeconds + "s");
+            return;
+        }
+
+        // Proactively refresh well ahead of jUPnP's ~15 min in-place renewal so we keep control of playback.
+        if (sinceResubscribe >= UPNP_RESUBSCRIBE_INTERVAL_SECONDS) {
+            logger.debug("{}: Proactively refreshing UPnP subscription ({}s since last event)", udn, staleSeconds);
+            upnpClient.resubscribe();
+            upnpClient.sendDeviceSearchRequest();
+            lastResubscribeNanos = System.nanoTime();
+        }
+    }
+
     private void cancelReconnectJob() {
         cancelJob(reconnectJob);
         reconnectJob = null;
@@ -1460,6 +1527,11 @@ public class LinkPlayHandler extends BaseThingHandler
     private void cancelUpnpServiceCheckJob() {
         cancelJob(upnpServiceCheck);
         upnpServiceCheck = null;
+    }
+
+    private void cancelUpnpWatchdogJob() {
+        cancelJob(upnpWatchdogJob);
+        upnpWatchdogJob = null;
     }
 
     private void cancelJob(@Nullable ScheduledFuture<?> job) {


### PR DESCRIPTION
These two issue have long plagued my system, i finally found some time to tack them down. First is that UPnP subscriptions would silently die, making the binding unusable for hours or days.  Second is that player commands where often failing the first time, which was very annoying and would get the player in a odd state.  This PR fixes both by watching our UPnP subscriptions and resubscribing if we loose one, while also modifying our HTTP client to NOT keep connections open as Linkplay devices aggressively close connections after 2-3 seconds.  