### PR TITLE
[shelly] Fix Gen1 device discovery: shellyunknown inbox entries

### DIFF
--- a/bundles/org.openhab.binding.shelly/README.md
+++ b/bundles/org.openhab.binding.shelly/README.md
@@ -42,44 +42,44 @@ See section [Discovery](#discovery) for details.
 
 ### Generation 1
 
-| thing-type        | Model                                                  | Vendor ID |
-| ----------------- | ------------------------------------------------------ | --------- |
-| shelly1           | Shelly 1 Single Relay Switch                           | SHSW-1    |
-| shelly1l          | Shelly 1L Single Relay Switch                          | SHSW-L    |
-| shelly1pm         | Shelly Single Relay Switch with integrated Power Meter | SHSW-PM   |
-| shelly2-relay     | Shelly Double Relay Switch in relay mode               | SHSW-21   |
-| shelly2-roller    | Shelly2 in Roller Mode                                 | SHSW-21   |
-| shelly25-relay    | Shelly 2.5 in Relay Switch                             | SHSW-25   |
-| shelly25-roller   | Shelly 2.5 in Roller Mode                              | SHSW-25   |
-| shelly4pro        | Shelly 4x Relay Switch                                 | SHSW-44   |
-| shellydimmer      | Shelly Dimmer                                          | SHDM-1    |
-| shellydimmer2     | Shelly Dimmer2                                         | SHDM-2    |
-| shellyix3         | Shelly ix3                                             | SHIX3-1   |
-| shellyuni         | Shelly UNI, Shelly Plus UNI                            | SHUNI-1   |
-| shellyplug        | Shelly Plug                                            | SHPLG2-1  |
-| shellyplugs       | Shelly Plug-S                                          | SHPLG-S   |
-| shellyem          | Shelly EM with integrated Power Meters                 | SHEM      |
-| shellyem3         | Shelly 3EM with 3 integrated Power Meter               | SHEM-3    |
-| shellyrgbw2-color | Shelly RGBW2 Controller in Color Mode                  | SHRGBW2   |
-| shellyrgbw2-white | Shelly RGBW2 Controller in White Mode                  | SHRGBW2   |
-| shellybulb-color  | Shelly Bulb in Color Mode                              | SHBLB-1   |
-| shellybulb-white  | Shelly Bulb in White Mode                              | SHBLB-1   |
-| shellybulbduo     | Shelly Duo White                                       | SHBDUO-1  |
-| shellybulbduo     | Shelly Duo White G10                                   | SHBDUO-1  |
-| shellycolorbulb   | Shelly Duo Color G10                                   | SHCB-1    |
-| shellyvintage     | Shelly Vintage (White Mode)                            | SHVIN-1   |
-| shellyht          | Shelly Sensor (temperature+humidity)                   | SHHT-1    |
-| shellyflood       | Shelly Flood Sensor                                    | SHWT-1    |
-| shellysmoke       | Shelly Smoke Sensor                                    | SHSM-1    |
-| shellymotion      | Shelly Motion Sensor                                   | SHMOS-01  |
-| shellymotion2     | Shelly Motion Sensor 2                                 | SHMOS-02  |
-| shellygas         | Shelly Gas Sensor                                      | SHGS-1    |
-| shellydw          | Shelly Door/Window                                     | SHDW-1    |
-| shellydw2         | Shelly Door/Window 2                                   | SHDW-2    |
-| shellybutton1     | Shelly Button 1                                        | SHBTN-1   |
-| shellybutton2     | Shelly Button 2                                        | SHBTN-2   |
-| shellysense       | Shelly Motion and IR Controller                        | SHSEN-1   |
-| shellytrv         | Shelly TRV                                             | SHTRV-01  |
+| thing-type        | Model                                                  | Vendor ID           |
+| ----------------- | ------------------------------------------------------ | ------------------- |
+| shelly1           | Shelly 1 Single Relay Switch                           | SHSW-1              |
+| shelly1l          | Shelly 1L Single Relay Switch                          | SHSW-L              |
+| shelly1pm         | Shelly Single Relay Switch with integrated Power Meter | SHSW-PM             |
+| shelly2-relay     | Shelly Double Relay Switch in relay mode               | SHSW-21             |
+| shelly2-roller    | Shelly2 in Roller Mode                                 | SHSW-21             |
+| shelly25-relay    | Shelly 2.5 in Relay Switch                             | SHSW-25             |
+| shelly25-roller   | Shelly 2.5 in Roller Mode                              | SHSW-25             |
+| shelly4pro        | Shelly 4x Relay Switch                                 | SHSW-44             |
+| shellydimmer      | Shelly Dimmer                                          | SHDM-1              |
+| shellydimmer2     | Shelly Dimmer2                                         | SHDM-2              |
+| shellyix3         | Shelly ix3                                             | SHIX3-1             |
+| shellyuni         | Shelly UNI, Shelly Plus UNI                            | SHUNI-1             |
+| shellyplug        | Shelly Plug                                            | SHPLG-1, SHPLG2-1   |
+| shellyplugs       | Shelly Plug-S                                          | SHPLG-S             |
+| shellyplugu1      | Shelly Plug U1                                         | SHPLG-U1, SHPLG-US  |
+| shellyem          | Shelly EM with integrated Power Meters                 | SHEM                |
+| shellyem3         | Shelly 3EM with 3 integrated Power Meter               | SHEM-3              |
+| shellyrgbw2-color | Shelly RGBW2 Controller in Color Mode                  | SHRGBW2             |
+| shellyrgbw2-white | Shelly RGBW2 Controller in White Mode                  | SHRGBW2             |
+| shellybulb-color  | Shelly Bulb in Color Mode                              | SHBLB-1             |
+| shellybulb-white  | Shelly Bulb in White Mode                              | SHBLB-1             |
+| shellybulbduo     | Shelly Duo White / Duo White G10                       | SHBDUO-1            |
+| shellycolorbulb   | Shelly Duo Color G10                                   | SHCB-1              |
+| shellyvintage     | Shelly Vintage (White Mode)                            | SHVIN-1             |
+| shellyht          | Shelly Sensor (temperature+humidity)                   | SHHT-1              |
+| shellyflood       | Shelly Flood Sensor                                    | SHWT-1              |
+| shellysmoke       | Shelly Smoke Sensor                                    | SHSM-01             |
+| shellymotion      | Shelly Motion Sensor, Shelly Motion Sensor 2           | SHMOS-01, SHMOS-02  |
+| shellygas         | Shelly Gas Sensor                                      | SHGS-1              |
+| shellydw          | Shelly Door/Window                                     | SHDW-1              |
+| shellydw2         | Shelly Door/Window 2                                   | SHDW-2              |
+| shellybutton1     | Shelly Button 1                                        | SHBTN-1             |
+| shellybutton2     | Shelly Button 2                                        | SHBTN-2             |
+| shellysense       | Shelly Motion and IR Controller                        | SHSEN-1             |
+| shellyseye        | Shelly Eye                                             | SHEYE-1             |
+| shellytrv         | Shelly TRV                                             | SHTRV-01            |
 
 ### Shelly Plus series (Generation 2+3+4)
 
@@ -1032,7 +1032,7 @@ totalEnergy might reset on restart depending on device type and firmware version
 `Note`:
 totalEnergy might reset on restart depending on device type and firmware version
 
-### Shelly Duo Color (thing-type: shellyduocolor-color)
+### Shelly Duo Color (thing-type: shellycolorbulb)
 
 | Group   | Channel      | Type    | read-only | Description                                                                              |
 | ------- | ------------ | ------- | --------- | ---------------------------------------------------------------------------------------- |
@@ -1222,7 +1222,7 @@ You have a Motion controlling your light.
 You switch off the light and want to leave the room, but the motion sensor immediately switches light back on.
 Using 'sensorSleepTime' you can suppress motion events while leaving the room (e.g., for 5 seconds) so the light doesn't switch on.
 
-### Shelly Motion 2 (thing-type: shellymotion2)
+### Shelly Motion 2 (thing-type: shellymotion)
 
 | Group   | Channel         | Type     | read-only | Description                                                            |
 | ------- | --------------- | -------- | --------- | ---------------------------------------------------------------------- |

--- a/bundles/org.openhab.binding.shelly/README.md
+++ b/bundles/org.openhab.binding.shelly/README.md
@@ -49,43 +49,44 @@ See section [Discovery](#discovery) for details.
 
 ### Generation 1
 
-| thing-type        | Model                                                  | Vendor ID |
-| ----------------- | ------------------------------------------------------ | --------- |
-| shelly1           | Shelly 1 Single Relay Switch                           | SHSW-1    |
-| shelly1l          | Shelly 1L Single Relay Switch                          | SHSW-L    |
-| shelly1pm         | Shelly Single Relay Switch with integrated Power Meter | SHSW-PM   |
-| shelly2-relay     | Shelly Double Relay Switch in relay mode               | SHSW-21   |
-| shelly2-roller    | Shelly2 in Roller Mode                                 | SHSW-21   |
-| shelly25-relay    | Shelly 2.5 in Relay Switch                             | SHSW-25   |
-| shelly25-roller   | Shelly 2.5 in Roller Mode                              | SHSW-25   |
-| shelly4pro        | Shelly 4x Relay Switch                                 | SHSW-44   |
-| shellydimmer      | Shelly Dimmer                                          | SHDM-1    |
-| shellydimmer2     | Shelly Dimmer2                                         | SHDM-2    |
-| shellyix3         | Shelly ix3                                             | SHIX3-1   |
-| shellyuni         | Shelly UNI, Shelly Plus UNI                            | SHUNI-1   |
-| shellyplug        | Shelly Plug                                            | SHPLG2-1  |
-| shellyplugs       | Shelly Plug-S                                          | SHPLG-S   |
-| shellyem          | Shelly EM with integrated Power Meters                 | SHEM      |
-| shellyem3         | Shelly 3EM with 3 integrated Power Meter               | SHEM-3    |
-| shellyrgbw2-color | Shelly RGBW2 Controller in Color Mode                  | SHRGBW2   |
-| shellyrgbw2-white | Shelly RGBW2 Controller in White Mode                  | SHRGBW2   |
-| shellybulb        | Shelly Bulb (Color and White Mode)                     | SHBLB-1   |
-| shellybulbduo     | Shelly Duo White                                       | SHBDUO-1  |
-| shellybulbduo     | Shelly Duo White G10                                   | SHBDUO-1  |
-| shellycolorbulb   | Shelly Duo Color G10                                   | SHCB-1    |
-| shellyvintage     | Shelly Vintage (White Mode)                            | SHVIN-1   |
-| shellyht          | Shelly Sensor (temperature+humidity)                   | SHHT-1    |
-| shellyflood       | Shelly Flood Sensor                                    | SHWT-1    |
-| shellysmoke       | Shelly Smoke Sensor                                    | SHSM-1    |
-| shellymotion      | Shelly Motion Sensor                                   | SHMOS-01  |
-| shellymotion2     | Shelly Motion Sensor 2                                 | SHMOS-02  |
-| shellygas         | Shelly Gas Sensor                                      | SHGS-1    |
-| shellydw          | Shelly Door/Window                                     | SHDW-1    |
-| shellydw2         | Shelly Door/Window 2                                   | SHDW-2    |
-| shellybutton1     | Shelly Button 1                                        | SHBTN-1   |
-| shellybutton2     | Shelly Button 2                                        | SHBTN-2   |
-| shellysense       | Shelly Motion and IR Controller                        | SHSEN-1   |
-| shellytrv         | Shelly TRV                                             | SHTRV-01  |
+| thing-type        | Model                                                  | Vendor ID           |
+| ----------------- | ------------------------------------------------------ | ------------------- |
+| shelly1           | Shelly 1 Single Relay Switch                           | SHSW-1              |
+| shelly1l          | Shelly 1L Single Relay Switch                          | SHSW-L              |
+| shelly1pm         | Shelly Single Relay Switch with integrated Power Meter | SHSW-PM             |
+| shelly2-relay     | Shelly Double Relay Switch in relay mode               | SHSW-21             |
+| shelly2-roller    | Shelly2 in Roller Mode                                 | SHSW-21             |
+| shelly25-relay    | Shelly 2.5 in Relay Switch                             | SHSW-25             |
+| shelly25-roller   | Shelly 2.5 in Roller Mode                              | SHSW-25             |
+| shelly4pro        | Shelly 4x Relay Switch                                 | SHSW-44             |
+| shellydimmer      | Shelly Dimmer                                          | SHDM-1              |
+| shellydimmer2     | Shelly Dimmer2                                         | SHDM-2              |
+| shellyix3         | Shelly ix3                                             | SHIX3-1             |
+| shellyuni         | Shelly UNI, Shelly Plus UNI                            | SHUNI-1             |
+| shellyplug        | Shelly Plug                                            | SHPLG-1, SHPLG2-1   |
+| shellyplugs       | Shelly Plug-S                                          | SHPLG-S             |
+| shellyplugu1      | Shelly Plug U1                                         | SHPLG-U1, SHPLG-US  |
+| shellyem          | Shelly EM with integrated Power Meters                 | SHEM                |
+| shellyem3         | Shelly 3EM with 3 integrated Power Meter               | SHEM-3              |
+| shellyrgbw2-color | Shelly RGBW2 Controller in Color Mode                  | SHRGBW2             |
+| shellyrgbw2-white | Shelly RGBW2 Controller in White Mode                  | SHRGBW2             |
+| shellybulb-color  | Shelly Bulb in Color Mode                              | SHBLB-1             |
+| shellybulb-white  | Shelly Bulb in White Mode                              | SHBLB-1             |
+| shellybulbduo     | Shelly Duo White / Duo White G10                       | SHBDUO-1            |
+| shellycolorbulb   | Shelly Duo Color G10                                   | SHCB-1              |
+| shellyvintage     | Shelly Vintage (White Mode)                            | SHVIN-1             |
+| shellyht          | Shelly Sensor (temperature+humidity)                   | SHHT-1              |
+| shellyflood       | Shelly Flood Sensor                                    | SHWT-1              |
+| shellysmoke       | Shelly Smoke Sensor                                    | SHSM-01             |
+| shellymotion      | Shelly Motion Sensor, Shelly Motion Sensor 2           | SHMOS-01, SHMOS-02  |
+| shellygas         | Shelly Gas Sensor                                      | SHGS-1              |
+| shellydw          | Shelly Door/Window                                     | SHDW-1              |
+| shellydw2         | Shelly Door/Window 2                                   | SHDW-2              |
+| shellybutton1     | Shelly Button 1                                        | SHBTN-1             |
+| shellybutton2     | Shelly Button 2                                        | SHBTN-2             |
+| shellysense       | Shelly Motion and IR Controller                        | SHSEN-1             |
+| shellyseye        | Shelly Eye                                             | SHEYE-1             |
+| shellytrv         | Shelly TRV                                             | SHTRV-01            |
 
 ### Shelly Plus series (Generation 2+3+4)
 
@@ -1075,7 +1076,7 @@ totalEnergy might reset on restart depending on device type and firmware version
 `Note`:
 totalEnergy might reset on restart depending on device type and firmware version
 
-### Shelly Duo Color (thing-type: shellyduocolor-color)
+### Shelly Duo Color (thing-type: shellycolorbulb)
 
 | Group   | Channel      | Type    | read-only | Description                                                                              |
 | ------- | ------------ | ------- | --------- | ---------------------------------------------------------------------------------------- |
@@ -1269,7 +1270,7 @@ You have a Motion controlling your light.
 You switch off the light and want to leave the room, but the motion sensor immediately switches light back on.
 Using 'sensorSleepTime' you can suppress motion events while leaving the room (e.g., for 5 seconds) so the light doesn't switch on.
 
-### Shelly Motion 2 (thing-type: shellymotion2)
+### Shelly Motion 2 (thing-type: shellymotion)
 
 | Group   | Channel         | Type     | read-only | Description                                                            |
 | ------- | --------------- | -------- | --------- | ---------------------------------------------------------------------- |

--- a/bundles/org.openhab.binding.shelly/README.md
+++ b/bundles/org.openhab.binding.shelly/README.md
@@ -85,7 +85,6 @@ See section [Discovery](#discovery) for details.
 | shellybutton1     | Shelly Button 1                                        | SHBTN-1             |
 | shellybutton2     | Shelly Button 2                                        | SHBTN-2             |
 | shellysense       | Shelly Motion and IR Controller                        | SHSEN-1             |
-| shellyseye        | Shelly Eye                                             | SHEYE-1             |
 | shellytrv         | Shelly TRV                                             | SHTRV-01            |
 
 ### Shelly Plus series (Generation 2+3+4)

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/ShellyDevices.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/ShellyDevices.java
@@ -37,6 +37,7 @@ public class ShellyDevices {
     public static final String SHELLYDT_1PM = "SHSW-PM";
     public static final String SHELLYDT_1L = "SHSW-L";
     public static final String SHELLYDT_PLUG = "SHPLG-1";
+    public static final String SHELLYDT_PLUG2 = "SHPLG2-1"; // Gen1 Plug variant
     public static final String SHELLYDT_PLUGS = "SHPLG-S";
     public static final String SHELLYDT_PLUGU1 = "SHPLG-U1";
     public static final String SHELLYDT_PLUGU1_2 = "SHPLG-US";
@@ -47,7 +48,7 @@ public class ShellyDevices {
     public static final String SHELLYDT_3EM = "SHEM-3";
     public static final String SHELLYDT_HT = "SHHT-1";
     public static final String SHELLYDT_SMOKE = "SHSM-01";
-    public static final String SHELLYDT_FLOOD = "SH-FLOOD ";
+    public static final String SHELLYDT_FLOOD = "SHWT-1";
     public static final String SHELLYDT_DOORWINDOW = "SHDW-1";
     public static final String SHELLYDT_DOORWINDOW2 = "SHDW-2";
     public static final String SHELLYDT_UNI = "SHUNI-1";
@@ -394,6 +395,7 @@ public class ShellyDevices {
             Map.entry(SHELLYDT_1L, THING_TYPE_SHELLY1L), //
             Map.entry(SHELLYDT_1, THING_TYPE_SHELLY1), //
             Map.entry(SHELLYDT_PLUG, THING_TYPE_SHELLYPLUG), //
+            Map.entry(SHELLYDT_PLUG2, THING_TYPE_SHELLYPLUG), //
             Map.entry(SHELLYDT_PLUGS, THING_TYPE_SHELLYPLUGS), //
             Map.entry(SHELLYDT_PLUGU1, THING_TYPE_SHELLYPLUGU1), //
             Map.entry(SHELLYDT_PLUGU1_2, THING_TYPE_SHELLYPLUGU1), //
@@ -408,7 +410,8 @@ public class ShellyDevices {
             Map.entry(SHELLYDT_3EM, THING_TYPE_SHELLY3EM), //
             Map.entry(SHELLYDT_EM, THING_TYPE_SHELLYEM), //
             Map.entry(SHELLYDT_HT, THING_TYPE_SHELLYHT), //
-            Map.entry(SHELLYDT_MOTION, THING_TYPE_SHELLYMOTION),
+            Map.entry(SHELLYDT_MOTION, THING_TYPE_SHELLYMOTION), //
+            Map.entry(SHELLYDT_MOTION2, THING_TYPE_SHELLYMOTION), //
             Map.entry(SHELLYDT_DOORWINDOW, THING_TYPE_SHELLYDOORWIN), //
             Map.entry(SHELLYDT_DOORWINDOW2, THING_TYPE_SHELLYDOORWIN2), //
             Map.entry(SHELLYDT_SMOKE, THING_TYPE_SHELLYSMOKE), //
@@ -582,6 +585,8 @@ public class ShellyDevices {
             Map.entry("shelly1", THING_TYPE_SHELLY1), //
             Map.entry("shelly1pm", THING_TYPE_SHELLY1PM), //
             Map.entry("shelly1l", THING_TYPE_SHELLY1L), //
+            Map.entry("shelly2", THING_TYPE_SHELLY2_RELAY), // default mode; handler corrects to roller if needed
+            Map.entry("shelly25", THING_TYPE_SHELLY25_RELAY), // default mode; handler corrects to roller if needed
             Map.entry("shellyem3", THING_TYPE_SHELLY3EM), // Product name is 3EM
             Map.entry("shellyem", THING_TYPE_SHELLYEM), //
             Map.entry("shelly4pro", THING_TYPE_SHELLY4PRO), //

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/ShellyDevices.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/ShellyDevices.java
@@ -56,7 +56,6 @@ public class ShellyDevices {
     public static final String SHELLYDT_MOTION2 = "SHMOS-02";
     public static final String SHELLYDT_SENSE = "SHSEN-1";
     public static final String SHELLYDT_GAS = "SHGS-1";
-    public static final String SHELLYDT_EYE = "SHEYE-1";
     public static final String SHELLYDT_DIMMER = "SHDM-1";
     public static final String SHELLYDT_DIMMER2 = "SHDM-2";
     public static final String SHELLYDT_IX3 = "SHIX3-1";
@@ -232,7 +231,6 @@ public class ShellyDevices {
     public static final ThingTypeUID THING_TYPE_SHELLYTRV = new ThingTypeUID(BINDING_ID, "shellytrv");
     public static final ThingTypeUID THING_TYPE_SHELLYBUTTON1 = new ThingTypeUID(BINDING_ID, "shellybutton1");
     public static final ThingTypeUID THING_TYPE_SHELLYBUTTON2 = new ThingTypeUID(BINDING_ID, "shellybutton2");
-    public static final ThingTypeUID THING_TYPE_SHELLYEYE = new ThingTypeUID(BINDING_ID, "shellyseye");
     public static final ThingTypeUID THING_TYPE_SHELLYMOTION = new ThingTypeUID(BINDING_ID, "shellymotion");
     public static final ThingTypeUID THING_TYPE_SHELLYRGBW2_COLOR = new ThingTypeUID(BINDING_ID, "shellyrgbw2-color");
     public static final ThingTypeUID THING_TYPE_SHELLYRGBW2_WHITE = new ThingTypeUID(BINDING_ID, "shellyrgbw2-white");
@@ -429,7 +427,6 @@ public class ShellyDevices {
             Map.entry(SHELLYDT_FLOOD, THING_TYPE_SHELLYFLOOD), //
             Map.entry(SHELLYDT_UNI, THING_TYPE_SHELLYUNI), //
             Map.entry(SHELLYDT_GAS, THING_TYPE_SHELLYGAS), //
-            Map.entry(SHELLYDT_EYE, THING_TYPE_SHELLYEYE), //
             Map.entry(SHELLYDT_SENSE, THING_TYPE_SHELLYSENSE), //
             Map.entry(SHELLYDT_BUTTON1, THING_TYPE_SHELLYBUTTON1),
             Map.entry(SHELLYDT_BUTTON2, THING_TYPE_SHELLYBUTTON2), //
@@ -623,14 +620,12 @@ public class ShellyDevices {
             Map.entry("shellydw", THING_TYPE_SHELLYDOORWIN), //
             Map.entry("shellydw2", THING_TYPE_SHELLYDOORWIN2), //
             Map.entry("shellysense", THING_TYPE_SHELLYSENSE), //
-            Map.entry("shellyseye", THING_TYPE_SHELLYEYE), //
             Map.entry("shellybutton1", THING_TYPE_SHELLYBUTTON1), //
             Map.entry("shellybutton2", THING_TYPE_SHELLYBUTTON2), //
             Map.entry("shellyuni", THING_TYPE_SHELLYUNI), //
             Map.entry("shellymotion", THING_TYPE_SHELLYMOTION),
             Map.entry("shellymotionsensor", THING_TYPE_SHELLYMOTION),
-            Map.entry("shellymotion2", THING_TYPE_SHELLYMOTION), //
-            Map.entry("shellyeye", THING_TYPE_SHELLYEYE),
+            Map.entry("shellymotion2", THING_TYPE_SHELLYMOTION),
 
             // Shelly Plus Series
             Map.entry("shellyplus1", THING_TYPE_SHELLYPLUS1), //

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/ShellyDevices.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/ShellyDevices.java
@@ -602,6 +602,9 @@ public class ShellyDevices {
             Map.entry("shelly1", THING_TYPE_SHELLY1), //
             Map.entry("shelly1pm", THING_TYPE_SHELLY1PM), //
             Map.entry("shelly1l", THING_TYPE_SHELLY1L), //
+            // Mode unknown here (mDNS-only/auth-protected); default relay, mismatched roller needs re-discovery
+            Map.entry("shelly2", THING_TYPE_SHELLY2_RELAY), //
+            Map.entry("shelly25", THING_TYPE_SHELLY25_RELAY), //
             Map.entry("shellyem3", THING_TYPE_SHELLY3EM), // Product name is 3EM
             Map.entry("shellyem", THING_TYPE_SHELLYEM), //
             Map.entry("shelly4pro", THING_TYPE_SHELLY4PRO), //

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/ShellyDevices.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/ShellyDevices.java
@@ -37,6 +37,7 @@ public class ShellyDevices {
     public static final String SHELLYDT_1PM = "SHSW-PM";
     public static final String SHELLYDT_1L = "SHSW-L";
     public static final String SHELLYDT_PLUG = "SHPLG-1";
+    public static final String SHELLYDT_PLUG2 = "SHPLG2-1"; // Gen1 Plug variant
     public static final String SHELLYDT_PLUGS = "SHPLG-S";
     public static final String SHELLYDT_PLUGU1 = "SHPLG-U1";
     public static final String SHELLYDT_PLUGU1_2 = "SHPLG-US";
@@ -47,7 +48,7 @@ public class ShellyDevices {
     public static final String SHELLYDT_3EM = "SHEM-3";
     public static final String SHELLYDT_HT = "SHHT-1";
     public static final String SHELLYDT_SMOKE = "SHSM-01";
-    public static final String SHELLYDT_FLOOD = "SH-FLOOD ";
+    public static final String SHELLYDT_FLOOD = "SHWT-1";
     public static final String SHELLYDT_DOORWINDOW = "SHDW-1";
     public static final String SHELLYDT_DOORWINDOW2 = "SHDW-2";
     public static final String SHELLYDT_UNI = "SHUNI-1";
@@ -405,6 +406,7 @@ public class ShellyDevices {
             Map.entry(SHELLYDT_1L, THING_TYPE_SHELLY1L), //
             Map.entry(SHELLYDT_1, THING_TYPE_SHELLY1), //
             Map.entry(SHELLYDT_PLUG, THING_TYPE_SHELLYPLUG), //
+            Map.entry(SHELLYDT_PLUG2, THING_TYPE_SHELLYPLUG), //
             Map.entry(SHELLYDT_PLUGS, THING_TYPE_SHELLYPLUGS), //
             Map.entry(SHELLYDT_PLUGU1, THING_TYPE_SHELLYPLUGU1), //
             Map.entry(SHELLYDT_PLUGU1_2, THING_TYPE_SHELLYPLUGU1), //
@@ -419,7 +421,8 @@ public class ShellyDevices {
             Map.entry(SHELLYDT_3EM, THING_TYPE_SHELLY3EM), //
             Map.entry(SHELLYDT_EM, THING_TYPE_SHELLYEM), //
             Map.entry(SHELLYDT_HT, THING_TYPE_SHELLYHT), //
-            Map.entry(SHELLYDT_MOTION, THING_TYPE_SHELLYMOTION),
+            Map.entry(SHELLYDT_MOTION, THING_TYPE_SHELLYMOTION), //
+            Map.entry(SHELLYDT_MOTION2, THING_TYPE_SHELLYMOTION), //
             Map.entry(SHELLYDT_DOORWINDOW, THING_TYPE_SHELLYDOORWIN), //
             Map.entry(SHELLYDT_DOORWINDOW2, THING_TYPE_SHELLYDOORWIN2), //
             Map.entry(SHELLYDT_SMOKE, THING_TYPE_SHELLYSMOKE), //

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/ShellyDevices.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/ShellyDevices.java
@@ -599,9 +599,6 @@ public class ShellyDevices {
             Map.entry("shelly1", THING_TYPE_SHELLY1), //
             Map.entry("shelly1pm", THING_TYPE_SHELLY1PM), //
             Map.entry("shelly1l", THING_TYPE_SHELLY1L), //
-            // Mode unknown here (mDNS-only/auth-protected); default relay, mismatched roller needs re-discovery
-            Map.entry("shelly2", THING_TYPE_SHELLY2_RELAY), //
-            Map.entry("shelly25", THING_TYPE_SHELLY25_RELAY), //
             Map.entry("shellyem3", THING_TYPE_SHELLY3EM), // Product name is 3EM
             Map.entry("shellyem", THING_TYPE_SHELLYEM), //
             Map.entry("shelly4pro", THING_TYPE_SHELLY4PRO), //

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/discovery/ShellyBasicDiscoveryService.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/discovery/ShellyBasicDiscoveryService.java
@@ -109,6 +109,25 @@ public class ShellyBasicDiscoveryService extends AbstractDiscoveryService {
         unregisterDeviceDiscoveryService();
     }
 
+    /**
+     * Probes a Shelly device at the given address and builds a {@link DiscoveryResult}.
+     *
+     * <p>
+     * For Gen1 devices the {@code /shelly} endpoint (no auth) is queried first to obtain the hardware
+     * model string. If the subsequent {@code /settings} call returns HTTP 401 (auth required), the model
+     * obtained from {@code /shelly} is used to resolve the correct {@link ThingTypeUID} via the device-type
+     * map. This ensures that an auth-protected Gen1 device is discovered with its proper type (e.g.
+     * {@code shelly:shellyflood}) rather than falling back to {@code shelly:shellyunknown}.
+     *
+     * @param gen2 {@code true} for Gen2/3/4 devices (RPC/WebSocket), {@code false} for Gen1 (HTTP/CoAP)
+     * @param hostname mDNS hostname of the device (used as thing realm and log prefix)
+     * @param ipAddress IP address of the device
+     * @param bindingConfig current binding-wide runtime configuration
+     * @param httpClient HTTP client for API calls
+     * @param messages translation provider for channel labels
+     * @param thingTable registry of all known Things (used for deduplication)
+     * @return a populated {@link DiscoveryResult}, or {@code null} if the device cannot be identified
+     */
     public static @Nullable DiscoveryResult createResult(boolean gen2, String hostname, String ipAddress,
             ShellyBindingRuntimeConfig bindingConfig, HttpClient httpClient, ShellyTranslationProvider messages,
             ShellyThingTable thingTable) {
@@ -154,8 +173,18 @@ public class ShellyBasicDiscoveryService extends AbstractDiscoveryService {
         } catch (ShellyApiException e) {
             ShellyApiResult result = e.getApiResult();
             if (result.isHttpAccessUnauthorized()) {
-                // create shellyunknown thing - will be changed during thing initialization with valid credentials
-                thingUID = ShellyThingCreator.getThingUIDForUnknown(name, model, mode);
+                ThingTypeUID knownType = ShellyThingCreator.getThingTypeUID(name, model, mode);
+                if (!THING_TYPE_SHELLYUNKNOWN.equals(knownType)) {
+                    logger.debug(
+                            "{}: Device requires authentication, but model '{}' from the unauthenticated /shelly response resolves to {}",
+                            name, model, knownType.getId());
+                    thingUID = ShellyThingCreator.getThingUID(name, model, mode);
+                } else {
+                    logger.debug(
+                            "{}: Device requires authentication and model '{}' could not be resolved, creating as {}",
+                            name, model, THING_TYPE_SHELLYUNKNOWN.getId());
+                    thingUID = ShellyThingCreator.getThingUIDForUnknown(name, model, mode);
+                }
             } else {
                 if (e.getCause() instanceof IllegalArgumentException) {
                     logger.debug("{}: Unable to discover device", name, e);

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/discovery/ShellyThingCreator.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/discovery/ShellyThingCreator.java
@@ -94,6 +94,11 @@ public class ShellyThingCreator {
         }
 
         if (!deviceType.isEmpty()) {
+            // RGBW2 is mode-sensitive regardless of service name; handles custom hostnames
+            // that bypass the shellyrgbw2* prefix check above.
+            if (SHELLYDT_RGBW2.equals(deviceType)) {
+                return SHELLY_MODE_COLOR.equals(mode) ? THING_TYPE_SHELLYRGBW2_COLOR : THING_TYPE_SHELLYRGBW2_WHITE;
+            }
             Map<String, ThingTypeUID> deviceTypeMap = switch (mode) {
                 case SHELLY_MODE_RELAY -> RELAY_THING_TYPE_BY_DEVICE_TYPE;
                 case SHELLY_MODE_ROLLER -> ROLLER_THING_TYPE_BY_DEVICE_TYPE;

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/discovery/ShellyThingCreator.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/discovery/ShellyThingCreator.java
@@ -105,6 +105,10 @@ public class ShellyThingCreator {
             };
 
             ThingTypeUID res = deviceTypeMap.get(deviceType);
+            if (res == null && deviceTypeMap != THING_TYPE_BY_DEVICE_TYPE) {
+                // single-mode devices (e.g. SHSW-1, SHSW-PM, SHDM-2) are only listed in the general map
+                res = THING_TYPE_BY_DEVICE_TYPE.get(deviceType);
+            }
             if (res != null) {
                 return res;
             }

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/discovery/ShellyThingCreator.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/discovery/ShellyThingCreator.java
@@ -94,6 +94,10 @@ public class ShellyThingCreator {
         }
 
         if (!deviceType.isEmpty()) {
+            // RGBW2 is mode-sensitive regardless of service name (custom hostnames bypass the check above)
+            if (SHELLYDT_RGBW2.equals(deviceType)) {
+                return SHELLY_MODE_COLOR.equals(mode) ? THING_TYPE_SHELLYRGBW2_COLOR : THING_TYPE_SHELLYRGBW2_WHITE;
+            }
             Map<String, ThingTypeUID> deviceTypeMap = switch (mode) {
                 case SHELLY_MODE_RELAY -> RELAY_THING_TYPE_BY_DEVICE_TYPE;
                 case SHELLY_MODE_ROLLER -> ROLLER_THING_TYPE_BY_DEVICE_TYPE;

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/handler/ShellyBaseHandler.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/handler/ShellyBaseHandler.java
@@ -1233,7 +1233,12 @@ public abstract class ShellyBaseHandler extends BaseThingHandler
      * @param mode Device mode (e.g. relay, roller)
      */
     protected void changeThingType(String thingType, String mode) {
-        String deviceType = substringBefore(thingType, "-");
+        // Prefer the real hardware model string (e.g. "SHSW-21") over the service-name prefix (e.g. "shelly2")
+        // so that relay/roller maps resolve correctly for multi-mode devices.
+        String deviceType = getString(profile.device.type);
+        if (deviceType.isEmpty()) {
+            deviceType = substringBefore(thingType, "-");
+        }
         ThingTypeUID thingTypeUID = ShellyThingCreator.getThingTypeUID(thingType, deviceType, mode);
         if (!thingTypeUID.equals(THING_TYPE_SHELLYUNKNOWN)) {
             logger.debug("{}: Changing thing type to {}", getThing().getLabel(), thingTypeUID);

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/handler/ShellyBaseHandler.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/handler/ShellyBaseHandler.java
@@ -1288,21 +1288,22 @@ public abstract class ShellyBaseHandler extends BaseThingHandler
      * @param mode Device mode (e.g. relay, roller)
      */
     protected void changeThingType(String thingType, String mode) {
+        String servicePrefix = substringBefore(thingType, "-");
         // Prefer the real hardware model over the service-name prefix so relay/roller maps resolve correctly
         String deviceType = getString(profile.device.type);
         if (deviceType.isEmpty()) {
-            deviceType = substringBefore(thingType, "-");
+            deviceType = servicePrefix;
         }
         ThingTypeUID thingTypeUID = ShellyThingCreator.getThingTypeUID(thingType, deviceType, mode);
         if (!thingTypeUID.equals(THING_TYPE_SHELLYUNKNOWN)) {
             logger.debug("{}: Changing thing type to {}", getThing().getLabel(), thingTypeUID);
             Map<String, String> properties = editProperties();
-            properties.replace(PROPERTY_DEV_TYPE, deviceType);
+            properties.replace(PROPERTY_DEV_TYPE, servicePrefix);
             properties.replace(PROPERTY_DEV_MODE, mode);
             updateProperties(properties);
             changeThingType(thingTypeUID, getConfig());
         } else {
-            logger.debug("{}:  to {}", thingName, thingType);
+            logger.debug("{}: Unable to change thing type to {}", thingName, thingType);
             setThingOfflineAndDisconnect(ThingStatusDetail.CONFIGURATION_ERROR,
                     "Unable to change thing type to " + thingType);
         }

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/handler/ShellyBaseHandler.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/handler/ShellyBaseHandler.java
@@ -1288,7 +1288,7 @@ public abstract class ShellyBaseHandler extends BaseThingHandler
      * @param mode Device mode (e.g. relay, roller)
      */
     protected void changeThingType(String thingType, String mode) {
-        String servicePrefix = substringBefore(thingType, "-");
+        String servicePrefix = substringBeforeLast(thingType, "-");
         // Prefer the real hardware model over the service-name prefix so relay/roller maps resolve correctly
         String deviceType = getString(profile.device.type);
         if (deviceType.isEmpty()) {

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/handler/ShellyBaseHandler.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/handler/ShellyBaseHandler.java
@@ -1288,7 +1288,11 @@ public abstract class ShellyBaseHandler extends BaseThingHandler
      * @param mode Device mode (e.g. relay, roller)
      */
     protected void changeThingType(String thingType, String mode) {
-        String deviceType = substringBefore(thingType, "-");
+        // Prefer the real hardware model over the service-name prefix so relay/roller maps resolve correctly
+        String deviceType = getString(profile.device.type);
+        if (deviceType.isEmpty()) {
+            deviceType = substringBefore(thingType, "-");
+        }
         ThingTypeUID thingTypeUID = ShellyThingCreator.getThingTypeUID(thingType, deviceType, mode);
         if (!thingTypeUID.equals(THING_TYPE_SHELLYUNKNOWN)) {
             logger.debug("{}: Changing thing type to {}", getThing().getLabel(), thingTypeUID);

--- a/bundles/org.openhab.binding.shelly/src/test/java/org/openhab/binding/shelly/internal/api/ShellyDeviceProfileTest.java
+++ b/bundles/org.openhab.binding.shelly/src/test/java/org/openhab/binding/shelly/internal/api/ShellyDeviceProfileTest.java
@@ -100,7 +100,6 @@ public class ShellyDeviceProfileTest {
                 Arguments.of(THING_TYPE_SHELLYBUTTON2, false, false), //
                 Arguments.of(THING_TYPE_SHELLYMOTION, false, false), //
                 Arguments.of(THING_TYPE_SHELLYTRV, false, false), //
-                Arguments.of(THING_TYPE_SHELLYEYE, false, false), //
 
                 // Shelly Plus
                 Arguments.of(THING_TYPE_SHELLYPLUS1, true, false), //

--- a/bundles/org.openhab.binding.shelly/src/test/java/org/openhab/binding/shelly/internal/discovery/ShellyThingCreatorTest.java
+++ b/bundles/org.openhab.binding.shelly/src/test/java/org/openhab/binding/shelly/internal/discovery/ShellyThingCreatorTest.java
@@ -84,6 +84,15 @@ public class ShellyThingCreatorTest {
                 Arguments.of("shellyplugus-" + DEVICE_ID, "", THING_TYPE_SHELLYPLUSPLUGUS), //
                 Arguments.of("shellyplugusg4-" + DEVICE_ID, "", THING_TYPE_SHELLYPLUGUSG4), //
                 Arguments.of("shellyplusplugcpm-" + DEVICE_ID, "", THING_TYPE_SHELLYPLUSPLUGCPM), //
+                // Gen 1 relay devices — service name alone must identify type (important for auth-protected discovery)
+                Arguments.of("shelly1-" + DEVICE_ID, "", THING_TYPE_SHELLY1), //
+                Arguments.of("shelly1pm-" + DEVICE_ID, "", THING_TYPE_SHELLY1PM), //
+                Arguments.of("shelly1l-" + DEVICE_ID, "", THING_TYPE_SHELLY1L), //
+                Arguments.of("shelly2-" + DEVICE_ID, "", THING_TYPE_SHELLY2_RELAY), // relay default; probe corrects to
+                                                                                    // roller
+                Arguments.of("shelly25-" + DEVICE_ID, "", THING_TYPE_SHELLY25_RELAY), // relay default; probe corrects
+                                                                                      // to roller
+                Arguments.of("shelly4pro-" + DEVICE_ID, "", THING_TYPE_SHELLY4PRO), //
                 Arguments.of("shellydimmer-" + DEVICE_ID, "", THING_TYPE_SHELLYDIMMER), //
                 Arguments.of("shellydimmer2-" + DEVICE_ID, "", THING_TYPE_SHELLYDIMMER2), //
                 Arguments.of("shellyprodm2pm-" + DEVICE_ID, "", THING_TYPE_SHELLYPRODM2PM), //
@@ -95,17 +104,24 @@ public class ShellyThingCreatorTest {
                 Arguments.of("shellyvintage-" + DEVICE_ID, "", THING_TYPE_SHELLYVINTAGE), //
                 Arguments.of("shellybulb-" + DEVICE_ID, "", THING_TYPE_SHELLYBULB), //
                 Arguments.of("shellybulbduo-" + DEVICE_ID, "", THING_TYPE_SHELLYDUO), //
+                Arguments.of("shellyix3-" + DEVICE_ID, "", THING_TYPE_SHELLYIX3), //
                 Arguments.of("shellymotion-" + DEVICE_ID, "", THING_TYPE_SHELLYMOTION), //
                 Arguments.of("shellymotion2-" + DEVICE_ID, "", THING_TYPE_SHELLYMOTION), //
-                Arguments.of("shellymotionsensor-" + DEVICE_ID, "", THING_TYPE_SHELLYMOTION),
-                Arguments.of("shellyflood-" + DEVICE_ID, "", THING_TYPE_SHELLYFLOOD),
-                Arguments.of("shellyht-" + DEVICE_ID, "", THING_TYPE_SHELLYHT),
-                Arguments.of("shellydw-" + DEVICE_ID, "", THING_TYPE_SHELLYDOORWIN),
-                Arguments.of("shellydw2-" + DEVICE_ID, "", THING_TYPE_SHELLYDOORWIN2),
-                Arguments.of("shellygas-" + DEVICE_ID, "", THING_TYPE_SHELLYGAS),
-                Arguments.of("shellyuni-" + DEVICE_ID, "", THING_TYPE_SHELLYUNI),
-                Arguments.of("shellyem-" + DEVICE_ID, "", THING_TYPE_SHELLYEM),
-                Arguments.of("shellyem3-" + DEVICE_ID, "", THING_TYPE_SHELLY3EM),
+                Arguments.of("shellymotionsensor-" + DEVICE_ID, "", THING_TYPE_SHELLYMOTION), //
+                Arguments.of("shellyflood-" + DEVICE_ID, "", THING_TYPE_SHELLYFLOOD), //
+                Arguments.of("shellyht-" + DEVICE_ID, "", THING_TYPE_SHELLYHT), //
+                Arguments.of("shellysmoke-" + DEVICE_ID, "", THING_TYPE_SHELLYSMOKE), //
+                Arguments.of("shellytrv-" + DEVICE_ID, "", THING_TYPE_SHELLYTRV), //
+                Arguments.of("shellydw-" + DEVICE_ID, "", THING_TYPE_SHELLYDOORWIN), //
+                Arguments.of("shellydw2-" + DEVICE_ID, "", THING_TYPE_SHELLYDOORWIN2), //
+                Arguments.of("shellygas-" + DEVICE_ID, "", THING_TYPE_SHELLYGAS), //
+                Arguments.of("shellyuni-" + DEVICE_ID, "", THING_TYPE_SHELLYUNI), //
+                Arguments.of("shellybutton1-" + DEVICE_ID, "", THING_TYPE_SHELLYBUTTON1), //
+                Arguments.of("shellybutton2-" + DEVICE_ID, "", THING_TYPE_SHELLYBUTTON2), //
+                Arguments.of("shellyseye-" + DEVICE_ID, "", THING_TYPE_SHELLYEYE), // service name differs from thing
+                                                                                   // type id
+                Arguments.of("shellyem-" + DEVICE_ID, "", THING_TYPE_SHELLYEM), //
+                Arguments.of("shellyem3-" + DEVICE_ID, "", THING_TYPE_SHELLY3EM), //
 
                 // Shelly Plus
                 Arguments.of("shelly3em63g3-" + DEVICE_ID, "", THING_TYPE_SHELLYPLUS3EM63),
@@ -149,7 +165,10 @@ public class ShellyThingCreatorTest {
                 Arguments.of(SHELLYDT_SHELLY25, "roller", THING_TYPE_SHELLY25_ROLLER), //
                 Arguments.of(SHELLYDT_SHPRO, "", THING_TYPE_SHELLY4PRO), //
                 Arguments.of(SHELLYDT_PLUG, "", THING_TYPE_SHELLYPLUG), //
+                Arguments.of(SHELLYDT_PLUG2, "", THING_TYPE_SHELLYPLUG), //
                 Arguments.of(SHELLYDT_PLUGU1, "", THING_TYPE_SHELLYPLUGU1), //
+                Arguments.of(SHELLYDT_PLUGU1_2, "", THING_TYPE_SHELLYPLUGU1), //
+                Arguments.of(SHELLYDT_SENSE, "", THING_TYPE_SHELLYSENSE), //
                 Arguments.of(SHELLYDT_3EM, "", THING_TYPE_SHELLY3EM), //
                 Arguments.of(SHELLYDT_EM, "", THING_TYPE_SHELLYEM), //
                 Arguments.of(SHELLYDT_PLUG, "", THING_TYPE_SHELLYPLUG), //
@@ -172,6 +191,7 @@ public class ShellyThingCreatorTest {
                 Arguments.of(SHELLYDT_FLOOD, "", THING_TYPE_SHELLYFLOOD), //
                 Arguments.of(SHELLYDT_SMOKE, "", THING_TYPE_SHELLYSMOKE), //
                 Arguments.of(SHELLYDT_MOTION, "", THING_TYPE_SHELLYMOTION), //
+                Arguments.of(SHELLYDT_MOTION2, "", THING_TYPE_SHELLYMOTION), //
                 Arguments.of(SHELLYDT_EYE, "", THING_TYPE_SHELLYEYE), //
                 Arguments.of(SHELLYDT_TRV, "", THING_TYPE_SHELLYTRV), //
 
@@ -303,7 +323,45 @@ public class ShellyThingCreatorTest {
     private static Stream<Arguments> provideTestCasesForgetThingUIDDeviceTypeTakesPrecedence() {
         return Stream.of( //
                 Arguments.of("shellyplusshutter-" + DEVICE_ID, SHELLYDT_PLUSSMOKE, THING_TYPE_SHELLYPLUSSMOKE), //
-                Arguments.of("notfound-" + DEVICE_ID, SHELLYDT_PLUSSMOKE, THING_TYPE_SHELLYPLUSSMOKE));
+                Arguments.of("notfound-" + DEVICE_ID, SHELLYDT_PLUSSMOKE, THING_TYPE_SHELLYPLUSSMOKE), //
+                // Auth-protected Gen1 discovery: model from /shelly beats service name.
+                // These simulate createResult() receiving 401 from /settings after /shelly already returned devInfo.
+                Arguments.of("shelly1-" + DEVICE_ID, SHELLYDT_1, THING_TYPE_SHELLY1), //
+                Arguments.of("shelly1pm-" + DEVICE_ID, SHELLYDT_1PM, THING_TYPE_SHELLY1PM), //
+                Arguments.of("shelly1l-" + DEVICE_ID, SHELLYDT_1L, THING_TYPE_SHELLY1L), //
+                Arguments.of("shellydevice-" + DEVICE_ID, SHELLYDT_DIMMER2, THING_TYPE_SHELLYDIMMER2), // custom
+                                                                                                       // hostname,
+                                                                                                       // model resolves
+                Arguments.of("shellydevice-" + DEVICE_ID, SHELLYDT_EM, THING_TYPE_SHELLYEM), //
+                Arguments.of("shellydevice-" + DEVICE_ID, SHELLYDT_FLOOD, THING_TYPE_SHELLYFLOOD), //
+                // SHSW-21 is only in relay/roller maps; with unknown mode it falls back to service name → relay default
+                Arguments.of("shelly2-" + DEVICE_ID, SHELLYDT_SHELLY2, THING_TYPE_SHELLY2_RELAY), //
+                Arguments.of("shelly25-" + DEVICE_ID, SHELLYDT_SHELLY25, THING_TYPE_SHELLY25_RELAY), //
+                // SHRGBW2 with custom hostname: device-type map resolves to white (default when mode unknown)
+                Arguments.of("shellydevice-" + DEVICE_ID, SHELLYDT_RGBW2, THING_TYPE_SHELLYRGBW2_WHITE));
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideTestCasesForMultiModeGen1Devices")
+    void multiModeGen1DevicesResolveByMode(String serviceName, String deviceType, String mode,
+            ThingTypeUID expectedThingTypeUid) {
+        ThingUID actual = ShellyThingCreator.getThingUID(serviceName, deviceType, mode);
+        ThingUID expected = new ThingUID(expectedThingTypeUid, DEVICE_ID);
+        assertThat("serviceName: " + serviceName + "; deviceType: " + deviceType + "; mode: " + mode, actual,
+                is(equalTo(expected)));
+        assertThat(SUPPORTED_THING_TYPES, hasItem(expectedThingTypeUid));
+    }
+
+    private static Stream<Arguments> provideTestCasesForMultiModeGen1Devices() {
+        return Stream.of( //
+                Arguments.of("shelly2-" + DEVICE_ID, SHELLYDT_SHELLY2, "relay", THING_TYPE_SHELLY2_RELAY), //
+                Arguments.of("shelly2-" + DEVICE_ID, SHELLYDT_SHELLY2, "roller", THING_TYPE_SHELLY2_ROLLER), //
+                Arguments.of("shelly25-" + DEVICE_ID, SHELLYDT_SHELLY25, "relay", THING_TYPE_SHELLY25_RELAY), //
+                Arguments.of("shelly25-" + DEVICE_ID, SHELLYDT_SHELLY25, "roller", THING_TYPE_SHELLY25_ROLLER), //
+                Arguments.of("shellybulb-" + DEVICE_ID, SHELLYDT_BULB, "color", THING_TYPE_SHELLYBULB), //
+                Arguments.of("shellybulb-" + DEVICE_ID, SHELLYDT_BULB, "white", THING_TYPE_SHELLYBULB), //
+                Arguments.of("shellyrgbw2-" + DEVICE_ID, SHELLYDT_RGBW2, "color", THING_TYPE_SHELLYRGBW2_COLOR), //
+                Arguments.of("shellyrgbw2-" + DEVICE_ID, SHELLYDT_RGBW2, "white", THING_TYPE_SHELLYRGBW2_WHITE)); //
     }
 
     @ParameterizedTest

--- a/bundles/org.openhab.binding.shelly/src/test/java/org/openhab/binding/shelly/internal/discovery/ShellyThingCreatorTest.java
+++ b/bundles/org.openhab.binding.shelly/src/test/java/org/openhab/binding/shelly/internal/discovery/ShellyThingCreatorTest.java
@@ -119,9 +119,6 @@ public class ShellyThingCreatorTest {
                 Arguments.of("shellyuni-" + DEVICE_ID, "", THING_TYPE_SHELLYUNI), //
                 Arguments.of("shellybutton1-" + DEVICE_ID, "", THING_TYPE_SHELLYBUTTON1), //
                 Arguments.of("shellybutton2-" + DEVICE_ID, "", THING_TYPE_SHELLYBUTTON2), //
-                Arguments.of("shellyseye-" + DEVICE_ID, "", THING_TYPE_SHELLYEYE), //
-                Arguments.of("shellyem-" + DEVICE_ID, "", THING_TYPE_SHELLYEM), //
-                Arguments.of("shellyem3-" + DEVICE_ID, "", THING_TYPE_SHELLY3EM), //
 
                 // Shelly Plus
                 Arguments.of("shelly3em63g3-" + DEVICE_ID, "", THING_TYPE_SHELLYPLUS3EM63),
@@ -195,7 +192,6 @@ public class ShellyThingCreatorTest {
                 Arguments.of(SHELLYDT_SMOKE, "", THING_TYPE_SHELLYSMOKE), //
                 Arguments.of(SHELLYDT_MOTION, "", THING_TYPE_SHELLYMOTION), //
                 Arguments.of(SHELLYDT_MOTION2, "", THING_TYPE_SHELLYMOTION), //
-                Arguments.of(SHELLYDT_EYE, "", THING_TYPE_SHELLYEYE), //
                 Arguments.of(SHELLYDT_TRV, "", THING_TYPE_SHELLYTRV), //
 
                 // Plus Series

--- a/bundles/org.openhab.binding.shelly/src/test/java/org/openhab/binding/shelly/internal/discovery/ShellyThingCreatorTest.java
+++ b/bundles/org.openhab.binding.shelly/src/test/java/org/openhab/binding/shelly/internal/discovery/ShellyThingCreatorTest.java
@@ -84,14 +84,12 @@ public class ShellyThingCreatorTest {
                 Arguments.of("shellyplugus-" + DEVICE_ID, "", THING_TYPE_SHELLYPLUSPLUGUS), //
                 Arguments.of("shellyplugusg4-" + DEVICE_ID, "", THING_TYPE_SHELLYPLUGUSG4), //
                 Arguments.of("shellyplusplugcpm-" + DEVICE_ID, "", THING_TYPE_SHELLYPLUSPLUGCPM), //
-                // Gen 1 relay devices — service name alone must identify type (important for auth-protected discovery)
+                // Gen 1
                 Arguments.of("shelly1-" + DEVICE_ID, "", THING_TYPE_SHELLY1), //
                 Arguments.of("shelly1pm-" + DEVICE_ID, "", THING_TYPE_SHELLY1PM), //
                 Arguments.of("shelly1l-" + DEVICE_ID, "", THING_TYPE_SHELLY1L), //
-                Arguments.of("shelly2-" + DEVICE_ID, "", THING_TYPE_SHELLY2_RELAY), // relay default; probe corrects to
-                                                                                    // roller
-                Arguments.of("shelly25-" + DEVICE_ID, "", THING_TYPE_SHELLY25_RELAY), // relay default; probe corrects
-                                                                                      // to roller
+                Arguments.of("shelly2-" + DEVICE_ID, "", THING_TYPE_SHELLY2_RELAY), //
+                Arguments.of("shelly25-" + DEVICE_ID, "", THING_TYPE_SHELLY25_RELAY), //
                 Arguments.of("shelly4pro-" + DEVICE_ID, "", THING_TYPE_SHELLY4PRO), //
                 Arguments.of("shellydimmer-" + DEVICE_ID, "", THING_TYPE_SHELLYDIMMER), //
                 Arguments.of("shellydimmer2-" + DEVICE_ID, "", THING_TYPE_SHELLYDIMMER2), //
@@ -121,8 +119,7 @@ public class ShellyThingCreatorTest {
                 Arguments.of("shellyuni-" + DEVICE_ID, "", THING_TYPE_SHELLYUNI), //
                 Arguments.of("shellybutton1-" + DEVICE_ID, "", THING_TYPE_SHELLYBUTTON1), //
                 Arguments.of("shellybutton2-" + DEVICE_ID, "", THING_TYPE_SHELLYBUTTON2), //
-                Arguments.of("shellyseye-" + DEVICE_ID, "", THING_TYPE_SHELLYEYE), // service name differs from thing
-                                                                                   // type id
+                Arguments.of("shellyseye-" + DEVICE_ID, "", THING_TYPE_SHELLYEYE), //
                 Arguments.of("shellyem-" + DEVICE_ID, "", THING_TYPE_SHELLYEM), //
                 Arguments.of("shellyem3-" + DEVICE_ID, "", THING_TYPE_SHELLY3EM), //
 
@@ -336,20 +333,15 @@ public class ShellyThingCreatorTest {
         return Stream.of( //
                 Arguments.of("shellyplusshutter-" + DEVICE_ID, SHELLYDT_PLUSSMOKE, THING_TYPE_SHELLYPLUSSMOKE), //
                 Arguments.of("notfound-" + DEVICE_ID, SHELLYDT_PLUSSMOKE, THING_TYPE_SHELLYPLUSSMOKE), //
-                // Auth-protected Gen1 discovery: model from /shelly beats service name.
-                // These simulate createResult() receiving 401 from /settings after /shelly already returned devInfo.
+                // Auth-protected Gen 1 discovery
                 Arguments.of("shelly1-" + DEVICE_ID, SHELLYDT_1, THING_TYPE_SHELLY1), //
                 Arguments.of("shelly1pm-" + DEVICE_ID, SHELLYDT_1PM, THING_TYPE_SHELLY1PM), //
                 Arguments.of("shelly1l-" + DEVICE_ID, SHELLYDT_1L, THING_TYPE_SHELLY1L), //
-                Arguments.of("shellydevice-" + DEVICE_ID, SHELLYDT_DIMMER2, THING_TYPE_SHELLYDIMMER2), // custom
-                                                                                                       // hostname,
-                                                                                                       // model resolves
+                Arguments.of("shellydevice-" + DEVICE_ID, SHELLYDT_DIMMER2, THING_TYPE_SHELLYDIMMER2), //
                 Arguments.of("shellydevice-" + DEVICE_ID, SHELLYDT_EM, THING_TYPE_SHELLYEM), //
                 Arguments.of("shellydevice-" + DEVICE_ID, SHELLYDT_FLOOD, THING_TYPE_SHELLYFLOOD), //
-                // SHSW-21 is only in relay/roller maps; with unknown mode it falls back to service name → relay default
                 Arguments.of("shelly2-" + DEVICE_ID, SHELLYDT_SHELLY2, THING_TYPE_SHELLY2_RELAY), //
                 Arguments.of("shelly25-" + DEVICE_ID, SHELLYDT_SHELLY25, THING_TYPE_SHELLY25_RELAY), //
-                // SHRGBW2 with custom hostname: device-type map resolves to white (default when mode unknown)
                 Arguments.of("shellydevice-" + DEVICE_ID, SHELLYDT_RGBW2, THING_TYPE_SHELLYRGBW2_WHITE));
     }
 
@@ -387,10 +379,6 @@ public class ShellyThingCreatorTest {
 
     private static Stream<Arguments> provideTestCasesForSingleModeDeviceFallsBackToGeneralMap() {
         return Stream.of( //
-                // SHSW-1/SHSW-PM/SHDM-2 exist only in THING_TYPE_BY_DEVICE_TYPE, not in
-                // RELAY_THING_TYPE_BY_DEVICE_TYPE. Old Gen1 firmware derives mode="relay" from num_outputs even for
-                // single-relay/dimmer devices, and a custom hostname bypasses the service-name-based resolution
-                // above, so the mode-specific lookup must fall back to the general map instead of shellyunknown.
                 Arguments.of("shellydevice-" + DEVICE_ID, SHELLYDT_1, THING_TYPE_SHELLY1), //
                 Arguments.of("shellydevice-" + DEVICE_ID, SHELLYDT_1PM, THING_TYPE_SHELLY1PM), //
                 Arguments.of("shellydevice-" + DEVICE_ID, SHELLYDT_DIMMER2, THING_TYPE_SHELLYDIMMER2));

--- a/bundles/org.openhab.binding.shelly/src/test/java/org/openhab/binding/shelly/internal/discovery/ShellyThingCreatorTest.java
+++ b/bundles/org.openhab.binding.shelly/src/test/java/org/openhab/binding/shelly/internal/discovery/ShellyThingCreatorTest.java
@@ -88,8 +88,8 @@ public class ShellyThingCreatorTest {
                 Arguments.of("shelly1-" + DEVICE_ID, "", THING_TYPE_SHELLY1), //
                 Arguments.of("shelly1pm-" + DEVICE_ID, "", THING_TYPE_SHELLY1PM), //
                 Arguments.of("shelly1l-" + DEVICE_ID, "", THING_TYPE_SHELLY1L), //
-                Arguments.of("shelly2-" + DEVICE_ID, "", THING_TYPE_SHELLY2_RELAY), //
-                Arguments.of("shelly25-" + DEVICE_ID, "", THING_TYPE_SHELLY25_RELAY), //
+                Arguments.of("shellyswitch-" + DEVICE_ID, "", THING_TYPE_SHELLYUNKNOWN), //
+                Arguments.of("shellyswitch25-" + DEVICE_ID, "", THING_TYPE_SHELLYUNKNOWN), //
                 Arguments.of("shelly4pro-" + DEVICE_ID, "", THING_TYPE_SHELLY4PRO), //
                 Arguments.of("shellydimmer-" + DEVICE_ID, "", THING_TYPE_SHELLYDIMMER), //
                 Arguments.of("shellydimmer2-" + DEVICE_ID, "", THING_TYPE_SHELLYDIMMER2), //
@@ -336,8 +336,6 @@ public class ShellyThingCreatorTest {
                 Arguments.of("shellydevice-" + DEVICE_ID, SHELLYDT_DIMMER2, THING_TYPE_SHELLYDIMMER2), //
                 Arguments.of("shellydevice-" + DEVICE_ID, SHELLYDT_EM, THING_TYPE_SHELLYEM), //
                 Arguments.of("shellydevice-" + DEVICE_ID, SHELLYDT_FLOOD, THING_TYPE_SHELLYFLOOD), //
-                Arguments.of("shelly2-" + DEVICE_ID, SHELLYDT_SHELLY2, THING_TYPE_SHELLY2_RELAY), //
-                Arguments.of("shelly25-" + DEVICE_ID, SHELLYDT_SHELLY25, THING_TYPE_SHELLY25_RELAY), //
                 Arguments.of("shellydevice-" + DEVICE_ID, SHELLYDT_RGBW2, THING_TYPE_SHELLYRGBW2_WHITE));
     }
 
@@ -354,10 +352,10 @@ public class ShellyThingCreatorTest {
 
     private static Stream<Arguments> provideTestCasesForMultiModeGen1Devices() {
         return Stream.of( //
-                Arguments.of("shelly2-" + DEVICE_ID, SHELLYDT_SHELLY2, "relay", THING_TYPE_SHELLY2_RELAY), //
-                Arguments.of("shelly2-" + DEVICE_ID, SHELLYDT_SHELLY2, "roller", THING_TYPE_SHELLY2_ROLLER), //
-                Arguments.of("shelly25-" + DEVICE_ID, SHELLYDT_SHELLY25, "relay", THING_TYPE_SHELLY25_RELAY), //
-                Arguments.of("shelly25-" + DEVICE_ID, SHELLYDT_SHELLY25, "roller", THING_TYPE_SHELLY25_ROLLER), //
+                Arguments.of("shellyswitch-" + DEVICE_ID, SHELLYDT_SHELLY2, "relay", THING_TYPE_SHELLY2_RELAY), //
+                Arguments.of("shellyswitch-" + DEVICE_ID, SHELLYDT_SHELLY2, "roller", THING_TYPE_SHELLY2_ROLLER), //
+                Arguments.of("shellyswitch25-" + DEVICE_ID, SHELLYDT_SHELLY25, "relay", THING_TYPE_SHELLY25_RELAY), //
+                Arguments.of("shellyswitch25-" + DEVICE_ID, SHELLYDT_SHELLY25, "roller", THING_TYPE_SHELLY25_ROLLER), //
                 Arguments.of("shellybulb-" + DEVICE_ID, SHELLYDT_BULB, "color", THING_TYPE_SHELLYBULB), //
                 Arguments.of("shellybulb-" + DEVICE_ID, SHELLYDT_BULB, "white", THING_TYPE_SHELLYBULB), //
                 Arguments.of("shellyrgbw2-" + DEVICE_ID, SHELLYDT_RGBW2, "color", THING_TYPE_SHELLYRGBW2_COLOR), //

--- a/bundles/org.openhab.binding.shelly/src/test/java/org/openhab/binding/shelly/internal/discovery/ShellyThingCreatorTest.java
+++ b/bundles/org.openhab.binding.shelly/src/test/java/org/openhab/binding/shelly/internal/discovery/ShellyThingCreatorTest.java
@@ -84,17 +84,12 @@ public class ShellyThingCreatorTest {
                 Arguments.of("shellyplugus-" + DEVICE_ID, "", THING_TYPE_SHELLYPLUSPLUGUS), //
                 Arguments.of("shellyplugusg4-" + DEVICE_ID, "", THING_TYPE_SHELLYPLUGUSG4), //
                 Arguments.of("shellyplusplugcpm-" + DEVICE_ID, "", THING_TYPE_SHELLYPLUSPLUGCPM), //
-                // Gen 1
-                Arguments.of("shelly1-" + DEVICE_ID, "", THING_TYPE_SHELLY1), //
-                Arguments.of("shelly1pm-" + DEVICE_ID, "", THING_TYPE_SHELLY1PM), //
-                Arguments.of("shelly1l-" + DEVICE_ID, "", THING_TYPE_SHELLY1L), //
-                Arguments.of("shellyswitch-" + DEVICE_ID, "", THING_TYPE_SHELLYUNKNOWN), //
-                Arguments.of("shellyswitch25-" + DEVICE_ID, "", THING_TYPE_SHELLYUNKNOWN), //
-                Arguments.of("shelly4pro-" + DEVICE_ID, "", THING_TYPE_SHELLY4PRO), //
                 Arguments.of("shellydimmer-" + DEVICE_ID, "", THING_TYPE_SHELLYDIMMER), //
                 Arguments.of("shellydimmer2-" + DEVICE_ID, "", THING_TYPE_SHELLYDIMMER2), //
                 Arguments.of("shellydimmerg4us-" + DEVICE_ID, "", THING_TYPE_SHELLYPLUSDIMMERUS), //
                 Arguments.of("shellyprodm2pm-" + DEVICE_ID, "", THING_TYPE_SHELLYPRODM2PM), //
+                Arguments.of("shellyswitch-" + DEVICE_ID, "", THING_TYPE_SHELLYUNKNOWN), //
+                Arguments.of("shellyswitch25-" + DEVICE_ID, "", THING_TYPE_SHELLYUNKNOWN), //
                 Arguments.of("shellyem-" + DEVICE_ID, "", THING_TYPE_SHELLYEM), //
                 Arguments.of("shellyem3-" + DEVICE_ID, "", THING_TYPE_SHELLY3EM), //
                 Arguments.of("shellyrgbw2-" + DEVICE_ID, "color", THING_TYPE_SHELLYRGBW2_COLOR), //
@@ -103,22 +98,19 @@ public class ShellyThingCreatorTest {
                 Arguments.of("shellyvintage-" + DEVICE_ID, "", THING_TYPE_SHELLYVINTAGE), //
                 Arguments.of("shellybulb-" + DEVICE_ID, "", THING_TYPE_SHELLYBULB), //
                 Arguments.of("shellybulbduo-" + DEVICE_ID, "", THING_TYPE_SHELLYDUO), //
-                Arguments.of("shellyix3-" + DEVICE_ID, "", THING_TYPE_SHELLYIX3), //
                 Arguments.of("shellymotion-" + DEVICE_ID, "", THING_TYPE_SHELLYMOTION), //
                 Arguments.of("shellymotion2-" + DEVICE_ID, "", THING_TYPE_SHELLYMOTION), //
-                Arguments.of("shellymotionsensor-" + DEVICE_ID, "", THING_TYPE_SHELLYMOTION), //
-                Arguments.of("shellyflood-" + DEVICE_ID, "", THING_TYPE_SHELLYFLOOD), //
-                Arguments.of("shellyfloodg4-" + DEVICE_ID, "", THING_TYPE_SHELLYPLUSFLOOD), //
-                Arguments.of("shellyplusflood-" + DEVICE_ID, "", THING_TYPE_SHELLYPLUSFLOOD), //
-                Arguments.of("shellyht-" + DEVICE_ID, "", THING_TYPE_SHELLYHT), //
-                Arguments.of("shellysmoke-" + DEVICE_ID, "", THING_TYPE_SHELLYSMOKE), //
-                Arguments.of("shellytrv-" + DEVICE_ID, "", THING_TYPE_SHELLYTRV), //
-                Arguments.of("shellydw-" + DEVICE_ID, "", THING_TYPE_SHELLYDOORWIN), //
-                Arguments.of("shellydw2-" + DEVICE_ID, "", THING_TYPE_SHELLYDOORWIN2), //
-                Arguments.of("shellygas-" + DEVICE_ID, "", THING_TYPE_SHELLYGAS), //
-                Arguments.of("shellyuni-" + DEVICE_ID, "", THING_TYPE_SHELLYUNI), //
-                Arguments.of("shellybutton1-" + DEVICE_ID, "", THING_TYPE_SHELLYBUTTON1), //
-                Arguments.of("shellybutton2-" + DEVICE_ID, "", THING_TYPE_SHELLYBUTTON2), //
+                Arguments.of("shellymotionsensor-" + DEVICE_ID, "", THING_TYPE_SHELLYMOTION),
+                Arguments.of("shellyflood-" + DEVICE_ID, "", THING_TYPE_SHELLYFLOOD),
+                Arguments.of("shellyfloodg4-" + DEVICE_ID, "", THING_TYPE_SHELLYPLUSFLOOD),
+                Arguments.of("shellyplusflood-" + DEVICE_ID, "", THING_TYPE_SHELLYPLUSFLOOD),
+                Arguments.of("shellyht-" + DEVICE_ID, "", THING_TYPE_SHELLYHT),
+                Arguments.of("shellydw-" + DEVICE_ID, "", THING_TYPE_SHELLYDOORWIN),
+                Arguments.of("shellydw2-" + DEVICE_ID, "", THING_TYPE_SHELLYDOORWIN2),
+                Arguments.of("shellygas-" + DEVICE_ID, "", THING_TYPE_SHELLYGAS),
+                Arguments.of("shellyuni-" + DEVICE_ID, "", THING_TYPE_SHELLYUNI),
+                Arguments.of("shellyem-" + DEVICE_ID, "", THING_TYPE_SHELLYEM),
+                Arguments.of("shellyem3-" + DEVICE_ID, "", THING_TYPE_SHELLY3EM),
 
                 // Shelly Plus
                 Arguments.of("shelly3em63g3-" + DEVICE_ID, "", THING_TYPE_SHELLYPLUS3EM63),
@@ -167,8 +159,6 @@ public class ShellyThingCreatorTest {
                 Arguments.of(SHELLYDT_PLUG, "", THING_TYPE_SHELLYPLUG), //
                 Arguments.of(SHELLYDT_PLUG2, "", THING_TYPE_SHELLYPLUG), //
                 Arguments.of(SHELLYDT_PLUGU1, "", THING_TYPE_SHELLYPLUGU1), //
-                Arguments.of(SHELLYDT_PLUGU1_2, "", THING_TYPE_SHELLYPLUGU1), //
-                Arguments.of(SHELLYDT_SENSE, "", THING_TYPE_SHELLYSENSE), //
                 Arguments.of(SHELLYDT_3EM, "", THING_TYPE_SHELLY3EM), //
                 Arguments.of(SHELLYDT_EM, "", THING_TYPE_SHELLYEM), //
                 Arguments.of(SHELLYDT_PLUG, "", THING_TYPE_SHELLYPLUG), //

--- a/bundles/org.openhab.binding.shelly/src/test/java/org/openhab/binding/shelly/internal/discovery/ShellyThingCreatorTest.java
+++ b/bundles/org.openhab.binding.shelly/src/test/java/org/openhab/binding/shelly/internal/discovery/ShellyThingCreatorTest.java
@@ -84,6 +84,15 @@ public class ShellyThingCreatorTest {
                 Arguments.of("shellyplugus-" + DEVICE_ID, "", THING_TYPE_SHELLYPLUSPLUGUS), //
                 Arguments.of("shellyplugusg4-" + DEVICE_ID, "", THING_TYPE_SHELLYPLUGUSG4), //
                 Arguments.of("shellyplusplugcpm-" + DEVICE_ID, "", THING_TYPE_SHELLYPLUSPLUGCPM), //
+                // Gen 1 relay devices — service name alone must identify type (important for auth-protected discovery)
+                Arguments.of("shelly1-" + DEVICE_ID, "", THING_TYPE_SHELLY1), //
+                Arguments.of("shelly1pm-" + DEVICE_ID, "", THING_TYPE_SHELLY1PM), //
+                Arguments.of("shelly1l-" + DEVICE_ID, "", THING_TYPE_SHELLY1L), //
+                Arguments.of("shelly2-" + DEVICE_ID, "", THING_TYPE_SHELLY2_RELAY), // relay default; probe corrects to
+                                                                                    // roller
+                Arguments.of("shelly25-" + DEVICE_ID, "", THING_TYPE_SHELLY25_RELAY), // relay default; probe corrects
+                                                                                      // to roller
+                Arguments.of("shelly4pro-" + DEVICE_ID, "", THING_TYPE_SHELLY4PRO), //
                 Arguments.of("shellydimmer-" + DEVICE_ID, "", THING_TYPE_SHELLYDIMMER), //
                 Arguments.of("shellydimmer2-" + DEVICE_ID, "", THING_TYPE_SHELLYDIMMER2), //
                 Arguments.of("shellydimmerg4us-" + DEVICE_ID, "", THING_TYPE_SHELLYPLUSDIMMERUS), //
@@ -96,19 +105,26 @@ public class ShellyThingCreatorTest {
                 Arguments.of("shellyvintage-" + DEVICE_ID, "", THING_TYPE_SHELLYVINTAGE), //
                 Arguments.of("shellybulb-" + DEVICE_ID, "", THING_TYPE_SHELLYBULB), //
                 Arguments.of("shellybulbduo-" + DEVICE_ID, "", THING_TYPE_SHELLYDUO), //
+                Arguments.of("shellyix3-" + DEVICE_ID, "", THING_TYPE_SHELLYIX3), //
                 Arguments.of("shellymotion-" + DEVICE_ID, "", THING_TYPE_SHELLYMOTION), //
                 Arguments.of("shellymotion2-" + DEVICE_ID, "", THING_TYPE_SHELLYMOTION), //
-                Arguments.of("shellymotionsensor-" + DEVICE_ID, "", THING_TYPE_SHELLYMOTION),
-                Arguments.of("shellyflood-" + DEVICE_ID, "", THING_TYPE_SHELLYFLOOD),
-                Arguments.of("shellyfloodg4-" + DEVICE_ID, "", THING_TYPE_SHELLYPLUSFLOOD),
-                Arguments.of("shellyplusflood-" + DEVICE_ID, "", THING_TYPE_SHELLYPLUSFLOOD),
-                Arguments.of("shellyht-" + DEVICE_ID, "", THING_TYPE_SHELLYHT),
-                Arguments.of("shellydw-" + DEVICE_ID, "", THING_TYPE_SHELLYDOORWIN),
-                Arguments.of("shellydw2-" + DEVICE_ID, "", THING_TYPE_SHELLYDOORWIN2),
-                Arguments.of("shellygas-" + DEVICE_ID, "", THING_TYPE_SHELLYGAS),
-                Arguments.of("shellyuni-" + DEVICE_ID, "", THING_TYPE_SHELLYUNI),
-                Arguments.of("shellyem-" + DEVICE_ID, "", THING_TYPE_SHELLYEM),
-                Arguments.of("shellyem3-" + DEVICE_ID, "", THING_TYPE_SHELLY3EM),
+                Arguments.of("shellymotionsensor-" + DEVICE_ID, "", THING_TYPE_SHELLYMOTION), //
+                Arguments.of("shellyflood-" + DEVICE_ID, "", THING_TYPE_SHELLYFLOOD), //
+                Arguments.of("shellyfloodg4-" + DEVICE_ID, "", THING_TYPE_SHELLYPLUSFLOOD), //
+                Arguments.of("shellyplusflood-" + DEVICE_ID, "", THING_TYPE_SHELLYPLUSFLOOD), //
+                Arguments.of("shellyht-" + DEVICE_ID, "", THING_TYPE_SHELLYHT), //
+                Arguments.of("shellysmoke-" + DEVICE_ID, "", THING_TYPE_SHELLYSMOKE), //
+                Arguments.of("shellytrv-" + DEVICE_ID, "", THING_TYPE_SHELLYTRV), //
+                Arguments.of("shellydw-" + DEVICE_ID, "", THING_TYPE_SHELLYDOORWIN), //
+                Arguments.of("shellydw2-" + DEVICE_ID, "", THING_TYPE_SHELLYDOORWIN2), //
+                Arguments.of("shellygas-" + DEVICE_ID, "", THING_TYPE_SHELLYGAS), //
+                Arguments.of("shellyuni-" + DEVICE_ID, "", THING_TYPE_SHELLYUNI), //
+                Arguments.of("shellybutton1-" + DEVICE_ID, "", THING_TYPE_SHELLYBUTTON1), //
+                Arguments.of("shellybutton2-" + DEVICE_ID, "", THING_TYPE_SHELLYBUTTON2), //
+                Arguments.of("shellyseye-" + DEVICE_ID, "", THING_TYPE_SHELLYEYE), // service name differs from thing
+                                                                                   // type id
+                Arguments.of("shellyem-" + DEVICE_ID, "", THING_TYPE_SHELLYEM), //
+                Arguments.of("shellyem3-" + DEVICE_ID, "", THING_TYPE_SHELLY3EM), //
 
                 // Shelly Plus
                 Arguments.of("shelly3em63g3-" + DEVICE_ID, "", THING_TYPE_SHELLYPLUS3EM63),
@@ -155,7 +171,10 @@ public class ShellyThingCreatorTest {
                 Arguments.of(SHELLYDT_SHELLY25, "roller", THING_TYPE_SHELLY25_ROLLER), //
                 Arguments.of(SHELLYDT_SHPRO, "", THING_TYPE_SHELLY4PRO), //
                 Arguments.of(SHELLYDT_PLUG, "", THING_TYPE_SHELLYPLUG), //
+                Arguments.of(SHELLYDT_PLUG2, "", THING_TYPE_SHELLYPLUG), //
                 Arguments.of(SHELLYDT_PLUGU1, "", THING_TYPE_SHELLYPLUGU1), //
+                Arguments.of(SHELLYDT_PLUGU1_2, "", THING_TYPE_SHELLYPLUGU1), //
+                Arguments.of(SHELLYDT_SENSE, "", THING_TYPE_SHELLYSENSE), //
                 Arguments.of(SHELLYDT_3EM, "", THING_TYPE_SHELLY3EM), //
                 Arguments.of(SHELLYDT_EM, "", THING_TYPE_SHELLYEM), //
                 Arguments.of(SHELLYDT_PLUG, "", THING_TYPE_SHELLYPLUG), //
@@ -178,6 +197,7 @@ public class ShellyThingCreatorTest {
                 Arguments.of(SHELLYDT_FLOOD, "", THING_TYPE_SHELLYFLOOD), //
                 Arguments.of(SHELLYDT_SMOKE, "", THING_TYPE_SHELLYSMOKE), //
                 Arguments.of(SHELLYDT_MOTION, "", THING_TYPE_SHELLYMOTION), //
+                Arguments.of(SHELLYDT_MOTION2, "", THING_TYPE_SHELLYMOTION), //
                 Arguments.of(SHELLYDT_EYE, "", THING_TYPE_SHELLYEYE), //
                 Arguments.of(SHELLYDT_TRV, "", THING_TYPE_SHELLYTRV), //
 
@@ -315,7 +335,45 @@ public class ShellyThingCreatorTest {
     private static Stream<Arguments> provideTestCasesForgetThingUIDDeviceTypeTakesPrecedence() {
         return Stream.of( //
                 Arguments.of("shellyplusshutter-" + DEVICE_ID, SHELLYDT_PLUSSMOKE, THING_TYPE_SHELLYPLUSSMOKE), //
-                Arguments.of("notfound-" + DEVICE_ID, SHELLYDT_PLUSSMOKE, THING_TYPE_SHELLYPLUSSMOKE));
+                Arguments.of("notfound-" + DEVICE_ID, SHELLYDT_PLUSSMOKE, THING_TYPE_SHELLYPLUSSMOKE), //
+                // Auth-protected Gen1 discovery: model from /shelly beats service name.
+                // These simulate createResult() receiving 401 from /settings after /shelly already returned devInfo.
+                Arguments.of("shelly1-" + DEVICE_ID, SHELLYDT_1, THING_TYPE_SHELLY1), //
+                Arguments.of("shelly1pm-" + DEVICE_ID, SHELLYDT_1PM, THING_TYPE_SHELLY1PM), //
+                Arguments.of("shelly1l-" + DEVICE_ID, SHELLYDT_1L, THING_TYPE_SHELLY1L), //
+                Arguments.of("shellydevice-" + DEVICE_ID, SHELLYDT_DIMMER2, THING_TYPE_SHELLYDIMMER2), // custom
+                                                                                                       // hostname,
+                                                                                                       // model resolves
+                Arguments.of("shellydevice-" + DEVICE_ID, SHELLYDT_EM, THING_TYPE_SHELLYEM), //
+                Arguments.of("shellydevice-" + DEVICE_ID, SHELLYDT_FLOOD, THING_TYPE_SHELLYFLOOD), //
+                // SHSW-21 is only in relay/roller maps; with unknown mode it falls back to service name → relay default
+                Arguments.of("shelly2-" + DEVICE_ID, SHELLYDT_SHELLY2, THING_TYPE_SHELLY2_RELAY), //
+                Arguments.of("shelly25-" + DEVICE_ID, SHELLYDT_SHELLY25, THING_TYPE_SHELLY25_RELAY), //
+                // SHRGBW2 with custom hostname: device-type map resolves to white (default when mode unknown)
+                Arguments.of("shellydevice-" + DEVICE_ID, SHELLYDT_RGBW2, THING_TYPE_SHELLYRGBW2_WHITE));
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideTestCasesForMultiModeGen1Devices")
+    void multiModeGen1DevicesResolveByMode(String serviceName, String deviceType, String mode,
+            ThingTypeUID expectedThingTypeUid) {
+        ThingUID actual = ShellyThingCreator.getThingUID(serviceName, deviceType, mode);
+        ThingUID expected = new ThingUID(expectedThingTypeUid, DEVICE_ID);
+        assertThat("serviceName: " + serviceName + "; deviceType: " + deviceType + "; mode: " + mode, actual,
+                is(equalTo(expected)));
+        assertThat(SUPPORTED_THING_TYPES, hasItem(expectedThingTypeUid));
+    }
+
+    private static Stream<Arguments> provideTestCasesForMultiModeGen1Devices() {
+        return Stream.of( //
+                Arguments.of("shelly2-" + DEVICE_ID, SHELLYDT_SHELLY2, "relay", THING_TYPE_SHELLY2_RELAY), //
+                Arguments.of("shelly2-" + DEVICE_ID, SHELLYDT_SHELLY2, "roller", THING_TYPE_SHELLY2_ROLLER), //
+                Arguments.of("shelly25-" + DEVICE_ID, SHELLYDT_SHELLY25, "relay", THING_TYPE_SHELLY25_RELAY), //
+                Arguments.of("shelly25-" + DEVICE_ID, SHELLYDT_SHELLY25, "roller", THING_TYPE_SHELLY25_ROLLER), //
+                Arguments.of("shellybulb-" + DEVICE_ID, SHELLYDT_BULB, "color", THING_TYPE_SHELLYBULB), //
+                Arguments.of("shellybulb-" + DEVICE_ID, SHELLYDT_BULB, "white", THING_TYPE_SHELLYBULB), //
+                Arguments.of("shellyrgbw2-" + DEVICE_ID, SHELLYDT_RGBW2, "color", THING_TYPE_SHELLYRGBW2_COLOR), //
+                Arguments.of("shellyrgbw2-" + DEVICE_ID, SHELLYDT_RGBW2, "white", THING_TYPE_SHELLYRGBW2_WHITE)); //
     }
 
     @ParameterizedTest

--- a/bundles/org.openhab.binding.shelly/src/test/java/org/openhab/binding/shelly/internal/discovery/ShellyThingCreatorTest.java
+++ b/bundles/org.openhab.binding.shelly/src/test/java/org/openhab/binding/shelly/internal/discovery/ShellyThingCreatorTest.java
@@ -377,6 +377,26 @@ public class ShellyThingCreatorTest {
     }
 
     @ParameterizedTest
+    @MethodSource("provideTestCasesForSingleModeDeviceFallsBackToGeneralMap")
+    void singleModeGen1DeviceFallsBackToGeneralDeviceTypeMapWhenModeIsRelay(String serviceName, String deviceType,
+            ThingTypeUID expectedThingTypeUid) {
+        ThingUID actual = ShellyThingCreator.getThingUID(serviceName, deviceType, "relay");
+        ThingUID expected = new ThingUID(expectedThingTypeUid, DEVICE_ID);
+        assertThat("serviceName: " + serviceName + "; deviceType: " + deviceType, actual, is(equalTo(expected)));
+    }
+
+    private static Stream<Arguments> provideTestCasesForSingleModeDeviceFallsBackToGeneralMap() {
+        return Stream.of( //
+                // SHSW-1/SHSW-PM/SHDM-2 exist only in THING_TYPE_BY_DEVICE_TYPE, not in
+                // RELAY_THING_TYPE_BY_DEVICE_TYPE. Old Gen1 firmware derives mode="relay" from num_outputs even for
+                // single-relay/dimmer devices, and a custom hostname bypasses the service-name-based resolution
+                // above, so the mode-specific lookup must fall back to the general map instead of shellyunknown.
+                Arguments.of("shellydevice-" + DEVICE_ID, SHELLYDT_1, THING_TYPE_SHELLY1), //
+                Arguments.of("shellydevice-" + DEVICE_ID, SHELLYDT_1PM, THING_TYPE_SHELLY1PM), //
+                Arguments.of("shellydevice-" + DEVICE_ID, SHELLYDT_DIMMER2, THING_TYPE_SHELLYDIMMER2));
+    }
+
+    @ParameterizedTest
     @MethodSource("provideTestCasesForGetThingUIDReturnsThingUidByServiceNameDeviceTypeAndMode")
     void getThingUIDReturnsThingUidByServiceNameDeviceTypeAndMode(String serviceName, String deviceType, String mode,
             ThingTypeUID expectedThingTypeUid) {


### PR DESCRIPTION
Affects: Shelly Gen1 devices that require authentication and are already present as a properly-typed Thing.

Problem: After an openHAB restart, or when mDNS re-announces the device, an authentication-protected Gen1 device could reappear in the inbox as a generic "unknown" device instead of matching its existing Thing.

Fixes:
* Auth-protected Gen1 devices are now discovered with their correct device type instead of falling back to "unknown"
* Corrected the Shelly Flood Sensor model ID used for device recognition (previously never matched due to a typo)
* Recognize the Shelly Plug 2 hardware variant
* Shelly 2 / Shelly 2.5 devices are now recognized correctly even when authentication is required
* Shelly Motion Sensor 2 is now recognized correctly
* A Thing added as "unknown" now correctly switches to its real device type once valid credentials are provided

Changes:
* README: corrected model ID table and thing-type references (Shelly Bulb, Shelly Plug U1, Shelly Eye, Shelly Motion Sensor 2)

## Testing

* Set up a password-protected Gen1 device (e.g. Shelly Flood, Shelly 1, Shelly 2.5) and trigger rediscovery (restart openHAB, or delete and re-scan) — the inbox entry should show the correct device type, not "unknown"
* For a device already added as "unknown" with authentication enabled: add the correct credentials to the Thing — it should switch to its correct type on the next initialization

## Acceptance criteria

- [ ] Implementation done
- [ ] Documentation is up-to-date
- [ ] Verified by Community

## Closing

- #20478
