### PR TITLE
[fineoffsetweatherstation] Mirror discrete add-on sensors' values onto their sensor Thing

### DIFF
--- a/bundles/org.openhab.binding.fineoffsetweatherstation/README.md
+++ b/bundles/org.openhab.binding.fineoffsetweatherstation/README.md
@@ -345,14 +345,14 @@ the gateway (bridge) Thing are still created and updated for backwards compatibi
 description carries a translatable note naming the full `ChannelUID` of the equivalent channel on the sensor Thing.
 For example, when a WH51 soil-moisture sensor is configured as `WH51_CH1` under a gateway with id `3906700515`:
 
-```
-deprecated — this value is now also available on the sensor Thing as channel: fineoffsetweatherstation:sensor:3906700515:WH51_CH1:moisture-soil-channel
+```text
+(deprecated — this value is now also available on the sensor Thing as channel: fineoffsetweatherstation:sensor:3906700515:WH51_CH1:moisture-soil-channel)
 ```
 
 When no matching sensor Thing is yet configured in openHAB, the note reads:
 
-```
-deprecated — this value is now also available on the sensor Thing
+```text
+(deprecated — this value is now also available on the sensor Thing)
 ```
 
 Prefer linking your items to the channels on the sensor Thing; the gateway-side duplicates may be removed in a future release.

--- a/bundles/org.openhab.binding.fineoffsetweatherstation/README.md
+++ b/bundles/org.openhab.binding.fineoffsetweatherstation/README.md
@@ -337,6 +337,17 @@ Especially the channels `temperature-dew-point` or `temperature-wind-chill` are 
 | batteryVoltage | Number:ElectricPotential | R          | The sensors battery voltage |
 | lowBattery     | Switch                   | R          | The sensors battery status  |
 
+## Deprecated channels
+
+Discrete add-on sensors (WH31, WH51, WH41, WH55, WH57, WH34, WH35, WH45, WH25) now expose their measured values
+directly on their own sensor Thing, alongside the signal and battery channels. The corresponding dynamic channels on
+the gateway (bridge) Thing are still created and updated for backwards compatibility, but are **deprecated**: their
+description carries a "(deprecated — this value is now also available on the sensor Thing)" note. Prefer linking your
+items to the channels on the sensor Thing; the gateway-side duplicates may be removed in a future release.
+
+This does not affect the main outdoor array (WH24/WH65/WH69/WH68/WH80/WH90/WS85), the rain group, or the aggregate
+`common_list` values — those remain gateway-only.
+
 ## Full Example
 
 This is an example configuration for the WH2650 gateway

--- a/bundles/org.openhab.binding.fineoffsetweatherstation/README.md
+++ b/bundles/org.openhab.binding.fineoffsetweatherstation/README.md
@@ -342,8 +342,9 @@ Especially the channels `temperature-dew-point` or `temperature-wind-chill` are 
 Discrete add-on sensors (WH31, WH51, WH41, WH55, WH57, WH34, WH35, WH45, WH25) now expose their measured values
 directly on their own sensor Thing, alongside the signal and battery channels. The corresponding dynamic channels on
 the gateway (bridge) Thing are still created and updated for backwards compatibility, but are **deprecated**: their
-description carries a "(deprecated — this value is now also available on the sensor Thing)" note. Prefer linking your
-items to the channels on the sensor Thing; the gateway-side duplicates may be removed in a future release.
+description carries a note naming the equivalent channel on the sensor Thing (for example "deprecated — this value is
+now also available on the sensor Thing as channel 'moisture-soil-channel'"). Prefer linking your items to the channels
+on the sensor Thing; the gateway-side duplicates may be removed in a future release.
 
 This does not affect the main outdoor array (WH24/WH65/WH69/WH68/WH80/WH90/WS85), the rain group, or the aggregate
 `common_list` values — those remain gateway-only.

--- a/bundles/org.openhab.binding.fineoffsetweatherstation/README.md
+++ b/bundles/org.openhab.binding.fineoffsetweatherstation/README.md
@@ -342,9 +342,20 @@ Especially the channels `temperature-dew-point` or `temperature-wind-chill` are 
 Discrete add-on sensors (WH31, WH51, WH41, WH55, WH57, WH34, WH35, WH45, WH25) now expose their measured values
 directly on their own sensor Thing, alongside the signal and battery channels. The corresponding dynamic channels on
 the gateway (bridge) Thing are still created and updated for backwards compatibility, but are **deprecated**: their
-description carries a note naming the equivalent channel on the sensor Thing (for example "deprecated — this value is
-now also available on the sensor Thing as channel 'moisture-soil-channel'"). Prefer linking your items to the channels
-on the sensor Thing; the gateway-side duplicates may be removed in a future release.
+description carries a translatable note naming the full `ChannelUID` of the equivalent channel on the sensor Thing.
+For example, when a WH51 soil-moisture sensor is configured as `WH51_CH1` under a gateway with id `3906700515`:
+
+```
+deprecated — this value is now also available on the sensor Thing as channel: fineoffsetweatherstation:sensor:3906700515:WH51_CH1:moisture-soil-channel
+```
+
+When no matching sensor Thing is yet configured in openHAB, the note reads:
+
+```
+deprecated — this value is now also available on the sensor Thing
+```
+
+Prefer linking your items to the channels on the sensor Thing; the gateway-side duplicates may be removed in a future release.
 
 This does not affect the main outdoor array (WH24/WH65/WH69/WH68/WH80/WH90/WS85), the rain group, or the aggregate
 `common_list` values — those remain gateway-only.

--- a/bundles/org.openhab.binding.fineoffsetweatherstation/src/main/java/org/openhab/binding/fineoffsetweatherstation/internal/FineOffsetWeatherStationHandlerFactory.java
+++ b/bundles/org.openhab.binding.fineoffsetweatherstation/src/main/java/org/openhab/binding/fineoffsetweatherstation/internal/FineOffsetWeatherStationHandlerFactory.java
@@ -73,7 +73,7 @@ public class FineOffsetWeatherStationHandlerFactory extends BaseThingHandlerFact
                     translationProvider, localeProvider);
         }
         if (THING_TYPE_SENSOR.equals(thingTypeUID)) {
-            return new FineOffsetSensorHandler(thing);
+            return new FineOffsetSensorHandler(thing, channelTypeRegistry);
         }
 
         return null;

--- a/bundles/org.openhab.binding.fineoffsetweatherstation/src/main/java/org/openhab/binding/fineoffsetweatherstation/internal/domain/Measurand.java
+++ b/bundles/org.openhab.binding.fineoffsetweatherstation/src/main/java/org/openhab/binding/fineoffsetweatherstation/internal/domain/Measurand.java
@@ -40,6 +40,8 @@ public class Measurand implements Parser {
 
     private @Nullable HttpSource httpSource;
 
+    private @Nullable Sensor sensor;
+
     Measurand(String channelPrefix, String name, MeasureType measureType) {
         this.channelPrefix = channelPrefix;
         this.name = name;
@@ -81,6 +83,16 @@ public class Measurand implements Parser {
         return this;
     }
 
+    Measurand sensor(Sensor sensor) {
+        this.sensor = sensor;
+        return this;
+    }
+
+    @Nullable
+    Sensor getSensor() {
+        return sensor;
+    }
+
     @Nullable
     HttpSource getHttpSource() {
         return httpSource;
@@ -100,7 +112,7 @@ public class Measurand implements Parser {
             debugDetails.addDebugDetails(offset, measureType.getByteSize(),
                     measureType.name() + ": " + state.toFullString());
             ChannelTypeUID channelType = channelTypeUID == null ? measureType.getChannelTypeId() : channelTypeUID;
-            result.add(new MeasuredValue(measureType, channelPrefix, channel, channelType, state, name));
+            result.add(new MeasuredValue(measureType, channelPrefix, channel, channelType, state, name, sensor));
         } else {
             debugDetails.addDebugDetails(offset, measureType.getByteSize(), measureType.name() + ": null");
         }
@@ -124,7 +136,7 @@ public class Measurand implements Parser {
             return null;
         }
         ChannelTypeUID channelType = channelTypeUID == null ? measureType.getChannelTypeId() : channelTypeUID;
-        return new MeasuredValue(measureType, channelPrefix, channel, channelType, state, name);
+        return new MeasuredValue(measureType, channelPrefix, channel, channelType, state, name, sensor);
     }
 
     static Measurand measurand(String channelPrefix, String name, MeasureType measureType) {

--- a/bundles/org.openhab.binding.fineoffsetweatherstation/src/main/java/org/openhab/binding/fineoffsetweatherstation/internal/domain/MeasurandRegistry.java
+++ b/bundles/org.openhab.binding.fineoffsetweatherstation/src/main/java/org/openhab/binding/fineoffsetweatherstation/internal/domain/MeasurandRegistry.java
@@ -106,7 +106,7 @@ public class MeasurandRegistry {
         b.add(0x01,
                 measurand("temperature-indoor", "Indoor Temperature", MeasureType.TEMPERATURE)
                         .channelType(DefaultSystemChannelTypeProvider.SYSTEM_CHANNEL_TYPE_UID_INDOOR_TEMPERATURE)
-                        .http(HttpGroup.WH25, "intemp"));
+                        .http(HttpGroup.WH25, "intemp").sensor(Sensor.WH25));
         b.add(0x02,
                 measurand("temperature-outdoor", "Outdoor Temperature", MeasureType.TEMPERATURE)
                         .channelType(DefaultSystemChannelTypeProvider.SYSTEM_CHANNEL_TYPE_UID_OUTDOOR_TEMPERATURE)
@@ -117,18 +117,18 @@ public class MeasurandRegistry {
                 measurand("temperature-wind-chill", "Wind chill", MeasureType.TEMPERATURE).http(HttpGroup.COMMON_LIST));
         b.add(0x05,
                 measurand("temperature-heat-index", "Heat index", MeasureType.TEMPERATURE).http(HttpGroup.COMMON_LIST));
-        b.add(0x06,
-                measurand("humidity-indoor", "Indoor Humidity", MeasureType.PERCENTAGE).http(HttpGroup.WH25, "inhumi"));
+        b.add(0x06, measurand("humidity-indoor", "Indoor Humidity", MeasureType.PERCENTAGE)
+                .http(HttpGroup.WH25, "inhumi").sensor(Sensor.WH25));
         b.add(0x07,
                 measurand("humidity-outdoor", "Outdoor Humidity", MeasureType.PERCENTAGE)
                         .channelType(DefaultSystemChannelTypeProvider.SYSTEM_CHANNEL_TYPE_UID_ATMOSPHERIC_HUMIDITY)
                         .http(HttpGroup.COMMON_LIST));
-        b.add(0x08, measurand("pressure-absolute", "Absolutely pressure", MeasureType.PRESSURE).http(HttpGroup.WH25,
-                "abs"));
+        b.add(0x08, measurand("pressure-absolute", "Absolutely pressure", MeasureType.PRESSURE)
+                .http(HttpGroup.WH25, "abs").sensor(Sensor.WH25));
         b.add(0x09,
                 measurand("pressure-relative", "Relative pressure", MeasureType.PRESSURE)
                         .channelType(DefaultSystemChannelTypeProvider.SYSTEM_CHANNEL_TYPE_UID_BAROMETRIC_PRESSURE)
-                        .http(HttpGroup.WH25, "rel"));
+                        .http(HttpGroup.WH25, "rel").sensor(Sensor.WH25));
         b.add(0x0A,
                 measurand("direction-wind", "Wind Direction", MeasureType.DEGREE)
                         .channelType(DefaultSystemChannelTypeProvider.SYSTEM_CHANNEL_TYPE_UID_WIND_DIRECTION)
@@ -167,35 +167,39 @@ public class MeasurandRegistry {
         b.add(0X19, measurand("wind-max-day", "Day max wind", MeasureType.SPEED)
                 .channelType(CHANNEL_TYPE_MAX_WIND_SPEED).http(HttpGroup.COMMON_LIST));
         b.addChannels(new int[] { 0x1A, 0x1B, 0x1C, 0x1D, 0x1E, 0x1F, 0x20, 0x21 },
-                measurand("temperature-channel", "Temperature", MeasureType.TEMPERATURE).http(HttpGroup.CH_AISLE,
-                        "temp"));
+                measurand("temperature-channel", "Temperature", MeasureType.TEMPERATURE)
+                        .http(HttpGroup.CH_AISLE, "temp").sensor(Sensor.WH31));
         b.addChannels(new int[] { 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28, 0x29 },
-                measurand("humidity-channel", "Humidity", MeasureType.PERCENTAGE).http(HttpGroup.CH_AISLE, "humidity"));
-        b.addChannels(new int[] { 0x2B, 0x2D, 0x2F, 0x31, 0x33, 0x35, 0x37, 0x39, 0x3B, 0x3D, 0x3F, 0x41, 0x43, 0x45,
-                0x47, 0x49 }, measurand("temperature-soil-channel", "Soil Temperature", MeasureType.TEMPERATURE));
+                measurand("humidity-channel", "Humidity", MeasureType.PERCENTAGE).http(HttpGroup.CH_AISLE, "humidity")
+                        .sensor(Sensor.WH31));
+        b.addChannels(
+                new int[] { 0x2B, 0x2D, 0x2F, 0x31, 0x33, 0x35, 0x37, 0x39, 0x3B, 0x3D, 0x3F, 0x41, 0x43, 0x45, 0x47,
+                        0x49 },
+                measurand("temperature-soil-channel", "Soil Temperature", MeasureType.TEMPERATURE).sensor(Sensor.WH51));
         b.addChannels(
                 new int[] { 0x2C, 0x2E, 0x30, 0x32, 0x34, 0x36, 0x38, 0x3A, 0x3C, 0x3E, 0x40, 0x42, 0x44, 0x46, 0x48,
                         0x4A },
                 measurand("moisture-soil-channel", "Soil Moisture", MeasureType.PERCENTAGE)
-                        .channelType(CHANNEL_TYPE_MOISTURE).http(HttpGroup.CH_SOIL, "humidity"));
+                        .channelType(CHANNEL_TYPE_MOISTURE).http(HttpGroup.CH_SOIL, "humidity").sensor(Sensor.WH51));
         b.skip(0x4C, 1);
-        b.addChannels(new int[] { 0x4D, 0x4E, 0x4F, 0x50 }, measurand("air-quality-24-hour-average-channel",
-                "PM2.5 Air Quality 24 hour average", MeasureType.PM25));
+        b.addChannels(new int[] { 0x4D, 0x4E, 0x4F, 0x50 },
+                measurand("air-quality-24-hour-average-channel", "PM2.5 Air Quality 24 hour average", MeasureType.PM25)
+                        .sensor(Sensor.WH41));
         b.addChannels(new int[] { 0x2A, 0x51, 0x52, 0x53 },
-                measurand("air-quality-channel", "PM2.5 Air Quality", MeasureType.PM25).http(HttpGroup.CH_PM25,
-                        "PM25"));
+                measurand("air-quality-channel", "PM2.5 Air Quality", MeasureType.PM25).http(HttpGroup.CH_PM25, "PM25")
+                        .sensor(Sensor.WH41));
         b.addChannels(new int[] { 0x58, 0x59, 0x5A, 0x5B },
-                measurand("water-leak-channel", "Leak", MeasureType.WATER_LEAK_DETECTION).http(HttpGroup.CH_LEAK,
-                        "status"));
+                measurand("water-leak-channel", "Leak", MeasureType.WATER_LEAK_DETECTION)
+                        .http(HttpGroup.CH_LEAK, "status").sensor(Sensor.WH55));
         b.add(0x60, measurand("lightning-distance", "Lightning distance 1~40KM", MeasureType.LIGHTNING_DISTANCE)
-                .http(HttpGroup.LIGHTNING, "distance"));
+                .http(HttpGroup.LIGHTNING, "distance").sensor(Sensor.WH57));
         b.add(0x61, measurand("lightning-time", "Lightning happened time", MeasureType.LIGHTNING_TIME)
-                .http(HttpGroup.LIGHTNING, "date"));
+                .http(HttpGroup.LIGHTNING, "date").sensor(Sensor.WH57));
         b.add(0x62, measurand("lightning-counter", "lightning counter for the day", MeasureType.LIGHTNING_COUNTER)
-                .http(HttpGroup.LIGHTNING, "count"));
+                .http(HttpGroup.LIGHTNING, "count").sensor(Sensor.WH57));
         b.addChannels(new int[] { 0x63, 0x64, 0x65, 0x66, 0x67, 0x68, 0x69, 0x6A },
                 measurand("temperature-external-channel", "Soil or Water temperature", MeasureType.TEMPERATURE)
-                        .http(HttpGroup.CH_TEMP, "temp"),
+                        .http(HttpGroup.CH_TEMP, "temp").sensor(Sensor.WH34),
                 // skip battery-level, since it is read via Command.CMD_READ_SENSOR_ID_NEW
                 skip(1));
         b.addGroup(0x6B,
@@ -229,21 +233,23 @@ public class MeasurandRegistry {
                 measurand("direction-wind-avg-10min", "Wind Direction (10-minute average)", MeasureType.DEGREE)
                         .channelType(DefaultSystemChannelTypeProvider.SYSTEM_CHANNEL_TYPE_UID_WIND_DIRECTION)
                         .http(HttpGroup.COMMON_LIST));
-        b.addGroup(0x70, measurand("sensor-co2-temperature", "Temperature (CO₂-Sensor)", MeasureType.TEMPERATURE),
-                measurand("sensor-co2-humidity", "Humidity (CO₂-Sensor)", MeasureType.PERCENTAGE),
-                measurand("sensor-co2-pm10", "PM10 Air Quality (CO₂-Sensor)", MeasureType.PM10),
+        b.addGroup(0x70,
+                measurand("sensor-co2-temperature", "Temperature (CO₂-Sensor)", MeasureType.TEMPERATURE)
+                        .sensor(Sensor.WH45),
+                measurand("sensor-co2-humidity", "Humidity (CO₂-Sensor)", MeasureType.PERCENTAGE).sensor(Sensor.WH45),
+                measurand("sensor-co2-pm10", "PM10 Air Quality (CO₂-Sensor)", MeasureType.PM10).sensor(Sensor.WH45),
                 measurand("sensor-co2-pm10-24-hour-average", "PM10 Air Quality 24 hour average (CO₂-Sensor)",
-                        MeasureType.PM10),
-                measurand("sensor-co2-pm25", "PM2.5 Air Quality (CO₂-Sensor)", MeasureType.PM25),
+                        MeasureType.PM10).sensor(Sensor.WH45),
+                measurand("sensor-co2-pm25", "PM2.5 Air Quality (CO₂-Sensor)", MeasureType.PM25).sensor(Sensor.WH45),
                 measurand("sensor-co2-pm25-24-hour-average", "PM2.5 Air Quality 24 hour average (CO₂-Sensor)",
-                        MeasureType.PM25),
-                measurand("sensor-co2-co2", "CO₂", MeasureType.CO2),
-                measurand("sensor-co2-co2-24-hour-average", "CO₂ 24 hour average", MeasureType.CO2),
+                        MeasureType.PM25).sensor(Sensor.WH45),
+                measurand("sensor-co2-co2", "CO₂", MeasureType.CO2).sensor(Sensor.WH45),
+                measurand("sensor-co2-co2-24-hour-average", "CO₂ 24 hour average", MeasureType.CO2).sensor(Sensor.WH45),
                 // skip battery-level, since it is read via Command.CMD_READ_SENSOR_ID_NEW
                 skip(1));
         b.addChannels(new int[] { 0x72, 0x73, 0x74, 0x75, 0x76, 0x77, 0x78, 0x79 },
                 measurand("leaf-wetness-channel", "Leaf Moisture", MeasureType.PERCENTAGE)
-                        .channelType(CHANNEL_TYPE_MOISTURE).http(HttpGroup.CH_LEAF, "humidity"));
+                        .channelType(CHANNEL_TYPE_MOISTURE).http(HttpGroup.CH_LEAF, "humidity").sensor(Sensor.WH35));
         b.skip(0x7a, 1);
         b.skip(0x7b, 1);
         b.add(0x80, measurand("piezo-rain-rate", "Rain Rate", MeasureType.HEIGHT_PER_HOUR).http(HttpGroup.PIEZO_RAIN,

--- a/bundles/org.openhab.binding.fineoffsetweatherstation/src/main/java/org/openhab/binding/fineoffsetweatherstation/internal/domain/SensorGatewayBinding.java
+++ b/bundles/org.openhab.binding.fineoffsetweatherstation/src/main/java/org/openhab/binding/fineoffsetweatherstation/internal/domain/SensorGatewayBinding.java
@@ -109,6 +109,8 @@ public enum SensorGatewayBinding {
 
     private static final Map<Byte, List<SensorGatewayBinding>> SENSOR_LOOKUP = new HashMap<>();
 
+    private static final Map<Sensor, Map<@Nullable Integer, SensorGatewayBinding>> SENSOR_CHANNEL_LOOKUP = new HashMap<>();
+
     static {
         for (SensorGatewayBinding sensorGatewayBinding : values()) {
             List<SensorGatewayBinding> bindings = SENSOR_LOOKUP.computeIfAbsent(sensorGatewayBinding.id,
@@ -117,6 +119,8 @@ public enum SensorGatewayBinding {
             if (bindings != null) {
                 bindings.add(sensorGatewayBinding);
             }
+            SENSOR_CHANNEL_LOOKUP.computeIfAbsent(sensorGatewayBinding.sensor, s -> new HashMap<>())
+                    .put(sensorGatewayBinding.channel, sensorGatewayBinding);
         }
     }
 
@@ -132,6 +136,19 @@ public enum SensorGatewayBinding {
 
     public static @Nullable List<SensorGatewayBinding> forIndex(byte idx) {
         return SENSOR_LOOKUP.get(idx);
+    }
+
+    /**
+     * Reverse lookup of the binding for a measured value's producing {@link Sensor} and channel index. Several
+     * measurands may share the same {@code (sensor, channel)} (e.g. WH51 soil moisture and soil temperature of the
+     * same physical sensor), so they all resolve to the one binding - and thus to one sensor Thing.
+     *
+     * @param channel the 1-based channel index, or {@code null} for single-instance sensors (e.g. WH57, WH45)
+     * @return the matching binding, or {@code null} if no sensor uses that {@code (sensor, channel)} combination
+     */
+    public static @Nullable SensorGatewayBinding forSensorAndChannel(Sensor sensor, @Nullable Integer channel) {
+        Map<@Nullable Integer, SensorGatewayBinding> byChannel = SENSOR_CHANNEL_LOOKUP.get(sensor);
+        return byChannel == null ? null : byChannel.get(channel);
     }
 
     public BatteryStatus getBatteryStatus(byte data) {

--- a/bundles/org.openhab.binding.fineoffsetweatherstation/src/main/java/org/openhab/binding/fineoffsetweatherstation/internal/domain/response/MeasuredValue.java
+++ b/bundles/org.openhab.binding.fineoffsetweatherstation/src/main/java/org/openhab/binding/fineoffsetweatherstation/internal/domain/response/MeasuredValue.java
@@ -15,6 +15,7 @@ package org.openhab.binding.fineoffsetweatherstation.internal.domain.response;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.fineoffsetweatherstation.internal.domain.MeasureType;
+import org.openhab.binding.fineoffsetweatherstation.internal.domain.Sensor;
 import org.openhab.core.thing.type.ChannelTypeUID;
 import org.openhab.core.types.State;
 
@@ -31,15 +32,21 @@ public class MeasuredValue {
     private final @Nullable ChannelTypeUID channelTypeUID;
     private final State state;
     private final String debugName;
+    private final @Nullable Sensor sensor;
 
     public MeasuredValue(MeasureType measureType, String channelPrefix, @Nullable Integer channelNumber,
-            @Nullable ChannelTypeUID channelTypeUID, State state, String debugName) {
+            @Nullable ChannelTypeUID channelTypeUID, State state, String debugName, @Nullable Sensor sensor) {
         this.measureType = measureType;
         this.channelPrefix = channelPrefix;
         this.channelNumber = channelNumber;
         this.channelTypeUID = channelTypeUID;
         this.state = state;
         this.debugName = debugName;
+        this.sensor = sensor;
+    }
+
+    public @Nullable Sensor getSensor() {
+        return sensor;
     }
 
     public String getChannelId() {

--- a/bundles/org.openhab.binding.fineoffsetweatherstation/src/main/java/org/openhab/binding/fineoffsetweatherstation/internal/handler/DynamicChannelReconciler.java
+++ b/bundles/org.openhab.binding.fineoffsetweatherstation/src/main/java/org/openhab/binding/fineoffsetweatherstation/internal/handler/DynamicChannelReconciler.java
@@ -36,9 +36,14 @@ import org.openhab.core.types.State;
  * Thing or posts state itself; the calling handler applies the returned {@link Plan} with its own builder.
  *
  * <p>
- * Used by both {@code FineOffsetGatewayHandler} (gateway channels - every channel is removal-eligible) and
- * {@code FineOffsetSensorHandler} (sensor Thing - only reconciler-created channels are removal-eligible, so the
- * static signal/battery channels are never touched).
+ * Removal-eligibility is derived from a fixed set of protected channel IDs: every channel except those is removable.
+ * Basing it on a static set rather than on which channels this instance created keeps it correct across restarts,
+ * where dynamic channels persisted on the Thing were never seen being created.
+ *
+ * <p>
+ * Used by both {@code FineOffsetGatewayHandler} (gateway channels - an empty protected set, so every channel is
+ * removal-eligible) and {@code FineOffsetSensorHandler} (sensor Thing - the static signal/battery channels are
+ * protected and never removed, while every other - dynamic measurement - channel is removal-eligible).
  *
  * @author Andreas Berger - Initial contribution
  */
@@ -75,18 +80,21 @@ class DynamicChannelReconciler {
         }
     }
 
-    private final boolean removeOnlyCreatedChannels;
+    private final Set<String> protectedChannelIds;
     private final Map<String, Integer> missingCounts = new HashMap<>();
-    private final Set<String> createdChannelIds = new HashSet<>();
 
-    DynamicChannelReconciler(boolean removeOnlyCreatedChannels) {
-        this.removeOnlyCreatedChannels = removeOnlyCreatedChannels;
+    /**
+     * @param protectedChannelIds channel IDs (by {@link ChannelUID#getId()}) that must never be removed - e.g. a
+     *            sensor Thing's static signal/battery channels. Pass an empty set to make every channel
+     *            removal-eligible (gateway semantics).
+     */
+    DynamicChannelReconciler(Set<String> protectedChannelIds) {
+        this.protectedChannelIds = protectedChannelIds;
     }
 
-    /** Clears all accumulated debounce/creation state, e.g. when the owning handler re-initializes. */
+    /** Clears the accumulated missing-value debounce state, e.g. when the owning handler re-initializes. */
     void reset() {
         missingCounts.clear();
-        createdChannelIds.clear();
     }
 
     Plan reconcile(Collection<MeasuredValue> values, Collection<Channel> currentChannels,
@@ -118,7 +126,6 @@ class DynamicChannelReconciler {
                         continue;
                     }
                     toAdd.add(created);
-                    createdChannelIds.add(id);
                     uid = created.getUID();
                     addedThisPass.put(id, uid);
                 }
@@ -129,7 +136,7 @@ class DynamicChannelReconciler {
         List<Channel> toRemove = new ArrayList<>();
         for (Channel channel : currentChannels) {
             String id = channel.getUID().getId();
-            if (removeOnlyCreatedChannels && !createdChannelIds.contains(id)) {
+            if (protectedChannelIds.contains(id)) {
                 continue;
             }
             if (reported.contains(id)) {
@@ -139,7 +146,6 @@ class DynamicChannelReconciler {
                 if (count != null && count >= MISSING_VALUE_REMOVAL_THRESHOLD) {
                     toRemove.add(channel);
                     missingCounts.remove(id);
-                    createdChannelIds.remove(id);
                 }
             }
         }

--- a/bundles/org.openhab.binding.fineoffsetweatherstation/src/main/java/org/openhab/binding/fineoffsetweatherstation/internal/handler/DynamicChannelReconciler.java
+++ b/bundles/org.openhab.binding.fineoffsetweatherstation/src/main/java/org/openhab/binding/fineoffsetweatherstation/internal/handler/DynamicChannelReconciler.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.fineoffsetweatherstation.internal.handler;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.fineoffsetweatherstation.internal.domain.response.MeasuredValue;
+import org.openhab.core.thing.Channel;
+import org.openhab.core.thing.ChannelUID;
+import org.openhab.core.types.State;
+
+/**
+ * Reconciles a batch of {@link MeasuredValue}s against a Thing's current channels: it decides which dynamic
+ * channels to create, which states to post, and which channels to remove once their value has been missing for
+ * {@link #MISSING_VALUE_REMOVAL_THRESHOLD} consecutive reconcile passes. It is a pure planner - it never mutates a
+ * Thing or posts state itself; the calling handler applies the returned {@link Plan} with its own builder.
+ *
+ * <p>
+ * Used by both {@code FineOffsetGatewayHandler} (gateway channels - every channel is removal-eligible) and
+ * {@code FineOffsetSensorHandler} (sensor Thing - only reconciler-created channels are removal-eligible, so the
+ * static signal/battery channels are never touched).
+ *
+ * @author Andreas Berger - Initial contribution
+ */
+@NonNullByDefault
+class DynamicChannelReconciler {
+
+    /**
+     * Number of consecutive reconcile passes a value may be missing before its channel is removed. Debounces
+     * transient gaps so dynamically created channels do not flip-flop.
+     */
+    static final int MISSING_VALUE_REMOVAL_THRESHOLD = 10;
+
+    /** Builds the {@link Channel} for a value whose channel does not exist yet, or {@code null} if it cannot. */
+    @FunctionalInterface
+    interface ChannelFactory {
+        @Nullable
+        Channel create(MeasuredValue value);
+    }
+
+    /** The changes one reconcile pass calls for. The handler applies these with its own Thing builder. */
+    static final class Plan {
+        final List<Channel> channelsToAdd;
+        final List<Channel> channelsToRemove;
+        final Map<ChannelUID, State> statesToPost;
+
+        Plan(List<Channel> channelsToAdd, List<Channel> channelsToRemove, Map<ChannelUID, State> statesToPost) {
+            this.channelsToAdd = channelsToAdd;
+            this.channelsToRemove = channelsToRemove;
+            this.statesToPost = statesToPost;
+        }
+
+        boolean hasChannelChanges() {
+            return !channelsToAdd.isEmpty() || !channelsToRemove.isEmpty();
+        }
+    }
+
+    private final boolean removeOnlyCreatedChannels;
+    private final Map<String, Integer> missingCounts = new HashMap<>();
+    private final Set<String> createdChannelIds = new HashSet<>();
+
+    DynamicChannelReconciler(boolean removeOnlyCreatedChannels) {
+        this.removeOnlyCreatedChannels = removeOnlyCreatedChannels;
+    }
+
+    Plan reconcile(Collection<MeasuredValue> values, Collection<Channel> currentChannels,
+            Function<MeasuredValue, String> channelIdResolver, ChannelFactory channelFactory) {
+        Map<String, Channel> currentById = new HashMap<>();
+        for (Channel channel : currentChannels) {
+            currentById.put(channel.getUID().getId(), channel);
+        }
+
+        Set<String> reported = new HashSet<>();
+        List<Channel> toAdd = new ArrayList<>();
+        Map<String, ChannelUID> addedThisPass = new HashMap<>();
+        Map<ChannelUID, State> states = new LinkedHashMap<>();
+
+        for (MeasuredValue value : values) {
+            String id = channelIdResolver.apply(value);
+            reported.add(id);
+            Channel existing = currentById.get(id);
+            ChannelUID uid;
+            if (existing != null) {
+                uid = existing.getUID();
+            } else {
+                ChannelUID queued = addedThisPass.get(id);
+                if (queued != null) {
+                    uid = queued;
+                } else {
+                    Channel created = channelFactory.create(value);
+                    if (created == null) {
+                        continue;
+                    }
+                    toAdd.add(created);
+                    createdChannelIds.add(id);
+                    uid = created.getUID();
+                    addedThisPass.put(id, uid);
+                }
+            }
+            states.put(uid, value.getState());
+        }
+
+        List<Channel> toRemove = new ArrayList<>();
+        for (Channel channel : currentChannels) {
+            String id = channel.getUID().getId();
+            if (removeOnlyCreatedChannels && !createdChannelIds.contains(id)) {
+                continue;
+            }
+            if (reported.contains(id)) {
+                missingCounts.remove(id);
+            } else {
+                Integer count = missingCounts.merge(id, 1, Integer::sum);
+                if (count != null && count >= MISSING_VALUE_REMOVAL_THRESHOLD) {
+                    toRemove.add(channel);
+                    missingCounts.remove(id);
+                    createdChannelIds.remove(id);
+                }
+            }
+        }
+
+        return new Plan(toAdd, toRemove, states);
+    }
+}

--- a/bundles/org.openhab.binding.fineoffsetweatherstation/src/main/java/org/openhab/binding/fineoffsetweatherstation/internal/handler/DynamicChannelReconciler.java
+++ b/bundles/org.openhab.binding.fineoffsetweatherstation/src/main/java/org/openhab/binding/fineoffsetweatherstation/internal/handler/DynamicChannelReconciler.java
@@ -83,6 +83,12 @@ class DynamicChannelReconciler {
         this.removeOnlyCreatedChannels = removeOnlyCreatedChannels;
     }
 
+    /** Clears all accumulated debounce/creation state, e.g. when the owning handler re-initializes. */
+    void reset() {
+        missingCounts.clear();
+        createdChannelIds.clear();
+    }
+
     Plan reconcile(Collection<MeasuredValue> values, Collection<Channel> currentChannels,
             Function<MeasuredValue, String> channelIdResolver, ChannelFactory channelFactory) {
         Map<String, Channel> currentById = new HashMap<>();

--- a/bundles/org.openhab.binding.fineoffsetweatherstation/src/main/java/org/openhab/binding/fineoffsetweatherstation/internal/handler/FineOffsetGatewayHandler.java
+++ b/bundles/org.openhab.binding.fineoffsetweatherstation/src/main/java/org/openhab/binding/fineoffsetweatherstation/internal/handler/FineOffsetGatewayHandler.java
@@ -111,6 +111,7 @@ public class FineOffsetGatewayHandler extends BaseBridgeHandler {
         gatewayQueryService = config.protocol.getGatewayQueryService(config, this::updateStatus);
 
         updateStatus(ThingStatus.UNKNOWN);
+        reconciler.reset();
         fetchAndUpdateSensors();
         disposed = false;
         updateBridgeInfo();

--- a/bundles/org.openhab.binding.fineoffsetweatherstation/src/main/java/org/openhab/binding/fineoffsetweatherstation/internal/handler/FineOffsetGatewayHandler.java
+++ b/bundles/org.openhab.binding.fineoffsetweatherstation/src/main/java/org/openhab/binding/fineoffsetweatherstation/internal/handler/FineOffsetGatewayHandler.java
@@ -71,7 +71,8 @@ import org.slf4j.LoggerFactory;
 public class FineOffsetGatewayHandler extends BaseBridgeHandler {
 
     private static final String PROPERTY_FREQUENCY = "frequency";
-    private static final String DEPRECATION_NOTE = " (deprecated — this value is now also available on the sensor Thing)";
+    private static final String DEPRECATION_NOTE_PREFIX = " (deprecated — this value is now also available on the sensor Thing as channel '";
+    private static final String DEPRECATION_NOTE_SUFFIX = "')";
 
     private final Logger logger = LoggerFactory.getLogger(FineOffsetGatewayHandler.class);
     private final Bundle bundle;
@@ -229,7 +230,8 @@ public class FineOffsetGatewayHandler extends BaseBridgeHandler {
         String description = translationProvider.getText(bundle, channelKey + ".description", null,
                 localeProvider.getLocale(), measuredValue.getChannelNumber());
         if (measuredValue.getSensor() != null) {
-            description = (description == null ? "" : description) + DEPRECATION_NOTE;
+            description = (description == null ? "" : description) + DEPRECATION_NOTE_PREFIX
+                    + measuredValue.getChannelPrefix() + DEPRECATION_NOTE_SUFFIX;
         }
         if (description != null) {
             builder.withDescription(description);

--- a/bundles/org.openhab.binding.fineoffsetweatherstation/src/main/java/org/openhab/binding/fineoffsetweatherstation/internal/handler/FineOffsetGatewayHandler.java
+++ b/bundles/org.openhab.binding.fineoffsetweatherstation/src/main/java/org/openhab/binding/fineoffsetweatherstation/internal/handler/FineOffsetGatewayHandler.java
@@ -71,6 +71,7 @@ import org.slf4j.LoggerFactory;
 public class FineOffsetGatewayHandler extends BaseBridgeHandler {
 
     private static final String PROPERTY_FREQUENCY = "frequency";
+    // {0} = the full ChannelUID of the equivalent channel on the sensor Thing
     private static final String DEFAULT_DEPRECATION_NOTE_WITH_TARGET = "(deprecated — this value is now also available on the sensor Thing as channel: {0})";
     private static final String DEFAULT_DEPRECATION_NOTE = "(deprecated — this value is now also available on the sensor Thing)";
 

--- a/bundles/org.openhab.binding.fineoffsetweatherstation/src/main/java/org/openhab/binding/fineoffsetweatherstation/internal/handler/FineOffsetGatewayHandler.java
+++ b/bundles/org.openhab.binding.fineoffsetweatherstation/src/main/java/org/openhab/binding/fineoffsetweatherstation/internal/handler/FineOffsetGatewayHandler.java
@@ -32,6 +32,7 @@ import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.fineoffsetweatherstation.internal.FineOffsetGatewayConfiguration;
 import org.openhab.binding.fineoffsetweatherstation.internal.FineOffsetSensorConfiguration;
 import org.openhab.binding.fineoffsetweatherstation.internal.discovery.FineOffsetGatewayDiscoveryService;
+import org.openhab.binding.fineoffsetweatherstation.internal.domain.Sensor;
 import org.openhab.binding.fineoffsetweatherstation.internal.domain.SensorGatewayBinding;
 import org.openhab.binding.fineoffsetweatherstation.internal.domain.response.MeasuredValue;
 import org.openhab.binding.fineoffsetweatherstation.internal.domain.response.SensorDevice;
@@ -70,6 +71,7 @@ import org.slf4j.LoggerFactory;
 public class FineOffsetGatewayHandler extends BaseBridgeHandler {
 
     private static final String PROPERTY_FREQUENCY = "frequency";
+    private static final String DEPRECATION_NOTE = " (deprecated — this value is now also available on the sensor Thing)";
 
     private final Logger logger = LoggerFactory.getLogger(FineOffsetGatewayHandler.class);
     private final Bundle bundle;
@@ -159,6 +161,8 @@ public class FineOffsetGatewayHandler extends BaseBridgeHandler {
             return;
         }
 
+        // Capture the bridge reference before reconcile may replace thing via updateBridgeThing.
+        Bridge bridge = (Bridge) thing;
         DynamicChannelReconciler.Plan plan = reconciler.reconcile(data, thing.getChannels(),
                 MeasuredValue::getChannelId, this::createChannel);
         if (plan.hasChannelChanges()) {
@@ -168,6 +172,44 @@ public class FineOffsetGatewayHandler extends BaseBridgeHandler {
             updateBridgeThing(bridgeBuilder -> bridgeBuilder.withChannels(channels));
         }
         plan.statesToPost.forEach(this::updateState);
+        dispatchToSensors(bridge, data);
+    }
+
+    /**
+     * Routes each value carrying a {@link Sensor} tag to the child sensor Thing that owns its
+     * {@code (sensor, channel)}. Every child sensor handler is called once per poll - with an empty collection when it
+     * produced nothing - so its missing-measurand debounce advances. Gateway channels are unaffected: they already
+     * received all values above.
+     *
+     * @param bridge the bridge captured before any channel reconcile may replace the {@code thing} reference
+     */
+    private void dispatchToSensors(Bridge bridge, Collection<MeasuredValue> data) {
+        Map<SensorGatewayBinding, List<MeasuredValue>> bySensor = new HashMap<>();
+        for (MeasuredValue value : data) {
+            Sensor sensor = value.getSensor();
+            if (sensor == null) {
+                continue;
+            }
+            SensorGatewayBinding binding = SensorGatewayBinding.forSensorAndChannel(sensor, value.getChannelNumber());
+            if (binding == null) {
+                continue;
+            }
+            bySensor.computeIfAbsent(binding, b -> new ArrayList<>()).add(value);
+        }
+
+        for (Thing child : bridge.getThings()) {
+            if (!THING_TYPE_SENSOR.equals(child.getThingTypeUID())) {
+                continue;
+            }
+            SensorGatewayBinding binding = child.getConfiguration().as(FineOffsetSensorConfiguration.class).sensor;
+            if (binding == null) {
+                continue;
+            }
+            ThingHandler handler = child.getHandler();
+            if (handler instanceof FineOffsetSensorHandler sensorHandler) {
+                sensorHandler.updateMeasuredValues(bySensor.getOrDefault(binding, List.of()));
+            }
+        }
     }
 
     private @Nullable Channel createChannel(MeasuredValue measuredValue) {
@@ -186,6 +228,9 @@ public class FineOffsetGatewayHandler extends BaseBridgeHandler {
         }
         String description = translationProvider.getText(bundle, channelKey + ".description", null,
                 localeProvider.getLocale(), measuredValue.getChannelNumber());
+        if (measuredValue.getSensor() != null) {
+            description = (description == null ? "" : description) + DEPRECATION_NOTE;
+        }
         if (description != null) {
             builder.withDescription(description);
         }

--- a/bundles/org.openhab.binding.fineoffsetweatherstation/src/main/java/org/openhab/binding/fineoffsetweatherstation/internal/handler/FineOffsetGatewayHandler.java
+++ b/bundles/org.openhab.binding.fineoffsetweatherstation/src/main/java/org/openhab/binding/fineoffsetweatherstation/internal/handler/FineOffsetGatewayHandler.java
@@ -19,12 +19,9 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
@@ -57,7 +54,6 @@ import org.openhab.core.thing.type.ChannelType;
 import org.openhab.core.thing.type.ChannelTypeRegistry;
 import org.openhab.core.thing.type.ChannelTypeUID;
 import org.openhab.core.types.Command;
-import org.openhab.core.types.State;
 import org.openhab.core.types.UnDefType;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.FrameworkUtil;
@@ -75,13 +71,6 @@ public class FineOffsetGatewayHandler extends BaseBridgeHandler {
 
     private static final String PROPERTY_FREQUENCY = "frequency";
 
-    /**
-     * Number of consecutive live data responses a measurand may be missing from before its channel is removed. This
-     * debounces dynamically created channels so that a measurand that is only intermittently reported (or a delay in
-     * the gateway adjusting its live data after a sensor change) does not cause channels to flip-flop.
-     */
-    private static final int MISSING_MEASURAND_REMOVAL_THRESHOLD = 10;
-
     private final Logger logger = LoggerFactory.getLogger(FineOffsetGatewayHandler.class);
     private final Bundle bundle;
 
@@ -95,7 +84,7 @@ public class FineOffsetGatewayHandler extends BaseBridgeHandler {
     private final ThingUID bridgeUID;
 
     private @Nullable Map<SensorGatewayBinding, SensorDevice> sensorDeviceMap;
-    private final Map<String, Integer> missingMeasurandCounts = new HashMap<>();
+    private final DynamicChannelReconciler reconciler = new DynamicChannelReconciler(false);
     private @Nullable ScheduledFuture<?> pollingJob;
     private @Nullable ScheduledFuture<?> discoverJob;
     private boolean disposed;
@@ -122,7 +111,6 @@ public class FineOffsetGatewayHandler extends BaseBridgeHandler {
         gatewayQueryService = config.protocol.getGatewayQueryService(config, this::updateStatus);
 
         updateStatus(ThingStatus.UNKNOWN);
-        missingMeasurandCounts.clear();
         fetchAndUpdateSensors();
         disposed = false;
         updateBridgeInfo();
@@ -170,48 +158,15 @@ public class FineOffsetGatewayHandler extends BaseBridgeHandler {
             return;
         }
 
-        Set<String> reportedChannelIds = new HashSet<>();
-        List<Channel> newChannels = new ArrayList<>();
-        Map<ChannelUID, State> newChannelStates = new LinkedHashMap<>();
-        for (MeasuredValue measuredValue : data) {
-            String channelId = measuredValue.getChannelId();
-            reportedChannelIds.add(channelId);
-            @Nullable
-            Channel channel = thing.getChannel(channelId);
-            if (channel == null) {
-                channel = createChannel(measuredValue);
-                if (channel != null) {
-                    newChannels.add(channel);
-                    newChannelStates.put(channel.getUID(), measuredValue.getState());
-                }
-            } else {
-                State state = measuredValue.getState();
-                updateState(channel.getUID(), state);
-            }
-        }
-
-        // Only remove a channel once its measurand has been missing from a number of consecutive live data
-        // responses. This debounces transient gaps (and delays in the gateway adjusting its live data) so that
-        // channels do not flip-flop, while channels of permanently removed sensors are eventually dropped.
-        List<Channel> staleChannels = new ArrayList<>();
-        for (Channel channel : thing.getChannels()) {
-            String channelId = channel.getUID().getId();
-            if (reportedChannelIds.contains(channelId)) {
-                missingMeasurandCounts.remove(channelId);
-            } else if (missingMeasurandCounts.merge(channelId, 1,
-                    Integer::sum) >= MISSING_MEASURAND_REMOVAL_THRESHOLD) {
-                staleChannels.add(channel);
-                missingMeasurandCounts.remove(channelId);
-            }
-        }
-
-        if (!newChannels.isEmpty() || !staleChannels.isEmpty()) {
+        DynamicChannelReconciler.Plan plan = reconciler.reconcile(data, thing.getChannels(),
+                MeasuredValue::getChannelId, this::createChannel);
+        if (plan.hasChannelChanges()) {
             List<Channel> channels = new ArrayList<>(thing.getChannels());
-            channels.addAll(newChannels);
-            channels.removeAll(staleChannels);
+            channels.addAll(plan.channelsToAdd);
+            channels.removeAll(plan.channelsToRemove);
             updateBridgeThing(bridgeBuilder -> bridgeBuilder.withChannels(channels));
         }
-        newChannelStates.forEach(this::updateState);
+        plan.statesToPost.forEach(this::updateState);
     }
 
     private @Nullable Channel createChannel(MeasuredValue measuredValue) {

--- a/bundles/org.openhab.binding.fineoffsetweatherstation/src/main/java/org/openhab/binding/fineoffsetweatherstation/internal/handler/FineOffsetGatewayHandler.java
+++ b/bundles/org.openhab.binding.fineoffsetweatherstation/src/main/java/org/openhab/binding/fineoffsetweatherstation/internal/handler/FineOffsetGatewayHandler.java
@@ -71,8 +71,8 @@ import org.slf4j.LoggerFactory;
 public class FineOffsetGatewayHandler extends BaseBridgeHandler {
 
     private static final String PROPERTY_FREQUENCY = "frequency";
-    private static final String DEPRECATION_NOTE_PREFIX = " (deprecated — this value is now also available on the sensor Thing as channel '";
-    private static final String DEPRECATION_NOTE_SUFFIX = "')";
+    private static final String DEFAULT_DEPRECATION_NOTE_WITH_TARGET = "(deprecated — this value is now also available on the sensor Thing as channel: {0})";
+    private static final String DEFAULT_DEPRECATION_NOTE = "(deprecated — this value is now also available on the sensor Thing)";
 
     private final Logger logger = LoggerFactory.getLogger(FineOffsetGatewayHandler.class);
     private final Bundle bundle;
@@ -230,8 +230,18 @@ public class FineOffsetGatewayHandler extends BaseBridgeHandler {
         String description = translationProvider.getText(bundle, channelKey + ".description", null,
                 localeProvider.getLocale(), measuredValue.getChannelNumber());
         if (measuredValue.getSensor() != null) {
-            description = (description == null ? "" : description) + DEPRECATION_NOTE_PREFIX
-                    + measuredValue.getChannelPrefix() + DEPRECATION_NOTE_SUFFIX;
+            String sensorChannelUid = sensorChannelUid(measuredValue);
+            String note;
+            if (sensorChannelUid != null) {
+                note = translationProvider.getText(bundle, "gateway.dynamic-channel.deprecation-note",
+                        DEFAULT_DEPRECATION_NOTE_WITH_TARGET, localeProvider.getLocale(), sensorChannelUid);
+            } else {
+                note = translationProvider.getText(bundle, "gateway.dynamic-channel.deprecation-note-no-target",
+                        DEFAULT_DEPRECATION_NOTE, localeProvider.getLocale());
+            }
+            if (note != null) {
+                description = (description == null ? "" : description) + " " + note;
+            }
         }
         if (description != null) {
             builder.withDescription(description);
@@ -242,6 +252,35 @@ public class FineOffsetGatewayHandler extends BaseBridgeHandler {
             builder.withAcceptedItemType(type.getItemType());
         }
         return builder.build();
+    }
+
+    private @Nullable String sensorChannelUid(MeasuredValue measuredValue) {
+        Sensor sensor = measuredValue.getSensor();
+        if (sensor == null) {
+            return null;
+        }
+        SensorGatewayBinding binding = SensorGatewayBinding.forSensorAndChannel(sensor,
+                measuredValue.getChannelNumber());
+        if (binding == null) {
+            return null;
+        }
+        for (Thing child : ((Bridge) thing).getThings()) {
+            if (!THING_TYPE_SENSOR.equals(child.getThingTypeUID())) {
+                continue;
+            }
+            SensorGatewayBinding childBinding = child.getConfiguration().as(FineOffsetSensorConfiguration.class).sensor;
+            if (childBinding == null) {
+                continue;
+            }
+            if (childBinding.equals(binding)) {
+                ThingUID childUid = child.getUID();
+                if (childUid == null) {
+                    continue;
+                }
+                return new ChannelUID(childUid, measuredValue.getChannelPrefix()).getAsString();
+            }
+        }
+        return null;
     }
 
     private void updateBridgeInfo() {

--- a/bundles/org.openhab.binding.fineoffsetweatherstation/src/main/java/org/openhab/binding/fineoffsetweatherstation/internal/handler/FineOffsetGatewayHandler.java
+++ b/bundles/org.openhab.binding.fineoffsetweatherstation/src/main/java/org/openhab/binding/fineoffsetweatherstation/internal/handler/FineOffsetGatewayHandler.java
@@ -22,6 +22,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
@@ -88,7 +89,7 @@ public class FineOffsetGatewayHandler extends BaseBridgeHandler {
     private final ThingUID bridgeUID;
 
     private @Nullable Map<SensorGatewayBinding, SensorDevice> sensorDeviceMap;
-    private final DynamicChannelReconciler reconciler = new DynamicChannelReconciler(false);
+    private final DynamicChannelReconciler reconciler = new DynamicChannelReconciler(Set.of());
     private @Nullable ScheduledFuture<?> pollingJob;
     private @Nullable ScheduledFuture<?> discoverJob;
     private boolean disposed;
@@ -160,6 +161,13 @@ public class FineOffsetGatewayHandler extends BaseBridgeHandler {
         Collection<MeasuredValue> data = query(GatewayQueryService::getMeasuredValues);
         if (data == null) {
             getThing().getChannels().forEach(c -> updateState(c.getUID(), UnDefType.UNDEF));
+            // Mirror the failure onto the sensor Things so their measurement channels do not keep stale state. Do not
+            // run the reconciler here: a poll failure must not advance the missing-value removal debounce.
+            for (Thing child : ((Bridge) thing).getThings()) {
+                if (child.getHandler() instanceof FineOffsetSensorHandler sensorHandler) {
+                    sensorHandler.markMeasuredValuesUndefined();
+                }
+            }
             return;
         }
 
@@ -241,7 +249,7 @@ public class FineOffsetGatewayHandler extends BaseBridgeHandler {
                         DEFAULT_DEPRECATION_NOTE, localeProvider.getLocale());
             }
             if (note != null) {
-                description = (description == null ? "" : description) + " " + note;
+                description = description == null ? note : description + " " + note;
             }
         }
         if (description != null) {

--- a/bundles/org.openhab.binding.fineoffsetweatherstation/src/main/java/org/openhab/binding/fineoffsetweatherstation/internal/handler/FineOffsetGatewayHandler.java
+++ b/bundles/org.openhab.binding.fineoffsetweatherstation/src/main/java/org/openhab/binding/fineoffsetweatherstation/internal/handler/FineOffsetGatewayHandler.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -171,6 +172,7 @@ public class FineOffsetGatewayHandler extends BaseBridgeHandler {
 
         Set<String> reportedChannelIds = new HashSet<>();
         List<Channel> newChannels = new ArrayList<>();
+        Map<ChannelUID, State> newChannelStates = new LinkedHashMap<>();
         for (MeasuredValue measuredValue : data) {
             String channelId = measuredValue.getChannelId();
             reportedChannelIds.add(channelId);
@@ -180,6 +182,7 @@ public class FineOffsetGatewayHandler extends BaseBridgeHandler {
                 channel = createChannel(measuredValue);
                 if (channel != null) {
                     newChannels.add(channel);
+                    newChannelStates.put(channel.getUID(), measuredValue.getState());
                 }
             } else {
                 State state = measuredValue.getState();
@@ -208,6 +211,7 @@ public class FineOffsetGatewayHandler extends BaseBridgeHandler {
             channels.removeAll(staleChannels);
             updateBridgeThing(bridgeBuilder -> bridgeBuilder.withChannels(channels));
         }
+        newChannelStates.forEach(this::updateState);
     }
 
     private @Nullable Channel createChannel(MeasuredValue measuredValue) {

--- a/bundles/org.openhab.binding.fineoffsetweatherstation/src/main/java/org/openhab/binding/fineoffsetweatherstation/internal/handler/FineOffsetSensorHandler.java
+++ b/bundles/org.openhab.binding.fineoffsetweatherstation/src/main/java/org/openhab/binding/fineoffsetweatherstation/internal/handler/FineOffsetSensorHandler.java
@@ -16,6 +16,7 @@ import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Set;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
@@ -52,9 +53,16 @@ import org.slf4j.LoggerFactory;
 @NonNullByDefault
 public class FineOffsetSensorHandler extends BaseThingHandler {
 
+    /** Static channels declared by the sensor thing-type; protected so the reconciler never removes them. */
+    private static final Set<String> STATIC_CHANNEL_IDS = Set.of(
+            FineOffsetWeatherStationBindingConstants.SENSOR_CHANNEL_SIGNAL,
+            FineOffsetWeatherStationBindingConstants.SENSOR_CHANNEL_LOW_BATTERY,
+            FineOffsetWeatherStationBindingConstants.SENSOR_CHANNEL_BATTERY_LEVEL,
+            FineOffsetWeatherStationBindingConstants.SENSOR_CHANNEL_BATTERY_VOLTAGE);
+
     private final Logger logger = LoggerFactory.getLogger(FineOffsetSensorHandler.class);
     private final ChannelTypeRegistry channelTypeRegistry;
-    private final DynamicChannelReconciler reconciler = new DynamicChannelReconciler(true);
+    private final DynamicChannelReconciler reconciler = new DynamicChannelReconciler(STATIC_CHANNEL_IDS);
 
     private boolean disposed;
 
@@ -70,6 +78,7 @@ public class FineOffsetSensorHandler extends BaseThingHandler {
     @Override
     public void initialize() {
         updateStatus(ThingStatus.ONLINE);
+        reconciler.reset();
         disposed = false;
     }
 
@@ -146,14 +155,32 @@ public class FineOffsetSensorHandler extends BaseThingHandler {
         plan.statesToPost.forEach(this::updateState);
     }
 
+    /**
+     * Sets the mirrored measurement channels to {@link UnDefType#UNDEF} when the gateway poll fails, so they do not
+     * keep stale state. The static signal/battery channels are left untouched (they are polled separately), and the
+     * reconciler is deliberately not run, so a poll failure does not advance the missing-value removal debounce.
+     */
+    public void markMeasuredValuesUndefined() {
+        if (disposed) {
+            return;
+        }
+        for (Channel channel : thing.getChannels()) {
+            if (!STATIC_CHANNEL_IDS.contains(channel.getUID().getId())) {
+                updateState(channel.getUID(), UnDefType.UNDEF);
+            }
+        }
+    }
+
     private @Nullable Channel createChannel(MeasuredValue value) {
         ChannelTypeUID channelTypeId = value.getChannelTypeUID();
         if (channelTypeId == null) {
             logger.debug("cannot create channel for {}", value.getDebugName());
             return null;
         }
+        // No explicit label: let the (translatable) ChannelType label apply. On a per-sensor Thing the value needs no
+        // channel-number disambiguation, unlike the aggregated gateway channels.
         ChannelBuilder builder = ChannelBuilder.create(new ChannelUID(thing.getUID(), value.getChannelPrefix()))
-                .withKind(ChannelKind.STATE).withType(channelTypeId).withLabel(value.getDebugName());
+                .withKind(ChannelKind.STATE).withType(channelTypeId);
         @Nullable
         ChannelType type = channelTypeRegistry.getChannelType(channelTypeId);
         if (type != null) {

--- a/bundles/org.openhab.binding.fineoffsetweatherstation/src/main/java/org/openhab/binding/fineoffsetweatherstation/internal/handler/FineOffsetSensorHandler.java
+++ b/bundles/org.openhab.binding.fineoffsetweatherstation/src/main/java/org/openhab/binding/fineoffsetweatherstation/internal/handler/FineOffsetSensorHandler.java
@@ -15,12 +15,7 @@ package org.openhab.binding.fineoffsetweatherstation.internal.handler;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
@@ -44,7 +39,6 @@ import org.openhab.core.thing.type.ChannelType;
 import org.openhab.core.thing.type.ChannelTypeRegistry;
 import org.openhab.core.thing.type.ChannelTypeUID;
 import org.openhab.core.types.Command;
-import org.openhab.core.types.State;
 import org.openhab.core.types.UnDefType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -58,19 +52,9 @@ import org.slf4j.LoggerFactory;
 @NonNullByDefault
 public class FineOffsetSensorHandler extends BaseThingHandler {
 
-    /**
-     * Number of consecutive live data dispatches a measured value may be missing before its (dynamically created)
-     * channel is removed. Mirrors {@code FineOffsetGatewayHandler.MISSING_MEASURAND_REMOVAL_THRESHOLD} so that
-     * transient gaps do not cause channels to flip-flop.
-     */
-    private static final int MISSING_MEASURAND_REMOVAL_THRESHOLD = 10;
-
     private final Logger logger = LoggerFactory.getLogger(FineOffsetSensorHandler.class);
     private final ChannelTypeRegistry channelTypeRegistry;
-
-    /** Channel ids this handler created from measured values - only these are subject to the debounce/removal. */
-    private final Set<String> managedChannelIds = new HashSet<>();
-    private final Map<String, Integer> missingMeasurandCounts = new HashMap<>();
+    private final DynamicChannelReconciler reconciler = new DynamicChannelReconciler(true);
 
     private boolean disposed;
 
@@ -143,56 +127,23 @@ public class FineOffsetSensorHandler extends BaseThingHandler {
     /**
      * Mirrors the sensor's measured values onto dynamic channels: creates channels that do not exist yet, updates the
      * state of existing ones, and removes a managed channel once its value has been absent for
-     * {@link #MISSING_MEASURAND_REMOVAL_THRESHOLD} consecutive dispatches. Static signal/battery channels are never
-     * affected. Called every poll by the gateway, with an empty collection when this sensor reported nothing.
+     * {@link DynamicChannelReconciler#MISSING_VALUE_REMOVAL_THRESHOLD} consecutive dispatches. Static signal/battery
+     * channels are never affected. Called every poll by the gateway, with an empty collection when this sensor
+     * reported nothing.
      */
     public void updateMeasuredValues(Collection<MeasuredValue> values) {
         if (disposed) {
             return;
         }
-        Set<String> reportedChannelIds = new HashSet<>();
-        List<Channel> newChannels = new ArrayList<>();
-        Map<ChannelUID, State> newChannelStates = new LinkedHashMap<>();
-        for (MeasuredValue value : values) {
-            String channelId = value.getChannelPrefix();
-            reportedChannelIds.add(channelId);
-            @Nullable
-            Channel channel = thing.getChannel(channelId);
-            if (channel == null) {
-                channel = createChannel(value);
-                if (channel != null) {
-                    newChannels.add(channel);
-                    managedChannelIds.add(channelId);
-                    newChannelStates.put(channel.getUID(), value.getState());
-                }
-            } else {
-                updateState(channel.getUID(), value.getState());
-            }
-        }
-
-        List<Channel> staleChannels = new ArrayList<>();
-        for (String channelId : new HashSet<>(managedChannelIds)) {
-            if (reportedChannelIds.contains(channelId)) {
-                missingMeasurandCounts.remove(channelId);
-            } else if (missingMeasurandCounts.merge(channelId, 1,
-                    Integer::sum) >= MISSING_MEASURAND_REMOVAL_THRESHOLD) {
-                @Nullable
-                Channel channel = thing.getChannel(channelId);
-                if (channel != null) {
-                    staleChannels.add(channel);
-                }
-                missingMeasurandCounts.remove(channelId);
-                managedChannelIds.remove(channelId);
-            }
-        }
-
-        if (!newChannels.isEmpty() || !staleChannels.isEmpty()) {
+        DynamicChannelReconciler.Plan plan = reconciler.reconcile(values, thing.getChannels(),
+                MeasuredValue::getChannelPrefix, this::createChannel);
+        if (plan.hasChannelChanges()) {
             List<Channel> channels = new ArrayList<>(thing.getChannels());
-            channels.addAll(newChannels);
-            channels.removeAll(staleChannels);
+            channels.addAll(plan.channelsToAdd);
+            channels.removeAll(plan.channelsToRemove);
             updateThing(editThing().withChannels(channels).build());
         }
-        newChannelStates.forEach(this::updateState);
+        plan.statesToPost.forEach(this::updateState);
     }
 
     private @Nullable Channel createChannel(MeasuredValue value) {

--- a/bundles/org.openhab.binding.fineoffsetweatherstation/src/main/java/org/openhab/binding/fineoffsetweatherstation/internal/handler/FineOffsetSensorHandler.java
+++ b/bundles/org.openhab.binding.fineoffsetweatherstation/src/main/java/org/openhab/binding/fineoffsetweatherstation/internal/handler/FineOffsetSensorHandler.java
@@ -17,6 +17,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -43,6 +44,7 @@ import org.openhab.core.thing.type.ChannelType;
 import org.openhab.core.thing.type.ChannelTypeRegistry;
 import org.openhab.core.thing.type.ChannelTypeUID;
 import org.openhab.core.types.Command;
+import org.openhab.core.types.State;
 import org.openhab.core.types.UnDefType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -150,6 +152,7 @@ public class FineOffsetSensorHandler extends BaseThingHandler {
         }
         Set<String> reportedChannelIds = new HashSet<>();
         List<Channel> newChannels = new ArrayList<>();
+        Map<ChannelUID, State> newChannelStates = new LinkedHashMap<>();
         for (MeasuredValue value : values) {
             String channelId = value.getChannelPrefix();
             reportedChannelIds.add(channelId);
@@ -160,6 +163,7 @@ public class FineOffsetSensorHandler extends BaseThingHandler {
                 if (channel != null) {
                     newChannels.add(channel);
                     managedChannelIds.add(channelId);
+                    newChannelStates.put(channel.getUID(), value.getState());
                 }
             } else {
                 updateState(channel.getUID(), value.getState());
@@ -188,6 +192,7 @@ public class FineOffsetSensorHandler extends BaseThingHandler {
             channels.removeAll(staleChannels);
             updateThing(editThing().withChannels(channels).build());
         }
+        newChannelStates.forEach(this::updateState);
     }
 
     private @Nullable Channel createChannel(MeasuredValue value) {

--- a/bundles/org.openhab.binding.fineoffsetweatherstation/src/main/java/org/openhab/binding/fineoffsetweatherstation/internal/handler/FineOffsetSensorHandler.java
+++ b/bundles/org.openhab.binding.fineoffsetweatherstation/src/main/java/org/openhab/binding/fineoffsetweatherstation/internal/handler/FineOffsetSensorHandler.java
@@ -13,11 +13,19 @@
 package org.openhab.binding.fineoffsetweatherstation.internal.handler;
 
 import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.fineoffsetweatherstation.internal.FineOffsetWeatherStationBindingConstants;
 import org.openhab.binding.fineoffsetweatherstation.internal.domain.response.BatteryStatus;
+import org.openhab.binding.fineoffsetweatherstation.internal.domain.response.MeasuredValue;
 import org.openhab.binding.fineoffsetweatherstation.internal.domain.response.SensorDevice;
 import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.library.types.OnOffType;
@@ -29,20 +37,44 @@ import org.openhab.core.thing.Thing;
 import org.openhab.core.thing.ThingStatus;
 import org.openhab.core.thing.ThingStatusDetail;
 import org.openhab.core.thing.binding.BaseThingHandler;
+import org.openhab.core.thing.binding.builder.ChannelBuilder;
+import org.openhab.core.thing.type.ChannelKind;
+import org.openhab.core.thing.type.ChannelType;
+import org.openhab.core.thing.type.ChannelTypeRegistry;
+import org.openhab.core.thing.type.ChannelTypeUID;
 import org.openhab.core.types.Command;
 import org.openhab.core.types.UnDefType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
- * The {@link FineOffsetSensorHandler} keeps track of the signal and battery of the sensor attached to the gateway.
+ * The {@link FineOffsetSensorHandler} keeps track of the signal and battery of the sensor attached to the gateway,
+ * and mirrors the sensor's measured values onto dynamically created channels.
  *
  * @author Andreas Berger - Initial contribution
  */
 @NonNullByDefault
 public class FineOffsetSensorHandler extends BaseThingHandler {
+
+    /**
+     * Number of consecutive live data dispatches a measured value may be missing before its (dynamically created)
+     * channel is removed. Mirrors {@code FineOffsetGatewayHandler.MISSING_MEASURAND_REMOVAL_THRESHOLD} so that
+     * transient gaps do not cause channels to flip-flop.
+     */
+    private static final int MISSING_MEASURAND_REMOVAL_THRESHOLD = 10;
+
+    private final Logger logger = LoggerFactory.getLogger(FineOffsetSensorHandler.class);
+    private final ChannelTypeRegistry channelTypeRegistry;
+
+    /** Channel ids this handler created from measured values - only these are subject to the debounce/removal. */
+    private final Set<String> managedChannelIds = new HashSet<>();
+    private final Map<String, Integer> missingMeasurandCounts = new HashMap<>();
+
     private boolean disposed;
 
-    public FineOffsetSensorHandler(Thing thing) {
+    public FineOffsetSensorHandler(Thing thing, ChannelTypeRegistry channelTypeRegistry) {
         super(thing);
+        this.channelTypeRegistry = channelTypeRegistry;
     }
 
     @Override
@@ -104,5 +136,73 @@ public class FineOffsetSensorHandler extends BaseThingHandler {
                 updateThing(editThing().withoutChannels(channel).build());
             }
         }
+    }
+
+    /**
+     * Mirrors the sensor's measured values onto dynamic channels: creates channels that do not exist yet, updates the
+     * state of existing ones, and removes a managed channel once its value has been absent for
+     * {@link #MISSING_MEASURAND_REMOVAL_THRESHOLD} consecutive dispatches. Static signal/battery channels are never
+     * affected. Called every poll by the gateway, with an empty collection when this sensor reported nothing.
+     */
+    public void updateMeasuredValues(Collection<MeasuredValue> values) {
+        if (disposed) {
+            return;
+        }
+        Set<String> reportedChannelIds = new HashSet<>();
+        List<Channel> newChannels = new ArrayList<>();
+        for (MeasuredValue value : values) {
+            String channelId = value.getChannelPrefix();
+            reportedChannelIds.add(channelId);
+            @Nullable
+            Channel channel = thing.getChannel(channelId);
+            if (channel == null) {
+                channel = createChannel(value);
+                if (channel != null) {
+                    newChannels.add(channel);
+                    managedChannelIds.add(channelId);
+                }
+            } else {
+                updateState(channel.getUID(), value.getState());
+            }
+        }
+
+        List<Channel> staleChannels = new ArrayList<>();
+        for (String channelId : new HashSet<>(managedChannelIds)) {
+            if (reportedChannelIds.contains(channelId)) {
+                missingMeasurandCounts.remove(channelId);
+            } else if (missingMeasurandCounts.merge(channelId, 1,
+                    Integer::sum) >= MISSING_MEASURAND_REMOVAL_THRESHOLD) {
+                @Nullable
+                Channel channel = thing.getChannel(channelId);
+                if (channel != null) {
+                    staleChannels.add(channel);
+                }
+                missingMeasurandCounts.remove(channelId);
+                managedChannelIds.remove(channelId);
+            }
+        }
+
+        if (!newChannels.isEmpty() || !staleChannels.isEmpty()) {
+            List<Channel> channels = new ArrayList<>(thing.getChannels());
+            channels.addAll(newChannels);
+            channels.removeAll(staleChannels);
+            updateThing(editThing().withChannels(channels).build());
+        }
+    }
+
+    private @Nullable Channel createChannel(MeasuredValue value) {
+        ChannelTypeUID channelTypeId = value.getChannelTypeUID();
+        if (channelTypeId == null) {
+            logger.debug("cannot create channel for {}", value.getDebugName());
+            return null;
+        }
+        ChannelBuilder builder = ChannelBuilder.create(new ChannelUID(thing.getUID(), value.getChannelPrefix()))
+                .withKind(ChannelKind.STATE).withType(channelTypeId).withLabel(value.getDebugName());
+        @Nullable
+        ChannelType type = channelTypeRegistry.getChannelType(channelTypeId);
+        if (type != null) {
+            builder.withAcceptedItemType(type.getItemType());
+        }
+        return builder.build();
     }
 }

--- a/bundles/org.openhab.binding.fineoffsetweatherstation/src/main/resources/OH-INF/i18n/fineoffsetweatherstation.properties
+++ b/bundles/org.openhab.binding.fineoffsetweatherstation/src/main/resources/OH-INF/i18n/fineoffsetweatherstation.properties
@@ -164,3 +164,5 @@ gateway.dynamic-channel.piezo-rain-week.label = Rain Week
 gateway.dynamic-channel.piezo-rain-month.label = Rain Month
 gateway.dynamic-channel.piezo-rain-year.label = Rain Year
 gateway.dynamic-channel.free-heap-size.label = Free Stack Size
+gateway.dynamic-channel.deprecation-note = (deprecated — this value is now also available on the sensor Thing as channel: {0})
+gateway.dynamic-channel.deprecation-note-no-target = (deprecated — this value is now also available on the sensor Thing)

--- a/bundles/org.openhab.binding.fineoffsetweatherstation/src/test/java/org/openhab/binding/fineoffsetweatherstation/internal/domain/MeasurandTest.java
+++ b/bundles/org.openhab.binding.fineoffsetweatherstation/src/test/java/org/openhab/binding/fineoffsetweatherstation/internal/domain/MeasurandTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.fineoffsetweatherstation.internal.domain;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.assertj.core.api.Assertions;
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.jupiter.api.Test;
+import org.openhab.binding.fineoffsetweatherstation.internal.domain.response.MeasuredValue;
+
+/**
+ * Verifies that a {@link Measurand}'s {@link Sensor} tag is carried onto the {@link MeasuredValue}s it produces,
+ * via both the TCP byte path and the HTTP string path.
+ *
+ * @author Andreas Berger - Initial contribution
+ */
+@NonNullByDefault
+class MeasurandTest {
+
+    /**
+     * DebugDetails requires (byte[], Command, Protocol); we pass a minimal zero-padded payload.
+     * CMD_GW1000_LIVEDATA has sizeBytes=2, so the constructor accesses indices 0-4 and data.length-1;
+     * a 6-byte array is sufficient.
+     */
+    private static DebugDetails stubDebugDetails() {
+        return new DebugDetails(new byte[6], Command.CMD_GW1000_LIVEDATA, Protocol.DEFAULT);
+    }
+
+    @Test
+    void tcpPathCarriesSensorTag() {
+        Measurand tagged = Measurand.measurand("moisture-soil-channel", "Soil Moisture", MeasureType.PERCENTAGE)
+                .sensor(Sensor.WH51);
+        List<MeasuredValue> result = new ArrayList<>();
+        // PERCENTAGE is a single unsigned byte; value 42 at offset 0
+        tagged.extractMeasuredValues(new byte[] { 42 }, 0, 1, null, result, stubDebugDetails());
+        Assertions.assertThat(result).singleElement()
+                .satisfies(value -> Assertions.assertThat(value.getSensor()).isEqualTo(Sensor.WH51));
+    }
+
+    @Test
+    void httpPathCarriesSensorTag() {
+        Measurand tagged = Measurand.measurand("moisture-soil-channel", "Soil Moisture", MeasureType.PERCENTAGE)
+                .sensor(Sensor.WH51);
+        MeasuredValue value = tagged.parseHttp("42", "%", 1, null);
+        Assertions.assertThat(value).isNotNull();
+        Assertions.assertThat(value.getSensor()).isEqualTo(Sensor.WH51);
+    }
+
+    @Test
+    void untaggedMeasurandHasNoSensor() {
+        Measurand untagged = Measurand.measurand("temperature-dew-point", "Dew point", MeasureType.TEMPERATURE);
+        Assertions.assertThat(untagged.getSensor()).isNull();
+    }
+}

--- a/bundles/org.openhab.binding.fineoffsetweatherstation/src/test/java/org/openhab/binding/fineoffsetweatherstation/internal/domain/MeasurandTest.java
+++ b/bundles/org.openhab.binding.fineoffsetweatherstation/src/test/java/org/openhab/binding/fineoffsetweatherstation/internal/domain/MeasurandTest.java
@@ -14,6 +14,7 @@ package org.openhab.binding.fineoffsetweatherstation.internal.domain;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import org.assertj.core.api.Assertions;
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -53,8 +54,7 @@ class MeasurandTest {
     void httpPathCarriesSensorTag() {
         Measurand tagged = Measurand.measurand("moisture-soil-channel", "Soil Moisture", MeasureType.PERCENTAGE)
                 .sensor(Sensor.WH51);
-        MeasuredValue value = tagged.parseHttp("42", "%", 1, null);
-        Assertions.assertThat(value).isNotNull();
+        MeasuredValue value = Objects.requireNonNull(tagged.parseHttp("42", "%", 1, null));
         Assertions.assertThat(value.getSensor()).isEqualTo(Sensor.WH51);
     }
 

--- a/bundles/org.openhab.binding.fineoffsetweatherstation/src/test/java/org/openhab/binding/fineoffsetweatherstation/internal/domain/SensorGatewayBindingTest.java
+++ b/bundles/org.openhab.binding.fineoffsetweatherstation/src/test/java/org/openhab/binding/fineoffsetweatherstation/internal/domain/SensorGatewayBindingTest.java
@@ -14,7 +14,6 @@ package org.openhab.binding.fineoffsetweatherstation.internal.domain;
 
 import org.assertj.core.api.Assertions;
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.eclipse.jdt.annotation.Nullable;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -45,14 +44,14 @@ class SensorGatewayBindingTest {
     }
 
     @Test
-    void soilMoistureAndTemperatureConvergeOnTheSameBinding() {
-        // WH51 soil moisture and soil temperature of channel 1 are the same physical sensor: both must resolve
-        // to the single WH51_CH1 binding so they land on one sensor Thing.
-        @Nullable
-        SensorGatewayBinding fromMoisture = SensorGatewayBinding.forSensorAndChannel(Sensor.WH51, 1);
-        @Nullable
-        SensorGatewayBinding fromTemperature = SensorGatewayBinding.forSensorAndChannel(Sensor.WH51, 1);
-        Assertions.assertThat(fromMoisture).isEqualTo(fromTemperature).isEqualTo(SensorGatewayBinding.WH51_CH1);
+    void soilMoistureAndTemperatureShareOneBinding() {
+        // The soil-moisture and soil-temperature measurands are two distinct measurands, but both are tagged
+        // Sensor.WH51 with the same channel (see MeasurandRegistry / the parser tests). forSensorAndChannel keys
+        // only on (Sensor, channel), so both collapse onto the single WH51_CH1 binding and thus onto one sensor
+        // Thing. Here we verify that shared key resolves to that one binding; the measurands' distinctness is
+        // verified upstream in the parser tests.
+        Assertions.assertThat(SensorGatewayBinding.forSensorAndChannel(Sensor.WH51, 1))
+                .isEqualTo(SensorGatewayBinding.WH51_CH1);
     }
 
     @Test

--- a/bundles/org.openhab.binding.fineoffsetweatherstation/src/test/java/org/openhab/binding/fineoffsetweatherstation/internal/domain/SensorGatewayBindingTest.java
+++ b/bundles/org.openhab.binding.fineoffsetweatherstation/src/test/java/org/openhab/binding/fineoffsetweatherstation/internal/domain/SensorGatewayBindingTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.fineoffsetweatherstation.internal.domain;
+
+import org.assertj.core.api.Assertions;
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies the reverse {@code (Sensor, channel) -> SensorGatewayBinding} lookup used to route measured values
+ * onto sensor Things.
+ *
+ * @author Andreas Berger - Initial contribution
+ */
+@NonNullByDefault
+class SensorGatewayBindingTest {
+
+    @Test
+    void channelledSensorResolvesByChannel() {
+        Assertions.assertThat(SensorGatewayBinding.forSensorAndChannel(Sensor.WH51, 1))
+                .isEqualTo(SensorGatewayBinding.WH51_CH1);
+        Assertions.assertThat(SensorGatewayBinding.forSensorAndChannel(Sensor.WH51, 16))
+                .isEqualTo(SensorGatewayBinding.WH51_CH16);
+        Assertions.assertThat(SensorGatewayBinding.forSensorAndChannel(Sensor.WH31, 8))
+                .isEqualTo(SensorGatewayBinding.WH31_CH8);
+    }
+
+    @Test
+    void channellessSensorResolvesWithNullChannel() {
+        Assertions.assertThat(SensorGatewayBinding.forSensorAndChannel(Sensor.WH57, null))
+                .isEqualTo(SensorGatewayBinding.WH57);
+        Assertions.assertThat(SensorGatewayBinding.forSensorAndChannel(Sensor.WH45, null))
+                .isEqualTo(SensorGatewayBinding.WH45);
+    }
+
+    @Test
+    void soilMoistureAndTemperatureConvergeOnTheSameBinding() {
+        // WH51 soil moisture and soil temperature of channel 1 are the same physical sensor: both must resolve
+        // to the single WH51_CH1 binding so they land on one sensor Thing.
+        @Nullable
+        SensorGatewayBinding fromMoisture = SensorGatewayBinding.forSensorAndChannel(Sensor.WH51, 1);
+        @Nullable
+        SensorGatewayBinding fromTemperature = SensorGatewayBinding.forSensorAndChannel(Sensor.WH51, 1);
+        Assertions.assertThat(fromMoisture).isEqualTo(fromTemperature).isEqualTo(SensorGatewayBinding.WH51_CH1);
+    }
+
+    @Test
+    void unknownCombinationsResolveToNull() {
+        // WH57 has no channels -> a channelled query must miss
+        Assertions.assertThat(SensorGatewayBinding.forSensorAndChannel(Sensor.WH57, 1)).isNull();
+        // WH31 is channelled -> a null-channel query must miss
+        Assertions.assertThat(SensorGatewayBinding.forSensorAndChannel(Sensor.WH31, null)).isNull();
+        // out-of-range channel
+        Assertions.assertThat(SensorGatewayBinding.forSensorAndChannel(Sensor.WH41, 9)).isNull();
+    }
+}

--- a/bundles/org.openhab.binding.fineoffsetweatherstation/src/test/java/org/openhab/binding/fineoffsetweatherstation/internal/handler/DynamicChannelReconcilerTest.java
+++ b/bundles/org.openhab.binding.fineoffsetweatherstation/src/test/java/org/openhab/binding/fineoffsetweatherstation/internal/handler/DynamicChannelReconcilerTest.java
@@ -1,0 +1,222 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.fineoffsetweatherstation.internal.handler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.openhab.binding.fineoffsetweatherstation.internal.FineOffsetWeatherStationBindingConstants.CHANNEL_TYPE_TEMPERATURE;
+import static org.openhab.binding.fineoffsetweatherstation.internal.FineOffsetWeatherStationBindingConstants.THING_TYPE_SENSOR;
+import static org.openhab.binding.fineoffsetweatherstation.internal.handler.DynamicChannelReconciler.MISSING_VALUE_REMOVAL_THRESHOLD;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.jupiter.api.Test;
+import org.openhab.binding.fineoffsetweatherstation.internal.domain.MeasureType;
+import org.openhab.binding.fineoffsetweatherstation.internal.domain.response.MeasuredValue;
+import org.openhab.core.library.types.DecimalType;
+import org.openhab.core.thing.Channel;
+import org.openhab.core.thing.ChannelUID;
+import org.openhab.core.thing.ThingUID;
+import org.openhab.core.thing.binding.builder.ChannelBuilder;
+import org.openhab.core.thing.type.ChannelKind;
+
+/**
+ * Unit tests for {@link DynamicChannelReconciler}.
+ *
+ * @author Andreas Berger - Initial contribution
+ */
+@NonNullByDefault
+class DynamicChannelReconcilerTest {
+
+    private static final ThingUID THING_UID = new ThingUID(THING_TYPE_SENSOR, "testThing");
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    private MeasuredValue measuredValue(String channelPrefix) {
+        return new MeasuredValue(MeasureType.TEMPERATURE, channelPrefix, null, CHANNEL_TYPE_TEMPERATURE,
+                new DecimalType(42), channelPrefix, null);
+    }
+
+    private Channel channel(String id) {
+        return ChannelBuilder.create(new ChannelUID(THING_UID, id)).withKind(ChannelKind.STATE).build();
+    }
+
+    /**
+     * Convenience: apply the plan (add/remove) to a mutable channel list, mirroring what a handler would do after
+     * calling reconcile().
+     */
+    private List<Channel> applyPlan(List<Channel> current, DynamicChannelReconciler.Plan plan) {
+        List<Channel> result = new ArrayList<>(current);
+        result.addAll(plan.channelsToAdd);
+        result.removeAll(plan.channelsToRemove);
+        return result;
+    }
+
+    // -----------------------------------------------------------------------
+    // Case 1: new value creates a channel and posts its state
+    // -----------------------------------------------------------------------
+
+    @Test
+    void newValueYieldsCreatedChannelAndPostedState() {
+        DynamicChannelReconciler reconciler = new DynamicChannelReconciler(false);
+        MeasuredValue value = measuredValue("temperature");
+
+        DynamicChannelReconciler.Plan plan = reconciler.reconcile(List.of(value), List.of(),
+                MeasuredValue::getChannelId, v -> channel(v.getChannelId()));
+
+        assertThat(plan.channelsToAdd).hasSize(1);
+        assertThat(plan.channelsToAdd.get(0).getUID().getId()).isEqualTo("temperature");
+        assertThat(plan.statesToPost).containsKey(plan.channelsToAdd.get(0).getUID());
+        assertThat(plan.channelsToRemove).isEmpty();
+    }
+
+    // -----------------------------------------------------------------------
+    // Case 2: existing channel yields no add but a posted state
+    // -----------------------------------------------------------------------
+
+    @Test
+    void existingChannelYieldsNoAddButPostedState() {
+        DynamicChannelReconciler reconciler = new DynamicChannelReconciler(false);
+        MeasuredValue value = measuredValue("temperature");
+        Channel existing = channel("temperature");
+
+        DynamicChannelReconciler.Plan plan = reconciler.reconcile(List.of(value), List.of(existing),
+                MeasuredValue::getChannelId, v -> channel(v.getChannelId()));
+
+        assertThat(plan.channelsToAdd).isEmpty();
+        assertThat(plan.statesToPost).containsKey(existing.getUID());
+        assertThat(plan.channelsToRemove).isEmpty();
+    }
+
+    // -----------------------------------------------------------------------
+    // Case 3: removeOnlyCreatedChannels=true never removes a non-created channel
+    // -----------------------------------------------------------------------
+
+    @Test
+    void removeOnlyCreatedDoesNotRemoveNonCreatedChannel() {
+        DynamicChannelReconciler reconciler = new DynamicChannelReconciler(true);
+        Channel staticSignal = channel("signal");
+        List<Channel> currentChannels = List.of(staticSignal);
+
+        // Reconcile THRESHOLD times without reporting "signal"
+        for (int i = 0; i < MISSING_VALUE_REMOVAL_THRESHOLD; i++) {
+            DynamicChannelReconciler.Plan plan = reconciler.reconcile(List.of(), currentChannels,
+                    MeasuredValue::getChannelPrefix, v -> channel(v.getChannelPrefix()));
+            assertThat(plan.channelsToRemove).doesNotContain(staticSignal);
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Case 4: removeOnlyCreatedChannels=true removes a reconciler-created channel
+    // after threshold, keeps it below threshold
+    // -----------------------------------------------------------------------
+
+    @Test
+    void removeOnlyCreatedRemovesCreatedChannelAfterThreshold() {
+        DynamicChannelReconciler reconciler = new DynamicChannelReconciler(true);
+        MeasuredValue value = measuredValue("moisture");
+
+        // First pass creates the channel
+        DynamicChannelReconciler.Plan firstPlan = reconciler.reconcile(List.of(value), List.of(),
+                MeasuredValue::getChannelPrefix, v -> channel(v.getChannelPrefix()));
+        assertThat(firstPlan.channelsToAdd).hasSize(1);
+
+        // Now include the created channel in subsequent current-channels list, mirroring handler commit
+        List<Channel> currentChannels = new ArrayList<>(List.of(firstPlan.channelsToAdd.get(0)));
+
+        // THRESHOLD - 1 passes missing → channel still there
+        for (int i = 0; i < MISSING_VALUE_REMOVAL_THRESHOLD - 1; i++) {
+            DynamicChannelReconciler.Plan plan = reconciler.reconcile(List.of(), currentChannels,
+                    MeasuredValue::getChannelPrefix, v -> channel(v.getChannelPrefix()));
+            assertThat(plan.channelsToRemove).isEmpty();
+            currentChannels = applyPlan(currentChannels, plan);
+        }
+
+        // One more (total = THRESHOLD) → removed
+        DynamicChannelReconciler.Plan lastPlan = reconciler.reconcile(List.of(), currentChannels,
+                MeasuredValue::getChannelPrefix, v -> channel(v.getChannelPrefix()));
+        assertThat(lastPlan.channelsToRemove).hasSize(1);
+        assertThat(lastPlan.channelsToRemove.get(0).getUID().getId()).isEqualTo("moisture");
+    }
+
+    // -----------------------------------------------------------------------
+    // Case 5: removeOnlyCreatedChannels=false removes ANY channel after threshold
+    // (gateway semantics)
+    // -----------------------------------------------------------------------
+
+    @Test
+    void removeAnyChannelAfterThresholdInGatewayMode() {
+        DynamicChannelReconciler reconciler = new DynamicChannelReconciler(false);
+        // A channel the reconciler did NOT create (pre-existing)
+        Channel existing = channel("wind-speed");
+        List<Channel> currentChannels = new ArrayList<>(List.of(existing));
+
+        // THRESHOLD - 1 → still kept
+        for (int i = 0; i < MISSING_VALUE_REMOVAL_THRESHOLD - 1; i++) {
+            DynamicChannelReconciler.Plan plan = reconciler.reconcile(List.of(), currentChannels,
+                    MeasuredValue::getChannelId, v -> channel(v.getChannelId()));
+            assertThat(plan.channelsToRemove).isEmpty();
+            currentChannels = applyPlan(currentChannels, plan);
+        }
+
+        // THRESHOLD → removed
+        DynamicChannelReconciler.Plan lastPlan = reconciler.reconcile(List.of(), currentChannels,
+                MeasuredValue::getChannelId, v -> channel(v.getChannelId()));
+        assertThat(lastPlan.channelsToRemove).hasSize(1);
+        assertThat(lastPlan.channelsToRemove.get(0).getUID().getId()).isEqualTo("wind-speed");
+    }
+
+    // -----------------------------------------------------------------------
+    // Case 6: reappearing value resets the miss counter
+    // -----------------------------------------------------------------------
+
+    @Test
+    void reappearingValueResetsMissCounter() {
+        DynamicChannelReconciler reconciler = new DynamicChannelReconciler(false);
+        MeasuredValue temperature = measuredValue("temperature");
+        MeasuredValue humidity = measuredValue("humidity");
+
+        // Create both channels
+        DynamicChannelReconciler.Plan firstPlan = reconciler.reconcile(List.of(temperature, humidity), List.of(),
+                MeasuredValue::getChannelId, v -> channel(v.getChannelId()));
+        List<Channel> currentChannels = applyPlan(new ArrayList<>(), firstPlan);
+
+        // Almost reach the threshold for humidity
+        for (int i = 0; i < MISSING_VALUE_REMOVAL_THRESHOLD - 1; i++) {
+            DynamicChannelReconciler.Plan plan = reconciler.reconcile(List.of(temperature), currentChannels,
+                    MeasuredValue::getChannelId, v -> channel(v.getChannelId()));
+            currentChannels = applyPlan(currentChannels, plan);
+        }
+
+        // Humidity reappears — resets counter
+        DynamicChannelReconciler.Plan resetPlan = reconciler.reconcile(List.of(temperature, humidity), currentChannels,
+                MeasuredValue::getChannelId, v -> channel(v.getChannelId()));
+        currentChannels = applyPlan(currentChannels, resetPlan);
+
+        // Almost reach the threshold again — humidity should still be present
+        for (int i = 0; i < MISSING_VALUE_REMOVAL_THRESHOLD - 1; i++) {
+            DynamicChannelReconciler.Plan plan = reconciler.reconcile(List.of(temperature), currentChannels,
+                    MeasuredValue::getChannelId, v -> channel(v.getChannelId()));
+            assertThat(plan.channelsToRemove).doesNotContain(currentChannels.stream()
+                    .filter(c -> "humidity".equals(c.getUID().getId())).findFirst().orElseThrow());
+            currentChannels = applyPlan(currentChannels, plan);
+        }
+
+        // humidity channel must still exist
+        List<String> ids = currentChannels.stream().map(c -> c.getUID().getId()).toList();
+        assertThat(ids).contains("humidity");
+    }
+}

--- a/bundles/org.openhab.binding.fineoffsetweatherstation/src/test/java/org/openhab/binding/fineoffsetweatherstation/internal/handler/DynamicChannelReconcilerTest.java
+++ b/bundles/org.openhab.binding.fineoffsetweatherstation/src/test/java/org/openhab/binding/fineoffsetweatherstation/internal/handler/DynamicChannelReconcilerTest.java
@@ -78,8 +78,9 @@ class DynamicChannelReconcilerTest {
                 MeasuredValue::getChannelId, v -> channel(v.getChannelId()));
 
         assertThat(plan.channelsToAdd).hasSize(1);
-        assertThat(plan.channelsToAdd.get(0).getUID().getId()).isEqualTo("temperature");
-        assertThat(plan.statesToPost).containsKey(plan.channelsToAdd.get(0).getUID());
+        ChannelUID createdUID = plan.channelsToAdd.get(0).getUID();
+        assertThat(createdUID.getId()).isEqualTo("temperature");
+        assertThat(plan.statesToPost).containsEntry(createdUID, new DecimalType(42));
         assertThat(plan.channelsToRemove).isEmpty();
     }
 
@@ -218,5 +219,45 @@ class DynamicChannelReconcilerTest {
         // humidity channel must still exist
         List<String> ids = currentChannels.stream().map(c -> c.getUID().getId()).toList();
         assertThat(ids).contains("humidity");
+    }
+
+    // -----------------------------------------------------------------------
+    // Case 7: reset() clears debounce and creation state
+    // -----------------------------------------------------------------------
+
+    @Test
+    void resetClearsAccumulatedState() {
+        DynamicChannelReconciler reconciler = new DynamicChannelReconciler(true);
+        MeasuredValue value = measuredValue("pressure");
+
+        // First pass: create the channel via the reconciler
+        DynamicChannelReconciler.Plan firstPlan = reconciler.reconcile(List.of(value), List.of(),
+                MeasuredValue::getChannelId, v -> channel(v.getChannelId()));
+        assertThat(firstPlan.channelsToAdd).hasSize(1);
+        List<Channel> currentChannels = new ArrayList<>(List.of(firstPlan.channelsToAdd.get(0)));
+
+        // Advance miss counter a few passes (below threshold) without reporting "pressure"
+        for (int i = 0; i < MISSING_VALUE_REMOVAL_THRESHOLD - 1; i++) {
+            DynamicChannelReconciler.Plan plan = reconciler.reconcile(List.of(), currentChannels,
+                    MeasuredValue::getChannelId, v -> channel(v.getChannelId()));
+            assertThat(plan.channelsToRemove).isEmpty();
+        }
+
+        // Reset clears both missingCounts and createdChannelIds
+        reconciler.reset();
+
+        // After reset, the channel is no longer tracked as reconciler-created, so with
+        // removeOnlyCreatedChannels=true the still-present channel is NOT a removal candidate
+        DynamicChannelReconciler.Plan afterResetMissing = reconciler.reconcile(List.of(), currentChannels,
+                MeasuredValue::getChannelId, v -> channel(v.getChannelId()));
+        assertThat(afterResetMissing.channelsToRemove).isEmpty();
+
+        // And the value, when re-supplied, is treated as brand-new: channel is added again
+        DynamicChannelReconciler.Plan afterResetPresent = reconciler.reconcile(List.of(value), List.of(),
+                MeasuredValue::getChannelId, v -> channel(v.getChannelId()));
+        ChannelUID recreatedUID = afterResetPresent.channelsToAdd.get(0).getUID();
+        assertThat(afterResetPresent.channelsToAdd).hasSize(1);
+        assertThat(recreatedUID.getId()).isEqualTo("pressure");
+        assertThat(afterResetPresent.statesToPost).containsEntry(recreatedUID, new DecimalType(42));
     }
 }

--- a/bundles/org.openhab.binding.fineoffsetweatherstation/src/test/java/org/openhab/binding/fineoffsetweatherstation/internal/handler/DynamicChannelReconcilerTest.java
+++ b/bundles/org.openhab.binding.fineoffsetweatherstation/src/test/java/org/openhab/binding/fineoffsetweatherstation/internal/handler/DynamicChannelReconcilerTest.java
@@ -19,6 +19,7 @@ import static org.openhab.binding.fineoffsetweatherstation.internal.handler.Dyna
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.junit.jupiter.api.Test;
@@ -71,7 +72,7 @@ class DynamicChannelReconcilerTest {
 
     @Test
     void newValueYieldsCreatedChannelAndPostedState() {
-        DynamicChannelReconciler reconciler = new DynamicChannelReconciler(false);
+        DynamicChannelReconciler reconciler = new DynamicChannelReconciler(Set.of());
         MeasuredValue value = measuredValue("temperature");
 
         DynamicChannelReconciler.Plan plan = reconciler.reconcile(List.of(value), List.of(),
@@ -90,7 +91,7 @@ class DynamicChannelReconcilerTest {
 
     @Test
     void existingChannelYieldsNoAddButPostedState() {
-        DynamicChannelReconciler reconciler = new DynamicChannelReconciler(false);
+        DynamicChannelReconciler reconciler = new DynamicChannelReconciler(Set.of());
         MeasuredValue value = measuredValue("temperature");
         Channel existing = channel("temperature");
 
@@ -103,12 +104,12 @@ class DynamicChannelReconcilerTest {
     }
 
     // -----------------------------------------------------------------------
-    // Case 3: removeOnlyCreatedChannels=true never removes a non-created channel
+    // Case 3: a protected (static) channel is never removed
     // -----------------------------------------------------------------------
 
     @Test
-    void removeOnlyCreatedDoesNotRemoveNonCreatedChannel() {
-        DynamicChannelReconciler reconciler = new DynamicChannelReconciler(true);
+    void staticChannelIsNeverRemoved() {
+        DynamicChannelReconciler reconciler = new DynamicChannelReconciler(Set.of("signal"));
         Channel staticSignal = channel("signal");
         List<Channel> currentChannels = List.of(staticSignal);
 
@@ -121,13 +122,12 @@ class DynamicChannelReconcilerTest {
     }
 
     // -----------------------------------------------------------------------
-    // Case 4: removeOnlyCreatedChannels=true removes a reconciler-created channel
-    // after threshold, keeps it below threshold
+    // Case 4: a reconciler-created channel is removed after threshold, kept below it
     // -----------------------------------------------------------------------
 
     @Test
-    void removeOnlyCreatedRemovesCreatedChannelAfterThreshold() {
-        DynamicChannelReconciler reconciler = new DynamicChannelReconciler(true);
+    void removesCreatedChannelAfterThreshold() {
+        DynamicChannelReconciler reconciler = new DynamicChannelReconciler(Set.of("signal"));
         MeasuredValue value = measuredValue("moisture");
 
         // First pass creates the channel
@@ -154,13 +154,13 @@ class DynamicChannelReconcilerTest {
     }
 
     // -----------------------------------------------------------------------
-    // Case 5: removeOnlyCreatedChannels=false removes ANY channel after threshold
-    // (gateway semantics)
+    // Case 5: with an empty protected set every channel is removable
+    // after threshold (gateway semantics)
     // -----------------------------------------------------------------------
 
     @Test
     void removeAnyChannelAfterThresholdInGatewayMode() {
-        DynamicChannelReconciler reconciler = new DynamicChannelReconciler(false);
+        DynamicChannelReconciler reconciler = new DynamicChannelReconciler(Set.of());
         // A channel the reconciler did NOT create (pre-existing)
         Channel existing = channel("wind-speed");
         List<Channel> currentChannels = new ArrayList<>(List.of(existing));
@@ -186,7 +186,7 @@ class DynamicChannelReconcilerTest {
 
     @Test
     void reappearingValueResetsMissCounter() {
-        DynamicChannelReconciler reconciler = new DynamicChannelReconciler(false);
+        DynamicChannelReconciler reconciler = new DynamicChannelReconciler(Set.of());
         MeasuredValue temperature = measuredValue("temperature");
         MeasuredValue humidity = measuredValue("humidity");
 
@@ -222,12 +222,12 @@ class DynamicChannelReconcilerTest {
     }
 
     // -----------------------------------------------------------------------
-    // Case 7: reset() clears debounce and creation state
+    // Case 7: reset() clears the debounce counters so removal debounce restarts
     // -----------------------------------------------------------------------
 
     @Test
-    void resetClearsAccumulatedState() {
-        DynamicChannelReconciler reconciler = new DynamicChannelReconciler(true);
+    void resetRestartsRemovalDebounce() {
+        DynamicChannelReconciler reconciler = new DynamicChannelReconciler(Set.of());
         MeasuredValue value = measuredValue("pressure");
 
         // First pass: create the channel via the reconciler
@@ -236,28 +236,52 @@ class DynamicChannelReconcilerTest {
         assertThat(firstPlan.channelsToAdd).hasSize(1);
         List<Channel> currentChannels = new ArrayList<>(List.of(firstPlan.channelsToAdd.get(0)));
 
-        // Advance miss counter a few passes (below threshold) without reporting "pressure"
+        // Advance miss counter to one below threshold without reporting "pressure"
         for (int i = 0; i < MISSING_VALUE_REMOVAL_THRESHOLD - 1; i++) {
             DynamicChannelReconciler.Plan plan = reconciler.reconcile(List.of(), currentChannels,
                     MeasuredValue::getChannelId, v -> channel(v.getChannelId()));
             assertThat(plan.channelsToRemove).isEmpty();
         }
 
-        // Reset clears both missingCounts and createdChannelIds
+        // Reset clears the accumulated miss counts
         reconciler.reset();
 
-        // After reset, the channel is no longer tracked as reconciler-created, so with
-        // removeOnlyCreatedChannels=true the still-present channel is NOT a removal candidate
-        DynamicChannelReconciler.Plan afterResetMissing = reconciler.reconcile(List.of(), currentChannels,
+        // The debounce restarts: it again takes a full THRESHOLD of misses before "pressure" is removed
+        for (int i = 0; i < MISSING_VALUE_REMOVAL_THRESHOLD - 1; i++) {
+            DynamicChannelReconciler.Plan plan = reconciler.reconcile(List.of(), currentChannels,
+                    MeasuredValue::getChannelId, v -> channel(v.getChannelId()));
+            assertThat(plan.channelsToRemove).isEmpty();
+        }
+        DynamicChannelReconciler.Plan removalPlan = reconciler.reconcile(List.of(), currentChannels,
                 MeasuredValue::getChannelId, v -> channel(v.getChannelId()));
-        assertThat(afterResetMissing.channelsToRemove).isEmpty();
+        assertThat(removalPlan.channelsToRemove).hasSize(1);
+        assertThat(removalPlan.channelsToRemove.get(0).getUID().getId()).isEqualTo("pressure");
+    }
 
-        // And the value, when re-supplied, is treated as brand-new: channel is added again
-        DynamicChannelReconciler.Plan afterResetPresent = reconciler.reconcile(List.of(value), List.of(),
-                MeasuredValue::getChannelId, v -> channel(v.getChannelId()));
-        ChannelUID recreatedUID = afterResetPresent.channelsToAdd.get(0).getUID();
-        assertThat(afterResetPresent.channelsToAdd).hasSize(1);
-        assertThat(recreatedUID.getId()).isEqualTo("pressure");
-        assertThat(afterResetPresent.statesToPost).containsEntry(recreatedUID, new DecimalType(42));
+    // -----------------------------------------------------------------------
+    // Case 8: a dynamic channel persisted across a restart (never created by this
+    // instance) is still removable because it is not protected, while a protected
+    // (static) channel stays untouched
+    // -----------------------------------------------------------------------
+
+    @Test
+    void persistedDynamicChannelIsRemovableAfterRestart() {
+        DynamicChannelReconciler reconciler = new DynamicChannelReconciler(Set.of("signal"));
+        Channel staticSignal = channel("signal");
+        Channel persistedMoisture = channel("moisture");
+        List<Channel> currentChannels = new ArrayList<>(List.of(staticSignal, persistedMoisture));
+
+        // THRESHOLD - 1 passes with neither value reported → nothing removed yet
+        for (int i = 0; i < MISSING_VALUE_REMOVAL_THRESHOLD - 1; i++) {
+            DynamicChannelReconciler.Plan plan = reconciler.reconcile(List.of(), currentChannels,
+                    MeasuredValue::getChannelPrefix, v -> channel(v.getChannelPrefix()));
+            assertThat(plan.channelsToRemove).isEmpty();
+            currentChannels = applyPlan(currentChannels, plan);
+        }
+
+        // THRESHOLD → only the adopted dynamic channel is removed; the static one is never touched
+        DynamicChannelReconciler.Plan lastPlan = reconciler.reconcile(List.of(), currentChannels,
+                MeasuredValue::getChannelPrefix, v -> channel(v.getChannelPrefix()));
+        assertThat(lastPlan.channelsToRemove).extracting(c -> c.getUID().getId()).containsExactly("moisture");
     }
 }

--- a/bundles/org.openhab.binding.fineoffsetweatherstation/src/test/java/org/openhab/binding/fineoffsetweatherstation/internal/handler/FineOffsetGatewayHandlerTest.java
+++ b/bundles/org.openhab.binding.fineoffsetweatherstation/src/test/java/org/openhab/binding/fineoffsetweatherstation/internal/handler/FineOffsetGatewayHandlerTest.java
@@ -14,6 +14,7 @@ package org.openhab.binding.fineoffsetweatherstation.internal.handler;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.openhab.binding.fineoffsetweatherstation.internal.FineOffsetWeatherStationBindingConstants.CHANNEL_TYPE_HUMIDITY;
@@ -35,8 +36,12 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
+import org.openhab.binding.fineoffsetweatherstation.internal.FineOffsetSensorConfiguration;
+import org.openhab.binding.fineoffsetweatherstation.internal.FineOffsetWeatherStationBindingConstants;
 import org.openhab.binding.fineoffsetweatherstation.internal.discovery.FineOffsetGatewayDiscoveryService;
 import org.openhab.binding.fineoffsetweatherstation.internal.domain.MeasureType;
+import org.openhab.binding.fineoffsetweatherstation.internal.domain.Sensor;
+import org.openhab.binding.fineoffsetweatherstation.internal.domain.SensorGatewayBinding;
 import org.openhab.binding.fineoffsetweatherstation.internal.domain.response.MeasuredValue;
 import org.openhab.binding.fineoffsetweatherstation.internal.service.GatewayQueryService;
 import org.openhab.core.config.core.Configuration;
@@ -46,6 +51,7 @@ import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.thing.Bridge;
 import org.openhab.core.thing.Channel;
 import org.openhab.core.thing.ChannelUID;
+import org.openhab.core.thing.Thing;
 import org.openhab.core.thing.ThingUID;
 import org.openhab.core.thing.binding.ThingHandlerCallback;
 import org.openhab.core.thing.type.ChannelTypeRegistry;
@@ -87,6 +93,7 @@ public class FineOffsetGatewayHandlerTest {
         when(bridgeMock.getConfiguration()).thenReturn(new Configuration());
         when(bridgeMock.getProperties()).thenReturn(Map.of());
         when(bridgeMock.getChannels()).thenReturn(List.of());
+        when(bridgeMock.getThings()).thenReturn(List.of());
 
         handler = new FineOffsetGatewayHandler(bridgeMock, discoveryServiceMock, channelTypeRegistryMock,
                 translationProviderMock, localeProviderMock);
@@ -122,6 +129,12 @@ public class FineOffsetGatewayHandlerTest {
     private MeasuredValue measuredValue(String channelPrefix, ChannelTypeUID channelTypeUID) {
         return new MeasuredValue(MeasureType.TEMPERATURE, channelPrefix, null, channelTypeUID, new DecimalType(1),
                 channelPrefix, null);
+    }
+
+    private MeasuredValue taggedValue(String channelPrefix, ChannelTypeUID channelTypeUID, Sensor sensor,
+            Integer channelNumber) {
+        return new MeasuredValue(MeasureType.TEMPERATURE, channelPrefix, channelNumber, channelTypeUID,
+                new DecimalType(1), channelPrefix, sensor);
     }
 
     @Test
@@ -203,5 +216,29 @@ public class FineOffsetGatewayHandlerTest {
 
         ChannelUID expectedUID = new ChannelUID(BRIDGE_UID, "temperature");
         verify(callbackMock).stateUpdated(expectedUID, new DecimalType(1));
+    }
+
+    @Test
+    void taggedValuesAreDispatchedToTheMatchingSensorHandler() throws Exception {
+        // a child WH51 channel-1 sensor Thing with a mocked handler
+        Thing sensorThing = org.mockito.Mockito.mock(Thing.class);
+        FineOffsetSensorHandler sensorHandler = org.mockito.Mockito.mock(FineOffsetSensorHandler.class);
+        Configuration sensorConfig = new Configuration(
+                Map.of(FineOffsetSensorConfiguration.SENSOR, SensorGatewayBinding.WH51_CH1.name()));
+        when(sensorThing.getThingTypeUID()).thenReturn(FineOffsetWeatherStationBindingConstants.THING_TYPE_SENSOR);
+        when(sensorThing.getConfiguration()).thenReturn(sensorConfig);
+        when(sensorThing.getHandler()).thenReturn(sensorHandler);
+        when(bridgeMock.getThings()).thenReturn(List.of(sensorThing));
+
+        MeasuredValue soilMoisture = taggedValue("moisture-soil-channel", CHANNEL_TYPE_HUMIDITY, Sensor.WH51, 1);
+        liveDataReturns(temperature, soilMoisture);
+        updateLiveData();
+
+        // the gateway still creates a channel for EVERY value (incl. the tagged one)
+        assertThat(currentChannelIds(), containsInAnyOrder("temperature", "moisture-soil-channel-1"));
+
+        // and the WH51-CH1 sensor handler received exactly its one tagged value
+        verify(sensorHandler).updateMeasuredValues(argThat(values -> values.size() == 1
+                && "moisture-soil-channel-1".equals(values.iterator().next().getChannelId())));
     }
 }

--- a/bundles/org.openhab.binding.fineoffsetweatherstation/src/test/java/org/openhab/binding/fineoffsetweatherstation/internal/handler/FineOffsetGatewayHandlerTest.java
+++ b/bundles/org.openhab.binding.fineoffsetweatherstation/src/test/java/org/openhab/binding/fineoffsetweatherstation/internal/handler/FineOffsetGatewayHandlerTest.java
@@ -18,6 +18,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.openhab.binding.fineoffsetweatherstation.internal.FineOffsetWeatherStationBindingConstants.CHANNEL_TYPE_HUMIDITY;
@@ -281,7 +282,7 @@ public class FineOffsetGatewayHandlerTest {
         updateLiveData();
 
         // The description of the created gateway channel must reference the full ChannelUID
-        String expectedUid = sensorThingUID + ":moisture-soil-channel";
+        String expectedUid = new ChannelUID(sensorThingUID, "moisture-soil-channel").getAsString();
         List<Channel> channels = ((Bridge) handler.getThing()).getChannels();
         Channel soilChannel = channels.stream().filter(c -> "moisture-soil-channel-1".equals(c.getUID().getId()))
                 .findFirst().orElseThrow();
@@ -304,5 +305,8 @@ public class FineOffsetGatewayHandlerTest {
         // Verify the no-target i18n key was used (no UID argument)
         verify(translationProviderMock).getText(any(), eq("gateway.dynamic-channel.deprecation-note-no-target"), any(),
                 any());
+        // Verify the with-target key was NOT used (double-call regression guard)
+        verify(translationProviderMock, never()).getText(any(), eq("gateway.dynamic-channel.deprecation-note"), any(),
+                any(), any());
     }
 }

--- a/bundles/org.openhab.binding.fineoffsetweatherstation/src/test/java/org/openhab/binding/fineoffsetweatherstation/internal/handler/FineOffsetGatewayHandlerTest.java
+++ b/bundles/org.openhab.binding.fineoffsetweatherstation/src/test/java/org/openhab/binding/fineoffsetweatherstation/internal/handler/FineOffsetGatewayHandlerTest.java
@@ -14,6 +14,7 @@ package org.openhab.binding.fineoffsetweatherstation.internal.handler;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.openhab.binding.fineoffsetweatherstation.internal.FineOffsetWeatherStationBindingConstants.CHANNEL_TYPE_HUMIDITY;
 import static org.openhab.binding.fineoffsetweatherstation.internal.FineOffsetWeatherStationBindingConstants.CHANNEL_TYPE_MAX_WIND_SPEED;
@@ -44,6 +45,7 @@ import org.openhab.core.i18n.TranslationProvider;
 import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.thing.Bridge;
 import org.openhab.core.thing.Channel;
+import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.ThingUID;
 import org.openhab.core.thing.binding.ThingHandlerCallback;
 import org.openhab.core.thing.type.ChannelTypeRegistry;
@@ -190,5 +192,16 @@ public class FineOffsetGatewayHandlerTest {
         pollTimes(REMOVAL_THRESHOLD - 1);
 
         assertThat(currentChannelIds(), containsInAnyOrder("temperature", "humidity"));
+    }
+
+    @Test
+    void firstPollStateIsPostedImmediately() throws Exception {
+        // When a channel is created for the first time, its initial state must be posted right away —
+        // not deferred until the next poll.
+        liveDataReturns(temperature);
+        updateLiveData();
+
+        ChannelUID expectedUID = new ChannelUID(BRIDGE_UID, "temperature");
+        verify(callbackMock).stateUpdated(expectedUID, new DecimalType(1));
     }
 }

--- a/bundles/org.openhab.binding.fineoffsetweatherstation/src/test/java/org/openhab/binding/fineoffsetweatherstation/internal/handler/FineOffsetGatewayHandlerTest.java
+++ b/bundles/org.openhab.binding.fineoffsetweatherstation/src/test/java/org/openhab/binding/fineoffsetweatherstation/internal/handler/FineOffsetGatewayHandlerTest.java
@@ -119,7 +119,7 @@ public class FineOffsetGatewayHandlerTest {
 
     private MeasuredValue measuredValue(String channelPrefix, ChannelTypeUID channelTypeUID) {
         return new MeasuredValue(MeasureType.TEMPERATURE, channelPrefix, null, channelTypeUID, new DecimalType(1),
-                channelPrefix);
+                channelPrefix, null);
     }
 
     @Test

--- a/bundles/org.openhab.binding.fineoffsetweatherstation/src/test/java/org/openhab/binding/fineoffsetweatherstation/internal/handler/FineOffsetGatewayHandlerTest.java
+++ b/bundles/org.openhab.binding.fineoffsetweatherstation/src/test/java/org/openhab/binding/fineoffsetweatherstation/internal/handler/FineOffsetGatewayHandlerTest.java
@@ -14,16 +14,21 @@ package org.openhab.binding.fineoffsetweatherstation.internal.handler;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.containsString;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.openhab.binding.fineoffsetweatherstation.internal.FineOffsetWeatherStationBindingConstants.CHANNEL_TYPE_HUMIDITY;
 import static org.openhab.binding.fineoffsetweatherstation.internal.FineOffsetWeatherStationBindingConstants.CHANNEL_TYPE_MAX_WIND_SPEED;
 import static org.openhab.binding.fineoffsetweatherstation.internal.FineOffsetWeatherStationBindingConstants.CHANNEL_TYPE_TEMPERATURE;
 import static org.openhab.binding.fineoffsetweatherstation.internal.FineOffsetWeatherStationBindingConstants.THING_TYPE_GATEWAY;
+import static org.openhab.binding.fineoffsetweatherstation.internal.FineOffsetWeatherStationBindingConstants.THING_TYPE_SENSOR;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.text.MessageFormat;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -240,5 +245,64 @@ public class FineOffsetGatewayHandlerTest {
         // and the WH51-CH1 sensor handler received exactly its one tagged value
         verify(sensorHandler).updateMeasuredValues(argThat(values -> values.size() == 1
                 && "moisture-soil-channel-1".equals(values.iterator().next().getChannelId())));
+    }
+
+    @Test
+    void deprecationNoteContainsFullSensorChannelUid() throws Exception {
+        // Stub getText to emulate the real TranslationProvider: format defaultText with varargs via MessageFormat.
+        // Return null when defaultText is null (mirrors real provider behaviour for missing descriptions).
+        when(translationProviderMock.getText(any(), any(), any(), any(), any())).thenAnswer(invocation -> {
+            String defaultText = invocation.getArgument(2);
+            if (defaultText == null) {
+                return null;
+            }
+            Object[] args = invocation.getArguments();
+            // args[4..] are the varargs passed after locale
+            Object[] msgArgs = new Object[args.length - 4];
+            for (int i = 0; i < msgArgs.length; i++) {
+                msgArgs[i] = args[i + 4];
+            }
+            return msgArgs.length > 0 ? MessageFormat.format(defaultText, msgArgs) : defaultText;
+        });
+
+        ThingUID sensorThingUID = new ThingUID(THING_TYPE_SENSOR, BRIDGE_UID.getId(), "WH51_CH1");
+        Thing sensorThing = org.mockito.Mockito.mock(Thing.class);
+        FineOffsetSensorHandler sensorHandler = org.mockito.Mockito.mock(FineOffsetSensorHandler.class);
+        Configuration sensorConfig = new Configuration(
+                Map.of(FineOffsetSensorConfiguration.SENSOR, SensorGatewayBinding.WH51_CH1.name()));
+        when(sensorThing.getThingTypeUID()).thenReturn(THING_TYPE_SENSOR);
+        when(sensorThing.getConfiguration()).thenReturn(sensorConfig);
+        when(sensorThing.getHandler()).thenReturn(sensorHandler);
+        when(sensorThing.getUID()).thenReturn(sensorThingUID);
+        when(bridgeMock.getThings()).thenReturn(List.of(sensorThing));
+
+        MeasuredValue soilMoisture = taggedValue("moisture-soil-channel", CHANNEL_TYPE_HUMIDITY, Sensor.WH51, 1);
+        liveDataReturns(soilMoisture);
+        updateLiveData();
+
+        // The description of the created gateway channel must reference the full ChannelUID
+        String expectedUid = sensorThingUID + ":moisture-soil-channel";
+        List<Channel> channels = ((Bridge) handler.getThing()).getChannels();
+        Channel soilChannel = channels.stream().filter(c -> "moisture-soil-channel-1".equals(c.getUID().getId()))
+                .findFirst().orElseThrow();
+        assertThat(soilChannel.getDescription(), containsString(expectedUid));
+
+        // Verify the correct i18n key was used
+        verify(translationProviderMock).getText(any(), eq("gateway.dynamic-channel.deprecation-note"), any(), any(),
+                eq(expectedUid));
+    }
+
+    @Test
+    void deprecationNoteNoTargetWhenNoMatchingSensorThingPresent() throws Exception {
+        // No child sensor Things at all -> sensorChannelUid() returns null
+        when(bridgeMock.getThings()).thenReturn(List.of());
+
+        MeasuredValue soilMoisture = taggedValue("moisture-soil-channel", CHANNEL_TYPE_HUMIDITY, Sensor.WH51, 1);
+        liveDataReturns(soilMoisture);
+        updateLiveData();
+
+        // Verify the no-target i18n key was used (no UID argument)
+        verify(translationProviderMock).getText(any(), eq("gateway.dynamic-channel.deprecation-note-no-target"), any(),
+                any());
     }
 }

--- a/bundles/org.openhab.binding.fineoffsetweatherstation/src/test/java/org/openhab/binding/fineoffsetweatherstation/internal/handler/FineOffsetSensorHandlerTest.java
+++ b/bundles/org.openhab.binding.fineoffsetweatherstation/src/test/java/org/openhab/binding/fineoffsetweatherstation/internal/handler/FineOffsetSensorHandlerTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.fineoffsetweatherstation.internal.handler;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.not;
+import static org.mockito.Mockito.when;
+import static org.openhab.binding.fineoffsetweatherstation.internal.FineOffsetWeatherStationBindingConstants.CHANNEL_TYPE_MOISTURE;
+import static org.openhab.binding.fineoffsetweatherstation.internal.FineOffsetWeatherStationBindingConstants.THING_TYPE_SENSOR;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.openhab.binding.fineoffsetweatherstation.internal.domain.MeasureType;
+import org.openhab.binding.fineoffsetweatherstation.internal.domain.Sensor;
+import org.openhab.binding.fineoffsetweatherstation.internal.domain.response.MeasuredValue;
+import org.openhab.core.config.core.Configuration;
+import org.openhab.core.library.types.DecimalType;
+import org.openhab.core.thing.Channel;
+import org.openhab.core.thing.Thing;
+import org.openhab.core.thing.ThingUID;
+import org.openhab.core.thing.binding.ThingHandlerCallback;
+import org.openhab.core.thing.type.ChannelTypeRegistry;
+import org.openhab.core.thing.type.ChannelTypeUID;
+
+/**
+ * Tests the dynamic measurement-channel handling of {@link FineOffsetSensorHandler}.
+ *
+ * @author Andreas Berger - Initial contribution
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@NonNullByDefault
+public class FineOffsetSensorHandlerTest {
+
+    private static final ThingUID SENSOR_UID = new ThingUID(THING_TYPE_SENSOR, "testSensor");
+
+    // must match FineOffsetSensorHandler.MISSING_MEASURAND_REMOVAL_THRESHOLD
+    private static final int REMOVAL_THRESHOLD = 10;
+
+    private @Mock @NonNullByDefault({}) Thing thingMock;
+    private @Mock @NonNullByDefault({}) ThingHandlerCallback callbackMock;
+    private @Mock @NonNullByDefault({}) ChannelTypeRegistry channelTypeRegistryMock;
+
+    private @NonNullByDefault({}) FineOffsetSensorHandler handler;
+
+    private final MeasuredValue moisture = measuredValue("moisture-soil-channel", CHANNEL_TYPE_MOISTURE);
+    private final MeasuredValue soilTemp = measuredValue("temperature-soil-channel", CHANNEL_TYPE_MOISTURE);
+
+    @BeforeEach
+    public void setUp() {
+        when(thingMock.getUID()).thenReturn(SENSOR_UID);
+        when(thingMock.getThingTypeUID()).thenReturn(THING_TYPE_SENSOR);
+        when(thingMock.getConfiguration()).thenReturn(new Configuration());
+        when(thingMock.getProperties()).thenReturn(java.util.Map.of());
+        when(thingMock.getChannels()).thenReturn(List.of());
+
+        handler = new FineOffsetSensorHandler(thingMock, channelTypeRegistryMock);
+        handler.setCallback(callbackMock);
+    }
+
+    private MeasuredValue measuredValue(String channelPrefix, ChannelTypeUID channelTypeUID) {
+        return new MeasuredValue(MeasureType.PERCENTAGE, channelPrefix, null, channelTypeUID, new DecimalType(1),
+                channelPrefix, Sensor.WH51);
+    }
+
+    private List<String> currentChannelIds() {
+        return handler.getThing().getChannels().stream().map(Channel::getUID).map(uid -> uid.getId())
+                .collect(Collectors.toList());
+    }
+
+    @Test
+    void createsAChannelPerMeasurandPrefix() {
+        handler.updateMeasuredValues(List.of(moisture, soilTemp));
+        assertThat(currentChannelIds(), containsInAnyOrder("moisture-soil-channel", "temperature-soil-channel"));
+    }
+
+    @Test
+    void keepsChannelAcrossTransientGapBelowThreshold() {
+        handler.updateMeasuredValues(List.of(moisture, soilTemp));
+        for (int i = 0; i < REMOVAL_THRESHOLD - 1; i++) {
+            handler.updateMeasuredValues(List.of(moisture)); // soilTemp missing
+        }
+        assertThat(currentChannelIds(), containsInAnyOrder("moisture-soil-channel", "temperature-soil-channel"));
+    }
+
+    @Test
+    void removesChannelAfterThreshold() {
+        handler.updateMeasuredValues(List.of(moisture, soilTemp));
+        for (int i = 0; i < REMOVAL_THRESHOLD; i++) {
+            handler.updateMeasuredValues(List.of(moisture)); // soilTemp missing
+        }
+        assertThat(currentChannelIds(), containsInAnyOrder("moisture-soil-channel"));
+        assertThat(currentChannelIds(), not(hasItem("temperature-soil-channel")));
+    }
+
+    @Test
+    void emptyUpdateNeverRemovesStaticChannels() {
+        // a sensor that produces no measurements this poll must not have its static signal/battery channels touched
+        handler.updateMeasuredValues(List.of());
+        // no dynamic channels were ever created, so nothing changes and no exception is thrown
+        assertThat(currentChannelIds(), containsInAnyOrder());
+    }
+}

--- a/bundles/org.openhab.binding.fineoffsetweatherstation/src/test/java/org/openhab/binding/fineoffsetweatherstation/internal/handler/FineOffsetSensorHandlerTest.java
+++ b/bundles/org.openhab.binding.fineoffsetweatherstation/src/test/java/org/openhab/binding/fineoffsetweatherstation/internal/handler/FineOffsetSensorHandlerTest.java
@@ -20,6 +20,7 @@ import static org.hamcrest.Matchers.not;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.openhab.binding.fineoffsetweatherstation.internal.FineOffsetWeatherStationBindingConstants.CHANNEL_TYPE_MOISTURE;
+import static org.openhab.binding.fineoffsetweatherstation.internal.FineOffsetWeatherStationBindingConstants.CHANNEL_TYPE_TEMPERATURE;
 import static org.openhab.binding.fineoffsetweatherstation.internal.FineOffsetWeatherStationBindingConstants.THING_TYPE_SENSOR;
 
 import java.util.List;
@@ -59,8 +60,7 @@ public class FineOffsetSensorHandlerTest {
 
     private static final ThingUID SENSOR_UID = new ThingUID(THING_TYPE_SENSOR, "testSensor");
 
-    // must match FineOffsetSensorHandler.MISSING_MEASURAND_REMOVAL_THRESHOLD
-    private static final int REMOVAL_THRESHOLD = 10;
+    private static final int REMOVAL_THRESHOLD = DynamicChannelReconciler.MISSING_VALUE_REMOVAL_THRESHOLD;
 
     private @Mock @NonNullByDefault({}) Thing thingMock;
     private @Mock @NonNullByDefault({}) ThingHandlerCallback callbackMock;
@@ -69,7 +69,7 @@ public class FineOffsetSensorHandlerTest {
     private @NonNullByDefault({}) FineOffsetSensorHandler handler;
 
     private final MeasuredValue moisture = measuredValue("moisture-soil-channel", CHANNEL_TYPE_MOISTURE);
-    private final MeasuredValue soilTemp = measuredValue("temperature-soil-channel", CHANNEL_TYPE_MOISTURE);
+    private final MeasuredValue soilTemp = measuredValue("temperature-soil-channel", CHANNEL_TYPE_TEMPERATURE);
 
     @BeforeEach
     public void setUp() {

--- a/bundles/org.openhab.binding.fineoffsetweatherstation/src/test/java/org/openhab/binding/fineoffsetweatherstation/internal/handler/FineOffsetSensorHandlerTest.java
+++ b/bundles/org.openhab.binding.fineoffsetweatherstation/src/test/java/org/openhab/binding/fineoffsetweatherstation/internal/handler/FineOffsetSensorHandlerTest.java
@@ -14,8 +14,10 @@ package org.openhab.binding.fineoffsetweatherstation.internal.handler;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.not;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.openhab.binding.fineoffsetweatherstation.internal.FineOffsetWeatherStationBindingConstants.CHANNEL_TYPE_MOISTURE;
 import static org.openhab.binding.fineoffsetweatherstation.internal.FineOffsetWeatherStationBindingConstants.THING_TYPE_SENSOR;
@@ -37,9 +39,11 @@ import org.openhab.binding.fineoffsetweatherstation.internal.domain.response.Mea
 import org.openhab.core.config.core.Configuration;
 import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.thing.Channel;
+import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.Thing;
 import org.openhab.core.thing.ThingUID;
 import org.openhab.core.thing.binding.ThingHandlerCallback;
+import org.openhab.core.thing.binding.builder.ChannelBuilder;
 import org.openhab.core.thing.type.ChannelTypeRegistry;
 import org.openhab.core.thing.type.ChannelTypeUID;
 
@@ -115,10 +119,39 @@ public class FineOffsetSensorHandlerTest {
     }
 
     @Test
-    void emptyUpdateNeverRemovesStaticChannels() {
-        // a sensor that produces no measurements this poll must not have its static signal/battery channels touched
+    void emptyUpdateOnFreshHandlerIsSafe() {
+        // a sensor that produces no measurements must not throw and must leave the channel list empty
         handler.updateMeasuredValues(List.of());
-        // no dynamic channels were ever created, so nothing changes and no exception is thrown
-        assertThat(currentChannelIds(), containsInAnyOrder());
+        assertThat(currentChannelIds(), empty());
+    }
+
+    @Test
+    void managedChannelRemovalPreservesStaticChannels() {
+        // Seed the mock thing with a static "signal" channel so that editThing() picks it up from the start.
+        Channel staticSignal = ChannelBuilder.create(new ChannelUID(SENSOR_UID, "signal")).build();
+        when(thingMock.getChannels()).thenReturn(List.of(staticSignal));
+
+        // Create a managed channel via the first measurement update.
+        handler.updateMeasuredValues(List.of(moisture));
+        assertThat(currentChannelIds(), containsInAnyOrder("signal", "moisture-soil-channel"));
+
+        // Drive the managed channel past the removal threshold without reporting it.
+        for (int i = 0; i < REMOVAL_THRESHOLD; i++) {
+            handler.updateMeasuredValues(List.of());
+        }
+
+        // The managed channel is gone; the static signal channel is untouched.
+        assertThat(currentChannelIds(), not(hasItem("moisture-soil-channel")));
+        assertThat(currentChannelIds(), hasItem("signal"));
+    }
+
+    @Test
+    void firstMeasurementStateIsPostedImmediately() {
+        // When a channel is created for the first time, its initial state must be posted right away —
+        // not deferred until the next poll.
+        handler.updateMeasuredValues(List.of(moisture));
+
+        ChannelUID expectedUID = new ChannelUID(SENSOR_UID, "moisture-soil-channel");
+        verify(callbackMock).stateUpdated(expectedUID, new DecimalType(1));
     }
 }

--- a/bundles/org.openhab.binding.fineoffsetweatherstation/src/test/java/org/openhab/binding/fineoffsetweatherstation/internal/service/EcowittDataParserTest.java
+++ b/bundles/org.openhab.binding.fineoffsetweatherstation/src/test/java/org/openhab/binding/fineoffsetweatherstation/internal/service/EcowittDataParserTest.java
@@ -25,6 +25,7 @@ import org.assertj.core.groups.Tuple;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.junit.jupiter.api.Test;
+import org.openhab.binding.fineoffsetweatherstation.internal.domain.Sensor;
 import org.openhab.binding.fineoffsetweatherstation.internal.domain.SensorGatewayBinding;
 import org.openhab.binding.fineoffsetweatherstation.internal.domain.response.MeasuredValue;
 import org.openhab.binding.fineoffsetweatherstation.internal.domain.response.SensorDevice;
@@ -160,6 +161,19 @@ class EcowittDataParserTest {
         Assertions.assertThat(parser.parseFirmwareVersion(version)).isEqualTo("GW1200A_V1.4.7");
         Assertions.assertThat(parser.parseSensorPageCount(version)).isEqualTo(4);
         Assertions.assertThat(parser.isEcowittPlatform(version)).isTrue();
+    }
+
+    @Test
+    void httpMeasurandsCarrySensorTag() {
+        // ch_soil uses CHANNEL keying: each element has a "channel" field and the field name "humidity" holds the value
+        // common_list uses CODE keying: each element has "id" and "val" (plus optional "unit")
+        String json = "{\"ch_soil\":[{\"channel\":\"1\",\"humidity\":\"50\"}],"
+                + "\"common_list\":[{\"id\":\"0x02\",\"val\":\"21.0\",\"unit\":\"C\"}]}";
+        List<MeasuredValue> data = parser.parseLiveData(json);
+        Assertions.assertThat(data).filteredOn(value -> "moisture-soil-channel-1".equals(value.getChannelId()))
+                .singleElement().satisfies(value -> Assertions.assertThat(value.getSensor()).isEqualTo(Sensor.WH51));
+        Assertions.assertThat(data).filteredOn(value -> "temperature-outdoor".equals(value.getChannelId()))
+                .singleElement().satisfies(value -> Assertions.assertThat(value.getSensor()).isNull());
     }
 
     private static Map<String, String> stateByChannel(List<MeasuredValue> values) {

--- a/bundles/org.openhab.binding.fineoffsetweatherstation/src/test/java/org/openhab/binding/fineoffsetweatherstation/internal/service/FineOffsetDataParserTest.java
+++ b/bundles/org.openhab.binding.fineoffsetweatherstation/src/test/java/org/openhab/binding/fineoffsetweatherstation/internal/service/FineOffsetDataParserTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 import org.openhab.binding.fineoffsetweatherstation.internal.domain.Command;
 import org.openhab.binding.fineoffsetweatherstation.internal.domain.DebugDetails;
 import org.openhab.binding.fineoffsetweatherstation.internal.domain.Protocol;
+import org.openhab.binding.fineoffsetweatherstation.internal.domain.Sensor;
 import org.openhab.binding.fineoffsetweatherstation.internal.domain.response.MeasuredValue;
 import org.openhab.core.library.types.DateTimeType;
 import org.openhab.core.util.HexUtils;
@@ -224,5 +225,25 @@ class FineOffsetDataParserTest {
         byte[] data = HexUtils.hexToBytes("FFFF501511456173795765617468657256312E362E3400");
         String firmware = new FineOffsetDataParser(Protocol.ELV).getFirmwareVersion(data);
         Assertions.assertThat(firmware).isEqualTo("EasyWeatherV1.6.4");
+    }
+
+    @Test
+    void tcpMeasurandsCarrySensorTag() {
+        // 0xff 0xff : header
+        // 0x27 : CMD_GW1000_LIVEDATA
+        // 0x00 0x0A : size = 10 (loop runs while idx < 10; items at 5..9, checksum at 10)
+        // 0x2C 0x32 : soil moisture channel 1 = 50 % (PERCENTAGE = 1 byte)
+        // 0x02 0x00 0xD2 : outdoor temperature = 21.0 °C (TEMPERATURE = 2 bytes, signed: 0x00D2 = 210 → /10)
+        // 0x00 : checksum slot
+        byte[] bytes = new byte[] { (byte) 0xff, (byte) 0xff, 0x27, 0x00, 0x0A, //
+                0x2C, 0x32, // soil moisture channel 1 = 50 %
+                0x02, 0x00, (byte) 0xD2, // outdoor temperature = 21.0 °C
+                0x00 };
+        List<MeasuredValue> data = new FineOffsetDataParser(Protocol.DEFAULT).getMeasuredValues(bytes,
+                new DebugDetails(bytes, Command.CMD_GW1000_LIVEDATA, Protocol.DEFAULT));
+
+        Assertions.assertThat(data).extracting(MeasuredValue::getChannelId, MeasuredValue::getSensor).containsExactly( //
+                Assertions.tuple("moisture-soil-channel-1", Sensor.WH51), //
+                Assertions.tuple("temperature-outdoor", null));
     }
 }


### PR DESCRIPTION
## Description

When you buy a discrete Fine Offset add-on sensor (e.g. a WH51 soil moisture sensor), its measurement values currently land only as dynamic channels on the **gateway** (bridge) Thing, while the per-sensor **sensor Thing** only carries signal strength and battery. Conceptually the measurement belongs to the sensor, so this change routes the measured values of discrete add-on sensors onto their own sensor Thing, while keeping the existing gateway channels working (now marked deprecated).

### How it works

- `Measurand` gains an optional `Sensor` tag that flows onto each produced `MeasuredValue` (through both the TCP and HTTP parse paths).
- The discrete-sensor measurands are tagged with their `Sensor` (WH25, WH31, WH51, WH41, WH55, WH57, WH34, WH35, WH45). Main-array, rain and `common_list` aggregates stay untagged; the WH46 CO₂ group stays gateway-only.
- `SensorGatewayBinding` gains a `(Sensor, channel)` reverse lookup.
- In `updateLiveData`, the gateway groups tagged values by their owning sensor and pushes each group to the matching `FineOffsetSensorHandler`, which creates/updates dynamic measurement channels on the sensor Thing. Gateway channels continue to receive **all** values (unchanged).
- The shared dynamic-channel create/update/debounce logic that previously lived in both the gateway and sensor handlers is extracted into a single `DynamicChannelReconciler` collaborator. Static signal/battery channels are never affected by the measurement-channel debounce.
- Mirrored gateway channels get a **translatable** deprecation note in their description naming the equivalent channel on the sensor Thing (e.g. `… as channel: fineoffsetweatherstation:sensor:<gatewayId>:WH51_CH1:moisture-soil-channel`), with a fallback note when the sensor Thing does not exist yet.

### Scope / notes

- **Additive and backward-compatible.** Existing gateway channels and their item links keep working; new sensor channels appear the next poll after data arrives. No new configuration, no Thing re-creation, no discovery change.
- **WH54 (LDS)** is intentionally a no-op here: the binding has no WH54 measurand today (only the sensor entry and an unused `ch_lds` HTTP group), and adding new measurands is out of scope for this change.
- The main outdoor array (WH24/WH65/WH69/WH68/WH80/WH90/WS85), the rain group, and the aggregate `common_list` values remain gateway-only.

### Testing

- Existing `FineOffsetDataParserTest`, `EcowittDataParserTest` and `MeasurandRegistryTest` continue to pass unchanged (behavior-preservation proof), extended to assert the `Sensor` tag is carried.
- New tests: `MeasurandTest`, `SensorGatewayBindingTest`, `FineOffsetSensorHandlerTest`, `DynamicChannelReconcilerTest`, plus gateway dispatch and deprecation-note tests.
- Full bundle: 55 tests pass; `spotless:check` clean.

## Signed-off-by

All commits include a DCO sign-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
