### PR TITLE
[jellyfin] Fix missing timeoutMs discovery parameter

### DIFF
--- a/bundles/org.openhab.binding.jellyfin/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.binding.jellyfin/src/main/resources/OH-INF/addon/addon.xml
@@ -60,6 +60,10 @@
 					<name>requestPlain</name>
 					<value>who is JellyfinServer?</value>
 				</discovery-parameter>
+				<discovery-parameter>
+					<name>timeoutMs</name>
+					<value>2000</value>
+				</discovery-parameter>
 			</discovery-parameters>
 			<match-properties>
 				<match-property>


### PR DESCRIPTION
Fixes #21013

### Problem
The Jellyfin binding declared `ip` as a discovery type (for `IpAddonFinder`) but was missing the required `timeoutMs` discovery parameter. This caused the following warning to be logged on every openHAB restart — even on systems without any Jellyfin server:

```
[WARN ] [fig.discovery.addon.ip.IpAddonFinder] - binding-jellyfin: discovery-parameter 'timeoutMs' cannot be parsed
```

### Fix
Added the missing `timeoutMs` discovery parameter (value: `2000` ms) to the Jellyfin binding's `addon.xml`.

### Files changed
- `bundles/org.openhab.binding.jellyfin/src/main/resources/OH-INF/addon/addon.xml`
