### PR TITLE
[nuvo] Fix encoding of accented characters

### DIFF
--- a/bundles/org.openhab.binding.nuvo/README.md
+++ b/bundles/org.openhab.binding.nuvo/README.md
@@ -348,8 +348,6 @@ sitemap nuvo label="Audio Control" {
 ### `nuvo.rules` Example
 
 ```java
-import java.text.Normalizer
-
 // To be used with a direct serial port or serial over IP connection
 
 val actions = getActions("nuvo","nuvo:amplifier:myamp")
@@ -399,34 +397,22 @@ rule "Load track name for Source 3"
 when
     Item Item_Containing_TrackName changed
 then
-    // The Nuvo keypad cannot display extended ASCII characters (accent, umlaut, etc.)
-    // Below we transform extended ASCII chars into their basic counterparts
-    // example: 'La Touché' becomes 'La Touche' and 'Nöel' becomes 'Noel'
-    var trackName = Normalizer::normalize(Item_Containing_TrackName.state.toString, Normalizer.Form.NFD).replaceAll("[^\\p{ASCII}]", "")
-
-    sendCommand(nuvo_s3_display_line4, trackName)
+    sendCommand(nuvo_s3_display_line4, Item_Containing_TrackName.state.toString)
     sendCommand(nuvo_s3_display_line1, "")
-
 end
 
 rule "Load album name for Source 3"
 when
     Item Item_Containing_AlbumName changed
 then
-    // fix extended ASCII chars
-    var albumName = Normalizer::normalize(Item_Containing_AlbumName.state.toString, Normalizer.Form.NFD).replaceAll("[^\\p{ASCII}]", "")
-
-    sendCommand(nuvo_s3_display_line2, albumName)
+    sendCommand(nuvo_s3_display_line2, Item_Containing_AlbumName.state.toString)
 end
 
 rule "Load artist name for Source 3"
 when
     Item Item_Containing_ArtistName changed
 then
-    // fix extended ASCII chars
-    var artistName = Normalizer::normalize(Item_Containing_ArtistName.state.toString, Normalizer.Form.NFD).replaceAll("[^\\p{ASCII}]", "")
-
-    sendCommand(nuvo_s3_display_line3, artistName)
+    sendCommand(nuvo_s3_display_line3, Item_Containing_ArtistName.state.toString)
 end
 
 // In this rule we have three items: Item_Containing_PlayMode, Item_Containing_TrackLength & Item_Containing_TrackPosition
@@ -548,8 +534,6 @@ The list of favorite names should be playable via another Thing connected to ope
 #### `nuvo-advanced.rules.rules` Example
 
 ```java
-import java.text.Normalizer
-
 // all examples using Source 6
 var source = "S6"
 
@@ -648,8 +632,7 @@ when
     Item music_Music_Album received update
 then
     if (music_Music_Album.state.toString() != "") {
-        albumName = Normalizer::normalize(music_Music_Album.state.toString, Normalizer.Form.NFD).replaceAll("[^\\p{ASCII}]", "")
-        sendCommand(nuvo_system_sendcmd, source + "DISPLINES0,0,0,\"\",\"" + albumName + "\",\"" + artistName + "\",\"" + trackName + "\"")
+        sendCommand(nuvo_system_sendcmd, source + "DISPLINES0,0,0,\"\",\"" + music_Music_Album.state.toString + "\",\"" + artistName + "\",\"" + trackName + "\"")
     }
 end
 
@@ -658,8 +641,7 @@ when
     Item music_Music_Artist received update
 then
     if (music_Music_Artist.state.toString() != "") {
-        artistName = Normalizer::normalize(music_Music_Artist.state.toString, Normalizer.Form.NFD).replaceAll("[^\\p{ASCII}]", "")
-        sendCommand(nuvo_system_sendcmd, source + "DISPLINES0,0,0,\"\",\"" + albumName + "\",\"" + artistName + "\",\"" + trackName + "\"")
+        sendCommand(nuvo_system_sendcmd, source + "DISPLINES0,0,0,\"\",\"" + music_Music_Artist.state.toString + "\",\"" + artistName + "\",\"" + trackName + "\"")
     }
 end
 
@@ -668,8 +650,7 @@ when
     Item music_Music_Track received update
 then
     if (music_Music_Track.state.toString() != "") {
-        trackName = Normalizer::normalize(music_Music_Track.state.toString, Normalizer.Form.NFD).replaceAll("[^\\p{ASCII}]", "")
-        sendCommand(nuvo_system_sendcmd, source + "DISPLINES0,0,0,\"\",\"" + albumName + "\",\"" + artistName + "\",\"" + trackName + "\"")
+        sendCommand(nuvo_system_sendcmd, source + "DISPLINES0,0,0,\"\",\"" + music_Music_Track.state.toString + "\",\"" + artistName + "\",\"" + trackName + "\"")
     }
 end
 

--- a/bundles/org.openhab.binding.nuvo/src/main/java/org/openhab/binding/nuvo/internal/communication/NuvoConnector.java
+++ b/bundles/org.openhab.binding.nuvo/src/main/java/org/openhab/binding/nuvo/internal/communication/NuvoConnector.java
@@ -291,7 +291,7 @@ public abstract class NuvoConnector {
                     && (command.endsWith(ON) || NuvoCommand.PAGE_ON.getValue().equals(command))) {
                 messageStr += messageStr;
             }
-            dataOut.write(messageStr.getBytes(StandardCharsets.US_ASCII));
+            dataOut.write(messageStr.getBytes(StandardCharsets.UTF_8));
             dataOut.flush();
         } catch (IOException e) {
             throw new NuvoException("Send command \"" + command + "\" failed: " + e.getMessage(), e);
@@ -322,7 +322,7 @@ public abstract class NuvoConnector {
      * @param incomingMessage the received message
      */
     public void handleIncomingMessage(byte[] incomingMessage) {
-        String message = new String(incomingMessage, StandardCharsets.US_ASCII).trim();
+        String message = new String(incomingMessage, StandardCharsets.UTF_8).trim();
 
         logger.debug("handleIncomingMessage: {}", message);
 


### PR DESCRIPTION
Fix the encoding of communications to/from the Nuvo to use UTF-8. Previously if accented characters were received from the MPS4, tuner, etc. they would be displayed incorrectly. Sending accented characters to the keypads for display was also not possible. The rules examples to convert accented characters to basic equivalents are no longer required.

Before:
<img width="479" height="190" alt="broke" src="https://github.com/user-attachments/assets/3428457a-6c0c-4fdf-be43-1af2c4ad812d" />


After:
<img width="488" height="187" alt="fix" src="https://github.com/user-attachments/assets/9c2fabd4-f07d-4d32-968a-8a7170a3a90a" />
