### PR TITLE
[gardena] Fix reconnection logic

### DIFF
--- a/bundles/org.openhab.binding.gardena/src/main/java/org/openhab/binding/gardena/internal/GardenaSmartImpl.java
+++ b/bundles/org.openhab.binding.gardena/src/main/java/org/openhab/binding/gardena/internal/GardenaSmartImpl.java
@@ -170,15 +170,28 @@ public class GardenaSmartImpl implements GardenaSmart, GardenaSmartWebSocketList
             for (LocationDataItem location : locationsResponse.data) {
                 WebSocketCreatedResponse webSocketCreatedResponse = getWebsocketInfo(location.id);
                 Location locationAttributes = location.attributes;
-                WebSocket webSocketAttributes = webSocketCreatedResponse.data.attributes;
-                if (locationAttributes == null || webSocketAttributes == null) {
+                String webSocketUrl = getWebSocketUrl(webSocketCreatedResponse);
+                if (locationAttributes == null || webSocketUrl == null) {
+                    logger.warn("Cannot start Gardena Webservice for location {} ({}): missing websocket data",
+                            location.id, locationAttributes == null ? null : locationAttributes.name);
                     continue;
                 }
                 String socketId = id + "-" + locationAttributes.name;
-                webSockets.put(location.id, new GardenaSmartWebSocket(this, webSocketClient, scheduler,
-                        webSocketAttributes.url, token, socketId, location.id));
+                webSockets.put(location.id, new GardenaSmartWebSocket(this, webSocketClient, scheduler, webSocketUrl,
+                        token, socketId, location.id));
             }
         }
+    }
+
+    private @Nullable String getWebSocketUrl(@Nullable WebSocketCreatedResponse webSocketCreatedResponse) {
+        if (webSocketCreatedResponse == null || webSocketCreatedResponse.data == null) {
+            return null;
+        }
+        WebSocket webSocketAttributes = webSocketCreatedResponse.data.attributes;
+        if (webSocketAttributes == null || webSocketAttributes.url == null || webSocketAttributes.url.isBlank()) {
+            return null;
+        }
+        return webSocketAttributes.url;
     }
 
     /**
@@ -423,14 +436,26 @@ public class GardenaSmartImpl implements GardenaSmart, GardenaSmartWebSocketList
             Thread.sleep(3000);
             WebSocketCreatedResponse webSocketCreatedResponse = getWebsocketInfo(socket.getLocationID());
             // only restart single socket, do not restart binding
-            WebSocket webSocketAttributes = webSocketCreatedResponse.data.attributes;
-            if (webSocketAttributes != null) {
-                socket.restart(webSocketAttributes.url);
+            String webSocketUrl = getWebSocketUrl(webSocketCreatedResponse);
+            if (webSocketUrl == null) {
+                throw new GardenaException(
+                        "No websocket URL received for location " + socket.getLocationID() + " during restart");
             }
+            socket.updateToken(token);
+            socket.restart(webSocketUrl);
         } catch (Exception ex) {
             // restart binding on error
-            logger.warn("Restarting GardenaSmart Webservice failed ({}): {}, restarting binding", socket.getSocketID(),
-                    ex.getMessage());
+            String message = ex.getMessage();
+            if (message == null || message.isBlank()) {
+                message = ex.getClass().getSimpleName();
+            }
+            if (logger.isDebugEnabled()) {
+                logger.warn("Restarting GardenaSmart Webservice failed ({}): {}, restarting binding",
+                        socket.getSocketID(), message, ex);
+            } else {
+                logger.warn("Restarting GardenaSmart Webservice failed ({}): {}, restarting binding",
+                        socket.getSocketID(), message);
+            }
             eventListener.onError();
         }
     }

--- a/bundles/org.openhab.binding.gardena/src/main/java/org/openhab/binding/gardena/internal/GardenaSmartWebSocket.java
+++ b/bundles/org.openhab.binding.gardena/src/main/java/org/openhab/binding/gardena/internal/GardenaSmartWebSocket.java
@@ -108,6 +108,10 @@ public class GardenaSmartWebSocket {
         return this.locationID;
     }
 
+    public synchronized void updateToken(@Nullable PostOAuth2Response token) {
+        this.token = token;
+    }
+
     public void restart(String newUrl) throws Exception {
         logger.debug("Reconnecting to Gardena Webservice ({})", socketId);
         session = (WebSocketSession) webSocketClient.connect(this, new URI(newUrl)).get();


### PR DESCRIPTION
When using the binding you get one of these log lines everyday:

``` 
2026-06-11 22:04:47.309 [WARN ] [ng.gardena.internal.GardenaSmartImpl] - Restarting GardenaSmart Webservice failed (home-My Garden): Cannot invoke "String.length()" because "s" is null, restarting binding
2026-06-19 22:26:37.413 [WARN ] [ng.gardena.internal.GardenaSmartImpl] - Restarting GardenaSmart Webservice failed (home-My Garden): null, restarting binding
```

Noticed it happened every 24 hour, so it looked something like token or session expiration. 
So i updated the logic to be more resilient and also update the token and reconnect pro-actively. This is now running for about a week without any issue.