### PR TITLE
[jsscripting] Fix dependency and build of repo

### DIFF
--- a/bundles/org.openhab.automation.jsscripting/pom.xml
+++ b/bundles/org.openhab.automation.jsscripting/pom.xml
@@ -66,7 +66,7 @@
             </goals>
             <configuration>
               <!--suppress UnresolvedMavenProperty -->
-              <arguments>install ${ohjs.version} webpack@^5.105.0 webpack-cli@^6.0.1 --prefix .</arguments>
+              <arguments>install ${ohjs.version} webpack@^5.105.0 webpack-cli@^6.0.1 terser-webpack-plugin@^5.3.16 --prefix .</arguments>
               <!-- webpack & webpack-cli versions should match to the ones from openhab-js -->
             </configuration>
           </execution>


### PR DESCRIPTION
When building this addon it fails due to the `terser-webpack-plugin` missing. I could not find a related PR and identify it as the root cause. Atleast this fixes the build.