### PR TITLE
[ring] Prevent ratelimiting from the ring API with snapshot requests

### DIFF
--- a/bundles/org.openhab.binding.ring/README.md
+++ b/bundles/org.openhab.binding.ring/README.md
@@ -14,7 +14,7 @@ _Other_ is identified as any of the non-traditional types such as the intercom.
 ## Discovery
 
 Auto-discovery is supported by this binding.
-After (manually) adding a Ring Account bridge, registered doorbells and chimes will be auto discovered.
+After (manually) adding a Ring Account bridge, registered devices will be auto discovered.
 
 ## Account Configuration
 
@@ -76,10 +76,10 @@ ring.things:
 
 ```java
 ring:account:ringAccount                "Ring Account"           [ username="user@domain.com", password="XXXXXXX", hardwareId="AA-BB-CC-DD-EE-FF", refreshInterval=5 ]
-ring:doorbell:<ring_device_id>          "Ring Doorbell"          [ refreshInterval=5, offOffset=0 ]
-ring:chime:<ring_device_id>             "Ring Chime"             [ refreshInterval=5, offOffset=0 ]
-ring:stickupcam:<ring_device_id>        "Ring Stickup Camera"    [ refreshInterval=5, offOffset=0 ]
-ring:other:<ring_device_id>             "Ring Other Device"      [ refreshInterval=5, offOffset=0 ]
+ring:doorbell:<ring_device_id>          "Ring Doorbell"          [ offOffset=0 ]
+ring:chime:<ring_device_id>             "Ring Chime"             [ offOffset=0 ]
+ring:stickupcam:<ring_device_id>        "Ring Stickup Camera"    [ offOffset=0 ]
+ring:other:<ring_device_id>             "Ring Other Device"      [ offOffset=0 ]
 ```
 
 ring.items:

--- a/bundles/org.openhab.binding.ring/src/main/java/org/openhab/binding/ring/internal/config/RingThingConfig.java
+++ b/bundles/org.openhab.binding.ring/src/main/java/org/openhab/binding/ring/internal/config/RingThingConfig.java
@@ -25,5 +25,4 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 public class RingThingConfig {
     public String id = "";
     public BigDecimal offOffset = BigDecimal.ZERO;
-    public int refreshInterval = 5;
 }

--- a/bundles/org.openhab.binding.ring/src/main/java/org/openhab/binding/ring/internal/handler/AbstractRingHandler.java
+++ b/bundles/org.openhab.binding.ring/src/main/java/org/openhab/binding/ring/internal/handler/AbstractRingHandler.java
@@ -74,7 +74,7 @@ public abstract class AbstractRingHandler extends BaseThingHandler {
      * Check every 60 seconds if any device settings have changed.
      */
     protected void startAutomaticRefresh() {
-        refreshJob = scheduler.scheduleWithFixedDelay(this::refresh, 0, 60, TimeUnit.SECONDS);
+        refreshJob = scheduler.scheduleWithFixedDelay(this::refresh, 0, 1, TimeUnit.MINUTES);
         refreshState();
     }
 

--- a/bundles/org.openhab.binding.ring/src/main/java/org/openhab/binding/ring/internal/handler/AbstractRingHandler.java
+++ b/bundles/org.openhab.binding.ring/src/main/java/org/openhab/binding/ring/internal/handler/AbstractRingHandler.java
@@ -73,8 +73,8 @@ public abstract class AbstractRingHandler extends BaseThingHandler {
     /**
      * Check every 60 seconds if one of the alarm times is reached.
      */
-    protected void startAutomaticRefresh(final int refreshInterval) {
-        refreshJob = scheduler.scheduleWithFixedDelay(this::refresh, 0, refreshInterval, TimeUnit.SECONDS);
+    protected void startAutomaticRefresh() {
+        refreshJob = scheduler.scheduleWithFixedDelay(this::refresh, 0, 60, TimeUnit.SECONDS);
         refreshState();
     }
 

--- a/bundles/org.openhab.binding.ring/src/main/java/org/openhab/binding/ring/internal/handler/AbstractRingHandler.java
+++ b/bundles/org.openhab.binding.ring/src/main/java/org/openhab/binding/ring/internal/handler/AbstractRingHandler.java
@@ -71,7 +71,7 @@ public abstract class AbstractRingHandler extends BaseThingHandler {
     }
 
     /**
-     * Check every 60 seconds if one of the alarm times is reached.
+     * Check every 60 seconds if any device settings have changed.
      */
     protected void startAutomaticRefresh() {
         refreshJob = scheduler.scheduleWithFixedDelay(this::refresh, 0, 60, TimeUnit.SECONDS);

--- a/bundles/org.openhab.binding.ring/src/main/java/org/openhab/binding/ring/internal/handler/RingDeviceHandler.java
+++ b/bundles/org.openhab.binding.ring/src/main/java/org/openhab/binding/ring/internal/handler/RingDeviceHandler.java
@@ -74,7 +74,7 @@ public abstract class RingDeviceHandler extends AbstractRingHandler {
         }
 
         if (this.refreshJob == null) {
-            startAutomaticRefresh(config.refreshInterval);
+            startAutomaticRefresh();
         }
     }
 
@@ -169,7 +169,7 @@ public abstract class RingDeviceHandler extends AbstractRingHandler {
                         enabled = xcommand;
                         updateState(channelUID, enabled);
                         if (enabled.equals(OnOffType.ON)) {
-                            startAutomaticRefresh(config.refreshInterval);
+                            startAutomaticRefresh();
                         } else {
                             stopAutomaticRefresh();
                         }

--- a/bundles/org.openhab.binding.ring/src/main/resources/OH-INF/i18n/ring.properties
+++ b/bundles/org.openhab.binding.ring/src/main/resources/OH-INF/i18n/ring.properties
@@ -38,26 +38,18 @@ thing-type.config.ring.chime.id.label = ID
 thing-type.config.ring.chime.id.description = The internal ID of the device.
 thing-type.config.ring.chime.offOffset.label = Power-off Time
 thing-type.config.ring.chime.offOffset.description = Offset in minutes to switch off
-thing-type.config.ring.chime.refreshInterval.label = Refresh Interval
-thing-type.config.ring.chime.refreshInterval.description = How often to poll the Ring service for events in seconds
 thing-type.config.ring.doorbell.id.label = ID
 thing-type.config.ring.doorbell.id.description = The internal ID of the device.
 thing-type.config.ring.doorbell.offOffset.label = Power-off Time
 thing-type.config.ring.doorbell.offOffset.description = Offset in minutes to switch off
-thing-type.config.ring.doorbell.refreshInterval.label = Refresh Interval
-thing-type.config.ring.doorbell.refreshInterval.description = How often to poll the Ring service for events in seconds
 thing-type.config.ring.otherdevice.id.label = ID
 thing-type.config.ring.otherdevice.id.description = The internal ID of the device.
 thing-type.config.ring.otherdevice.offOffset.label = Power-off Time
 thing-type.config.ring.otherdevice.offOffset.description = Offset in minutes to switch off
-thing-type.config.ring.otherdevice.refreshInterval.label = Refresh Interval
-thing-type.config.ring.otherdevice.refreshInterval.description = How often to poll the Ring service for events in seconds
 thing-type.config.ring.stickupcam.id.label = ID
 thing-type.config.ring.stickupcam.id.description = The internal ID of the device.
 thing-type.config.ring.stickupcam.offOffset.label = Power-off Time
 thing-type.config.ring.stickupcam.offOffset.description = Offset in minutes to switch off
-thing-type.config.ring.stickupcam.refreshInterval.label = Refresh Interval
-thing-type.config.ring.stickupcam.refreshInterval.description = How often to poll the Ring service for events in seconds
 
 # channel group types
 
@@ -81,10 +73,16 @@ channel-type.ring.doorbotId.label = Event Device ID
 channel-type.ring.doorbotId.description = The ID of the Ring device (doorbell, chime, etc.) that generated the currently selected event
 channel-type.ring.enabled.label = Enable Polling
 channel-type.ring.enabled.description = Account Polling Enabled (on=yes, off=no)
+channel-type.ring.extendedDescription.label = Extended Description
+channel-type.ring.extendedDescription.description = Extended description, similar to notifications from the Ring app
 channel-type.ring.kind.label = Event Type
 channel-type.ring.kind.description = The kind of event, usually 'motion' or 'ding'
 channel-type.ring.light.label = Light Status
 channel-type.ring.light.description = Current status of the light
+channel-type.ring.motionDetection.label = Motion Detection Status
+channel-type.ring.motionDetection.description = Current status of Motion Detection (ON=Enabled, OFF=Disabled)
+channel-type.ring.opendoor.label = Open Door
+channel-type.ring.opendoor.description = Open Door linked to Intercom
 channel-type.ring.siren.label = Siren Status
 channel-type.ring.siren.description = Current status of the siren
 channel-type.ring.snapshot-timestamp.label = Snapshot DateTime

--- a/bundles/org.openhab.binding.ring/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.ring/src/main/resources/OH-INF/thing/thing-types.xml
@@ -83,11 +83,6 @@
 				<description>Offset in minutes to switch off</description>
 				<default>0</default>
 			</parameter>
-			<parameter name="refreshInterval" type="integer">
-				<label>Refresh Interval</label>
-				<description>How often to poll the Ring service for events in seconds</description>
-				<default>5</default>
-			</parameter>
 		</config-description>
 	</thing-type>
 	<!-- Ring Chime Thing Type -->
@@ -110,11 +105,6 @@
 				<label>Power-off Time</label>
 				<description>Offset in minutes to switch off</description>
 				<default>0</default>
-			</parameter>
-			<parameter name="refreshInterval" type="integer">
-				<label>Refresh Interval</label>
-				<description>How often to poll the Ring service for events in seconds</description>
-				<default>5</default>
 			</parameter>
 		</config-description>
 	</thing-type>
@@ -143,11 +133,6 @@
 				<description>Offset in minutes to switch off</description>
 				<default>0</default>
 			</parameter>
-			<parameter name="refreshInterval" type="integer">
-				<label>Refresh Interval</label>
-				<description>How often to poll the Ring service for events in seconds</description>
-				<default>5</default>
-			</parameter>
 		</config-description>
 	</thing-type>
 	<!-- StickupCam Thing Type -->
@@ -174,11 +159,6 @@
 				<label>Power-off Time</label>
 				<description>Offset in minutes to switch off</description>
 				<default>0</default>
-			</parameter>
-			<parameter name="refreshInterval" type="integer">
-				<label>Refresh Interval</label>
-				<description>How often to poll the Ring service for events in seconds</description>
-				<default>5</default>
 			</parameter>
 		</config-description>
 	</thing-type>


### PR DESCRIPTION
With the recent change to introduce support for snapshots, users have started receiving 429 rate limit errors. This PR moves device things to 60 second polling which is the original intents. All the of the channels in a device thing change at a low frequency.