### PR TITLE
[yamlcomposer] Add docs sidebar navigation links for the child pages

### DIFF
--- a/bundles/org.openhab.io.yamlcomposer/README.md
+++ b/bundles/org.openhab.io.yamlcomposer/README.md
@@ -1,3 +1,15 @@
+---
+children:
+  - ["doc/basics", "YAML Basics"]
+  - ["doc/variables", "Variables"]
+  - ["doc/conditionals", "Conditionals"]
+  - ["doc/include", "Include"]
+  - ["doc/templates", "Templates"]
+  - ["doc/packages", "Packages"]
+  - ["doc/anchors", "Anchors and Aliases"]
+  - ["doc/merge-keys", "Merge Keys"]
+---
+
 # YAML Composer
 
 YAML Composer introduces extended YAML features that make openHAB configuration more modular, reusable, and maintainable. These features let you structure configuration as composable building blocks rather than large, repetitive files.


### PR DESCRIPTION
Depends on openhab/openhab-website#565

<img width="598" height="1598" alt="image" src="https://github.com/user-attachments/assets/9af4d8a5-7218-4bbf-8311-2706af1b354b" />

footer:
<img width="875" height="135" alt="image" src="https://github.com/user-attachments/assets/8da46163-105b-40a3-aaf3-e917b13d3e0d" />
---
<img width="877" height="145" alt="image" src="https://github.com/user-attachments/assets/911c9ae8-be51-44b2-88c2-4b1b66f3276c" />
