### PR TITLE
[enphase] Fix stale consumption data on firmware 7+ (IQ Gateway D8.x)

### DIFF
--- a/bundles/org.openhab.binding.enphase/src/main/java/org/openhab/binding/enphase/internal/dto/ProductionJsonDTO.java
+++ b/bundles/org.openhab.binding.enphase/src/main/java/org/openhab/binding/enphase/internal/dto/ProductionJsonDTO.java
@@ -21,6 +21,7 @@ public class ProductionJsonDTO {
 
     public static class DataDTO {
         public String type;
+        public String measurementType;
         public int activeCount;
         public float whLifetime;
         public float whLastSevenDays;

--- a/bundles/org.openhab.binding.enphase/src/main/java/org/openhab/binding/enphase/internal/handler/EnvoyEntrezConnector.java
+++ b/bundles/org.openhab.binding.enphase/src/main/java/org/openhab/binding/enphase/internal/handler/EnvoyEntrezConnector.java
@@ -32,6 +32,7 @@ import org.openhab.binding.enphase.internal.EnvoyConfiguration;
 import org.openhab.binding.enphase.internal.dto.EnvoyEnergyDTO;
 import org.openhab.binding.enphase.internal.dto.PdmEnergyDTO;
 import org.openhab.binding.enphase.internal.dto.PdmEnergyDTO.PdmProductionDTO;
+import org.openhab.binding.enphase.internal.dto.ProductionJsonDTO.DataDTO;
 import org.openhab.binding.enphase.internal.exception.EnphaseException;
 import org.openhab.binding.enphase.internal.exception.EntrezJwtInvalidException;
 import org.openhab.binding.enphase.internal.exception.EnvoyConnectionException;
@@ -52,6 +53,7 @@ public class EnvoyEntrezConnector extends EnvoyConnector {
     private static final String LOGIN_URL = "/auth/check_jwt";
     private static final String SESSION_COOKIE_NAME = "session";
     private static final String IVP_PDM_ENERGY_URL = "/ivp/pdm/energy";
+    private static final String TOTAL_CONSUMPTION = "total-consumption";
     private static final EnvoyEnergyDTO NO_DATA = new EnvoyEnergyDTO();
 
     private final Logger logger = LoggerFactory.getLogger(EnvoyEntrezConnector.class);
@@ -104,6 +106,39 @@ public class EnvoyEntrezConnector extends EnvoyConnector {
 
     private @Nullable PdmEnergyDTO jsonToPdmEnergyDTO(final String json) {
         return gson.fromJson(json, PdmEnergyDTO.class);
+    }
+
+    /**
+     * Retrieves consumption data from the {@code /production.json} endpoint instead of the {@code /api/v1/consumption}
+     * endpoint used by the base connector. On firmware version 7 and higher the {@code /api/v1/consumption} (and the
+     * {@code /ivp/pdm/energy}) aggregated consumption values can freeze after a firmware update and report a constant,
+     * stale value, while {@code /production.json} keeps reporting live data. The {@code total-consumption} entry
+     * represents the household load and matches the value shown in the Enphase app.
+     *
+     * @return the consumption data from the Envoy gateway
+     */
+    @Override
+    public EnvoyEnergyDTO getConsumption() throws EnphaseException {
+        final DataDTO @Nullable [] consumption = getProductionJson().consumption;
+
+        if (consumption != null) {
+            for (final DataDTO data : consumption) {
+                if (TOTAL_CONSUMPTION.equals(data.measurementType)) {
+                    return toEnvoyEnergyDTO(data);
+                }
+            }
+        }
+        throw new EnvoyConnectionException("No total-consumption data available from the Envoy.");
+    }
+
+    private EnvoyEnergyDTO toEnvoyEnergyDTO(final DataDTO data) {
+        final EnvoyEnergyDTO dto = new EnvoyEnergyDTO();
+
+        dto.wattsNow = Math.round(data.wNow);
+        dto.wattHoursToday = Math.round(data.whToday);
+        dto.wattHoursSevenDays = Math.round(data.whLastSevenDays);
+        dto.wattHoursLifetime = Math.round(data.whLifetime);
+        return dto;
     }
 
     @Override


### PR DESCRIPTION
Fixes #21069.

## Problem

On IQ Gateway firmware 7+ the `EnvoyEntrezConnector` overrides `getProduction()` (→ `/ivp/pdm/energy`) but inherits `getConsumption()` from the base connector, which uses the legacy `/api/v1/consumption` endpoint. On recent firmware (reproduced on **D8.3.5528**) the PDM/EIM consumption aggregation behind both `/api/v1/consumption` and `/ivp/pdm/energy` stops tracking and returns a constant, wrong value — a frozen `wattsNow`, then `0` after the midnight rollover — while the CT meters keep working. A gateway power-cycle does **not** restore it.

The `consumption#*` channels therefore flatline, while production is unaffected (it comes from inverter telemetry).

## Fix

Override `getConsumption()` in `EnvoyEntrezConnector` to read the live `total-consumption` entry from `/production.json` instead of `/api/v1/consumption`. The connector already had a parser for this endpoint (the previously-unused `getProductionJson()` / `ProductionJsonDTO`); a `measurementType` field is added to `ProductionJsonDTO.DataDTO` to select `total-consumption` over `net-consumption`. The field shape maps 1:1 onto the existing `EnvoyEnergyDTO`.

## Scope / compatibility

- Change is confined to the firmware-7+ `EnvoyEntrezConnector`; the pre-7 `EnvoyConnector` and its `/api/v1/consumption` usage are untouched.
- The channel/DTO contract (`EnvoyEnergyDTO`) is unchanged, so no item/thing changes.
- An `EnvoyConnectionException` is still thrown when no consumption data is present, so non-metered gateways keep degrading cleanly (consumption marked unsupported), exactly as before.

## Testing

- Built with full reactor checks (`mvn clean install -pl :org.openhab.binding.enphase`) — passes SAT / SpotBugs / spotless / null-annotation checks.
- Deployed to a live openHAB instance against an IQ Gateway (PN 800-00654-r06, firmware D8.3.5528). `consumption#wattsNow` now tracks real household load (verified against the Enphase app) instead of the stale value; confirmed `api/v1/consumption` stayed broken across a reboot while `/production.json` reported correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
