### PR TITLE
[mcp] Don't log a 'Roots list changed notification' warning message

### DIFF
--- a/bundles/org.openhab.io.mcp/src/main/java/org/openhab/io/mcp/internal/McpService.java
+++ b/bundles/org.openhab.io.mcp/src/main/java/org/openhab/io/mcp/internal/McpService.java
@@ -329,6 +329,7 @@ public class McpService {
                     .jsonSchemaValidator(new DefaultJsonSchemaValidator()).serverInfo(SERVER_NAME, SERVER_VERSION)
                     .capabilities(capabilities).resources(resourceProvider.resources())
                     .resourceTemplates(resourceProvider.templates()).instructions(buildInstructions())
+                    .rootsChangeHandlers(List.of((exchange, roots) -> logger.debug("Roots list changed: {}", roots)))
                     .toolCall(semanticTools.getSemanticModelTool(),
                             (exchange, req) -> semanticTools.handleGetSemanticModel(req))
                     .toolCall(itemTools.getSearchItemsTool(), (exchange, req) -> itemTools.handleSearchItems(req))


### PR DESCRIPTION
When using [Antigravity CLI](https://antigravity.google/product/antigravity-cli), `openhab.log` is full of messages similar to:

```
2026-06-29 13:49:57.115 [WARN ] [ontextprotocol.server.McpAsyncServer] - Roots list changed notification, but no consumers provided. Roots list changed: [Root[uri=/a/b/..., name=null, meta=null]]
```

With this change, the message is only logged when debug logging is enabled.

