### PR TITLE
[shelly] Fix TRV Gen1 controlMode command always setting Manual mode

### DIFF
--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api1/Shelly1HttpApi.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api1/Shelly1HttpApi.java
@@ -278,12 +278,7 @@ public class Shelly1HttpApi extends ShellyHttpClient implements ShellyApiInterfa
 
     @Override
     public void setValveMode(int valveId, boolean auto) throws ShellyApiException {
-        String uri = "/settings/thermostat/" + valveId + "?target_t_enabled=" + (auto ? "1" : "0");
-        List<ShellyThermnostat> thermostats = profile.settings.thermostats;
-        if (auto && thermostats != null) {
-            uri = uri + "&target_t=" + getDouble(thermostats.get(0).targetTemp.value);
-        }
-        httpRequest(uri); // percentage to open the valve
+        httpRequest("/settings/thermostat/" + valveId + "?schedule=" + (auto ? "1" : "0"));
     }
 
     @Override

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/handler/ShellyBaseHandler.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/handler/ShellyBaseHandler.java
@@ -510,7 +510,7 @@ public abstract class ShellyBaseHandler extends BaseThingHandler
                     break;
                 case CHANNEL_CONTROL_MODE:
                     logger.debug("{}: Set mode to {}", thingName, command);
-                    api.setValveMode(0, CHANNEL_CONTROL_MODE.equalsIgnoreCase(command.toString()));
+                    api.setValveMode(0, SHELLY_TRV_MODE_AUTO.equalsIgnoreCase(command.toString()));
                     break;
                 case CHANNEL_CONTROL_SETTEMP:
                     logger.debug("{}: Set temperature to {}", thingName, command);

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/handler/ShellyComponents.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/handler/ShellyComponents.java
@@ -443,8 +443,8 @@ public class ShellyComponents {
                             getOnOff(getInteger(t.boostMinutes) > 0));
                     updated |= thingHandler.updateChannel(CHANNEL_GROUP_CONTROL, CHANNEL_CONTROL_BTIMER,
                             toQuantityType((double) bminutes, DIGITS_NONE, Units.MINUTE));
-                    updated |= thingHandler.updateChannel(CHANNEL_GROUP_CONTROL, CHANNEL_CONTROL_MODE, getStringType(
-                            getBool(t.targetTemp.enabled) ? SHELLY_TRV_MODE_AUTO : SHELLY_TRV_MODE_MANUAL));
+                    updated |= thingHandler.updateChannel(CHANNEL_GROUP_CONTROL, CHANNEL_CONTROL_MODE,
+                            getStringType(getBool(t.schedule) ? SHELLY_TRV_MODE_AUTO : SHELLY_TRV_MODE_MANUAL));
 
                     int pid = getBool(t.schedule) ? getInteger(t.profile) : 0;
                     updated |= thingHandler.updateChannel(CHANNEL_GROUP_CONTROL, CHANNEL_CONTROL_SCHEDULE,


### PR DESCRIPTION
## Description

Fixes the `control#mode` channel on the **Shelly TRV Gen1 (SHTRV-01)** — sending `automatic` or `manual` had no effect; the device always stayed in manual mode.

Two bugs in the same code path:

**1. Wrong comparison in `ShellyBaseHandler`**

```java
// Before — CHANNEL_CONTROL_MODE is "mode", never equals "automatic"
api.setValveMode(0, CHANNEL_CONTROL_MODE.equalsIgnoreCase(command.toString()));

// After
api.setValveMode(0, SHELLY_TRV_MODE_AUTO.equalsIgnoreCase(command.toString()));
```

**2. Wrong API parameter in `Shelly1HttpApi.setValveMode`**

The method was calling `/settings/thermostat/0?target_t_enabled=1/0`, which toggles temperature control on/off. The correct parameter to switch between automatic (schedule) and manual mode is `?schedule=1/0`.

## Testing

Tested on SHTRV-01 firmware v2.2.4. Full `automatic → manual → automatic` cycle verified on two devices (bedroom + kitchen) by querying the device HTTP API after each openHAB command.

Signed-off-by: Konstantin Polihronov <polychronov@gmail.com>