### PR TITLE
[doorbird] Add a servlet to trigger events through webhooks

### DIFF
--- a/bundles/org.openhab.binding.doorbird/README.md
+++ b/bundles/org.openhab.binding.doorbird/README.md
@@ -6,11 +6,11 @@ Binding for Doorbird D101 and D210x video doorbells.
 
 The following thing types are supported:
 
-| Device                           | Thing ID  |
-|----------------------------------|-----------|
-| Doorbird D101/D201/D205/D1101V  Doorbell | d101      |
-| Doorbird D210x Doorbell          | d210x     |
-| Doorbird A1081 Controller        | a1081     |
+| Device                                   | Thing ID |
+|------------------------------------------|----------|
+| Doorbird D101/D201/D205/D1101V  Doorbell | d101     |
+| Doorbird D210x Doorbell                  | d210x    |
+| Doorbird A1081 Controller                | a1081    |
 
 ## Thing Configuration
 
@@ -18,27 +18,27 @@ The following thing types are supported:
 
 The following configuration parameters are available on the Doorbird D101/D201/D205/D1101V and D210x Doorbell things:
 
-| Parameter                | Parameter ID       | Required/Optional | Description |
-|--------------------------|--------------------|-------------------|-------------|
-| Hostname                 | doorbirdHost       | Required          | The hostname or IP address of the Doorbird device. |
+| Parameter                | Parameter ID       | Required/Optional | Description                                                                                                                                             |
+|--------------------------|--------------------|-------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Hostname                 | doorbirdHost       | Required          | The hostname or IP address of the Doorbird device.                                                                                                      |
 | User ID                  | userId             | Required          | User Id of a Doorbird user that has permissions to access the API. The User ID and Password must be created using the Doorbird smart phone application. |
-| Password                 | userPassword       | Required          | Password of a Doorbird user. |
-| Image Refresh Rate       | imageRefreshRate   | Optional          | Rate at which image channel should be automatically updated. Leave field blank (default) to disable refresh. |
-| Doorbell Off Delay       | doorbellOffDelay   | Optional          | Number of seconds to wait before setting doorbell channel OFF after a doorbell event. Leave field blank to disable. |
-| Motion Off Delay         | motionOffDelay     | Optional          | Number of seconds to wait before setting motion channel OFF after a motion event. Leave field blank to disable. |
-| Montage Number of Images | montageNumImages   | Required          | Number of images to include in the doorbell and motion montage images. Default is 0. |
-| Montage Scale Factor     | montageScaleFactor | Required          | Percent scaling factor for montage image. Default is 100. |
+| Password                 | userPassword       | Required          | Password of a Doorbird user.                                                                                                                            |
+| Image Refresh Rate       | imageRefreshRate   | Optional          | Rate at which image channel should be automatically updated. Leave field blank (default) to disable refresh.                                            |
+| Doorbell Off Delay       | doorbellOffDelay   | Optional          | Number of seconds to wait before setting doorbell channel OFF after a doorbell event. Leave field blank to disable.                                     |
+| Motion Off Delay         | motionOffDelay     | Optional          | Number of seconds to wait before setting motion channel OFF after a motion event. Leave field blank to disable.                                         |
+| Montage Number of Images | montageNumImages   | Required          | Number of images to include in the doorbell and motion montage images. Default is 0.                                                                    |
+| Montage Scale Factor     | montageScaleFactor | Required          | Percent scaling factor for montage image. Default is 100.                                                                                               |
 
 ### A1081 Controller
 
 The following configuration parameters are available on the Doorbird A1081 Controller thing:
 
-| Parameter                | Parameter ID | Required/Optional | Description |
-|--------------------------|--------------|-------------------|-------------|
-| Hostname                 | doorbirdHost | Required          | The hostname or IP address of the Doorbird device. |
-| User ID                  | userId       | Required          | User Id of a Doorbird user that has permissions to access the API. The User ID and Password must be created using the Doorbird smart phone application. |
-| Password                 | userPassword | Required          | Password of a Doorbird user. |
-| Controller Id            | controllerId | Optional          | Doorbird Id of the controller to reliable target the relays of this device. E.g. "gggaaa" |
+| Parameter     | Parameter ID | Required/Optional | Description                                                                                                                                             |
+|---------------|--------------|-------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Hostname      | doorbirdHost | Required          | The hostname or IP address of the Doorbird device.                                                                                                      |
+| User ID       | userId       | Required          | User Id of a Doorbird user that has permissions to access the API. The User ID and Password must be created using the Doorbird smart phone application. |
+| Password      | userPassword | Required          | Password of a Doorbird user.                                                                                                                            |
+| Controller Id | controllerId | Optional          | Doorbird Id of the controller to reliable target the relays of this device. E.g. "gggaaa"                                                               |
 
 ## Discovery
 
@@ -133,7 +133,7 @@ if(actions === null) {
 ## Known Issues
 
 The Doorbird uses the UDP protocol on port 6524 to broadcast events for Doorbird actions, such as doorbell pressed, motion detected, etc.
-If the Doorbord is on a separate subnet or VLAN from openHAB, those UDP packets will not route by default.
+If the Doorbird is on a separate subnet or VLAN from openHAB, those UDP packets will not route by default.
 In that case, the Doorbird binding will not receive those events.
 Either put the Doorbird and openHAB on the same subnet/VLAN, or set up your network to explicitly route those UDP packets.
 

--- a/bundles/org.openhab.binding.doorbird/README.md
+++ b/bundles/org.openhab.binding.doorbird/README.md
@@ -137,6 +137,11 @@ If the Doorbord is on a separate subnet or VLAN from openHAB, those UDP packets 
 In that case, the Doorbird binding will not receive those events.
 Either put the Doorbird and openHAB on the same subnet/VLAN, or set up your network to explicitly route those UDP packets.
 
+Alternatively to UDP broadcast, you can configure the following webhooks in your doorbell:
+
+- Doorbell (pressed) wbehook: `http[s]://<openhab-ip>:<openhab-port>/doorbird/<thing-uid>/doorbell`
+- Motion Webhook: `http[s]://<openhab-ip>:<openhab-port>/doorbird/<thing-uid>/motion`
+
 ## Example
 
 ### Things

--- a/bundles/org.openhab.binding.doorbird/pom.xml
+++ b/bundles/org.openhab.binding.doorbird/pom.xml
@@ -37,6 +37,12 @@
       <version>${jna.version}</version>
       <scope>compile</scope>
     </dependency>
+    <dependency>
+      <groupId>org.openhab.core.bundles</groupId>
+      <artifactId>org.openhab.core.io.rest</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/bundles/org.openhab.binding.doorbird/pom.xml
+++ b/bundles/org.openhab.binding.doorbird/pom.xml
@@ -37,12 +37,6 @@
       <version>${jna.version}</version>
       <scope>compile</scope>
     </dependency>
-    <dependency>
-      <groupId>org.openhab.core.bundles</groupId>
-      <artifactId>org.openhab.core.io.rest</artifactId>
-      <version>${project.version}</version>
-      <scope>provided</scope>
-    </dependency>
   </dependencies>
 
 </project>

--- a/bundles/org.openhab.binding.doorbird/src/main/java/org/openhab/binding/doorbird/internal/DoorbirdHandlerFactory.java
+++ b/bundles/org.openhab.binding.doorbird/src/main/java/org/openhab/binding/doorbird/internal/DoorbirdHandlerFactory.java
@@ -19,6 +19,7 @@ import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.jetty.client.HttpClient;
 import org.openhab.binding.doorbird.internal.handler.ControllerHandler;
 import org.openhab.binding.doorbird.internal.handler.DoorbellHandler;
+import org.openhab.binding.doorbird.internal.servlet.DoorbirdHTTPServlet;
 import org.openhab.core.io.net.http.HttpClientFactory;
 import org.openhab.core.thing.Thing;
 import org.openhab.core.thing.ThingTypeUID;
@@ -39,10 +40,13 @@ import org.osgi.service.component.annotations.Reference;
 @Component(configurationPid = "binding.doorbird", service = ThingHandlerFactory.class)
 public class DoorbirdHandlerFactory extends BaseThingHandlerFactory {
     private final HttpClient httpClient;
+    private final DoorbirdHTTPServlet callbackServlet;
 
     @Activate
-    public DoorbirdHandlerFactory(@Reference HttpClientFactory httpClientFactory) {
+    public DoorbirdHandlerFactory(final @Reference HttpClientFactory httpClientFactory,
+            final @Reference DoorbirdHTTPServlet callbackServlet) {
         this.httpClient = httpClientFactory.getCommonHttpClient();
+        this.callbackServlet = callbackServlet;
     }
 
     @Override
@@ -54,7 +58,7 @@ public class DoorbirdHandlerFactory extends BaseThingHandlerFactory {
     protected @Nullable ThingHandler createHandler(Thing thing) {
         ThingTypeUID thingTypeUID = thing.getThingTypeUID();
         if (THING_TYPE_D101.equals(thingTypeUID) || THING_TYPE_D210X.equals(thingTypeUID)) {
-            return new DoorbellHandler(thing, httpClient, bundleContext);
+            return new DoorbellHandler(thing, httpClient, bundleContext, callbackServlet);
         } else if (THING_TYPE_A1081.equals(thingTypeUID)) {
             return new ControllerHandler(thing);
         }

--- a/bundles/org.openhab.binding.doorbird/src/main/java/org/openhab/binding/doorbird/internal/handler/DoorbellHandler.java
+++ b/bundles/org.openhab.binding.doorbird/src/main/java/org/openhab/binding/doorbird/internal/handler/DoorbellHandler.java
@@ -43,6 +43,7 @@ import org.openhab.binding.doorbird.internal.api.SipStatus;
 import org.openhab.binding.doorbird.internal.audio.DoorbirdAudioSink;
 import org.openhab.binding.doorbird.internal.config.DoorbellConfiguration;
 import org.openhab.binding.doorbird.internal.listener.DoorbirdUdpListener;
+import org.openhab.binding.doorbird.internal.servlet.DoorbirdHTTPServlet;
 import org.openhab.core.audio.AudioSink;
 import org.openhab.core.common.ThreadPoolManager;
 import org.openhab.core.library.types.DateTimeType;
@@ -101,11 +102,14 @@ public class DoorbellHandler extends BaseThingHandler {
     private @Nullable ServiceRegistration<AudioSink> audioSinkRegistration;
 
     private final HttpClient httpClient;
+    private final DoorbirdHTTPServlet callbackServlet;
 
-    public DoorbellHandler(Thing thing, HttpClient httpClient, BundleContext bundleContext) {
+    public DoorbellHandler(Thing thing, HttpClient httpClient, BundleContext bundleContext,
+            DoorbirdHTTPServlet callbackServlet) {
         super(thing);
         this.httpClient = httpClient;
         this.bundleContext = bundleContext;
+        this.callbackServlet = callbackServlet;
         udpListener = new DoorbirdUdpListener(this);
     }
 
@@ -133,11 +137,19 @@ public class DoorbellHandler extends BaseThingHandler {
         startImageRefreshJob();
         startUDPListenerJob();
         startAudioSink();
+
+        callbackServlet.registerHandler(thing.getUID(), this);
+        String thingUid = thing.getUID().getAsString();
+        logger.info("Doorbird webhook URLs configured for device {}:", thingUid);
+        logger.info("  Doorbell event: /doorbird/{}/doorbell", thingUid);
+        logger.info("  Motion event:   /doorbird/{}/motion", thingUid);
+
         updateStatus(ThingStatus.ONLINE);
     }
 
     @Override
     public void dispose() {
+        callbackServlet.unregisterHandler(thing.getUID());
         stopUDPListenerJob();
         stopImageRefreshJob();
         stopDoorbellOffJob();

--- a/bundles/org.openhab.binding.doorbird/src/main/java/org/openhab/binding/doorbird/internal/servlet/DoorbirdHTTPServlet.java
+++ b/bundles/org.openhab.binding.doorbird/src/main/java/org/openhab/binding/doorbird/internal/servlet/DoorbirdHTTPServlet.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.doorbird.internal.servlet;
+
+import static org.openhab.binding.doorbird.internal.DoorbirdBindingConstants.CHANNEL_DOORBELL;
+import static org.openhab.binding.doorbird.internal.DoorbirdBindingConstants.CHANNEL_MOTION;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.Serial;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import javax.servlet.Servlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.doorbird.internal.handler.DoorbellHandler;
+import org.openhab.core.thing.ThingUID;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.http.whiteboard.propertytypes.HttpWhiteboardServletAsyncSupported;
+import org.osgi.service.http.whiteboard.propertytypes.HttpWhiteboardServletName;
+import org.osgi.service.http.whiteboard.propertytypes.HttpWhiteboardServletPattern;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Servlet to handle incoming webhooks from DoorBird devices or the openHAB Cloud.
+ *
+ * @author Florian Hotze - Initial contribution
+ */
+@NonNullByDefault
+@HttpWhiteboardServletAsyncSupported
+@HttpWhiteboardServletName("/doorbird")
+@HttpWhiteboardServletPattern("/doorbird/*")
+@Component(immediate = true, service = { Servlet.class, DoorbirdHTTPServlet.class })
+public class DoorbirdHTTPServlet extends HttpServlet {
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    private final Logger logger = LoggerFactory.getLogger(DoorbirdHTTPServlet.class);
+
+    private final Map<String, DoorbellHandler> handlers = new ConcurrentHashMap<>();
+
+    public void registerHandler(ThingUID thingUID, DoorbellHandler handler) {
+        handlers.put(thingUID.getAsString(), handler);
+        logger.debug("Registered Doorbird callback handler for {}", thingUID);
+    }
+
+    public void unregisterHandler(ThingUID thingUID) {
+        handlers.remove(thingUID.getAsString());
+        logger.debug("Unregistered Doorbird callback handler for {}", thingUID);
+    }
+
+    @Override
+    protected void doGet(@Nullable HttpServletRequest req, @Nullable HttpServletResponse resp) throws IOException {
+        if (req == null || resp == null) {
+            return;
+        }
+
+        String pathInfo = req.getPathInfo(); // E.g., "/doorbird:doorbird:mydevice/doorbell"
+        logger.trace("Doorbird webhook request: pathInfo={}", pathInfo);
+
+        if (pathInfo == null || pathInfo.isEmpty() || "/".equals(pathInfo)) {
+            resp.sendError(HttpServletResponse.SC_BAD_REQUEST, "Missing target path segments");
+            return;
+        }
+
+        // pathInfo begins with a leading slash, so substring(1) ignores it.
+        // Expected segments: ["<thingUID>", "<event>"]
+        String[] segments = pathInfo.substring(1).split("/");
+
+        if (segments.length != 2) {
+            logger.warn("Doorbird webhook rejected: Invalid path structure '{}'", pathInfo);
+            resp.sendError(HttpServletResponse.SC_NOT_FOUND);
+            return;
+        }
+
+        String thingUidParam = segments[0];
+        String eventParam = segments[1];
+
+        @Nullable
+        DoorbellHandler handler = handlers.get(thingUidParam);
+        if (handler == null) {
+            logger.warn("No Doorbird handler found for thing UID: '{}'", thingUidParam);
+            resp.sendError(HttpServletResponse.SC_BAD_REQUEST, "No matching Doorbird device found");
+            return;
+        }
+
+        if (CHANNEL_DOORBELL.equalsIgnoreCase(eventParam)) {
+            logger.debug("Triggering doorbell channel via webhook for thing {}", handler.getThing().getUID());
+            handler.updateDoorbellChannel(System.currentTimeMillis() / 1000L);
+        } else if (CHANNEL_MOTION.equalsIgnoreCase(eventParam)) {
+            logger.debug("Triggering motion channel via webhook for thing {}", handler.getThing().getUID());
+            handler.updateMotionChannel(System.currentTimeMillis() / 1000L);
+        } else {
+            logger.warn("Doorbird webhook rejected: Invalid event type '{}'", eventParam);
+            resp.sendError(HttpServletResponse.SC_BAD_REQUEST, "Invalid event type");
+            return;
+        }
+
+        sendOkResponse(resp);
+    }
+
+    private void sendOkResponse(HttpServletResponse resp) throws IOException {
+        resp.setStatus(HttpServletResponse.SC_OK);
+        resp.setContentType("text/plain");
+        try (PrintWriter writer = resp.getWriter()) {
+            writer.print("OK");
+            writer.flush();
+        }
+    }
+}

--- a/bundles/org.openhab.binding.doorbird/src/test/java/org/openhab/binding/doorbird/internal/servlet/DoorbirdHTTPServletTest.java
+++ b/bundles/org.openhab.binding.doorbird/src/test/java/org/openhab/binding/doorbird/internal/servlet/DoorbirdHTTPServletTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.doorbird.internal.servlet;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openhab.binding.doorbird.internal.handler.DoorbellHandler;
+import org.openhab.core.thing.Thing;
+import org.openhab.core.thing.ThingUID;
+
+/**
+ * Unit tests for {@link DoorbirdHTTPServlet}.
+ *
+ * @author Florian Hotze - Initial contribution
+ */
+@NonNullByDefault
+public class DoorbirdHTTPServletTest {
+    private @NonNullByDefault({}) DoorbirdHTTPServlet servlet;
+    private @NonNullByDefault({}) DoorbellHandler handler;
+    private @NonNullByDefault({}) Thing thing;
+    private @NonNullByDefault({}) ThingUID thingUID;
+
+    @BeforeEach
+    public void setUp() {
+        servlet = new DoorbirdHTTPServlet();
+        handler = mock(DoorbellHandler.class);
+        thing = mock(Thing.class);
+        thingUID = new ThingUID("doorbird:d101:doorbell");
+
+        when(handler.getThing()).thenReturn(thing);
+        when(thing.getUID()).thenReturn(thingUID);
+    }
+
+    @Test
+    public void testDoorbellWebhook() throws Exception {
+        servlet.registerHandler(thingUID, handler);
+
+        HttpServletRequest req = mock(HttpServletRequest.class);
+        HttpServletResponse resp = mock(HttpServletResponse.class);
+        StringWriter sw = new StringWriter();
+        PrintWriter pw = new PrintWriter(sw);
+
+        when(req.getPathInfo()).thenReturn("/doorbird:d101:doorbell/doorbell");
+        when(resp.getWriter()).thenReturn(pw);
+
+        servlet.doGet(req, resp);
+
+        verify(handler).updateDoorbellChannel(anyLong());
+        verify(resp).setStatus(HttpServletResponse.SC_OK);
+        assertEquals("OK", sw.toString());
+    }
+
+    @Test
+    public void testMotionWebhook() throws Exception {
+        servlet.registerHandler(thingUID, handler);
+
+        HttpServletRequest req = mock(HttpServletRequest.class);
+        HttpServletResponse resp = mock(HttpServletResponse.class);
+        StringWriter sw = new StringWriter();
+        PrintWriter pw = new PrintWriter(sw);
+
+        when(req.getPathInfo()).thenReturn("/doorbird:d101:doorbell/motion");
+        when(resp.getWriter()).thenReturn(pw);
+
+        servlet.doGet(req, resp);
+
+        verify(handler).updateMotionChannel(anyLong());
+        verify(resp).setStatus(HttpServletResponse.SC_OK);
+        assertEquals("OK", sw.toString());
+    }
+
+    @Test
+    public void testInvalidPathStructureReturnsNotFound() throws Exception {
+        servlet.registerHandler(thingUID, handler);
+
+        HttpServletRequest req = mock(HttpServletRequest.class);
+        HttpServletResponse resp = mock(HttpServletResponse.class);
+
+        when(req.getPathInfo()).thenReturn("/doorbell");
+
+        servlet.doGet(req, resp);
+
+        verify(resp).sendError(HttpServletResponse.SC_NOT_FOUND);
+        verify(handler, never()).updateDoorbellChannel(anyLong());
+        verify(handler, never()).updateMotionChannel(anyLong());
+    }
+
+    @Test
+    public void testInvalidEventReturnsBadRequest() throws Exception {
+        servlet.registerHandler(thingUID, handler);
+
+        HttpServletRequest req = mock(HttpServletRequest.class);
+        HttpServletResponse resp = mock(HttpServletResponse.class);
+
+        when(req.getPathInfo()).thenReturn("/doorbird:d101:doorbell/unknown_event");
+
+        servlet.doGet(req, resp);
+
+        verify(resp).sendError(HttpServletResponse.SC_BAD_REQUEST, "Invalid event type");
+        verify(handler, never()).updateDoorbellChannel(anyLong());
+        verify(handler, never()).updateMotionChannel(anyLong());
+    }
+}


### PR DESCRIPTION
The DoorBird binding relies on the door stations UDP broadcast to receive doorbell and motion events.
As it is difficult to get this UDP broadcast working across multiple VLANs (requiring UDP broadcast relaying, which not all FWs, e.g., UniFi support), introduce a servlet that provides webhooks to trigger doorbell and motion events manually.
These webhooks have to be configured on the doorbird device.

Note: 
This does deliberately not register a `org.openhab.core.io.rest.WebhookService` as the webhooks provided by this binding don't need to be available through openHAB Cloud.