### PR TITLE
[renault] Improve logging of http error 429

### DIFF
--- a/bundles/org.openhab.binding.renault/src/main/java/org/openhab/binding/renault/internal/api/MyRenaultHttpSession.java
+++ b/bundles/org.openhab.binding.renault/src/main/java/org/openhab/binding/renault/internal/api/MyRenaultHttpSession.java
@@ -370,6 +370,8 @@ public class MyRenaultHttpSession {
                 throw new RenaultForbiddenException("@text/error.renault.session.kamereon_request_forbidden");
             case HttpStatus.NOT_FOUND_404:
                 throw new RenaultNotImplementedException("@text/error.renault.session.kamereon_service_not_found");
+            case HttpStatus.TOO_MANY_REQUESTS_429:
+                throw new RenaultAPIGatewayException("@text/error.renault.session.kamereon_quota_limit_exceeded");
             case HttpStatus.NOT_IMPLEMENTED_501:
                 throw new RenaultNotImplementedException(
                         "@text/error.renault.session.kamereon_request_not_implemented");

--- a/bundles/org.openhab.binding.renault/src/main/resources/OH-INF/i18n/renault.properties
+++ b/bundles/org.openhab.binding.renault/src/main/resources/OH-INF/i18n/renault.properties
@@ -124,6 +124,7 @@ error.renault.session.jwt.no_jwt = Get JWT Error: jwt value not found in JSON re
 error.renault.session.kamereon_cant_get_account_id = Can not get Kamereon {0} Account ID.
 error.renault.session.kamereon_request_forbidden = Kamereon request forbidden! Ensure the car is paired in your MyRenault App.
 error.renault.session.kamereon_privacy_on = Privacy mode currently ON. Change your privacy settings in your Car.
+error.renault.session.kamereon_quota_limit_exceeded = Kamereon request quota exceeded. Increase the refresh interval to reduce the number of requests.
 error.renault.session.kamereon_request_not_implemented = Kamereon request not implemented.
 error.renault.session.kamereon_request_failed = Kamereon request failed.
 error.renault.session.kamereon_service_not_found = Kamereon service not found.


### PR DESCRIPTION
Fixes issue: https://github.com/openhab/openhab-addons/issues/15106

This fix was tested by setting my refresh interval to 1 minute.  However there were no HTTP 429 Errors in a 24 hour period.  So either the Renault backend has changed to allow more requests or the improvements from the PR: github.com/openhab/openhab-addons/pull/20773 have fixed this issue.  However I offer this PR to catch this state better in future should it return.