### PR TITLE
[zwavejs] Improve metadata handling

### DIFF
--- a/bundles/org.openhab.binding.zwavejs/src/main/java/org/openhab/binding/zwavejs/internal/action/ZwaveJSActions.java
+++ b/bundles/org.openhab.binding.zwavejs/src/main/java/org/openhab/binding/zwavejs/internal/action/ZwaveJSActions.java
@@ -13,6 +13,7 @@
 package org.openhab.binding.zwavejs.internal.action;
 
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -46,16 +47,19 @@ public class ZwaveJSActions implements ThingActions {
             .getScheduledPool(BindingConstants.BINDING_ID);
     private static final int INCLUSION_EXCLUSION_TIMEOUT_SECONDS = 30;
     private @Nullable ZwaveJSBridgeHandler handler;
+    private @Nullable ScheduledFuture<?> actionStopJob;
+    private @Nullable ActiveAction activeAction;
 
     @RuleAction(label = "@text/action.start-inclusion.label", description = "@text/action.start-inclusion.description")
-    public void startInclusion() {
+    public synchronized void startInclusion() {
         ZwaveJSBridgeHandler localHandler = handler;
         if (localHandler != null) {
             logger.debug("Inclusion action issued");
+            stopActiveAction(localHandler);
             localHandler.startInclusion();
-            SCHEDULER.schedule(() -> {
-                localHandler.stopInclusion();
-            }, INCLUSION_EXCLUSION_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            activeAction = ActiveAction.INCLUSION;
+            actionStopJob = SCHEDULER.schedule(() -> stopActiveAction(localHandler, ActiveAction.INCLUSION),
+                    INCLUSION_EXCLUSION_TIMEOUT_SECONDS, TimeUnit.SECONDS);
         }
     }
 
@@ -64,14 +68,15 @@ public class ZwaveJSActions implements ThingActions {
     }
 
     @RuleAction(label = "@text/action.start-exclusion.label", description = "@text/action.start-exclusion.description")
-    public void startExclusion() {
+    public synchronized void startExclusion() {
         ZwaveJSBridgeHandler localHandler = handler;
         if (localHandler != null) {
             logger.debug("Exclusion action issued");
+            stopActiveAction(localHandler);
             localHandler.startExclusion();
-            SCHEDULER.schedule(() -> {
-                localHandler.stopExclusion();
-            }, INCLUSION_EXCLUSION_TIMEOUT_SECONDS, java.util.concurrent.TimeUnit.SECONDS);
+            activeAction = ActiveAction.EXCLUSION;
+            actionStopJob = SCHEDULER.schedule(() -> stopActiveAction(localHandler, ActiveAction.EXCLUSION),
+                    INCLUSION_EXCLUSION_TIMEOUT_SECONDS, TimeUnit.SECONDS);
         }
     }
 
@@ -99,14 +104,48 @@ public class ZwaveJSActions implements ThingActions {
     }
 
     @Override
-    public void setThingHandler(@Nullable ThingHandler handler) {
+    public synchronized void setThingHandler(@Nullable ThingHandler handler) {
+        cancelActionStopJob();
+        activeAction = null;
         if (handler instanceof ZwaveJSBridgeHandler bridgeHandler) {
             this.handler = bridgeHandler;
+        } else {
+            this.handler = null;
         }
     }
 
     @Override
     public @Nullable ThingHandler getThingHandler() {
         return handler;
+    }
+
+    private synchronized void stopActiveAction(ZwaveJSBridgeHandler expectedHandler, ActiveAction expectedAction) {
+        if (expectedHandler.equals(handler) && activeAction == expectedAction) {
+            stopActiveAction(expectedHandler);
+        }
+    }
+
+    private void stopActiveAction(ZwaveJSBridgeHandler handler) {
+        cancelActionStopJob();
+        ActiveAction activeAction = this.activeAction;
+        this.activeAction = null;
+        if (activeAction == ActiveAction.INCLUSION) {
+            handler.stopInclusion();
+        } else if (activeAction == ActiveAction.EXCLUSION) {
+            handler.stopExclusion();
+        }
+    }
+
+    private void cancelActionStopJob() {
+        ScheduledFuture<?> actionStopJob = this.actionStopJob;
+        if (actionStopJob != null) {
+            actionStopJob.cancel(false);
+            this.actionStopJob = null;
+        }
+    }
+
+    private enum ActiveAction {
+        INCLUSION,
+        EXCLUSION
     }
 }

--- a/bundles/org.openhab.binding.zwavejs/src/main/java/org/openhab/binding/zwavejs/internal/action/ZwaveJSActions.java
+++ b/bundles/org.openhab.binding.zwavejs/src/main/java/org/openhab/binding/zwavejs/internal/action/ZwaveJSActions.java
@@ -43,12 +43,19 @@ import org.slf4j.LoggerFactory;
 @NonNullByDefault
 public class ZwaveJSActions implements ThingActions {
     private final Logger logger = LoggerFactory.getLogger(ZwaveJSActions.class);
-    private static final ScheduledExecutorService SCHEDULER = ThreadPoolManager
-            .getScheduledPool(BindingConstants.BINDING_ID);
+    private final ScheduledExecutorService scheduler;
     private static final int INCLUSION_EXCLUSION_TIMEOUT_SECONDS = 30;
     private @Nullable ZwaveJSBridgeHandler handler;
     private @Nullable ScheduledFuture<?> actionStopJob;
     private @Nullable ActiveAction activeAction;
+
+    public ZwaveJSActions() {
+        this(ThreadPoolManager.getScheduledPool(BindingConstants.BINDING_ID));
+    }
+
+    ZwaveJSActions(ScheduledExecutorService scheduler) {
+        this.scheduler = scheduler;
+    }
 
     @RuleAction(label = "@text/action.start-inclusion.label", description = "@text/action.start-inclusion.description")
     public synchronized void startInclusion() {
@@ -57,8 +64,8 @@ public class ZwaveJSActions implements ThingActions {
             logger.debug("Inclusion action issued");
             stopActiveAction(localHandler);
             localHandler.startInclusion();
-            activeAction = ActiveAction.INCLUSION;
-            actionStopJob = SCHEDULER.schedule(() -> stopActiveAction(localHandler, ActiveAction.INCLUSION),
+            ActiveAction action = this.activeAction = new ActiveAction(ActionType.INCLUSION);
+            actionStopJob = scheduler.schedule(() -> stopActiveAction(localHandler, action),
                     INCLUSION_EXCLUSION_TIMEOUT_SECONDS, TimeUnit.SECONDS);
         }
     }
@@ -74,8 +81,8 @@ public class ZwaveJSActions implements ThingActions {
             logger.debug("Exclusion action issued");
             stopActiveAction(localHandler);
             localHandler.startExclusion();
-            activeAction = ActiveAction.EXCLUSION;
-            actionStopJob = SCHEDULER.schedule(() -> stopActiveAction(localHandler, ActiveAction.EXCLUSION),
+            ActiveAction action = this.activeAction = new ActiveAction(ActionType.EXCLUSION);
+            actionStopJob = scheduler.schedule(() -> stopActiveAction(localHandler, action),
                     INCLUSION_EXCLUSION_TIMEOUT_SECONDS, TimeUnit.SECONDS);
         }
     }
@@ -120,7 +127,7 @@ public class ZwaveJSActions implements ThingActions {
     }
 
     private synchronized void stopActiveAction(ZwaveJSBridgeHandler expectedHandler, ActiveAction expectedAction) {
-        if (expectedHandler.equals(handler) && activeAction == expectedAction) {
+        if (expectedHandler.equals(handler) && expectedAction.equals(activeAction)) {
             stopActiveAction(expectedHandler);
         }
     }
@@ -129,9 +136,9 @@ public class ZwaveJSActions implements ThingActions {
         cancelActionStopJob();
         ActiveAction activeAction = this.activeAction;
         this.activeAction = null;
-        if (activeAction == ActiveAction.INCLUSION) {
+        if (activeAction != null && activeAction.type == ActionType.INCLUSION) {
             handler.stopInclusion();
-        } else if (activeAction == ActiveAction.EXCLUSION) {
+        } else if (activeAction != null && activeAction.type == ActionType.EXCLUSION) {
             handler.stopExclusion();
         }
     }
@@ -144,7 +151,15 @@ public class ZwaveJSActions implements ThingActions {
         }
     }
 
-    private enum ActiveAction {
+    private static class ActiveAction {
+        private final ActionType type;
+
+        private ActiveAction(ActionType type) {
+            this.type = type;
+        }
+    }
+
+    private enum ActionType {
         INCLUSION,
         EXCLUSION
     }

--- a/bundles/org.openhab.binding.zwavejs/src/main/java/org/openhab/binding/zwavejs/internal/conversion/BaseMetadata.java
+++ b/bundles/org.openhab.binding.zwavejs/src/main/java/org/openhab/binding/zwavejs/internal/conversion/BaseMetadata.java
@@ -126,6 +126,7 @@ public abstract class BaseMetadata {
         this.min = value.metadata.min;
         this.max = value.metadata.max;
         this.id = generateChannelId(value);
+        this.value = value.value;
 
         this.label = normalizeLabel(value.metadata.label, value.endpoint, value.propertyName);
         this.description = value.metadata.description != null ? value.metadata.description : null;
@@ -138,7 +139,6 @@ public abstract class BaseMetadata {
             logger.warn("Node {}, unable to parse unitSymbol '{}', please file a bug report", nodeId, unitSymbol);
         }
         this.optionList = value.metadata.states;
-        this.value = value.value;
         this.isAdvanced = isAdvanced(value.commandClass, value.propertyName, value.propertyKey);
 
         if (writable) {

--- a/bundles/org.openhab.binding.zwavejs/src/main/java/org/openhab/binding/zwavejs/internal/conversion/BaseMetadata.java
+++ b/bundles/org.openhab.binding.zwavejs/src/main/java/org/openhab/binding/zwavejs/internal/conversion/BaseMetadata.java
@@ -128,6 +128,7 @@ public abstract class BaseMetadata {
         this.min = value.metadata.min;
         this.max = value.metadata.max;
         this.id = generateChannelId(value);
+        this.value = value.value;
 
         this.label = normalizeLabel(value.metadata.label, value.endpoint, value.propertyName);
         this.description = value.metadata.description != null ? value.metadata.description : null;
@@ -140,7 +141,6 @@ public abstract class BaseMetadata {
             logger.warn("Node {}, unable to parse unitSymbol '{}', please file a bug report", nodeId, unitSymbol);
         }
         this.optionList = value.metadata.states;
-        this.value = value.value;
         this.isAdvanced = isAdvanced(value.commandClass, value.propertyName, value.propertyKey);
 
         if (writable) {

--- a/bundles/org.openhab.binding.zwavejs/src/main/java/org/openhab/binding/zwavejs/internal/conversion/ChannelMetadata.java
+++ b/bundles/org.openhab.binding.zwavejs/src/main/java/org/openhab/binding/zwavejs/internal/conversion/ChannelMetadata.java
@@ -108,8 +108,12 @@ public class ChannelMetadata extends BaseMetadata {
      *         not possible
      */
     public @Nullable State setState(Object value, String itemType, @Nullable String unitSymbol, boolean inverted) {
+        return setState(value, itemType, unitSymbol, inverted, determineFactor(unitSymbol));
+    }
+
+    public @Nullable State setState(Object value, String itemType, @Nullable String unitSymbol, boolean inverted,
+            Double factor) {
         this.unitSymbol = normalizeUnit(unitSymbol, value);
-        Double factor = determineFactor(unitSymbol);
         this.unit = UnitUtils.parseUnit(this.unitSymbol);
         if (unitSymbol != null && this.unit == null) {
             logger.warn("Node {}. Unable to parse unitSymbol '{}' from channel config, this is a bug", nodeId,

--- a/bundles/org.openhab.binding.zwavejs/src/main/java/org/openhab/binding/zwavejs/internal/discovery/NodeDiscoveryService.java
+++ b/bundles/org.openhab.binding.zwavejs/src/main/java/org/openhab/binding/zwavejs/internal/discovery/NodeDiscoveryService.java
@@ -119,14 +119,14 @@ public class NodeDiscoveryService extends AbstractThingHandlerDiscoveryService<Z
 
             properties.put(CONFIG_NODE_ID, node.nodeId);
 
-            properties.put(PROPERTY_NODE_IS_LISTENING, node.isListening);
-            properties.put(PROPERTY_NODE_IS_ROUTING, node.isRouting);
-            properties.put(PROPERTY_NODE_IS_SECURE, node.isSecure);
+            properties.put(PROPERTY_NODE_IS_LISTENING, String.valueOf(node.isListening));
+            properties.put(PROPERTY_NODE_IS_ROUTING, String.valueOf(node.isRouting));
+            properties.put(PROPERTY_NODE_IS_SECURE, String.valueOf(node.isSecure));
             properties.put(PROPERTY_VENDOR, manufacturer);
             properties.put(PROPERTY_MODEL_ID, product);
-            properties.put(PROPERTY_NODE_LASTSEEN, node.lastSeen);
-            properties.put(PROPERTY_NODE_FREQ_LISTENING, node.isFrequentListening);
-            properties.put(PROPERTY_FIRMWARE_VERSION, node.firmwareVersion);
+            properties.put(PROPERTY_NODE_LASTSEEN, node.lastSeen != null ? node.lastSeen.toString() : "");
+            properties.put(PROPERTY_NODE_FREQ_LISTENING, String.valueOf(node.isFrequentListening));
+            properties.put(PROPERTY_FIRMWARE_VERSION, node.firmwareVersion != null ? node.firmwareVersion : "");
 
             DiscoveryResult discoveryResult = DiscoveryResultBuilder.create(thingUID).withThingType(thingTypeUID)
                     .withProperties(properties).withBridge(getBridgeUID()).withRepresentationProperty(CONFIG_NODE_ID)

--- a/bundles/org.openhab.binding.zwavejs/src/main/java/org/openhab/binding/zwavejs/internal/handler/ZwaveJSNodeHandler.java
+++ b/bundles/org.openhab.binding.zwavejs/src/main/java/org/openhab/binding/zwavejs/internal/handler/ZwaveJSNodeHandler.java
@@ -552,7 +552,7 @@ public class ZwaveJSNodeHandler extends BaseThingHandler implements ZwaveNodeLis
         }
 
         State state = metadata.setState(event.args.newValue, Objects.requireNonNull(channel.getAcceptedItemType()),
-                channelConfig.incomingUnit, channelConfig.inverted);
+                channelConfig.incomingUnit, channelConfig.inverted, channelConfig.factor);
 
         if (state == null) {
             return true;
@@ -574,7 +574,7 @@ public class ZwaveJSNodeHandler extends BaseThingHandler implements ZwaveNodeLis
                 rollerShutterCapability.setPosition(newValue.intValue(), isUpDownInverted);
                 rollerShutterState = metadata.setState(event.args.newValue,
                         Objects.requireNonNull(channel.getAcceptedItemType()), channelConfig.incomingUnit,
-                        rollerShutterConfig.inverted);
+                        rollerShutterConfig.inverted, channelConfig.factor);
             } else if (event.args.newValue instanceof Boolean newValue) {
                 boolean isCommandForUp = channelId.equals(rollerShutterCapability.upChannel.getId());
                 boolean isCommandForDown = channelId.equals(rollerShutterCapability.downChannel.getId());
@@ -837,13 +837,19 @@ public class ZwaveJSNodeHandler extends BaseThingHandler implements ZwaveNodeLis
     private void initializeChannelAndConfigState(Node node, ZwaveJSTypeGeneratorResult result) {
         // Set initial state for linked channels
         for (Channel channel : thing.getChannels()) {
-            if (result.values.containsKey(channel.getUID().getId()) && isLinked(channel.getUID())) {
-                ChannelMetadata dummy = new ChannelMetadata(getId(), node.values.get(0));
+            String channelId = channel.getUID().getId();
+            if (result.values.containsKey(channelId) && isLinked(channel.getUID())) {
+                ChannelMetadata metadata = result.channelMetadata.get(channelId);
+                if (metadata == null) {
+                    logger.debug("Node {}. Channel {} has a value but no metadata, skipping initial state", node.nodeId,
+                            channelId);
+                    continue;
+                }
                 ZwaveJSChannelConfiguration channelConfig = channel.getConfiguration()
                         .as(ZwaveJSChannelConfiguration.class);
-                State state = dummy.setState(Objects.requireNonNull(result.values.get(channel.getUID().getId())),
+                State state = metadata.setState(Objects.requireNonNull(result.values.get(channelId)),
                         Objects.requireNonNull(channel.getAcceptedItemType()), channelConfig.incomingUnit,
-                        channelConfig.inverted);
+                        channelConfig.inverted, channelConfig.factor);
                 if (state != null) {
                     // Initialize color and color temperature channels
                     ColorCapability colorCap = colorCapabilities.get(channelConfig.endpoint);

--- a/bundles/org.openhab.binding.zwavejs/src/main/java/org/openhab/binding/zwavejs/internal/handler/ZwaveJSNodeHandler.java
+++ b/bundles/org.openhab.binding.zwavejs/src/main/java/org/openhab/binding/zwavejs/internal/handler/ZwaveJSNodeHandler.java
@@ -301,7 +301,7 @@ public class ZwaveJSNodeHandler extends BaseThingHandler implements ZwaveNodeLis
         } else if (command instanceof PercentType percentTypeCommand) {
             zwaveCommand.value = handlePercentTypeCommand(channel, colorCap, channelConfig, percentTypeCommand);
         } else if (command instanceof DecimalType decimalCommand) {
-            zwaveCommand.value = decimalCommand.doubleValue();
+            zwaveCommand.value = decimalCommand.doubleValue() / channelConfig.factor;
         } else if (command instanceof DateTimeType dateTimeCommand) {
             throw new UnsupportedOperationException(dateTimeCommand.toString() + " is currently not supported");
         } else if (command instanceof IncreaseDecreaseType increaseDecreaseCommand) {

--- a/bundles/org.openhab.binding.zwavejs/src/main/java/org/openhab/binding/zwavejs/internal/type/ZwaveJSTypeGeneratorImpl.java
+++ b/bundles/org.openhab.binding.zwavejs/src/main/java/org/openhab/binding/zwavejs/internal/type/ZwaveJSTypeGeneratorImpl.java
@@ -254,6 +254,7 @@ public class ZwaveJSTypeGeneratorImpl implements ZwaveJSTypeGenerator {
                     .build();
 
             result.channels.put(details.id, channel);
+            result.channelMetadata.put(details.id, details);
         }
     }
 
@@ -374,6 +375,7 @@ public class ZwaveJSTypeGeneratorImpl implements ZwaveJSTypeGenerator {
         }
 
         result.channels.put(details.id, builder.build());
+        result.channelMetadata.put(details.id, details);
 
         // if necessary add or update the entry in our ZwaveJSTypeGeneratorResult's map of ColorCapabilities
         updateColorCapabilities(thingUID, details, result);
@@ -798,6 +800,7 @@ public class ZwaveJSTypeGeneratorImpl implements ZwaveJSTypeGenerator {
                     .build();
 
             result.channels.put(details.id, channel);
+            result.channelMetadata.put(details.id, details);
             Object dimmerValue = result.values.get(rollerShutterCapability.dimmerChannel.getId());
             if (dimmerValue != null) {
                 result.values.put(details.id, dimmerValue);
@@ -851,6 +854,7 @@ public class ZwaveJSTypeGeneratorImpl implements ZwaveJSTypeGenerator {
                     .build();
 
             result.channels.put(details.id, channel);
+            result.channelMetadata.put(details.id, details);
             colorCapability.colorTempChannel = channel.getUID();
         });
     }

--- a/bundles/org.openhab.binding.zwavejs/src/main/java/org/openhab/binding/zwavejs/internal/type/ZwaveJSTypeGeneratorResult.java
+++ b/bundles/org.openhab.binding.zwavejs/src/main/java/org/openhab/binding/zwavejs/internal/type/ZwaveJSTypeGeneratorResult.java
@@ -16,6 +16,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.binding.zwavejs.internal.conversion.ChannelMetadata;
 import org.openhab.binding.zwavejs.internal.type.capabilities.ColorCapability;
 import org.openhab.binding.zwavejs.internal.type.capabilities.RollerShutterCapability;
 import org.openhab.core.thing.Channel;
@@ -33,6 +34,7 @@ public class ZwaveJSTypeGeneratorResult {
 
     public Map<String, Channel> channels = new HashMap<>();
     public Map<String, Object> values = new HashMap<>();
+    public Map<String, ChannelMetadata> channelMetadata = new HashMap<>();
     public Map<Integer, ColorCapability> colorCapabilities = new HashMap<>();
     public Map<Integer, RollerShutterCapability> rollerShutterCapabilities = new HashMap<>();
     public String location = "";

--- a/bundles/org.openhab.binding.zwavejs/src/test/java/org/openhab/binding/zwavejs/internal/action/ZwaveJSActionsTest.java
+++ b/bundles/org.openhab.binding.zwavejs/src/test/java/org/openhab/binding/zwavejs/internal/action/ZwaveJSActionsTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.zwavejs.internal.action;
+
+import static org.mockito.Mockito.*;
+
+import java.util.List;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.openhab.binding.zwavejs.internal.handler.ZwaveJSBridgeHandler;
+
+/**
+ * @author Leo Siepel - Initial contribution
+ */
+@NonNullByDefault
+public class ZwaveJSActionsTest {
+
+    @Test
+    public void staleTimeoutDoesNotStopNewInvocationOfSameAction() {
+        ScheduledExecutorService scheduler = mock(ScheduledExecutorService.class);
+        ScheduledFuture<?> firstStopJob = mock(ScheduledFuture.class);
+        ScheduledFuture<?> secondStopJob = mock(ScheduledFuture.class);
+        ArgumentCaptor<Runnable> timeoutCaptor = ArgumentCaptor.forClass(Runnable.class);
+        doReturn(firstStopJob, secondStopJob).when(scheduler).schedule(timeoutCaptor.capture(), eq(30L),
+                eq(TimeUnit.SECONDS));
+
+        ZwaveJSBridgeHandler handler = mock(ZwaveJSBridgeHandler.class);
+        ZwaveJSActions actions = new ZwaveJSActions(scheduler);
+        actions.setThingHandler(handler);
+
+        actions.startInclusion();
+        actions.startInclusion();
+
+        verify(handler, times(2)).startInclusion();
+        verify(handler).stopInclusion();
+        verify(firstStopJob).cancel(false);
+
+        List<Runnable> timeouts = timeoutCaptor.getAllValues();
+        timeouts.get(0).run();
+
+        verify(handler).stopInclusion();
+        verify(secondStopJob, never()).cancel(false);
+
+        timeouts.get(1).run();
+
+        verify(handler, times(2)).stopInclusion();
+        verify(secondStopJob).cancel(false);
+    }
+}

--- a/bundles/org.openhab.binding.zwavejs/src/test/java/org/openhab/binding/zwavejs/internal/discovery/NodeDiscoveryServiceTest.java
+++ b/bundles/org.openhab.binding.zwavejs/src/test/java/org/openhab/binding/zwavejs/internal/discovery/NodeDiscoveryServiceTest.java
@@ -83,14 +83,14 @@ public class NodeDiscoveryServiceTest {
         DiscoveryResult result = captor.getValue();
         Map<String, Object> expectedProperties = new HashMap<>();
         expectedProperties.put("id", node.nodeId);
-        expectedProperties.put(PROPERTY_NODE_IS_LISTENING, node.isListening);
-        expectedProperties.put(PROPERTY_NODE_IS_ROUTING, node.isRouting);
-        expectedProperties.put(PROPERTY_NODE_IS_SECURE, node.isSecure);
+        expectedProperties.put(PROPERTY_NODE_IS_LISTENING, String.valueOf(node.isListening));
+        expectedProperties.put(PROPERTY_NODE_IS_ROUTING, String.valueOf(node.isRouting));
+        expectedProperties.put(PROPERTY_NODE_IS_SECURE, String.valueOf(node.isSecure));
         expectedProperties.put(PROPERTY_VENDOR, node.deviceConfig.manufacturer);
         expectedProperties.put(PROPERTY_MODEL_ID, node.deviceConfig.label);
-        expectedProperties.put(PROPERTY_NODE_LASTSEEN, node.lastSeen);
-        expectedProperties.put(PROPERTY_NODE_FREQ_LISTENING, node.isFrequentListening);
-        expectedProperties.put(PROPERTY_FIRMWARE_VERSION, node.firmwareVersion);
+        expectedProperties.put(PROPERTY_NODE_LASTSEEN, node.lastSeen.toString());
+        expectedProperties.put(PROPERTY_NODE_FREQ_LISTENING, String.valueOf(node.isFrequentListening));
+        expectedProperties.put(PROPERTY_FIRMWARE_VERSION, "");
 
         assertEquals(expectedProperties, result.getProperties());
         assertEquals(bridgeUID, result.getBridgeUID());

--- a/bundles/org.openhab.binding.zwavejs/src/test/java/org/openhab/binding/zwavejs/internal/handler/ZwaveJSNodeHandlerTest.java
+++ b/bundles/org.openhab.binding.zwavejs/src/test/java/org/openhab/binding/zwavejs/internal/handler/ZwaveJSNodeHandlerTest.java
@@ -15,6 +15,7 @@ package org.openhab.binding.zwavejs.internal.handler;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
+import static org.openhab.binding.zwavejs.internal.BindingConstants.*;
 
 import java.io.IOException;
 import java.util.List;
@@ -31,6 +32,7 @@ import org.openhab.binding.zwavejs.internal.api.dto.commands.NodeSetValueCommand
 import org.openhab.binding.zwavejs.internal.api.dto.messages.EventMessage;
 import org.openhab.binding.zwavejs.internal.handler.mock.ZwaveJSNodeHandlerMock;
 import org.openhab.core.config.core.Configuration;
+import org.openhab.core.library.CoreItemFactory;
 import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.library.types.HSBType;
 import org.openhab.core.library.types.OnOffType;
@@ -605,6 +607,32 @@ public class ZwaveJSNodeHandlerTest {
             nodeHandler.handleCommand(channel.getUID(), new QuantityType<>(5.0, Units.WATT));
             // Should call sendCommand once
             verify(nodeHandler.getBridgeHandler(), times(1)).sendCommand(any(NodeSetValueCommand.class));
+        } finally {
+            nodeHandler.dispose();
+        }
+    }
+
+    @Test
+    public void testHandleCommand_DecimalTypeAppliesInverseFactor() {
+        final Thing thing = ZwaveJSNodeHandlerMock.mockThing(7);
+        final ThingHandlerCallback callback = mock(ThingHandlerCallback.class);
+        final ZwaveJSNodeHandlerMock nodeHandler = ZwaveJSNodeHandlerMock.createAndInitHandler(callback, thing,
+                "store_4.json", true);
+        ZwaveJSBridgeHandler bridgeHandler = nodeHandler.getBridgeHandler();
+        doReturn(bridgeHandler).when(nodeHandler).getBridgeHandler();
+
+        try {
+            Channel channel = nodeHandler.getThing().getChannels().stream()
+                    .filter(c -> CoreItemFactory.NUMBER.equals(c.getAcceptedItemType()))
+                    .filter(c -> c.getConfiguration().get(CONFIG_CHANNEL_WRITE_PROPERTY_INT) != null).findFirst()
+                    .orElse(null);
+            assertNotNull(channel);
+            channel.getConfiguration().put(CONFIG_CHANNEL_FACTOR, 0.1);
+
+            nodeHandler.handleCommand(channel.getUID(), new DecimalType(5.0));
+
+            NodeSetValueCommand sendCommand = captureCommand(nodeHandler, NodeSetValueCommand.class);
+            assertEquals(50.0, sendCommand.value);
         } finally {
             nodeHandler.dispose();
         }

--- a/bundles/org.openhab.binding.zwavejs/src/test/java/org/openhab/binding/zwavejs/internal/handler/ZwaveJSNodeHandlerTest.java
+++ b/bundles/org.openhab.binding.zwavejs/src/test/java/org/openhab/binding/zwavejs/internal/handler/ZwaveJSNodeHandlerTest.java
@@ -202,6 +202,29 @@ public class ZwaveJSNodeHandlerTest {
     }
 
     @Test
+    public void testNode7PowerEventUpdateAppliesConfiguredFactor() throws IOException {
+        final Thing thing = ZwaveJSNodeHandlerMock.mockThing(7);
+        final ThingHandlerCallback callback = mock(ThingHandlerCallback.class);
+        final ZwaveJSNodeHandlerMock handler = ZwaveJSNodeHandlerMock.createAndInitHandler(callback, thing,
+                "store_4.json");
+
+        ChannelUID channelUID = new ChannelUID("zwavejs:test-bridge:test-thing:meter-value-66049-1");
+        Channel channel = handler.getThing().getChannel(channelUID);
+        assertNotNull(channel);
+        channel.getConfiguration().put(CONFIG_CHANNEL_FACTOR, 2.0);
+        clearInvocations(callback);
+
+        EventMessage eventMessage = DataUtil.fromJson("event_node_7_power.json", EventMessage.class);
+        handler.onNodeStateChanged(eventMessage.event);
+
+        try {
+            verify(callback).stateUpdated(eq(channelUID), eq(new QuantityType<Power>(4.32, Units.WATT)));
+        } finally {
+            handler.dispose();
+        }
+    }
+
+    @Test
     public void testNode25SwitchEventUpdate() throws IOException {
         final Thing thing = ZwaveJSNodeHandlerMock.mockThing(25);
         final ThingHandlerCallback callback = mock(ThingHandlerCallback.class);

--- a/bundles/org.openhab.binding.zwavejs/src/test/java/org/openhab/binding/zwavejs/internal/handler/ZwaveJSNodeHandlerTest.java
+++ b/bundles/org.openhab.binding.zwavejs/src/test/java/org/openhab/binding/zwavejs/internal/handler/ZwaveJSNodeHandlerTest.java
@@ -636,7 +636,7 @@ public class ZwaveJSNodeHandlerTest {
     }
 
     @Test
-    public void testHandleCommand_DecimalTypeAppliesInverseFactor() {
+    public void testHandleCommandDecimalTypeAppliesInverseFactor() {
         final Thing thing = ZwaveJSNodeHandlerMock.mockThing(7);
         final ThingHandlerCallback callback = mock(ThingHandlerCallback.class);
         final ZwaveJSNodeHandlerMock nodeHandler = ZwaveJSNodeHandlerMock.createAndInitHandler(callback, thing,


### PR DESCRIPTION
This PR refactors some areas. I tried to isolate the changes in specific commits.

1. Thing properties are now normalized in String values. Both in regular updates as in discovery
2. In- and exclusion mechanism now resets the state before performing the action, preventing irratic behavior after starting multiple actions in a short timeframe.
3. Some minor issues with how metadata was handeld are resolved:
    - dummy data was mixed with actual data, not a runtime issue, but code wise ugly
    - configured factor was not always taken into account, but recalculated in setState
    - storing metadata is a first step towards dynamic metadata updates, requested in the community forums. 