### PR TITLE
Use issue types rather than labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,7 +1,7 @@
 ---
 name: "🐛 Bug report"
 about: Something isn't working correctly with an add-on. This is the wrong place for user-interfaces or openHAB Core issues.
-labels: bug
+Type: Bug
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,7 +1,7 @@
 ---
 name: "✨ Feature request"
 about: You think that your favorite add-on should gain another feature
-labels: enhancement
+type: Feature
 
 ---
 


### PR DESCRIPTION
This is a proposal to prefer issue type over bug/enhancement label.

Issue types are managed [per organization](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/managing-issue-types-in-an-organization) rather than per repository, which makes it easier to enforce consistency.

Only one issue type can be selected, which prevents the ambiguity currently possible by adding both "bug" and "enhancement" labels.

In lists, issue types are vertically aligned, so it's easier to distinguish the issue type.

I have already assigned issue types to all open issues. If accepted, I will try to find a way to bulk edit closed issues as well (I was only able to bulk edit one page at a time). Once done, we could also remove all existing bug/enhancement labels.