### PR TITLE
[tapocontrol] Fix KLAP-protocol powercycle recovery for 1.4.6 firmware

### DIFF
--- a/bundles/org.openhab.binding.tapocontrol/README.md
+++ b/bundles/org.openhab.binding.tapocontrol/README.md
@@ -32,6 +32,7 @@ The following Tapo-Devices are supported. For precise channel-description look a
 
 Before using Smart Plugs with openHAB the devices must be connected to the Wi-Fi network.
 This can be done using the Tapo provided mobile app.
+Some devices require Third-Party Compatibility to be enabled via the mobile app.
 You need to setup a bridge (Cloud-Login) to communicate with your devices.
 
 **Note:** If the Tapo device is to be isolated from the internet e.g. on an IoT LAN, the P110 will not expose its energy and power data until it has successfully synchronised it's clock with an NTP server - at time of writing, this was `pool.ntp.org`.

--- a/bundles/org.openhab.binding.tapocontrol/README.md
+++ b/bundles/org.openhab.binding.tapocontrol/README.md
@@ -4,7 +4,7 @@ This binding adds support to control Tapo (Copyright © TP-Link Corporation Limi
 
 ## Supported Things
 
-The following Tapo-Devices are supported. For precise channel-description look at `channels-table` below
+The following Tapo-Devices are supported. For precise channel-description look at `channels-table` below:
 
 | DeviceType                         | ThingType | Description                                   |
 |------------------------------------|-----------|-----------------------------------------------|
@@ -32,7 +32,7 @@ The following Tapo-Devices are supported. For precise channel-description look a
 
 Before using Smart Plugs with openHAB the devices must be connected to the Wi-Fi network.
 This can be done using the Tapo provided mobile app.
-Some devices require Third-Party Compatibility to be enabled via the mobile app.
+Some devices require Third-Party Compatibility to be disabled then re-enabled via the mobile app after initial installation or firmware upgrade.
 You need to setup a bridge (Cloud-Login) to communicate with your devices.
 
 **Note:** If the Tapo device is to be isolated from the internet e.g. on an IoT LAN, the P110 will not expose its energy and power data until it has successfully synchronised it's clock with an NTP server - at time of writing, this was `pool.ntp.org`.

--- a/bundles/org.openhab.binding.tapocontrol/src/main/java/org/openhab/binding/tapocontrol/internal/api/TapoCloudConnector.java
+++ b/bundles/org.openhab.binding.tapocontrol/src/main/java/org/openhab/binding/tapocontrol/internal/api/TapoCloudConnector.java
@@ -12,10 +12,10 @@
  */
 package org.openhab.binding.tapocontrol.internal.api;
 
-import static org.openhab.binding.tapocontrol.internal.constants.TapoBindingSettings.*;
+import static org.openhab.binding.tapocontrol.internal.constants.TapoBindingSettings.TAPO_CLOUD_URL;
 import static org.openhab.binding.tapocontrol.internal.constants.TapoComConstants.*;
 import static org.openhab.binding.tapocontrol.internal.constants.TapoErrorCode.*;
-import static org.openhab.binding.tapocontrol.internal.helpers.utils.JsonUtils.*;
+import static org.openhab.binding.tapocontrol.internal.helpers.utils.JsonUtils.getObjectFromJson;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jetty.client.HttpClient;
@@ -167,6 +167,11 @@ public class TapoCloudConnector implements TapoConnectorInterface {
     @Override
     public String getThingUID() {
         return bridge.getUID().toString();
+    }
+
+    @Override
+    public TapoBridgeHandler getBridge() {
+        return bridge;
     }
 
     /************************

--- a/bundles/org.openhab.binding.tapocontrol/src/main/java/org/openhab/binding/tapocontrol/internal/api/TapoConnectorInterface.java
+++ b/bundles/org.openhab.binding.tapocontrol/src/main/java/org/openhab/binding/tapocontrol/internal/api/TapoConnectorInterface.java
@@ -14,6 +14,7 @@ package org.openhab.binding.tapocontrol.internal.api;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jetty.client.HttpClient;
+import org.openhab.binding.tapocontrol.internal.devices.bridge.TapoBridgeHandler;
 import org.openhab.binding.tapocontrol.internal.dto.TapoResponse;
 import org.openhab.binding.tapocontrol.internal.helpers.TapoErrorHandler;
 
@@ -40,6 +41,9 @@ public interface TapoConnectorInterface {
     /* get base url of device */
     public String getBaseUrl();
 
-    /* geth ThingUID of device */
+    /* get ThingUID of device */
     public String getThingUID();
+
+    /* get bridge */
+    public TapoBridgeHandler getBridge();
 }

--- a/bundles/org.openhab.binding.tapocontrol/src/main/java/org/openhab/binding/tapocontrol/internal/api/TapoDeviceConnector.java
+++ b/bundles/org.openhab.binding.tapocontrol/src/main/java/org/openhab/binding/tapocontrol/internal/api/TapoDeviceConnector.java
@@ -172,7 +172,7 @@ public class TapoDeviceConnector implements TapoConnectorInterface {
 
     /**
      * Send "set_device_info" command to device and query info immediately
-     * 
+     *
      * @param deviceDataClass clazz contains devicedata which should be sent
      */
     public void sendDeviceCommand(Object deviceDataClass) {
@@ -181,7 +181,7 @@ public class TapoDeviceConnector implements TapoConnectorInterface {
 
     /**
      * Send command to device with params and query info immediately
-     * 
+     *
      * @param command command
      * @param deviceDataClass clazz contains devicedata which should be sent
      */
@@ -191,7 +191,7 @@ public class TapoDeviceConnector implements TapoConnectorInterface {
 
     /**
      * Send command to device with params
-     * 
+     *
      * @param command command
      * @param deviceDataClass clazz contains devicedata which should be sent
      * @param ignoreGap ignore gap to last query. query anyway
@@ -208,7 +208,7 @@ public class TapoDeviceConnector implements TapoConnectorInterface {
 
     /**
      * Send command to device with params and query info immediately
-     * 
+     *
      * @param deviceDataClass clazz contains devicedata which should be sent
      * @param multipleRequestSupported set to true if device supports multipleRequests
      */
@@ -218,7 +218,7 @@ public class TapoDeviceConnector implements TapoConnectorInterface {
 
     /**
      * Send command to device with params and query info immediately
-     * 
+     *
      * @param command command
      * @param deviceDataClass clazz contains devicedata which should be sent
      * @param multipleRequestSupported set to true if device supports multipleRequests
@@ -237,7 +237,7 @@ public class TapoDeviceConnector implements TapoConnectorInterface {
 
     /**
      * Send command to child device
-     * 
+     *
      * @param childData ChildDeviceData-Class
      */
     public void sendChildCommand(TapoChildDeviceData childData) {
@@ -246,7 +246,7 @@ public class TapoDeviceConnector implements TapoConnectorInterface {
 
     /**
      * Send command to child device
-     * 
+     *
      * @param childData ChildDeviceData-Class
      * @param ignoreGap ignore gap to last query. query anyway
      */
@@ -271,7 +271,7 @@ public class TapoDeviceConnector implements TapoConnectorInterface {
 
     /**
      * send asynchronous multi-request igrnoring min-gap
-     * 
+     *
      * @param requests list of TapoRequests should be sent to device
      * @param ignoreGap ignoreGap ignore gap to last query. query anyway
      */
@@ -288,7 +288,7 @@ public class TapoDeviceConnector implements TapoConnectorInterface {
 
     /**
      * send asynchron multi-request
-     * 
+     *
      * @param requests array of TapoRequest
      */
     public void sendMultipleRequest(TapoRequest... requests) {
@@ -297,7 +297,7 @@ public class TapoDeviceConnector implements TapoConnectorInterface {
 
     /**
      * send asynchron request to protocol handler
-     * 
+     *
      * @param tapoRequest Request inherits TapoBaseRequestInterface
      */
     public void sendAsyncRequest(TapoBaseRequestInterface tapoRequest) {
@@ -314,7 +314,7 @@ public class TapoDeviceConnector implements TapoConnectorInterface {
 
     /**
      * Return class object from json formated string
-     * 
+     *
      * @param json json formatted string
      * @param clazz class string should parsed to
      */
@@ -335,7 +335,7 @@ public class TapoDeviceConnector implements TapoConnectorInterface {
 
     /**
      * Return class object from JsonObject
-     * 
+     *
      * @param jso JsonOject
      * @param clazz class string should parsed to
      */
@@ -345,7 +345,7 @@ public class TapoDeviceConnector implements TapoConnectorInterface {
 
     /**
      * handle and decrypt response from device
-     * 
+     *
      * @param response TapoResponse was received
      * @param command was sent to device belonging to response
      */
@@ -364,7 +364,7 @@ public class TapoDeviceConnector implements TapoConnectorInterface {
 
     /**
      * Handle response got from single-request
-     * 
+     *
      * @param response response from request
      * @param command command was sent
      */
@@ -381,7 +381,7 @@ public class TapoDeviceConnector implements TapoConnectorInterface {
 
     /**
      * Handle response got from multiple-request
-     * 
+     *
      * @param response response from request
      */
     private void handleMultipleRespone(TapoResponse response) {
@@ -393,13 +393,13 @@ public class TapoDeviceConnector implements TapoConnectorInterface {
 
     /**
      * Parse responsedata from result to object and inform device about new data
-     * 
+     *
      * @param response response from request
      * @param command command was sent
      */
     private void handleQueryResult(TapoResponse response, String command) {
         if (!response.hasError()) {
-            logger.trace("({}) queryResponse successfull '{}'", uid, response);
+            logger.trace("({}) queryResponse successful '{}'", uid, response);
             queryResponse = response;
             device.newDataResult(command);
         } else {
@@ -410,7 +410,7 @@ public class TapoDeviceConnector implements TapoConnectorInterface {
 
     /**
      * Handle SuccessResponse (setDeviceInfo)
-     * 
+     *
      * @param response response from request
      */
     private void handleSuccessResponse(TapoResponse response) {
@@ -418,7 +418,7 @@ public class TapoDeviceConnector implements TapoConnectorInterface {
             logger.debug("({}) set deviceInfo not successful: {}", uid, response);
             device.setError(new TapoErrorHandler(response.errorCode()));
         } else {
-            logger.trace("({}) setcommand successfull '{}'", uid, response);
+            logger.trace("({}) setcommand successful '{}'", uid, response);
             if (queryAfterCommand) {
                 sendQueryCommand(DEVICE_CMD_GETINFO, true);
             }
@@ -479,7 +479,7 @@ public class TapoDeviceConnector implements TapoConnectorInterface {
 
     /**
      * Get Dataobject from response
-     * 
+     *
      * @param clazz object class response should be transformed
      */
     public <T> T getResponseData(Class<T> clazz) {
@@ -487,7 +487,7 @@ public class TapoDeviceConnector implements TapoConnectorInterface {
     }
 
     /**
-     * Ping to IP of device - return true if successfull
+     * Ping to IP of device - return true if successful
      */
     public boolean pingDevice() {
         try {
@@ -517,5 +517,10 @@ public class TapoDeviceConnector implements TapoConnectorInterface {
     @Override
     public String getThingUID() {
         return device.getThingUID().toString();
+    }
+
+    @Override
+    public TapoBridgeHandler getBridge() {
+        return bridge;
     }
 }

--- a/bundles/org.openhab.binding.tapocontrol/src/main/java/org/openhab/binding/tapocontrol/internal/api/protocol/klap/KlapProtocol.java
+++ b/bundles/org.openhab.binding.tapocontrol/src/main/java/org/openhab/binding/tapocontrol/internal/api/protocol/klap/KlapProtocol.java
@@ -18,6 +18,7 @@ import static org.openhab.binding.tapocontrol.internal.constants.TapoErrorCode.*
 import static org.openhab.binding.tapocontrol.internal.helpers.utils.ByteUtils.byteArrayToHex;
 import static org.openhab.binding.tapocontrol.internal.helpers.utils.JsonUtils.isValidJson;
 
+import java.io.IOException;
 import java.util.Objects;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -43,9 +44,16 @@ import org.slf4j.LoggerFactory;
  * Handler class for TAPO-KLAP-Protocol
  *
  * @author Christian Wild - Initial contribution
+ * @author David Henshaw - Improvements to handle tapo device error states in send
  */
 @NonNullByDefault
 public class KlapProtocol implements org.openhab.binding.tapocontrol.internal.api.protocol.TapoProtocolInterface {
+
+    private enum SuccessState {
+        failed,
+        retry,
+        success
+    };
 
     private final Logger logger = LoggerFactory.getLogger(KlapProtocol.class);
     protected final TapoConnectorInterface httpDelegator;
@@ -151,30 +159,20 @@ public class KlapProtocol implements org.openhab.binding.tapocontrol.internal.ap
 
         while (true) {
             attemptCount++;
-            if (attemptCount > 1) {
-                try {
-                    /* re-login using existing credentials */
-                    session.reset();
-                    if (!session.login()) {
-                        logger.debug("({}) sendRequestRetryable login error", uid);
-                        httpDelegator.handleError(new TapoErrorHandler(ERR_BINDING_LOGIN));
-                        return;
-                    }
-                    logger.trace("({}) sendRequestRetryable re-login successful attempt {}", uid, attemptCount);
-                } catch (TapoErrorHandler e) {
-                    logger.trace("({}) sendRequestRetryable error1 {}", uid, e.getMessage());
-                    if (attemptCount < maxAttempts) {
+
+            // @@DGH
+            // if (attemptCount > 2) { // try to init comms via UDP
+            // sendUdpDiscoveryMessage(); // ignore any errors & retry login
+            // }
+
+            if (attemptCount > 1) { // re-login using existing credentials
+                switch (reLoginExistingCredentials(attemptCount, maxAttempts)) {
+                    case SuccessState.success:
+                        break; // move on to send message
+                    case SuccessState.retry:
                         continue;
-                    }
-                    httpDelegator.handleError(e);
-                    return;
-                } catch (Exception ex) {
-                    logger.trace("({}) sendRequestRetryable error2 {}", uid, ex.getMessage());
-                    if (attemptCount < maxAttempts) {
-                        continue;
-                    }
-                    httpDelegator.handleError(new TapoErrorHandler(ERR_BINDING_LOGIN, ex.getMessage()));
-                    return;
+                    default:
+                        return; // error
                 }
             }
             try {
@@ -236,10 +234,49 @@ public class KlapProtocol implements org.openhab.binding.tapocontrol.internal.ap
             } catch (Exception e) {
                 String errorMessage = e.getMessage();
                 logger.debug("({}) sendRequestRetryable failed'{}'", uid, errorMessage);
-                httpDelegator.handleError(new TapoErrorHandler(new Exception(e), errorMessage));
-                return;
+                session.reset();
+                if (e.getCause() instanceof IOException) {
+                    httpDelegator.handleError(new TapoErrorHandler(ERR_BINDING_SEND_REQUEST));
+                } else {
+                    throw new TapoErrorHandler(ERR_BINDING_SEND_REQUEST, errorMessage);
+                }
             }
         } /* end of loop */
+    }
+
+    /**
+     * Try to re-login using the already-provided credentials
+     *
+     * @param attemptCount - how many times have we tried
+     * @param maxAttempts - how many attempts are allowed
+     * @return
+     */
+    private SuccessState reLoginExistingCredentials(int attemptCount, int maxAttempts) {
+        /* re-login using existing credentials - return false if aborting */
+        try {
+            session.reset();
+            if (!session.login()) {
+                logger.debug("({}) sendRequestRetryable login error", uid);
+                httpDelegator.handleError(new TapoErrorHandler(ERR_BINDING_LOGIN));
+                return SuccessState.failed;
+            }
+            logger.trace("({}) sendRequestRetryable re-login successful attempt {}", uid, attemptCount);
+            return SuccessState.success;
+        } catch (TapoErrorHandler e) {
+            logger.trace("({}) sendRequestRetryable error1 {}", uid, e.getMessage());
+            if (attemptCount < maxAttempts) {
+                return SuccessState.retry;
+            }
+            httpDelegator.handleError(e);
+            return SuccessState.failed;
+        } catch (Exception ex) {
+            logger.trace("({}) sendRequestRetryable error2 {}", uid, ex.getMessage());
+            if (attemptCount < maxAttempts) {
+                return SuccessState.retry;
+            }
+            httpDelegator.handleError(new TapoErrorHandler(ERR_BINDING_LOGIN, ex.getMessage()));
+            return SuccessState.failed;
+        }
     }
 
     /************************

--- a/bundles/org.openhab.binding.tapocontrol/src/main/java/org/openhab/binding/tapocontrol/internal/api/protocol/klap/KlapProtocol.java
+++ b/bundles/org.openhab.binding.tapocontrol/src/main/java/org/openhab/binding/tapocontrol/internal/api/protocol/klap/KlapProtocol.java
@@ -157,7 +157,7 @@ public class KlapProtocol implements org.openhab.binding.tapocontrol.internal.ap
         String command = tapoRequest.method();
         logger.trace("({}) sendRequestRetryable unencrypted request: '{}' to '{}' ", uid, tapoRequest, url);
 
-        while (true) {
+        while (attemptCount < maxAttempts) {
             attemptCount++;
 
             // @@DGH
@@ -167,9 +167,9 @@ public class KlapProtocol implements org.openhab.binding.tapocontrol.internal.ap
 
             if (attemptCount > 1) { // re-login using existing credentials
                 switch (reLoginExistingCredentials(attemptCount, maxAttempts)) {
-                    case SuccessState.success:
+                    case success:
                         break; // move on to send message
-                    case SuccessState.retry:
+                    case retry:
                         continue;
                     default:
                         return; // error
@@ -237,6 +237,7 @@ public class KlapProtocol implements org.openhab.binding.tapocontrol.internal.ap
                 session.reset();
                 if (e.getCause() instanceof IOException) {
                     httpDelegator.handleError(new TapoErrorHandler(ERR_BINDING_SEND_REQUEST));
+                    return;
                 } else {
                     throw new TapoErrorHandler(ERR_BINDING_SEND_REQUEST, errorMessage);
                 }

--- a/bundles/org.openhab.binding.tapocontrol/src/main/java/org/openhab/binding/tapocontrol/internal/api/protocol/klap/KlapSession.java
+++ b/bundles/org.openhab.binding.tapocontrol/src/main/java/org/openhab/binding/tapocontrol/internal/api/protocol/klap/KlapSession.java
@@ -136,7 +136,7 @@ public class KlapSession {
             byte[] bLocalSeedAuthHash = sha256Encode(concatByteArray);
 
             if (Arrays.equals(bLocalSeedAuthHash, serverHash)) {
-                logger.trace("handshake1 sucessful");
+                logger.trace("handshake1 successful");
                 this.remoteSeed = remoteSeed;
                 this.serverHash = serverHash;
                 this.localSeedAuthHash = bLocalSeedAuthHash;
@@ -211,6 +211,9 @@ public class KlapSession {
                 if (!createHandshake1()) {
                     throw new TapoErrorHandler(NO_ERROR, BINDING_ID);
                 }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new TapoErrorHandler(ERR_API_UNKNOWN_COM_ERROR, BINDING_ID);
             } catch (Exception ex) {
                 // Handshake1 failed - Try repeating after a UDP comms reset
                 if (!sendUdpDiscoveryMessage()) {

--- a/bundles/org.openhab.binding.tapocontrol/src/main/java/org/openhab/binding/tapocontrol/internal/api/protocol/klap/KlapSession.java
+++ b/bundles/org.openhab.binding.tapocontrol/src/main/java/org/openhab/binding/tapocontrol/internal/api/protocol/klap/KlapSession.java
@@ -17,6 +17,7 @@ import static org.openhab.binding.tapocontrol.internal.constants.TapoErrorCode.*
 import static org.openhab.binding.tapocontrol.internal.helpers.TapoEncoder.*;
 import static org.openhab.binding.tapocontrol.internal.helpers.utils.ByteUtils.*;
 
+import java.net.InetAddress;
 import java.nio.charset.StandardCharsets;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
@@ -30,6 +31,7 @@ import org.eclipse.jetty.client.api.ContentResponse;
 import org.eclipse.jetty.client.api.Request;
 import org.eclipse.jetty.client.util.BytesContentProvider;
 import org.eclipse.jetty.http.HttpMethod;
+import org.openhab.binding.tapocontrol.internal.discovery.TapoUdpDiscovery;
 import org.openhab.binding.tapocontrol.internal.helpers.TapoCredentials;
 import org.openhab.binding.tapocontrol.internal.helpers.TapoErrorHandler;
 import org.slf4j.Logger;
@@ -97,7 +99,9 @@ public class KlapSession {
         cipher = null;
     }
 
-    /* set sessionId (cookie) */
+    /**
+     * set sessionId (cookie) & save RemoteSeed & ServerHash
+     */
     public boolean setSession(ContentResponse response) throws TapoErrorHandler {
         try {
             /* get cookie */
@@ -132,7 +136,7 @@ public class KlapSession {
             byte[] bLocalSeedAuthHash = sha256Encode(concatByteArray);
 
             if (Arrays.equals(bLocalSeedAuthHash, serverHash)) {
-                logger.trace("handshake1 sucessfull");
+                logger.trace("handshake1 sucessful");
                 this.remoteSeed = remoteSeed;
                 this.serverHash = serverHash;
                 this.localSeedAuthHash = bLocalSeedAuthHash;
@@ -186,22 +190,12 @@ public class KlapSession {
     public boolean login(TapoCredentials credentials) throws TapoErrorHandler {
         try {
             authHash = generateAuthHash(credentials);
-            if (createHandshake1()) {
-                logger.trace("({}) handshake1 successful", uid);
-                if (createHandshake2()) {
-                    logger.trace("({}) handshake2 successful", uid);
-                    completeHandshake();
-                    return isHandshakeComplete();
-                }
-            } else {
-                throw new TapoErrorHandler(NO_ERROR, BINDING_ID);
-            }
+            return login();
         } catch (TapoErrorHandler e) {
             throw e;
         } catch (Exception e) {
-            throw new TapoErrorHandler(ERR_API_HAND_SHAKE_FAILED);
+            throw new TapoErrorHandler(ERR_API_HAND_SHAKE_FAILED, e.getMessage());
         }
-        return false;
     }
 
     /**
@@ -210,29 +204,38 @@ public class KlapSession {
     public boolean login() throws TapoErrorHandler {
         try {
             /* check credentials exist */
-            if (authHash.length <= 1) {
+            if (authHash.length <= 1) { // SHA256 should be 32 bytes long
                 return false;
             }
-            if (createHandshake1()) {
-                logger.trace("({}) handshake1 successful", uid);
-                if (createHandshake2()) {
-                    logger.trace("({}) handshake2 successful", uid);
-                    completeHandshake();
-                    return isHandshakeComplete();
+            try {
+                if (!createHandshake1()) {
+                    throw new TapoErrorHandler(NO_ERROR, BINDING_ID);
                 }
-            } else {
-                throw new TapoErrorHandler(NO_ERROR, BINDING_ID);
+            } catch (Exception ex) {
+                // Handshake1 failed - Try repeating after a UDP comms reset
+                if (!sendUdpDiscoveryMessage()) {
+                    throw new TapoErrorHandler(NO_ERROR, BINDING_ID);
+                } // now retry
+                if (!createHandshake1()) {
+                    throw new TapoErrorHandler(NO_ERROR, BINDING_ID);
+                }
             }
+            logger.trace("({}) handshake1 successful", uid);
+            if (!createHandshake2()) {
+                return false;
+            }
+            logger.trace("({}) handshake2 successful", uid);
+            completeHandshake();
+            return isHandshakeComplete();
         } catch (TapoErrorHandler e) {
             throw e;
         } catch (Exception e) {
             throw new TapoErrorHandler(ERR_API_HAND_SHAKE_FAILED);
         }
-        return false;
     }
 
     /**
-     * Handle Handshake (set session)
+     * Do Handshake1 using a local seed & use response to set session (save RemoteSeed & check ServerHash)
      */
     private boolean createHandshake1()
             throws TimeoutException, InterruptedException, ExecutionException, TapoErrorHandler {
@@ -244,27 +247,55 @@ public class KlapSession {
             setSession(response);
             return seedIsOkay();
         } else {
+            reset();
             logger.debug("({}) invalid handshake1 response {}", uid, response.getStatus());
-            throw new TapoErrorHandler(ERR_BINDING_HTTP_RESPONSE, "invalid response receicved");
+            throw new TapoErrorHandler(ERR_BINDING_HTTP_RESPONSE, "invalid response received");
         }
     }
 
     /**
-     * Complete Handshake2 (set cipher)
+     * Complete Handshake2 (set cipher) using credentials, check for valid response
      */
     private boolean createHandshake2() throws TimeoutException, InterruptedException, ExecutionException,
             NoSuchAlgorithmException, TapoErrorHandler {
         String handshakeUrl = klap.getUrl() + "/" + DEVICE_CMD_HANDSHAKE2;
+        /* send Hash made from localSeed, RemoteSeed & authHash */
         byte[] byteArr = concatBytes(remoteSeed, localSeed, authHash);
         byte[] payloadBytes = sha256Encode(byteArr);
         ContentResponse response = sendHandshake(handshakeUrl, payloadBytes, DEVICE_CMD_HANDSHAKE2);
-
         if (response.getStatus() == 200) {
             return true;
         } else {
+            reset();
             logger.debug("({}) invalid handshake2 response {}", uid, response.getStatus());
             throw new TapoErrorHandler(ERR_BINDING_HTTP_RESPONSE, response.getReason());
         }
+    }
+
+    /**
+     * Send the UDP discovery message to the device - sometimes needed after a power outage, prior to login
+     *
+     * @return success or failed
+     */
+    private boolean sendUdpDiscoveryMessage() {
+        var httpDelegator = klap.httpDelegator;
+        try {
+            var bridge = httpDelegator.getBridge();
+            var udpSender = new TapoUdpDiscovery(bridge);
+            var url = httpDelegator.getBaseUrl();
+            var urlparts = url.split("://"); // strip http:// from start
+            if (urlparts.length > 1) {
+                url = urlparts[1];
+            }
+            url = url.split(":")[0]; // strip port from end
+            var addr = InetAddress.getByName(url);
+            udpSender.sendAllPorts(addr);
+        } catch (Exception ex) {
+            logger.trace("({}) sendRequestRetryable error {}", uid, ex.getMessage());
+            httpDelegator.handleError(new TapoErrorHandler(ERR_BINDING_LOGIN, ex.getMessage()));
+            return false;
+        }
+        return true;
     }
 
     /************************
@@ -272,7 +303,7 @@ public class KlapSession {
      ************************/
 
     /**
-     * generate auth-hash from credentials
+     * generate SHA256 auth-hash from credentials (username & password)
      */
     private byte[] generateAuthHash(TapoCredentials credentials) throws NoSuchAlgorithmException, TapoErrorHandler {
         byte[] bUsername = sha1Encode(credentials.username().getBytes(StandardCharsets.UTF_8));
@@ -343,7 +374,9 @@ public class KlapSession {
         return (expireAt - (System.currentTimeMillis())) <= 40 * 1000;
     }
 
-    /* return true if seeds are set */
+    /**
+     * return true if seeds are set (serverHash matches localSeedAuthHash)
+     */
     public boolean seedIsOkay() {
         return serverHash.length > 0 && Arrays.equals(localSeedAuthHash, serverHash);
     }

--- a/bundles/org.openhab.binding.tapocontrol/src/main/java/org/openhab/binding/tapocontrol/internal/discovery/TapoDiscoveryService.java
+++ b/bundles/org.openhab.binding.tapocontrol/src/main/java/org/openhab/binding/tapocontrol/internal/discovery/TapoDiscoveryService.java
@@ -13,7 +13,7 @@
 package org.openhab.binding.tapocontrol.internal.discovery;
 
 import static org.openhab.binding.tapocontrol.internal.constants.TapoBindingSettings.*;
-import static org.openhab.binding.tapocontrol.internal.constants.TapoComConstants.*;
+import static org.openhab.binding.tapocontrol.internal.constants.TapoComConstants.DEVICE_REPRESENTATION_PROPERTY;
 import static org.openhab.binding.tapocontrol.internal.constants.TapoThingConstants.*;
 import static org.openhab.binding.tapocontrol.internal.helpers.utils.TapoUtils.*;
 
@@ -133,7 +133,7 @@ public class TapoDiscoveryService extends AbstractDiscoveryService implements Th
 
     /**
      * Stop scheduler
-     * 
+     *
      * @param scheduler ScheduledFeature which should be stopped
      */
     protected void stopScheduler(@Nullable ScheduledFuture<?> scheduler) {
@@ -211,7 +211,7 @@ public class TapoDiscoveryService extends AbstractDiscoveryService implements Th
 
     /**
      * work with result from get devices from deviceList
-     * 
+     *
      * @param deviceList
      */
     protected void handleDiscoveryList(TapoDiscoveryResultList deviceList) {
@@ -244,7 +244,7 @@ public class TapoDiscoveryService extends AbstractDiscoveryService implements Th
     /**
      * CREATE DISCOVERY RESULT
      * creates discoveryResult (Thing) from JsonObject got from Cloud
-     * 
+     *
      * @param device JsonObject with device information
      * @return DiscoveryResult-Object
      */
@@ -265,8 +265,8 @@ public class TapoDiscoveryService extends AbstractDiscoveryService implements Th
         properties.put(Thing.PROPERTY_SERIAL_NUMBER, device.deviceId());
         if (device.ip().length() >= 7) {
             properties.put(TapoDeviceConfiguration.CONFIG_DEVICE_IP, device.ip());
-            properties.put(TapoDeviceConfiguration.CONFIG_HTTP_PORT, device.encryptionShema().httpPort());
-            properties.put(TapoDeviceConfiguration.CONFIG_PROTOCOL, device.encryptionShema().encryptType());
+            properties.put(TapoDeviceConfiguration.CONFIG_HTTP_PORT, device.encryptionSchema().httpPort());
+            properties.put(TapoDeviceConfiguration.CONFIG_PROTOCOL, device.encryptionSchema().encryptType());
         }
 
         logger.debug("device {} discovered with mac {}", deviceModel, deviceMAC);

--- a/bundles/org.openhab.binding.tapocontrol/src/main/java/org/openhab/binding/tapocontrol/internal/discovery/TapoUdpDiscovery.java
+++ b/bundles/org.openhab.binding.tapocontrol/src/main/java/org/openhab/binding/tapocontrol/internal/discovery/TapoUdpDiscovery.java
@@ -12,20 +12,31 @@
  */
 package org.openhab.binding.tapocontrol.internal.discovery;
 
-import static org.openhab.binding.tapocontrol.internal.helpers.TapoEncoder.*;
+import static org.openhab.binding.tapocontrol.internal.helpers.TapoEncoder.crc32Checksum;
 import static org.openhab.binding.tapocontrol.internal.helpers.utils.ByteUtils.*;
-import static org.openhab.binding.tapocontrol.internal.helpers.utils.JsonUtils.*;
+import static org.openhab.binding.tapocontrol.internal.helpers.utils.JsonUtils.getObjectFromJson;
 
+import java.io.IOException;
 import java.net.DatagramPacket;
 import java.net.DatagramSocket;
 import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.net.NetworkInterface;
+import java.net.SocketAddress;
 import java.net.SocketTimeoutException;
+import java.net.StandardSocketOptions;
 import java.net.UnknownHostException;
+import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.nio.channels.DatagramChannel;
+import java.nio.channels.SelectionKey;
+import java.nio.channels.Selector;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Enumeration;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
 import java.util.Random;
@@ -45,7 +56,6 @@ import com.google.gson.JsonObject;
 
 /**
  * Handler class for TAPO Smart Home device UDP-connections.
- * THIS IS FOR TESTING
  *
  * @author Christian Wild - Initial contribution
  */
@@ -56,7 +66,7 @@ public class TapoUdpDiscovery {
     private String uid;
 
     private static final Integer BROADCAST_TIMEOUT_MS = 8000;
-    private static final int[] BROADCAST_DISCOVERY_PORTS = { 9999, 20002 };
+    private static final int[] BROADCAST_DISCOVERY_PORTS = { 9999, 20002, 20004 };
     private static final int TDP_CHECKSUM_DEFAULT = 1516993677;
     private static final int TDP_RANDOM_BOUND = 268435456;
     private static final int BUFFER_SIZE = 2048;
@@ -97,18 +107,36 @@ public class TapoUdpDiscovery {
     }
 
     /**
-     * Scan all defined ports of an specific broadcastAddress
-     * 
+     * Scan all defined ports of a specific broadcastAddress
+     *
      * @param broadcastAddress
      */
     protected void scanAllPorts(InetAddress broadcastAddress) throws TapoErrorHandler {
-        for (int port : BROADCAST_DISCOVERY_PORTS) {
-            udpScan(getBroadcastMessage(port), broadcastAddress, port);
-        }
+        udpScanMany(broadcastAddress, BROADCAST_DISCOVERY_PORTS);
     }
 
     /**
-     * 
+     * Scan specific port of a specific broadcastAddress, return after reply or timeout
+     *
+     * @param broadcastAddress
+     * @param port
+     */
+    protected void scanSinglePort(InetAddress broadcastAddress, int port) throws TapoErrorHandler {
+        udpScan(getBroadcastMessage(port), broadcastAddress, port);
+    }
+
+    /**
+     * Send to all ports of a specific device address, return after first port to reply (or timeout)
+     *
+     * @param Address of device
+     */
+    public void sendAllPorts(InetAddress address) throws TapoErrorHandler {
+        udpSendManyWaitOne(address, BROADCAST_DISCOVERY_PORTS);
+    }
+
+    /**
+     * Broadcast to one address:port and wait for reply or timeout
+     *
      * @param sendData
      * @param broadcastAddress
      * @param discoveryPort
@@ -147,9 +175,200 @@ public class TapoUdpDiscovery {
         }
     }
 
+    /**
+     * Send messages to array of ports at one NON-BROADCAST device address, return after one port replies or timeout.
+     * Return message is passed to DiscoveryList
+     * This contrasts with udpScanXXX which always wait for timeout.
+     *
+     * @param address
+     * @param destinationPorts
+     * @throws TapoErrorHandler
+     */
+    private void udpSendManyWaitOne(InetAddress deviceAaddress, int[] destinationPorts) throws TapoErrorHandler {
+        logger.trace("({}) start udpSendManyWaitOne with address: '{}' to ports {}", uid, deviceAaddress,
+                destinationPorts);
+        try {
+            int nPorts = destinationPorts.length;
+            Selector selector = Selector.open();
+            DatagramChannel[] channels = new DatagramChannel[nPorts];
+            for (int p = 0; p < nPorts; p++) {
+                var port = destinationPorts[p];
+                DatagramChannel chan = DatagramChannel.open();
+                chan.configureBlocking(false);
+                chan.connect(new InetSocketAddress(deviceAaddress, port));
+                chan.register(selector, SelectionKey.OP_READ);
+                ByteBuffer bufMessage = ByteBuffer.wrap(getBroadcastMessage(port));
+                chan.send(bufMessage, new InetSocketAddress(deviceAaddress, port));
+                channels[p] = chan;
+            }
+            var timeOut = Instant.now().plusMillis(BROADCAST_TIMEOUT_MS);
+            while (true) {
+                try {
+                    // wait for at least one reply or a timeout...
+                    long millisWait = Duration.between(Instant.now(), timeOut).toMillis();
+                    if (millisWait <= 0) { // exceeded timeout
+                        break;
+                    }
+                    int nkeys = selector.select(millisWait);
+                    if (nkeys == 0) {
+                        logger.trace("({}) udpSendManyWaitOne timed out on reply", uid);
+                        break;
+                    }
+                    Iterator<SelectionKey> selectedKeys = selector.selectedKeys().iterator();
+                    while (selectedKeys.hasNext()) {
+                        SelectionKey key = selectedKeys.next();
+                        selectedKeys.remove();
+                        if (key.isValid() && key.isReadable()) {
+                            // read message and close channel since not a broadcast
+                            if (!readSelectionKey(key, true)) {
+                                break;
+                            }
+                        }
+                    }
+                } catch (IOException e) {
+                    logger.trace("({}) udpSendManyWaitOne I/O error1: '{}'", uid, e.getMessage());
+                    break;
+                }
+                if (isAllChannelsClosed(channels)) {
+                    break;
+                }
+            } // end of While
+            selector.close();
+            for (DatagramChannel chan : channels) {
+                chan.close();
+            }
+        } catch (IOException e) {
+            logger.debug("({}) udpSendManyWaitOne I/O error2: '{}'", uid, e.getMessage());
+            throw new TapoErrorHandler(e);
+        } catch (Exception e) {
+            logger.debug("({}) udpSendManyWaitOne failed: '{}'", uid, e.getMessage());
+            throw new TapoErrorHandler(e);
+        }
+    }
+
+    /**
+     * Send Broadcast messages to array of ports at given broadcast address.
+     * Sends to all ports in parallel.
+     * Reply messages are passed to DiscoveryList
+     * Return after BROADCAST_TIMEOUT_MS
+     *
+     * @param address
+     * @param destinationPorts
+     * @throws TapoErrorHandler
+     */
+    private void udpScanMany(InetAddress broadcastAddress, int[] destinationPorts) throws TapoErrorHandler {
+        logger.trace("({}) start udpScanMany with address: '{}' to ports {}", uid, broadcastAddress, destinationPorts);
+        try {
+            int nPorts = destinationPorts.length;
+            if (nPorts == 0) {
+                return;
+            }
+            Selector selector = Selector.open();
+            DatagramChannel[] channels = new DatagramChannel[nPorts];
+            // open a channel for each port and register to selector
+            for (int p = 0; p < nPorts; p++) {
+                var port = destinationPorts[p];
+                DatagramChannel chan = DatagramChannel.open();
+                chan.configureBlocking(false);
+                chan.setOption(StandardSocketOptions.SO_BROADCAST, true);
+                // chan.connect(new InetSocketAddress(broadcastAddress, port));
+                chan.register(selector, SelectionKey.OP_READ);
+                ByteBuffer bufMessage = ByteBuffer.wrap(getBroadcastMessage(port));
+                chan.send(bufMessage, new InetSocketAddress(broadcastAddress, port));
+                channels[p] = chan;
+            }
+            var timeOut = Instant.now().plusMillis(BROADCAST_TIMEOUT_MS);
+            while (true) {
+                try {
+                    // wait for reply or a timeout...
+                    long millisWait = Duration.between(Instant.now(), timeOut).toMillis();
+                    if (millisWait <= 0) { // exceeded timeout
+                        break;
+                    }
+                    int nkeys = selector.select(millisWait);
+                    if (nkeys == 0) {
+                        logger.trace("({}) udpScanMany timeout reached", uid);
+                        break;
+                    }
+                    Iterator<SelectionKey> selectedKeys = selector.selectedKeys().iterator();
+                    while (selectedKeys.hasNext()) {
+                        SelectionKey key = selectedKeys.next();
+                        selectedKeys.remove();
+                        if (key.isValid() && key.isReadable()) {
+                            // read the reply and keep the channel open
+                            if (!readSelectionKey(key, false)) {
+                                break;
+                            }
+                        }
+                    }
+                } catch (IOException e) {
+                    logger.trace("({}) udpScanMany I/O error1: '{}'", uid, e.getMessage());
+                    break;
+                }
+                if (isAllChannelsClosed(channels)) { // should always be false for this broadcast method
+                    break;
+                }
+            } // end of While
+            selector.close();
+            for (DatagramChannel chan : channels) {
+                chan.close();
+            }
+        } catch (IOException e) {
+            logger.debug("({}) udpScanMany I/O error2: '{}'", uid, e.getMessage());
+            throw new TapoErrorHandler(e);
+        } catch (Exception e) {
+            logger.debug("({}) udpScanMany failed: '{}'", uid, e.getMessage());
+            throw new TapoErrorHandler(e);
+        }
+    }
+
+    /**
+     * process DiscoveryResult from selectionKey if possible then close channel
+     *
+     * @param key
+     * @param closeChannel true to close channel afterwards (e.g. non-broadcast mode & only 1 reply expected)
+     * @return true if message received and processed
+     */
+    private boolean readSelectionKey(SelectionKey key, boolean closeChannel) {
+        boolean success = false;
+        var buf = ByteBuffer.allocate(BUFFER_SIZE);
+        DatagramChannel chan = (DatagramChannel) key.channel();
+        try {
+            SocketAddress sender = chan.receive(buf);
+            if (buf.position() > 0) {
+                buf.flip();
+                String receiveString = StandardCharsets.UTF_8.decode(buf).toString();
+                handleDiscoveryResult(receiveString);
+                success = true;
+            }
+            logger.trace("({}) readSelectionKey, reply from {}", uid, sender);
+        } catch (IOException e) { // port may be inaccessible
+            logger.trace("({}) readSelectionKey IOException '{}'", uid, e.getMessage());
+        }
+        try {
+            if (closeChannel) {
+                chan.close();
+            }
+        } catch (IOException e) {
+        }
+        return success;
+    }
+
     /***********************************
      * PRIVATE HELPERS
      ************************************/
+
+    /*
+     * test if all channels are closed
+     */
+    private boolean isAllChannelsClosed(DatagramChannel[] channels) {
+        for (DatagramChannel chan : channels) {
+            if (chan.isOpen()) {
+                return false;
+            }
+        }
+        return true;
+    }
 
     /*
      * List all Broadcast-Addresses from all Interfaces
@@ -175,7 +394,7 @@ public class TapoUdpDiscovery {
     }
 
     /**
-     * 
+     *
      * @param port
      * @return
      */
@@ -254,14 +473,22 @@ public class TapoUdpDiscovery {
 
     /**
      * Handle discoveryresult and add to resultList
-     * 
+     *
      * @param receivePacket
      */
     private void handleDiscoveryResult(DatagramPacket receivePacket) {
-        String responseMessage = new String(receivePacket.getData(), StandardCharsets.UTF_8);
+        handleDiscoveryResult(new String(receivePacket.getData(), StandardCharsets.UTF_8));
+    }
+
+    /**
+     * Handle discoveryresult and add to resultList
+     *
+     * @param receivePacket buffer as string
+     */
+    private void handleDiscoveryResult(String responseMessage) {
         logger.trace("({}) received responseMessage: '{}'", uid, responseMessage);
-        responseMessage = responseMessage.substring(responseMessage.indexOf("{")).trim();
-        TapoResponse tapoResponse = getObjectFromJson(responseMessage, TapoResponse.class);
+        String responseContent = responseMessage.substring(responseMessage.indexOf("{")).trim();
+        TapoResponse tapoResponse = getObjectFromJson(responseContent, TapoResponse.class);
         bridge.getDiscoveryService().addScanResult(getObjectFromJson(tapoResponse.result(), TapoDiscoveryResult.class));
     }
 }

--- a/bundles/org.openhab.binding.tapocontrol/src/main/java/org/openhab/binding/tapocontrol/internal/discovery/TapoUdpDiscovery.java
+++ b/bundles/org.openhab.binding.tapocontrol/src/main/java/org/openhab/binding/tapocontrol/internal/discovery/TapoUdpDiscovery.java
@@ -53,6 +53,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
 
 /**
  * Handler class for TAPO Smart Home device UDP-connections.
@@ -487,8 +488,21 @@ public class TapoUdpDiscovery {
      */
     private void handleDiscoveryResult(String responseMessage) {
         logger.trace("({}) received responseMessage: '{}'", uid, responseMessage);
-        String responseContent = responseMessage.substring(responseMessage.indexOf("{")).trim();
-        TapoResponse tapoResponse = getObjectFromJson(responseContent, TapoResponse.class);
-        bridge.getDiscoveryService().addScanResult(getObjectFromJson(tapoResponse.result(), TapoDiscoveryResult.class));
+        while (true) {
+            try {
+                int jsonIndex = responseMessage.indexOf("{");
+                if (jsonIndex < 0) {
+                    break;
+                }
+                String responseContent = responseMessage.substring(jsonIndex).trim();
+                TapoResponse tapoResponse = getObjectFromJson(responseContent, TapoResponse.class);
+                bridge.getDiscoveryService()
+                        .addScanResult(getObjectFromJson(tapoResponse.result(), TapoDiscoveryResult.class));
+            } catch (JsonParseException | IndexOutOfBoundsException e) {
+                break;
+            }
+            return;
+        }
+        logger.debug("({}) unexpected response - JSON object not found", uid);
     }
 }

--- a/bundles/org.openhab.binding.tapocontrol/src/main/java/org/openhab/binding/tapocontrol/internal/discovery/dto/TapoDiscoveryResult.java
+++ b/bundles/org.openhab.binding.tapocontrol/src/main/java/org/openhab/binding/tapocontrol/internal/discovery/dto/TapoDiscoveryResult.java
@@ -12,7 +12,7 @@
  */
 package org.openhab.binding.tapocontrol.internal.discovery.dto;
 
-import static org.openhab.binding.tapocontrol.internal.api.protocol.TapoProtocolEnum.*;
+import static org.openhab.binding.tapocontrol.internal.api.protocol.TapoProtocolEnum.SECUREPASSTROUGH;
 import static org.openhab.binding.tapocontrol.internal.helpers.TapoEncoder.isBase64Encoded;
 
 import java.util.Base64;
@@ -32,7 +32,8 @@ import com.google.gson.annotations.SerializedName;
 @NonNullByDefault
 public record TapoDiscoveryResult(@Expose @SerializedName("factory_default") boolean factoryDefault,
         @Expose @SerializedName("is_support_iot_cloud") boolean isSupportIOT,
-        @Expose @SerializedName("mgt_encrypt_schm") EncryptionShema encryptionShema, @Expose int role,
+        @Expose @SerializedName("tpap_preferred") boolean tpapPreferred,
+        @Expose @SerializedName("mgt_encrypt_schm") EncryptionSchema encryptionSchema, @Expose int role,
         @Expose int status, @Expose String alias, @Expose String appServerUrl, @Expose String deviceHwVer,
         @Expose @SerializedName(value = "deviceID", alternate = "device_id") String deviceId,
         @Expose @SerializedName(value = "deviceMac", alternate = "mac") String deviceMac,
@@ -42,16 +43,16 @@ public record TapoDiscoveryResult(@Expose @SerializedName("factory_default") boo
         @Expose String fwVer, @Expose String hwId, @Expose String ip, @Expose String isSameRegion,
         @Expose String oemId) {
 
-    public record EncryptionShema(@Expose @SerializedName("is_support_https") boolean isSupportHttps,
+    public record EncryptionSchema(@Expose @SerializedName("is_support_https") boolean isSupportHttps,
             @Expose @SerializedName("encrypt_type") String encryptType,
-            @Expose @SerializedName("http_port") int httpPort, @Expose int lv2) {
+            @Expose @SerializedName("http_port") int httpPort, @Expose int lv) {
     }
 
-    /* init new emty record */
+    /* init new empty record */
 
     public TapoDiscoveryResult() {
-        this(false, false, new EncryptionShema(false, SECUREPASSTROUGH.toString(), 80, 0), 0, 0, "", "", "", "", "", "",
-                "", "", "", "", "", "", "", "", "");
+        this(false, false, false, new EncryptionSchema(false, SECUREPASSTROUGH.toString(), 80, 0), 0, 0, "", "", "", "",
+                "", "", "", "", "", "", "", "", "", "", "");
     }
 
     /**********************************************
@@ -66,6 +67,11 @@ public record TapoDiscoveryResult(@Expose @SerializedName("factory_default") boo
     @Override
     public boolean isSupportIOT() {
         return Objects.requireNonNullElse(isSupportIOT, false);
+    }
+
+    @Override
+    public boolean tpapPreferred() {
+        return Objects.requireNonNullElse(tpapPreferred, false);
     }
 
     @Override
@@ -131,9 +137,9 @@ public record TapoDiscoveryResult(@Expose @SerializedName("factory_default") boo
     }
 
     @Override
-    public EncryptionShema encryptionShema() {
-        return Objects.requireNonNullElse(encryptionShema,
-                new EncryptionShema(false, SECUREPASSTROUGH.toString(), 80, 0));
+    public EncryptionSchema encryptionSchema() {
+        return Objects.requireNonNullElse(encryptionSchema,
+                new EncryptionSchema(false, SECUREPASSTROUGH.toString(), 80, 0));
     }
 
     @Override

--- a/bundles/org.openhab.binding.tapocontrol/src/main/java/org/openhab/binding/tapocontrol/internal/discovery/dto/TapoDiscoveryResultList.java
+++ b/bundles/org.openhab.binding.tapocontrol/src/main/java/org/openhab/binding/tapocontrol/internal/discovery/dto/TapoDiscoveryResultList.java
@@ -60,7 +60,7 @@ public class TapoDiscoveryResultList implements Iterable<TapoDiscoveryResult> {
             int role = compareValuesAgainstComparator(old.role(), result.role(), 0);
             int status = compareValuesAgainstComparator(old.status(), result.status(), 0);
             String alias = compareValuesAgainstComparator(old.alias(), result.alias(), "");
-            String appServerUrl = compareValuesAgainstComparator(old.alias(), result.alias(), "");
+            String appServerUrl = compareValuesAgainstComparator(old.appServerUrl(), result.appServerUrl(), "");
             String deviceHwVer = compareValuesAgainstComparator(old.deviceHwVer(), result.deviceHwVer(), "");
             String deviceId = compareValuesAgainstComparator(old.deviceId(), result.deviceId(), "");
             String deviceMac = compareValuesAgainstComparator(old.deviceMac(), result.deviceMac(), "");

--- a/bundles/org.openhab.binding.tapocontrol/src/main/java/org/openhab/binding/tapocontrol/internal/discovery/dto/TapoDiscoveryResultList.java
+++ b/bundles/org.openhab.binding.tapocontrol/src/main/java/org/openhab/binding/tapocontrol/internal/discovery/dto/TapoDiscoveryResultList.java
@@ -12,7 +12,7 @@
  */
 package org.openhab.binding.tapocontrol.internal.discovery.dto;
 
-import static org.openhab.binding.tapocontrol.internal.helpers.utils.TapoUtils.*;
+import static org.openhab.binding.tapocontrol.internal.helpers.utils.TapoUtils.compareValuesAgainstComparator;
 
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -35,13 +35,13 @@ public class TapoDiscoveryResultList implements Iterable<TapoDiscoveryResult> {
     @Expose
     private List<TapoDiscoveryResult> deviceList = new ArrayList<>(0);
 
-    /* init new emty list */
+    /* init new empty list */
     public TapoDiscoveryResultList() {
     }
 
     /**
      * Add device to devicelist. Overwrite fields of device with new data if already exists and field has values
-     * 
+     *
      * @param result
      */
     public void addResult(TapoDiscoveryResult result) {
@@ -53,8 +53,10 @@ public class TapoDiscoveryResultList implements Iterable<TapoDiscoveryResult> {
             boolean factoryDefault = compareValuesAgainstComparator(old.factoryDefault(), result.factoryDefault(),
                     false);
             boolean isSupportIOT = compareValuesAgainstComparator(old.isSupportIOT(), result.isSupportIOT(), false);
-            TapoDiscoveryResult.EncryptionShema enctyptionShema = compareValuesAgainstComparator(old.encryptionShema(),
-                    result.encryptionShema(), new TapoDiscoveryResult.EncryptionShema(false, "", 0, 0));
+            boolean tpapPreferred = compareValuesAgainstComparator(old.tpapPreferred(), result.tpapPreferred(), false);
+            TapoDiscoveryResult.EncryptionSchema encryptionSchema = compareValuesAgainstComparator(
+                    old.encryptionSchema(), result.encryptionSchema(),
+                    new TapoDiscoveryResult.EncryptionSchema(false, "", 0, 0));
             int role = compareValuesAgainstComparator(old.role(), result.role(), 0);
             int status = compareValuesAgainstComparator(old.status(), result.status(), 0);
             String alias = compareValuesAgainstComparator(old.alias(), result.alias(), "");
@@ -74,9 +76,9 @@ public class TapoDiscoveryResultList implements Iterable<TapoDiscoveryResult> {
 
             /* add new result */
             deviceList.remove(old);
-            deviceList.add(new TapoDiscoveryResult(factoryDefault, isSupportIOT, enctyptionShema, role, status, alias,
-                    appServerUrl, deviceHwVer, deviceId, deviceMac, deviceModel, deviceModel, deviceRegion, deviceType,
-                    fwId, fwVer, hwId, ip, isSameRegion, oemId));
+            deviceList.add(new TapoDiscoveryResult(factoryDefault, isSupportIOT, tpapPreferred, encryptionSchema, role,
+                    status, alias, appServerUrl, deviceHwVer, deviceId, deviceMac, deviceModel, deviceModel,
+                    deviceRegion, deviceType, fwId, fwVer, hwId, ip, isSameRegion, oemId));
         }
     }
 

--- a/bundles/org.openhab.binding.tapocontrol/src/main/java/org/openhab/binding/tapocontrol/internal/helpers/utils/TapoUtils.java
+++ b/bundles/org.openhab.binding.tapocontrol/src/main/java/org/openhab/binding/tapocontrol/internal/helpers/utils/TapoUtils.java
@@ -12,7 +12,7 @@
  */
 package org.openhab.binding.tapocontrol.internal.helpers.utils;
 
-import static org.openhab.binding.tapocontrol.internal.constants.TapoBindingSettings.*;
+import static org.openhab.binding.tapocontrol.internal.constants.TapoBindingSettings.BINDING_ID;
 import static org.openhab.binding.tapocontrol.internal.constants.TapoThingConstants.*;
 
 import java.util.Objects;
@@ -36,7 +36,7 @@ public class TapoUtils {
      ***********************************/
     /**
      * Limit Value between limits
-     * 
+     *
      * @param value Integer
      * @param lowerLimit
      * @param upperLimit
@@ -56,7 +56,7 @@ public class TapoUtils {
      ***********************************/
     /**
      * return value or default val if it's null
-     * 
+     *
      * @param <T> Type of value
      * @param value value
      * @param defaultValue defaut value
@@ -67,9 +67,9 @@ public class TapoUtils {
     }
 
     /**
-     * compare tow values against an comparator and return the other one
+     * compare two values against an comparator and return the other one
      * if both are null, comparator will be returned - if both have values val2 will be returned
-     * 
+     *
      * @param <T> Type of return value
      * @param val1 fist value to campare - will be returned if val2 is null or matches comparator
      * @param val2 second value to compare - will be returned if val1 is null or matches comparator
@@ -90,7 +90,7 @@ public class TapoUtils {
 
     /**
      * Format MAC-Address replacing old division chars and add new one
-     * 
+     *
      * @param mac unformated mac-Address
      * @param newDivisionChar new division char (e.g. ":","-" )
      * @return new formated mac-Address
@@ -102,7 +102,7 @@ public class TapoUtils {
 
     /**
      * unformat MAC-Address replace all division chars
-     * 
+     *
      * @param mac string with mac address
      * @return mac address without any division chars
      */
@@ -116,7 +116,7 @@ public class TapoUtils {
 
     /**
      * Get DeviceModel from String - Formats different spellings in model-strings
-     * 
+     *
      * @param device JsonObject with deviceData
      * @return String with DeviceModel
      */
@@ -126,7 +126,7 @@ public class TapoUtils {
 
     /**
      * Get DeviceModel from String - Formats different spellings in model-strings
-     * 
+     *
      * @param deviceModel String to find model from
      * @return String with DeviceModel
      */
@@ -151,7 +151,7 @@ public class TapoUtils {
 
     /**
      * GET DEVICE LABEL
-     * 
+     *
      * @param device JsonObject with deviceData
      * @return String with DeviceLabel
      */


### PR DESCRIPTION
Bugfix to resend RSA discovery key to device if logon permanently fails, e.g. after power-cycle of P110 or P115 with firmware 1.4.6.

(Note it is still necessary to disable & re-enable third-party compatibility in the Tapo-App following a firmware update or new device addition.)
Also: Add port 20004 to discovery port list.
Speed up discovery by using parallel discovery-port scanning rather than sequential scans.
Add tapo device's "tpap-preferred" status to its discoveryResult record.

Link to binding for testing: https://drive.google.com/file/d/1dPvA9KfQF0TzXfud4R5qlkzVHZcxy8DS/view?usp=sharing

(Both @fabski and @Stefan136 have tested this modification with their tapo devices)

Fixes https://github.com/openhab/openhab-addons/issues/20710
Signed-off-by: David Henshaw <david@henshaws.me>