### PR TITLE
[yamahareceiver] Limit number of max parallel status requests per bridge

### DIFF
--- a/bundles/org.openhab.binding.yamahareceiver/src/main/java/org/openhab/binding/yamahareceiver/internal/config/YamahaBridgeConfig.java
+++ b/bundles/org.openhab.binding.yamahareceiver/src/main/java/org/openhab/binding/yamahareceiver/internal/config/YamahaBridgeConfig.java
@@ -24,6 +24,7 @@ import org.eclipse.jdt.annotation.Nullable;
  */
 @NonNullByDefault
 public class YamahaBridgeConfig {
+    public static final int DEFAULT_MAX_PARALLEL_CONNECTIONS = 4;
 
     /**
      * The host name of the Yamaha AVR.
@@ -45,6 +46,10 @@ public class YamahaBridgeConfig {
      * Input source mapping for each command. This is a comma separated list of settings.
      */
     private String inputMapping = "";
+    /**
+     * The maximum number of parallel connections to the AVR.
+     */
+    private int maxParallelConnections = DEFAULT_MAX_PARALLEL_CONNECTIONS;
 
     public @Nullable String getHost() {
         return host;
@@ -72,5 +77,9 @@ public class YamahaBridgeConfig {
 
     public String getInputMapping() {
         return inputMapping;
+    }
+
+    public int getMaxParallelConnections() {
+        return maxParallelConnections;
     }
 }

--- a/bundles/org.openhab.binding.yamahareceiver/src/main/java/org/openhab/binding/yamahareceiver/internal/handler/YamahaBridgeHandler.java
+++ b/bundles/org.openhab.binding.yamahareceiver/src/main/java/org/openhab/binding/yamahareceiver/internal/handler/YamahaBridgeHandler.java
@@ -21,9 +21,13 @@ import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.yamahareceiver.internal.config.YamahaBridgeConfig;
 import org.openhab.binding.yamahareceiver.internal.discovery.ZoneDiscoveryService;
 import org.openhab.binding.yamahareceiver.internal.protocol.AbstractConnection;
@@ -37,6 +41,7 @@ import org.openhab.binding.yamahareceiver.internal.protocol.xml.XMLProtocolFacto
 import org.openhab.binding.yamahareceiver.internal.state.DeviceInformationState;
 import org.openhab.binding.yamahareceiver.internal.state.SystemControlState;
 import org.openhab.binding.yamahareceiver.internal.state.SystemControlStateListener;
+import org.openhab.core.common.NamedThreadFactory;
 import org.openhab.core.config.core.Configuration;
 import org.openhab.core.library.types.IncreaseDecreaseType;
 import org.openhab.core.library.types.OnOffType;
@@ -59,20 +64,23 @@ import org.slf4j.LoggerFactory;
  * @author David Graeff - Initial contribution
  * @author Tomasz Maruszak - Input mapping fix, volumeDB fix, better feature detection, added config object
  */
+@NonNullByDefault
 public class YamahaBridgeHandler extends BaseBridgeHandler
         implements ConnectionStateListener, SystemControlStateListener {
 
     private final Logger logger = LoggerFactory.getLogger(YamahaBridgeHandler.class);
 
-    private YamahaBridgeConfig bridgeConfig;
-    private InputConverter inputConverter;
+    private ExecutorService executorService;
 
-    private ScheduledFuture<?> refreshTimer;
-    private ZoneDiscoveryService zoneDiscoveryService;
+    private @NonNullByDefault({}) YamahaBridgeConfig bridgeConfig;
+    private @Nullable InputConverter inputConverter;
+
+    private @Nullable ScheduledFuture<?> refreshTimer;
+    private @Nullable ZoneDiscoveryService zoneDiscoveryService;
 
     private final DeviceInformationState deviceInformationState = new DeviceInformationState();
 
-    private SystemControl systemControl;
+    private @Nullable SystemControl systemControl;
     private SystemControlState systemControlState = new SystemControlState();
 
     private final CountDownLatch loadingDone = new CountDownLatch(1);
@@ -80,32 +88,36 @@ public class YamahaBridgeHandler extends BaseBridgeHandler
     private boolean disposed = false;
 
     private ProtocolFactory protocolFactory;
-    private AbstractConnection connection;
+    private @Nullable AbstractConnection connection;
 
     public YamahaBridgeHandler(Bridge bridge) {
         super(bridge);
+        executorService = Executors.newFixedThreadPool(YamahaBridgeConfig.DEFAULT_MAX_PARALLEL_CONNECTIONS,
+                new NamedThreadFactory("yamahareceiver-" + getThing().getUID().getId(), true));
         protocolFactory = new XMLProtocolFactory();
     }
 
+    public ExecutorService getExecutorService() {
+        return executorService;
+    }
+
     /**
-     * Return the input mapping converter
+     * @return the input mapping converter
      */
-    public InputConverter getInputConverter() {
+    public @Nullable InputConverter getInputConverter() {
         return inputConverter;
     }
 
     /**
-     * @return Return the protocol communication object. This may be null
+     * @return The protocol communication object. This may be null
      *         if the bridge is offline.
      */
-    public AbstractConnection getConnection() {
+    public @Nullable AbstractConnection getConnection() {
         return connection;
     }
 
     /**
-     * Gets the current protocol factory.
-     *
-     * @return
+     * @return the current protocol factory
      */
     public ProtocolFactory getProtocolFactory() {
         return protocolFactory;
@@ -123,6 +135,9 @@ public class YamahaBridgeHandler extends BaseBridgeHandler
     @Override
     public void dispose() {
         cancelRefreshTimer();
+        if (!executorService.isShutdown() && !executorService.isTerminated()) {
+            executorService.shutdown();
+        }
 
         super.dispose();
         disposed = true;
@@ -144,7 +159,9 @@ public class YamahaBridgeHandler extends BaseBridgeHandler
 
     @Override
     public void handleCommand(ChannelUID channelUID, Command command) {
-        if (connection == null || deviceInformationState.host == null) {
+        var connection = this.connection;
+        var systemControl = this.systemControl;
+        if (connection == null || deviceInformationState.host == null || systemControl == null) {
             return;
         }
 
@@ -154,17 +171,16 @@ public class YamahaBridgeHandler extends BaseBridgeHandler
         }
 
         try {
-            // Might be extended in the future, therefore a switch statement
             String id = channelUID.getId();
             switch (id) {
                 case CHANNEL_POWER:
-                    systemControl.setPower(((OnOffType) command) == OnOffType.ON);
+                    systemControl.setPower(command == OnOffType.ON);
                     break;
                 case CHANNEL_PARTY_MODE:
-                    systemControl.setPartyMode(((OnOffType) command) == OnOffType.ON);
+                    systemControl.setPartyMode(command == OnOffType.ON);
                     break;
                 case CHANNEL_PARTY_MODE_MUTE:
-                    systemControl.setPartyModeMute(((OnOffType) command) == OnOffType.ON);
+                    systemControl.setPartyModeMute(command == OnOffType.ON);
                     break;
                 case CHANNEL_PARTY_MODE_VOLUME:
                     if (command instanceof IncreaseDecreaseType increaseDecreaseCommand) {
@@ -185,7 +201,6 @@ public class YamahaBridgeHandler extends BaseBridgeHandler
     }
 
     private void refreshFromState(ChannelUID channelUID) {
-        // Might be extended in the future, therefore a switch statement
         switch (channelUID.getId()) {
             case CHANNEL_POWER:
                 updateState(channelUID, OnOffType.from(systemControlState.power));
@@ -212,17 +227,20 @@ public class YamahaBridgeHandler extends BaseBridgeHandler
         cancelRefreshTimer();
         logger.trace("Setting up refresh timer with fixed delay {} seconds, starting in {} seconds",
                 bridgeConfig.getRefreshInterval(), initialWaitTime);
-        refreshTimer = scheduler.scheduleWithFixedDelay(() -> updateAllZoneInformation(), initialWaitTime,
-                bridgeConfig.getRefreshInterval(), TimeUnit.SECONDS);
+        refreshTimer = scheduler.scheduleWithFixedDelay(() -> {
+            ExecutorService executor = executorService;
+            executor.submit(this::updateAllZoneInformation);
+        }, initialWaitTime, bridgeConfig.getRefreshInterval(), TimeUnit.SECONDS);
     }
 
     /**
      * Cancels the refresh timer (if one was setup).
      */
     private void cancelRefreshTimer() {
+        var refreshTimer = this.refreshTimer;
         if (refreshTimer != null) {
             refreshTimer.cancel(false);
-            refreshTimer = null;
+            this.refreshTimer = null;
         }
     }
 
@@ -237,6 +255,12 @@ public class YamahaBridgeHandler extends BaseBridgeHandler
 
         if (!ensureConnectionInitialized()) {
             // The initialization did not yet happen and the device is still offline (or not reachable)
+            return;
+        }
+
+        var systemControl = this.systemControl;
+        if (systemControl == null) {
+            logger.trace("updateAllZoneInformation will be skipped because the systemControl is null");
             return;
         }
 
@@ -296,8 +320,15 @@ public class YamahaBridgeHandler extends BaseBridgeHandler
         logger.trace("Update configuration of {} with host '{}' and port {}", getThing().getLabel(),
                 bridgeConfig.getHost(), bridgeConfig.getPort());
 
+        if (!executorService.isShutdown() && !executorService.isTerminated()) {
+            executorService.shutdown();
+        }
+        executorService = Executors.newFixedThreadPool(bridgeConfig.getMaxParallelConnections(),
+                new NamedThreadFactory("yamahareceiver-" + getThing().getUID().getId(), true));
+
         Optional<String> host = bridgeConfig.getHostWithPort();
-        if (host.isPresent()) {
+        var connection = this.connection;
+        if (host.isPresent() && connection != null && !host.get().equals(connection.getHost())) {
             connection.setHost(host.get());
             onConnectionCreated(connection);
         }
@@ -348,11 +379,17 @@ public class YamahaBridgeHandler extends BaseBridgeHandler
             return;
         }
 
+        if (!executorService.isShutdown() && !executorService.isTerminated()) {
+            executorService.shutdown();
+        }
+        executorService = Executors.newFixedThreadPool(bridgeConfig.getMaxParallelConnections(),
+                new NamedThreadFactory("yamahareceiver-" + getThing().getUID().getId(), true));
+
         protocolFactory.createConnection(host.get(), this);
     }
 
     @Override
-    public void onConnectionCreated(AbstractConnection connection) {
+    public void onConnectionCreated(@Nullable AbstractConnection connection) {
         updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_PENDING,
                 "Waiting for connection with Yamaha device");
 
@@ -372,8 +409,12 @@ public class YamahaBridgeHandler extends BaseBridgeHandler
      * @return true if initialization was successful
      */
     private boolean ensureConnectionInitialized() {
+        var zoneDiscoveryService = this.zoneDiscoveryService;
         if (systemControl != null) {
             return true;
+        }
+        if (zoneDiscoveryService == null) {
+            return false;
         }
 
         logger.trace("Initializing connection");
@@ -406,7 +447,11 @@ public class YamahaBridgeHandler extends BaseBridgeHandler
     }
 
     @Override
-    public void systemControlStateChanged(SystemControlState msg) {
+    public void systemControlStateChanged(@Nullable SystemControlState msg) {
+        if (msg == null) {
+            return;
+        }
+
         // If the device was off and now turns on, we trigger a refresh of all zone things.
         // The user might have renamed some of the inputs etc.
         boolean needsCompleteRefresh = msg.power && !systemControlState.power;

--- a/bundles/org.openhab.binding.yamahareceiver/src/main/java/org/openhab/binding/yamahareceiver/internal/handler/YamahaZoneThingHandler.java
+++ b/bundles/org.openhab.binding.yamahareceiver/src/main/java/org/openhab/binding/yamahareceiver/internal/handler/YamahaZoneThingHandler.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.yamahareceiver.internal.ChannelsTypeProviderAvailableInputs;
 import org.openhab.binding.yamahareceiver.internal.ChannelsTypeProviderPreset;
 import org.openhab.binding.yamahareceiver.internal.YamahaReceiverBindingConstants.Feature;
@@ -38,9 +39,6 @@ import org.openhab.binding.yamahareceiver.internal.protocol.ProtocolFactory;
 import org.openhab.binding.yamahareceiver.internal.protocol.ReceivedMessageParseException;
 import org.openhab.binding.yamahareceiver.internal.protocol.ZoneAvailableInputs;
 import org.openhab.binding.yamahareceiver.internal.protocol.ZoneControl;
-import org.openhab.binding.yamahareceiver.internal.protocol.xml.InputWithNavigationControlXML;
-import org.openhab.binding.yamahareceiver.internal.protocol.xml.InputWithPlayControlXML;
-import org.openhab.binding.yamahareceiver.internal.protocol.xml.ZoneControlXML;
 import org.openhab.binding.yamahareceiver.internal.state.AvailableInputState;
 import org.openhab.binding.yamahareceiver.internal.state.AvailableInputStateListener;
 import org.openhab.binding.yamahareceiver.internal.state.DabBandState;
@@ -83,20 +81,23 @@ import org.slf4j.LoggerFactory;
  * The {@link YamahaZoneThingHandler} is managing one zone of a Yamaha AVR.
  * It has a state consisting of the zone, the current input ID, {@link ZoneControlState}
  * and some more state objects and uses the zone control protocol
- * class {@link ZoneControlXML}, {@link InputWithPlayControlXML} and {@link InputWithNavigationControlXML}
+ * class {@link org.openhab.binding.yamahareceiver.internal.protocol.xml.ZoneControlXML},
+ * {@link org.openhab.binding.yamahareceiver.internal.protocol.xml.InputWithPlayControlXML} and
+ * {@link org.openhab.binding.yamahareceiver.internal.protocol.xml.InputWithNavigationControlXML}
  * for communication.
  *
  * @author David Graeff - Initial contribution
  * @author Tomasz Maruszak - [yamaha] Tuner band selection and preset feature for dual band models (RX-S601D), added
  *         config object
  */
+@NonNullByDefault
 public class YamahaZoneThingHandler extends BaseThingHandler
         implements ZoneControlStateListener, NavigationControlStateListener, PlayInfoStateListener,
         AvailableInputStateListener, PresetInfoStateListener, DabBandStateListener {
 
     private final Logger logger = LoggerFactory.getLogger(YamahaZoneThingHandler.class);
 
-    private YamahaZoneConfig zoneConfig;
+    private @NonNullByDefault({}) YamahaZoneConfig zoneConfig;
 
     /// ChannelType providers
     public @NonNullByDefault({}) ChannelsTypeProviderPreset channelsTypeProviderPreset;
@@ -110,12 +111,12 @@ public class YamahaZoneThingHandler extends BaseThingHandler
     protected NavigationControlState navigationInfoState = new NavigationControlState();
 
     /// Control
-    protected ZoneControl zoneControl;
-    protected InputWithPlayControl inputWithPlayControl;
-    protected InputWithNavigationControl inputWithNavigationControl;
-    protected ZoneAvailableInputs zoneAvailableInputs;
-    protected InputWithPresetControl inputWithPresetControl;
-    protected InputWithTunerBandControl inputWithDabBandControl;
+    protected @Nullable ZoneControl zoneControl;
+    protected @Nullable InputWithPlayControl inputWithPlayControl;
+    protected @Nullable InputWithNavigationControl inputWithNavigationControl;
+    protected @Nullable ZoneAvailableInputs zoneAvailableInputs;
+    protected @Nullable InputWithPresetControl inputWithPresetControl;
+    protected @Nullable InputWithTunerBandControl inputWithDabBandControl;
 
     public YamahaZoneThingHandler(Thing thing) {
         super(thing);
@@ -129,8 +130,12 @@ public class YamahaZoneThingHandler extends BaseThingHandler
     /**
      * Sets the {@link DeviceInformationState} for the handler.
      */
-    public DeviceInformationState getDeviceInformationState() {
-        return getBridgeHandler().getDeviceInformationState();
+    public @Nullable DeviceInformationState getDeviceInformationState() {
+        var bridgeHnd = getBridgeHandler();
+        if (bridgeHnd == null) {
+            return null;
+        }
+        return bridgeHnd.getDeviceInformationState();
     }
 
     @Override
@@ -170,7 +175,7 @@ public class YamahaZoneThingHandler extends BaseThingHandler
         initializeThing(bridge != null ? bridge.getStatus() : null);
     }
 
-    protected YamahaBridgeHandler getBridgeHandler() {
+    protected @Nullable YamahaBridgeHandler getBridgeHandler() {
         Bridge bridge = getBridge();
         if (bridge == null) {
             return null;
@@ -178,12 +183,20 @@ public class YamahaZoneThingHandler extends BaseThingHandler
         return (YamahaBridgeHandler) bridge.getHandler();
     }
 
-    protected ProtocolFactory getProtocolFactory() {
-        return getBridgeHandler().getProtocolFactory();
+    protected @Nullable ProtocolFactory getProtocolFactory() {
+        var bridgeHnd = getBridgeHandler();
+        if (bridgeHnd == null) {
+            return null;
+        }
+        return bridgeHnd.getProtocolFactory();
     }
 
-    protected AbstractConnection getConnection() {
-        return getBridgeHandler().getConnection();
+    protected @Nullable AbstractConnection getConnection() {
+        var bridgeHnd = getBridgeHandler();
+        if (bridgeHnd == null) {
+            return null;
+        }
+        return bridgeHnd.getConnection();
     }
 
     @Override
@@ -191,11 +204,11 @@ public class YamahaZoneThingHandler extends BaseThingHandler
         initializeThing(bridgeStatusInfo.getStatus());
     }
 
-    private void initializeThing(ThingStatus bridgeStatus) {
+    private void initializeThing(@Nullable ThingStatus bridgeStatus) {
         YamahaBridgeHandler bridgeHandler = getBridgeHandler();
         if (bridgeHandler != null && bridgeStatus != null) {
             if (bridgeStatus == ThingStatus.ONLINE) {
-                if (zoneConfig == null || zoneConfig.getZone() == null) {
+                if (zoneConfig.getZone() == null) {
                     String msg = String.format(
                             "Zone not set or invalid zone name used: '%s'. It needs to be on of: '%s'",
                             zoneConfig.getZoneValue(), Arrays.toString(Zone.values()));
@@ -204,11 +217,23 @@ public class YamahaZoneThingHandler extends BaseThingHandler
                 } else {
                     if (zoneControl == null) {
                         YamahaBridgeHandler brHandler = getBridgeHandler();
+                        if (brHandler == null) {
+                            logger.warn("Bridge handler not initialized, cannot initialize zone");
+                            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_UNINITIALIZED);
+                            return;
+                        }
 
-                        zoneControl = getProtocolFactory().ZoneControl(getConnection(), zoneConfig, this,
+                        var protocolFactory = getProtocolFactory();
+                        if (protocolFactory == null) {
+                            logger.warn("Protocol factory not initialized, cannot initialize zone");
+                            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_UNINITIALIZED);
+                            return;
+                        }
+
+                        zoneControl = protocolFactory.ZoneControl(getConnection(), zoneConfig, this,
                                 brHandler::getInputConverter, getDeviceInformationState());
-                        zoneAvailableInputs = getProtocolFactory().ZoneAvailableInputs(getConnection(), zoneConfig,
-                                this, brHandler::getInputConverter, getDeviceInformationState());
+                        zoneAvailableInputs = protocolFactory.ZoneAvailableInputs(getConnection(), zoneConfig, this,
+                                brHandler::getInputConverter, getDeviceInformationState());
 
                         updateZoneInformation();
                     }
@@ -258,9 +283,14 @@ public class YamahaZoneThingHandler extends BaseThingHandler
 
     @Override
     public void handleCommand(ChannelUID channelUID, Command command) {
+        var zoneControl = this.zoneControl;
         if (zoneControl == null) {
             return;
         }
+        var inputWithNavigationControl = this.inputWithNavigationControl;
+        var inputWithPresetControl = this.inputWithPresetControl;
+        var inputWithDabBandControl = this.inputWithDabBandControl;
+        var inputWithPlayControl = this.inputWithPlayControl;
 
         String id = channelUID.getIdWithoutGroup();
 
@@ -272,7 +302,7 @@ public class YamahaZoneThingHandler extends BaseThingHandler
 
             switch (id) {
                 case CHANNEL_POWER:
-                    zoneControl.setPower(((OnOffType) command) == OnOffType.ON);
+                    zoneControl.setPower(command == OnOffType.ON);
                     break;
                 case CHANNEL_INPUT:
                     zoneControl.setInput(((StringType) command).toString());
@@ -293,7 +323,7 @@ public class YamahaZoneThingHandler extends BaseThingHandler
                     }
                     break;
                 case CHANNEL_MUTE:
-                    zoneControl.setMute(((OnOffType) command) == OnOffType.ON);
+                    zoneControl.setMute(command == OnOffType.ON);
                     break;
                 case CHANNEL_SCENE:
                     zoneControl.setScene(((StringType) command).toString());
@@ -303,11 +333,11 @@ public class YamahaZoneThingHandler extends BaseThingHandler
                     break;
 
                 case CHANNEL_HDMI1OUT:
-                    zoneControl.setHDMI1Out(((OnOffType) command) == OnOffType.ON);
+                    zoneControl.setHDMI1Out(command == OnOffType.ON);
                     break;
 
                 case CHANNEL_HDMI2OUT:
-                    zoneControl.setHDMI2Out(((OnOffType) command) == OnOffType.ON);
+                    zoneControl.setHDMI2Out(command == OnOffType.ON);
                     break;
 
                 case CHANNEL_NAVIGATION_MENU:
@@ -316,7 +346,7 @@ public class YamahaZoneThingHandler extends BaseThingHandler
                         return;
                     }
 
-                    String path = ((StringType) command).toFullString();
+                    String path = command.toFullString();
                     inputWithNavigationControl.selectItemFullPath(path);
                     break;
 
@@ -325,7 +355,7 @@ public class YamahaZoneThingHandler extends BaseThingHandler
                         logger.warn("Channel {} not working with {} input!", id, zoneState.inputID);
                         return;
                     }
-                    if (((UpDownType) command) == UpDownType.UP) {
+                    if (command == UpDownType.UP) {
                         inputWithNavigationControl.goUp();
                     } else {
                         inputWithNavigationControl.goDown();
@@ -337,7 +367,7 @@ public class YamahaZoneThingHandler extends BaseThingHandler
                         logger.warn("Channel {} not working with {} input!", id, zoneState.inputID);
                         return;
                     }
-                    if (((UpDownType) command) == UpDownType.UP) {
+                    if (command == UpDownType.UP) {
                         inputWithNavigationControl.goLeft();
                     } else {
                         inputWithNavigationControl.goRight();
@@ -378,7 +408,7 @@ public class YamahaZoneThingHandler extends BaseThingHandler
                         inputWithPresetControl.selectItemByPresetNumber(decimalCommand.intValue());
                     } else if (command instanceof StringType stringCommand) {
                         try {
-                            int v = Integer.valueOf(stringCommand.toString());
+                            int v = Integer.parseInt(stringCommand.toString());
                             inputWithPresetControl.selectItemByPresetNumber(v);
                         } catch (NumberFormatException e) {
                             logger.warn("Provide a number for {}", id);
@@ -405,55 +435,62 @@ public class YamahaZoneThingHandler extends BaseThingHandler
                         return;
                     }
 
-                    if (command instanceof PlayPauseType t) {
-                        switch (t) {
-                            case PAUSE:
-                                inputWithPlayControl.pause();
-                                break;
-                            case PLAY:
-                                inputWithPlayControl.play();
-                                break;
+                    switch (command) {
+                        case PlayPauseType t -> {
+                            switch (t) {
+                                case PAUSE:
+                                    inputWithPlayControl.pause();
+                                    break;
+                                case PLAY:
+                                    inputWithPlayControl.play();
+                                    break;
+                            }
                         }
-                    } else if (command instanceof NextPreviousType t) {
-                        switch (t) {
-                            case NEXT:
-                                inputWithPlayControl.nextTrack();
-                                break;
-                            case PREVIOUS:
-                                inputWithPlayControl.previousTrack();
-                                break;
+                        case NextPreviousType t -> {
+                            switch (t) {
+                                case NEXT:
+                                    inputWithPlayControl.nextTrack();
+                                    break;
+                                case PREVIOUS:
+                                    inputWithPlayControl.previousTrack();
+                                    break;
+                            }
                         }
-                    } else if (command instanceof DecimalType decimalCommand) {
-                        int v = decimalCommand.intValue();
-                        if (v < 0) {
-                            inputWithPlayControl.skipREV();
-                        } else if (v > 0) {
-                            inputWithPlayControl.skipFF();
-                        }
-                    } else if (command instanceof StringType stringCommand) {
-                        String v = stringCommand.toFullString();
-                        switch (v) {
-                            case "Play":
-                                inputWithPlayControl.play();
-                                break;
-                            case "Pause":
-                                inputWithPlayControl.pause();
-                                break;
-                            case "Stop":
-                                inputWithPlayControl.stop();
-                                break;
-                            case "Rewind":
+                        case DecimalType decimalCommand -> {
+                            int v = decimalCommand.intValue();
+                            if (v < 0) {
                                 inputWithPlayControl.skipREV();
-                                break;
-                            case "FastForward":
+                            } else if (v > 0) {
                                 inputWithPlayControl.skipFF();
-                                break;
-                            case "Next":
-                                inputWithPlayControl.nextTrack();
-                                break;
-                            case "Previous":
-                                inputWithPlayControl.previousTrack();
-                                break;
+                            }
+                        }
+                        case StringType stringCommand -> {
+                            String v = stringCommand.toFullString();
+                            switch (v) {
+                                case "Play":
+                                    inputWithPlayControl.play();
+                                    break;
+                                case "Pause":
+                                    inputWithPlayControl.pause();
+                                    break;
+                                case "Stop":
+                                    inputWithPlayControl.stop();
+                                    break;
+                                case "Rewind":
+                                    inputWithPlayControl.skipREV();
+                                    break;
+                                case "FastForward":
+                                    inputWithPlayControl.skipFF();
+                                    break;
+                                case "Next":
+                                    inputWithPlayControl.nextTrack();
+                                    break;
+                                case "Previous":
+                                    inputWithPlayControl.previousTrack();
+                                    break;
+                            }
+                        }
+                        default -> {
                         }
                     }
                     break;
@@ -530,7 +567,11 @@ public class YamahaZoneThingHandler extends BaseThingHandler
     }
 
     @Override
-    public void zoneStateChanged(ZoneControlState msg) {
+    public void zoneStateChanged(@Nullable ZoneControlState msg) {
+        if (msg == null) {
+            return;
+        }
+
         boolean inputChanged = !msg.inputID.equals(zoneState.inputID);
         zoneState = msg;
 
@@ -578,17 +619,19 @@ public class YamahaZoneThingHandler extends BaseThingHandler
      * @return true when input is supported
      */
     private boolean isInputSupported(String inputID) {
-        switch (inputID) {
-            case INPUT_SPOTIFY:
-                return getDeviceInformationState().features.contains(Feature.SPOTIFY);
+        var deviceInformationState = getDeviceInformationState();
+        if (deviceInformationState == null) {
+            return false;
+        }
 
-            case INPUT_TUNER:
-                return getDeviceInformationState().features.contains(Feature.TUNER)
-                        || getDeviceInformationState().features.contains(Feature.DAB);
+        return switch (inputID) {
+            case INPUT_SPOTIFY -> deviceInformationState.features.contains(Feature.SPOTIFY);
+            case INPUT_TUNER -> deviceInformationState.features.contains(Feature.TUNER)
+                    || deviceInformationState.features.contains(Feature.DAB);
 
             // Note: add more inputs here in the future
-        }
-        return true;
+            default -> true;
+        };
     }
 
     private void inputChangedCheckForNavigationControl() {
@@ -610,6 +653,14 @@ public class YamahaZoneThingHandler extends BaseThingHandler
 
         logger.trace("Navigation control requested by channel");
 
+        var protocolFactory = getProtocolFactory();
+        var deviceInformationState = getDeviceInformationState();
+        if (protocolFactory == null || deviceInformationState == null) {
+            logger.warn(
+                    "Protocol factory or device information not available, cannot fulfill navigation control request");
+            return;
+        }
+
         if (!includeInputWithNavigationControl) {
             inputWithNavigationControl = null;
             navigationInfoState.invalidate();
@@ -617,8 +668,8 @@ public class YamahaZoneThingHandler extends BaseThingHandler
             return;
         }
 
-        inputWithNavigationControl = getProtocolFactory().InputWithNavigationControl(getConnection(),
-                navigationInfoState, zoneState.inputID, this, getDeviceInformationState());
+        inputWithNavigationControl = protocolFactory.InputWithNavigationControl(getConnection(), navigationInfoState,
+                zoneState.inputID, this, deviceInformationState);
 
         updateAsyncMakeOfflineIfFail(inputWithNavigationControl);
     }
@@ -635,6 +686,20 @@ public class YamahaZoneThingHandler extends BaseThingHandler
 
         logger.trace("Playback control requested by channel");
 
+        var bridgeHnd = getBridgeHandler();
+        if (bridgeHnd == null) {
+            logger.warn("Bridge handler not available, cannot fulfill playback control request");
+            return;
+        }
+
+        var protocolFactory = getProtocolFactory();
+        var deviceInformationState = getDeviceInformationState();
+        if (protocolFactory == null || deviceInformationState == null) {
+            logger.warn(
+                    "Protocol factory or device information not available, cannot fulfill playback control request");
+            return;
+        }
+
         if (includeInputWithPlaybackControl) {
             includeInputWithPlaybackControl = InputWithPlayControl.SUPPORTED_INPUTS.contains(zoneState.inputID);
             if (!includeInputWithPlaybackControl) {
@@ -649,16 +714,14 @@ public class YamahaZoneThingHandler extends BaseThingHandler
             return;
         }
 
-        /**
-         * The {@link inputChangedCheckForDabBand} needs to be called first before this method, in case the AVR Supports
-         * DAB
-         */
+        // The {@link inputChangedCheckForDabBand} needs to be called first before this method, in case the AVR Supports
+        // DAB
         if (inputWithDabBandControl != null) {
             // When input is Tuner DAB there is no playback control
             inputWithPlayControl = null;
         } else {
-            inputWithPlayControl = getProtocolFactory().InputWithPlayControl(getConnection(), zoneState.inputID, this,
-                    getBridgeHandler().getConfiguration(), getDeviceInformationState());
+            inputWithPlayControl = protocolFactory.InputWithPlayControl(getConnection(), zoneState.inputID, this,
+                    bridgeHnd.getConfiguration(), deviceInformationState);
 
             updateAsyncMakeOfflineIfFail(inputWithPlayControl);
         }
@@ -668,6 +731,13 @@ public class YamahaZoneThingHandler extends BaseThingHandler
         boolean includeInput = isLinked(grpPlayback(CHANNEL_PLAYBACK_PRESET));
 
         logger.trace("Preset control requested by channel");
+
+        var protocolFactory = getProtocolFactory();
+        var deviceInformationState = getDeviceInformationState();
+        if (protocolFactory == null || deviceInformationState == null) {
+            logger.warn("Protocol factory or device information not available, cannot fulfill preset control request");
+            return;
+        }
 
         if (includeInput) {
             includeInput = InputWithPresetControl.SUPPORTED_INPUTS.contains(zoneState.inputID);
@@ -683,18 +753,16 @@ public class YamahaZoneThingHandler extends BaseThingHandler
             return;
         }
 
-        /**
-         * The {@link inputChangedCheckForDabBand} needs to be called first before this method, in case the AVR Supports
-         * DAB
-         */
+        // The {@link inputChangedCheckForDabBand} needs to be called first before this method, in case the AVR Supports
+        // DAB
         if (inputWithDabBandControl != null) {
             // When the input is Tuner DAB the control also provides preset functionality
             inputWithPresetControl = (InputWithPresetControl) inputWithDabBandControl;
             // Note: No need to update state - it will be already called for DabBand control (see
             // inputChangedCheckForDabBand)
         } else {
-            inputWithPresetControl = getProtocolFactory().InputWithPresetControl(getConnection(), zoneState.inputID,
-                    this, getDeviceInformationState());
+            inputWithPresetControl = protocolFactory.InputWithPresetControl(getConnection(), zoneState.inputID, this,
+                    deviceInformationState);
 
             updateAsyncMakeOfflineIfFail(inputWithPresetControl);
         }
@@ -705,10 +773,18 @@ public class YamahaZoneThingHandler extends BaseThingHandler
 
         logger.trace("Band control requested by channel");
 
+        var protocolFactory = getProtocolFactory();
+        var deviceInformationState = getDeviceInformationState();
+        if (protocolFactory == null || deviceInformationState == null) {
+            logger.warn(
+                    "Protocol factory or device information not available, cannot fulfill DAB band control request");
+            return;
+        }
+
         if (includeInput) {
             // Check if TUNER input is DAB - dual bands radio tuner
             includeInput = InputWithTunerBandControl.SUPPORTED_INPUTS.contains(zoneState.inputID)
-                    && getDeviceInformationState().features.contains(Feature.DAB);
+                    && deviceInformationState.features.contains(Feature.DAB);
             if (!includeInput) {
                 logger.debug("Band control not supported by {}", zoneState.inputID);
             }
@@ -722,14 +798,24 @@ public class YamahaZoneThingHandler extends BaseThingHandler
         }
 
         logger.debug("InputWithTunerBandControl created for {}", zoneState.inputID);
-        inputWithDabBandControl = getProtocolFactory().InputWithDabBandControl(zoneState.inputID, getConnection(), this,
-                this, this, getDeviceInformationState());
+        inputWithDabBandControl = protocolFactory.InputWithDabBandControl(zoneState.inputID, getConnection(), this,
+                this, this, deviceInformationState);
 
         updateAsyncMakeOfflineIfFail(inputWithDabBandControl);
     }
 
-    protected void updateAsyncMakeOfflineIfFail(IStateUpdatable stateUpdatable) {
-        scheduler.submit(() -> {
+    protected void updateAsyncMakeOfflineIfFail(@Nullable IStateUpdatable stateUpdatable) {
+        if (stateUpdatable == null) {
+            return;
+        }
+
+        var bridgeHnd = getBridgeHandler();
+        if (bridgeHnd == null) {
+            return;
+        }
+        var executor = bridgeHnd.getExecutorService();
+
+        executor.submit(() -> {
             try {
                 stateUpdatable.update();
             } catch (IOException e) {
@@ -749,7 +835,11 @@ public class YamahaZoneThingHandler extends BaseThingHandler
      * The thing is updated with a new CHANNEL_AVAILABLE_INPUT which lists the available inputs for the current zone..
      */
     @Override
-    public void availableInputsChanged(AvailableInputState msg) {
+    public void availableInputsChanged(@Nullable AvailableInputState msg) {
+        if (msg == null) {
+            return;
+        }
+
         // Update channel type provider with a list of available inputs
         channelsTypeProviderAvailableInputs.changeAvailableInputs(msg.availableInputs);
 
@@ -778,7 +868,11 @@ public class YamahaZoneThingHandler extends BaseThingHandler
     }
 
     @Override
-    public void playInfoUpdated(PlayInfoState msg) {
+    public void playInfoUpdated(@Nullable PlayInfoState msg) {
+        if (msg == null) {
+            return;
+        }
+
         playInfoState = msg;
 
         updateState(grpPlayback(CHANNEL_PLAYBACK), new StringType(msg.playbackMode));
@@ -790,7 +884,11 @@ public class YamahaZoneThingHandler extends BaseThingHandler
     }
 
     @Override
-    public void presetInfoUpdated(PresetInfoState msg) {
+    public void presetInfoUpdated(@Nullable PresetInfoState msg) {
+        if (msg == null) {
+            return;
+        }
+
         presetInfoState = msg;
 
         if (msg.presetChannelNamesChanged) {
@@ -815,13 +913,21 @@ public class YamahaZoneThingHandler extends BaseThingHandler
     }
 
     @Override
-    public void dabBandUpdated(DabBandState msg) {
+    public void dabBandUpdated(@Nullable DabBandState msg) {
+        if (msg == null) {
+            return;
+        }
+
         dabBandState = msg;
         updateState(grpPlayback(CHANNEL_TUNER_BAND), new StringType(msg.band));
     }
 
     @Override
-    public void navigationUpdated(NavigationControlState msg) {
+    public void navigationUpdated(@Nullable NavigationControlState msg) {
+        if (msg == null) {
+            return;
+        }
+
         navigationInfoState = msg;
         updateState(grpNav(CHANNEL_NAVIGATION_MENU), new StringType(msg.menuName));
         updateState(grpNav(CHANNEL_NAVIGATION_LEVEL), new DecimalType(msg.menuLayer));
@@ -830,7 +936,11 @@ public class YamahaZoneThingHandler extends BaseThingHandler
     }
 
     @Override
-    public void navigationError(String msg) {
+    public void navigationError(@Nullable String msg) {
+        if (msg == null) {
+            return;
+        }
+
         updateProperty(PROPERTY_MENU_ERROR, msg);
         logger.warn("Navigation error: {}", msg);
     }

--- a/bundles/org.openhab.binding.yamahareceiver/src/main/resources/OH-INF/i18n/yamahareceiver.properties
+++ b/bundles/org.openhab.binding.yamahareceiver/src/main/resources/OH-INF/i18n/yamahareceiver.properties
@@ -18,6 +18,8 @@ thing-type.config.yamahareceiver.yamahaAV.host.label = Address
 thing-type.config.yamahareceiver.yamahaAV.host.description = The address of the AVR to control.
 thing-type.config.yamahareceiver.yamahaAV.inputMapping.label = Input Mapping
 thing-type.config.yamahareceiver.yamahaAV.inputMapping.description = Some Yamaha models return different input values on status update than required in the change input commands. For example, an HDMI1 command may be reported as HDMI_1 after status update. There are other related edge cases (USB, iPad_USB). This setting allows you to customize the return input mapping to meet your AVR model requirements. The setting is a comma-separated list of value mappings in the format from=to. Example: HDMI_1=HDMI1,HDMI 1=HDMI1,HDMI1=HDMI1
+thing-type.config.yamahareceiver.yamahaAV.maxParallelConnections.label = Max Parallel Connections
+thing-type.config.yamahareceiver.yamahaAV.maxParallelConnections.description = The maximum number of parallel status requests allowed to the AVR.
 thing-type.config.yamahareceiver.yamahaAV.port.label = Port
 thing-type.config.yamahareceiver.yamahaAV.port.description = The API port of the AVR to control (usually 80).
 thing-type.config.yamahareceiver.yamahaAV.refreshInterval.label = Refresh Interval

--- a/bundles/org.openhab.binding.yamahareceiver/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.yamahareceiver/src/main/resources/OH-INF/thing/thing-types.xml
@@ -67,6 +67,12 @@
 				<default></default>
 				<advanced>true</advanced>
 			</parameter>
+			<parameter name="maxParallelConnections" type="integer" required="false">
+				<label>Max Parallel Connections</label>
+				<description>The maximum number of parallel status requests allowed to the AVR.</description>
+				<default>4</default>
+				<advanced>true</advanced>
+			</parameter>
 		</config-description>
 	</bridge-type>
 

--- a/bundles/org.openhab.binding.yamahareceiver/src/test/java/org/openhab/binding/yamahareceiver/internal/YamahaReceiverHandlerTest.java
+++ b/bundles/org.openhab.binding.yamahareceiver/src/test/java/org/openhab/binding/yamahareceiver/internal/YamahaReceiverHandlerTest.java
@@ -17,6 +17,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
+import static org.openhab.binding.yamahareceiver.internal.YamahaReceiverBindingConstants.BINDING_ID;
 
 import java.util.HashMap;
 import java.util.List;
@@ -35,6 +36,7 @@ import org.openhab.core.config.core.Configuration;
 import org.openhab.core.thing.Bridge;
 import org.openhab.core.thing.ThingStatus;
 import org.openhab.core.thing.ThingStatusInfo;
+import org.openhab.core.thing.ThingUID;
 import org.openhab.core.thing.binding.ThingHandlerCallback;
 
 /**
@@ -59,6 +61,8 @@ public class YamahaReceiverHandlerTest extends AbstractXMLProtocolTest {
         ctx.prepareForModel(TestModels.RX_S601D);
         ctx.respondWith("<Main_Zone><Input><Input_Sel_Item>GetParam</Input_Sel_Item></Input></Main_Zone>",
                 "Main_Zone_Input_Input_Sel.xml");
+
+        when(bridge.getUID()).thenReturn(new ThingUID(BINDING_ID, "yamahaAV", "bridge"));
 
         Configuration configuration = new Configuration(new HashMap<>());
         configuration.put("host", "localhost");


### PR DESCRIPTION
Regression from #17769.

If too many parallel requests are performed, they time out before receiving a response, incorrectly setting zone Things to OFFLINE.
Fix this by avoiding "overloading" the AVR with too many status requests in the same time, so it can answer them before timing out. Status requests now use a executor service with a fixed-size thread pool.

This also adds null annotations to the handler classes.