### PR TITLE
[ecovacs] Add GOAT robotic lawn mower support

### DIFF
--- a/bundles/org.openhab.binding.ecovacs/.kiro
+++ b/bundles/org.openhab.binding.ecovacs/.kiro
@@ -1,0 +1,33 @@
+# Ecovacs Binding - Development Notes
+
+## Lessons Learned from PR #21129 Review (maniac103)
+
+### Code Style & Architecture
+- **No empty constructors** — Java provides default no-arg constructors. Don't add them explicitly unless they do something.
+- **No AI-typical comments** — Avoid comments that over-explain "why something isn't here" or that reference other layers of abstraction. Comments should explain non-obvious logic, not justify architecture decisions inline.
+- **Respect abstraction boundaries** — Lower-level code (parser, API layer) should not reference or be aware of handler-level concerns.
+- **Avoid repeated try-catch blocks** — Use helper methods to reduce boilerplate. If the pattern is "try command, catch and log", extract a reusable `pollCommand()` helper.
+- **Consider base classes for shared behavior** — When two handlers share significant code (init, teardown, reconnection, battery, errors), consider an abstract base class. Note this as a TODO if too risky for the current PR.
+- **Prefer separate callbacks over overloaded parameters** — Don't add device-specific parameters to shared interfaces (e.g. adding `mowedArea` to `onCleaningStatsUpdated`). Instead, create a separate callback (`onMowingStatsUpdated`) and dispatch based on the data.
+- **Name callbacks by what they represent** — `onMowingSessionFinished()` is better than `onLastCleanStatsUpdated()`. Names should convey when/why the event fires, not describe the data structure.
+
+### Data & Configuration Files
+- **NEVER let AI rewrite large JSON/data files** — Always start from the original file and make surgical additions only. AI tends to drop entries when rewriting large files.
+- **supported_device_list.json changes should be minimal** — Only add new fields to existing entries or append new entries. Never reorder, restructure, or remove existing entries.
+- **Mandatory fields should not be @Nullable** — If a field must always be present (like `deviceType` once added to all entries), make it non-nullable and remove defensive null-checks.
+
+### Build & Dependencies
+- **Don't add optional resolution to required dependencies** — If a dependency (like smack/XMPP) is needed at runtime, don't mark it as `resolution:=optional` in bnd imports.
+- **Test on the target branch** — If the PR targets `main`, make sure it builds there. Don't add workarounds for local deployment issues into the PR.
+
+### Documentation
+- **Don't add footnotes for unverified capability differences** — If you can't confirm which models lack which features, use a single generic note rather than per-feature footnotes.
+- **Remove remarks that become redundant** — If a change makes documentation self-evident (e.g. all entries now have deviceType), remove hints that were only needed before the change.
+
+### DTO & Serialization
+- **Use DTOs over manual JSON parsing when possible** — If you only need a few fields, a simple DTO with those fields works fine. Gson ignores unknown fields by default.
+- **Drop @SerializedName when field name matches JSON key** — The annotation is only needed when the Java field name differs from the JSON key.
+
+### General PR Hygiene
+- **Keep PRs focused** — Large PRs get scrutinized more. Separate refactoring from feature additions when possible.
+- **Verify data file changes with diff** — Always diff large data files against the original to ensure nothing was accidentally removed.

--- a/bundles/org.openhab.binding.ecovacs/README.md
+++ b/bundles/org.openhab.binding.ecovacs/README.md
@@ -1,12 +1,15 @@
 # Ecovacs Binding
 
-This binding provides integration for vacuum cleaning / mopping robots made by Ecovacs (<https://www.ecovacs.com/>).
+This binding provides integration for vacuum cleaning / mopping robots and robotic lawn mowers made by Ecovacs (<https://www.ecovacs.com/>).
 It discovers devices and communicates to them by using Ecovacs' cloud services.
 
 ## Supported Things
 
 - Ecovacs cloud API (`ecovacsapi`)
 - Vacuum cleaner (`vacuum`)
+- Robotic lawn mower (`mower`)
+
+### Vacuum Cleaners
 
 At this point, the following devices are fully supported and verified to be working:
 
@@ -37,6 +40,18 @@ The following devices will likely work because they are using similar protocols 
 - Deebot X1 series
 - Deebot X2 series
 
+### Robotic Lawn Mowers (GOAT Series)
+
+The following GOAT mowers are supported:
+
+- GOAT O500 Panorama
+- GOAT G1 / G1-800
+- GOAT O600 RTK
+- GOAT O800 RTK
+- GOAT O1200 LiDAR Pro
+- GOAT A1600 RTK
+- GOAT A3000 LiDAR / LiDAR Pro
+
 ## Discovery
 
 At first, you need to manually create the bridge thing for the cloud API.
@@ -57,6 +72,13 @@ For the vacuum things, there is no required configuration (when using discovery)
 | Config       | Description                                                                                                                   |
 |--------------|-------------------------------------------------------------------------------------------------------------------------------|
 | serialNumber | Required: The device's serial number as printed on the barcode below the dust bin. Filled automatically when using discovery. |
+| refresh      | Refresh interval for polled data (see below), in minutes. By default set to 5 minutes.                                        |
+
+For the mower things, the same configuration parameters apply:
+
+| Config       | Description                                                                                                                   |
+|--------------|-------------------------------------------------------------------------------------------------------------------------------|
+| serialNumber | Required: The device's serial number. Filled automatically when using discovery.                                              |
 | refresh      | Refresh interval for polled data (see below), in minutes. By default set to 5 minutes.                                        |
 
 ## Channels
@@ -115,6 +137,58 @@ Remarks:
 - [14] Only present if device has voice reporting
 - [15] Only present if device has a mopping system. Possible values include `low`, `medium`, `high` and `veryhigh`
 - [16] Only present on Deebot X8 or newer.
+
+## Mower Channels
+
+The following channels are available for GOAT mower devices.
+Channels not supported by a particular model are automatically removed.
+
+| Channel                                 | Type                 | Description                                               | Read Only | Updated By | Remarks  |
+|-----------------------------------------|----------------------|-----------------------------------------------------------|-----------|------------|----------|
+| actions#command                         | String               | Command to execute                                        | No        | Event      | [M1]     |
+| status#state                            | String               | Current operational state                                 | Yes       | Event      | [M2]     |
+| status#battery                          | Number               | Battery level (percentage)                                | Yes       | Event      |          |
+| status#current-mowing-time              | Number:Time          | Time spent in current mowing session                      | Yes       | Event      |          |
+| status#current-mowed-area               | Number:Area          | Area mowed in current session                             | Yes       | Event      |          |
+| status#wifi-rssi                        | Number:Power         | The current Wi-Fi signal strength of the device           | Yes       | Polling    |          |
+| status#error-code                       | Number               | The numerical value of the last error (0 = none)          | Yes       | Event      |          |
+| status#error-description                | String               | Text describing the last error                            | Yes       | Event      |          |
+| consumables#blade-lifetime              | Number:Dimensionless | The remaining life time of the cutting blades in percent  | Yes       | Polling    |          |
+| last-mow#last-mow-start                 | DateTime             | Start time of the last completed mowing run               | Yes       | Event      |          |
+| last-mow#last-mow-duration              | Number:Time          | Duration of the last completed mowing run                 | Yes       | Event      |          |
+| last-mow#last-mow-area                  | Number:Area          | Area mowed in the last completed mowing run               | Yes       | Event      |          |
+| total-stats#total-mowing-time           | Number:Time          | Total mowing time in device life time                     | Yes       | Polling    |          |
+| total-stats#total-mowed-area            | Number:Area          | Total area mowed in device life time                      | Yes       | Polling    |          |
+| total-stats#total-mow-runs              | Number               | Total number of mowing runs in device life time           | Yes       | Polling    |          |
+| settings#cutting-height                 | Number:Length        | Cutting height (30-75mm in 5mm steps)                     | [M3]      | Polling    | [M3]     |
+| settings#voice-volume                   | Dimmer               | Voice volume level in percent                             | No        | Polling    |          |
+| settings#true-detect-3d                 | Switch               | Whether TrueDetect 3D obstacle avoidance is enabled       | No        | Polling    |          |
+| settings#safe-protect                   | Switch               | Stop mower on obstacle or unsafe condition                | No        | Polling    |          |
+| settings#child-lock                     | Switch               | Lock mower to prevent unintended operation                | No        | Polling    |          |
+| settings#rain-delay                     | Switch               | Rain detected, mowing delayed                             | Yes       | Polling    |          |
+| settings#moveup-warning                 | Switch               | Alarm when mower is lifted off the ground                 | No        | Polling    |          |
+
+Note: Some channels may be automatically removed if the device does not report support for the corresponding feature.
+
+Remarks:
+
+- [M1] See [Mower Command Channel Actions](#mower-command-channel-actions)
+- [M2] Possible states: `mowing`, `paused`, `returning`, `charging`, `idle`, `docked`, `error`, `edgeCutting`
+- [M3] Only present if device supports cutting height reporting. Currently read-only.
+
+## Mower Command Channel Actions
+
+The following actions are supported by the mower `command` channel:
+
+| Name         | Action                                      | Remarks                                                                                       |
+|--------------|---------------------------------------------|-----------------------------------------------------------------------------------------------|
+| `mow`        | Start mowing in automatic mode.             | If currently paused, sends resume instead of start.                                           |
+| `edgeCut`    | Start edge cutting.                         | Only if device supports edge mowing.                                                          |
+| `zone:<ids>` | Start mowing specific zones.                | Only if device supports zone mowing. Format: `zone:<zone IDs>` (as shown in Ecovacs' app).    |
+| `pause`      | Pause mowing if currently active.           | If the mower is idle, the command is ignored.                                                 |
+| `resume`     | Resume mowing if currently paused.          | If the mower is not paused, the command is ignored.                                           |
+| `stop`       | Stop mowing immediately.                    |                                                                                               |
+| `dock`       | Send mower back to the charging station.    |                                                                                               |
 
 ## Command Channel Actions
 
@@ -182,6 +256,41 @@ Bridge ecovacs:ecovacsapi:ecovacsapi [ email="your.email@provider.com", password
 {
     Thing vacuum myDeebot "Deebot Vacuum" [ serialNumber="serial as printed on label below dust bin" ]
 }
+```
+
+For mowers:
+
+```java
+Bridge ecovacs:ecovacsapi:ecovacsapi [ email="your.email@provider.com", password="yourpassword", continent="eu" ]
+{
+    Thing mower myGoat "GOAT O500 Panorama" [ serialNumber="your mower serial number" ]
+}
+```
+
+### Mower Items Example
+
+```java
+String       GoatState              "Mower State [%s]"                    { channel="ecovacs:mower:myapi:myGoat:status#state" }
+Number       GoatBattery            "Mower Battery [%d %%]"               { channel="ecovacs:mower:myapi:myGoat:status#battery" }
+Number:Time  GoatMowingTime         "Current Mowing Time [%d %unit%]"     { channel="ecovacs:mower:myapi:myGoat:status#current-mowing-time" }
+Number:Area  GoatMowedArea          "Current Mowed Area [%d %unit%]"      { channel="ecovacs:mower:myapi:myGoat:status#current-mowed-area" }
+Number:Length GoatCuttingHeight     "Cutting Height [%d %unit%]"          { channel="ecovacs:mower:myapi:myGoat:settings#cutting-height" }
+Dimmer       GoatVolume             "Voice Volume [%d %%]"                { channel="ecovacs:mower:myapi:myGoat:settings#voice-volume" }
+Switch       GoatSafeProtect        "SafeProtect"                         { channel="ecovacs:mower:myapi:myGoat:settings#safe-protect" }
+Switch       GoatChildLock          "Child Lock"                          { channel="ecovacs:mower:myapi:myGoat:settings#child-lock" }
+Number:Dimensionless GoatBladeLife  "Blade Lifetime [%d %%]"              { channel="ecovacs:mower:myapi:myGoat:consumables#blade-lifetime" }
+Number:Time  GoatTotalTime          "Total Mowing Time [%d %unit%]"       { channel="ecovacs:mower:myapi:myGoat:total-stats#total-mowing-time" }
+Number:Area  GoatTotalArea          "Total Mowed Area [%d %unit%]"        { channel="ecovacs:mower:myapi:myGoat:total-stats#total-mowed-area" }
+Number       GoatTotalRuns          "Total Mow Runs [%d]"                 { channel="ecovacs:mower:myapi:myGoat:total-stats#total-mow-runs" }
+Number       GoatErrorCode          "Error Code [%d]"                     { channel="ecovacs:mower:myapi:myGoat:status#error-code" }
+String       GoatErrorDesc          "Error [%s]"                          { channel="ecovacs:mower:myapi:myGoat:status#error-description" }
+Number:Power GoatWifiRssi           "WiFi RSSI [%d %unit%]"               { channel="ecovacs:mower:myapi:myGoat:status#wifi-rssi" }
+DateTime     GoatLastMowStart       "Last Mow Start [%1$tF %1$tR]"       { channel="ecovacs:mower:myapi:myGoat:last-mow#last-mow-start" }
+Number:Time  GoatLastMowDuration    "Last Mow Duration [%d %unit%]"       { channel="ecovacs:mower:myapi:myGoat:last-mow#last-mow-duration" }
+Number:Area  GoatLastMowArea        "Last Mowed Area [%d %unit%]"         { channel="ecovacs:mower:myapi:myGoat:last-mow#last-mow-area" }
+Switch       GoatTrueDetect         "TrueDetect 3D"                       { channel="ecovacs:mower:myapi:myGoat:settings#true-detect-3d" }
+Switch       GoatMoveUpWarning      "Move-Up Warning"                     { channel="ecovacs:mower:myapi:myGoat:settings#moveup-warning" }
+String       GoatCommand            "Mower Command"                       { channel="ecovacs:mower:myapi:myGoat:actions#command" }
 ```
 
 ## Adding support for unsupported models

--- a/bundles/org.openhab.binding.ecovacs/src/main/java/org/openhab/binding/ecovacs/internal/EcovacsBindingConstants.java
+++ b/bundles/org.openhab.binding.ecovacs/src/main/java/org/openhab/binding/ecovacs/internal/EcovacsBindingConstants.java
@@ -42,6 +42,7 @@ public class EcovacsBindingConstants {
     // List of all Thing Type UIDs
     public static final ThingTypeUID THING_TYPE_API = new ThingTypeUID(BINDING_ID, "ecovacsapi");
     public static final ThingTypeUID THING_TYPE_VACUUM = new ThingTypeUID(BINDING_ID, "vacuum");
+    public static final ThingTypeUID THING_TYPE_MOWER = new ThingTypeUID(BINDING_ID, "mower");
 
     // List of all channel UIDs
     public static final String CHANNEL_ID_AUTO_EMPTY = "settings#auto-empty";
@@ -77,6 +78,23 @@ public class EcovacsBindingConstants {
     public static final String CHANNEL_ID_WATER_AMOUNT_PERCENT = "settings#water-amount-percent";
     public static final String CHANNEL_ID_WIFI_RSSI = "status#wifi-rssi";
 
+    // Mower-specific channel IDs
+    public static final String CHANNEL_ID_MOWER_STATE = "status#state";
+    public static final String CHANNEL_ID_CUTTING_HEIGHT = "settings#cutting-height";
+    public static final String CHANNEL_ID_MOWING_TIME = "status#current-mowing-time";
+    public static final String CHANNEL_ID_MOWED_AREA = "status#current-mowed-area";
+    public static final String CHANNEL_ID_BLADE_LIFETIME = "consumables#blade-lifetime";
+    public static final String CHANNEL_ID_SAFE_PROTECT = "settings#safe-protect";
+    public static final String CHANNEL_ID_CHILD_LOCK = "settings#child-lock";
+    public static final String CHANNEL_ID_RAIN_DELAY = "settings#rain-delay";
+    public static final String CHANNEL_ID_MOVEUP_WARNING = "settings#moveup-warning";
+    public static final String CHANNEL_ID_TOTAL_MOWING_TIME = "total-stats#total-mowing-time";
+    public static final String CHANNEL_ID_TOTAL_MOWED_AREA = "total-stats#total-mowed-area";
+    public static final String CHANNEL_ID_TOTAL_MOW_RUNS = "total-stats#total-mow-runs";
+    public static final String CHANNEL_ID_LAST_MOW_START = "last-mow#last-mow-start";
+    public static final String CHANNEL_ID_LAST_MOW_DURATION = "last-mow#last-mow-duration";
+    public static final String CHANNEL_ID_LAST_MOW_AREA = "last-mow#last-mow-area";
+
     public static final String CHANNEL_TYPE_ID_CLEAN_MODE = "current-cleaning-mode";
     public static final String CHANNEL_TYPE_ID_LAST_CLEAN_MODE = "last-clean-mode";
 
@@ -88,6 +106,11 @@ public class EcovacsBindingConstants {
     public static final String CMD_SPOT_AREA = "spotArea";
     public static final String CMD_CUSTOM_AREA = "customArea";
     public static final String CMD_SCENE_CLEAN = "sceneClean";
+
+    // Mower commands
+    public static final String CMD_MOW = "mow";
+    public static final String CMD_EDGE_CUT = "edgeCut";
+    public static final String CMD_DOCK = "dock";
 
     public static final StateOptionMapping<CleanMode> CLEAN_MODE_MAPPING = StateOptionMapping.of(
             new StateOptionEntry<>(CleanMode.AUTO, "auto"),

--- a/bundles/org.openhab.binding.ecovacs/src/main/java/org/openhab/binding/ecovacs/internal/EcovacsHandlerFactory.java
+++ b/bundles/org.openhab.binding.ecovacs/src/main/java/org/openhab/binding/ecovacs/internal/EcovacsHandlerFactory.java
@@ -34,6 +34,7 @@ import org.jivesoftware.smackx.disco.provider.DiscoverInfoProvider;
 import org.jivesoftware.smackx.disco.provider.DiscoverItemsProvider;
 import org.jivesoftware.smackx.xdata.provider.DataFormProvider;
 import org.openhab.binding.ecovacs.internal.handler.EcovacsApiHandler;
+import org.openhab.binding.ecovacs.internal.handler.EcovacsMowerHandler;
 import org.openhab.binding.ecovacs.internal.handler.EcovacsVacuumHandler;
 import org.openhab.core.i18n.LocaleProvider;
 import org.openhab.core.i18n.TranslationProvider;
@@ -62,7 +63,8 @@ public class EcovacsHandlerFactory extends BaseThingHandlerFactory {
     private final TranslationProvider i18Provider;
     private final EcovacsDynamicStateDescriptionProvider stateDescriptionProvider;
 
-    private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Set.of(THING_TYPE_API, THING_TYPE_VACUUM);
+    private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Set.of(THING_TYPE_API, THING_TYPE_VACUUM,
+            THING_TYPE_MOWER);
 
     @Activate
     public EcovacsHandlerFactory(final @Reference HttpClientFactory httpClientFactory,
@@ -98,6 +100,8 @@ public class EcovacsHandlerFactory extends BaseThingHandlerFactory {
 
         if (THING_TYPE_API.equals(thingTypeUID)) {
             return new EcovacsApiHandler((Bridge) thing, httpClientFactory.getCommonHttpClient(), localeProvider);
+        } else if (THING_TYPE_MOWER.equals(thingTypeUID)) {
+            return new EcovacsMowerHandler(thing, i18Provider, localeProvider);
         } else {
             return new EcovacsVacuumHandler(thing, i18Provider, localeProvider, stateDescriptionProvider);
         }

--- a/bundles/org.openhab.binding.ecovacs/src/main/java/org/openhab/binding/ecovacs/internal/api/EcovacsDevice.java
+++ b/bundles/org.openhab.binding.ecovacs/src/main/java/org/openhab/binding/ecovacs/internal/api/EcovacsDevice.java
@@ -21,6 +21,7 @@ import org.openhab.binding.ecovacs.internal.api.commands.IotDeviceCommand;
 import org.openhab.binding.ecovacs.internal.api.model.CleanLogRecord;
 import org.openhab.binding.ecovacs.internal.api.model.CleanMode;
 import org.openhab.binding.ecovacs.internal.api.model.DeviceCapability;
+import org.openhab.binding.ecovacs.internal.api.model.DeviceType;
 
 /**
  * @author Danny Baumann - Initial contribution
@@ -38,9 +39,13 @@ public interface EcovacsDevice {
 
         void onCleaningStatsUpdated(EcovacsDevice device, int cleanedArea, int cleaningTimeSeconds);
 
+        void onMowingStatsUpdated(EcovacsDevice device, int mowedAreaSqCm, int timeSeconds);
+
         void onWaterSystemPresentUpdated(EcovacsDevice device, boolean present);
 
         void onErrorReported(EcovacsDevice device, int errorCode);
+
+        void onMowingSessionFinished(EcovacsDevice device, long startTimestamp, int durationSeconds, int areaSqCm);
 
         void onEventStreamFailure(EcovacsDevice device, Throwable error);
     }
@@ -48,6 +53,8 @@ public interface EcovacsDevice {
     String getSerialNumber();
 
     String getModelName();
+
+    DeviceType getDeviceType();
 
     boolean hasCapability(DeviceCapability cap);
 

--- a/bundles/org.openhab.binding.ecovacs/src/main/java/org/openhab/binding/ecovacs/internal/api/commands/AbstractMowerCommand.java
+++ b/bundles/org.openhab.binding.ecovacs/src/main/java/org/openhab/binding/ecovacs/internal/api/commands/AbstractMowerCommand.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.ecovacs.internal.api.commands;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * Base class for GOAT mower action commands (start, stop, pause, resume).
+ * Overrides the payload header version to "0.0.22" which is what the official
+ * Ecovacs app sends. The mower firmware uses the 'ver' field to select its parser;
+ * with the library default of "0.0.50" the firmware rejects commands with error code
+ * 20003 "unknow type".
+ *
+ * @author Stefan Höhn - Initial contribution
+ */
+@NonNullByDefault
+public abstract class AbstractMowerCommand extends AbstractNoResponseCommand {
+
+    @Override
+    protected String getHeaderVersion() {
+        return "0.0.22";
+    }
+}

--- a/bundles/org.openhab.binding.ecovacs/src/main/java/org/openhab/binding/ecovacs/internal/api/commands/GetChildLockCommand.java
+++ b/bundles/org.openhab.binding.ecovacs/src/main/java/org/openhab/binding/ecovacs/internal/api/commands/GetChildLockCommand.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.ecovacs.internal.api.commands;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.binding.ecovacs.internal.api.impl.ProtocolVersion;
+import org.openhab.binding.ecovacs.internal.api.impl.dto.response.portal.AbstractPortalIotCommandResponse;
+import org.openhab.binding.ecovacs.internal.api.impl.dto.response.portal.PortalIotCommandJsonResponse;
+import org.openhab.binding.ecovacs.internal.api.util.DataParsingException;
+
+import com.google.gson.Gson;
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * @author Stefan Höhn - Initial contribution
+ */
+@NonNullByDefault
+public class GetChildLockCommand extends IotDeviceCommand<Boolean> {
+
+    private static class ChildLockReport {
+        @SerializedName("on")
+        public int on;
+    }
+
+    @Override
+    public String getName(ProtocolVersion version) {
+        if (version == ProtocolVersion.XML) {
+            throw new IllegalStateException("Mower commands are not supported for XML");
+        }
+        return "getChildLock";
+    }
+
+    @Override
+    public Boolean convertResponse(AbstractPortalIotCommandResponse response, ProtocolVersion version, Gson gson)
+            throws DataParsingException {
+        ChildLockReport resp = ((PortalIotCommandJsonResponse) response).getResponsePayloadAs(gson,
+                ChildLockReport.class);
+        return resp.on != 0;
+    }
+}

--- a/bundles/org.openhab.binding.ecovacs/src/main/java/org/openhab/binding/ecovacs/internal/api/commands/GetCuttingHeightCommand.java
+++ b/bundles/org.openhab.binding.ecovacs/src/main/java/org/openhab/binding/ecovacs/internal/api/commands/GetCuttingHeightCommand.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.ecovacs.internal.api.commands;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.binding.ecovacs.internal.api.impl.ProtocolVersion;
+import org.openhab.binding.ecovacs.internal.api.impl.dto.response.portal.AbstractPortalIotCommandResponse;
+import org.openhab.binding.ecovacs.internal.api.impl.dto.response.portal.PortalIotCommandJsonResponse;
+import org.openhab.binding.ecovacs.internal.api.util.DataParsingException;
+
+import com.google.gson.Gson;
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * @author Stefan Höhn - Initial contribution
+ */
+@NonNullByDefault
+public class GetCuttingHeightCommand extends IotDeviceCommand<Integer> {
+
+    private static class CuttingHeightReport {
+        @SerializedName("height")
+        public int height;
+
+        @SerializedName("level")
+        public int level;
+    }
+
+    @Override
+    public String getName(ProtocolVersion version) {
+        if (version == ProtocolVersion.XML) {
+            throw new IllegalStateException("Mower commands are not supported for XML");
+        }
+        return "getCutHeight";
+    }
+
+    @Override
+    public Integer convertResponse(AbstractPortalIotCommandResponse response, ProtocolVersion version, Gson gson)
+            throws DataParsingException {
+        CuttingHeightReport resp = ((PortalIotCommandJsonResponse) response).getResponsePayloadAs(gson,
+                CuttingHeightReport.class);
+        // Some models return 'height' in mm directly, others return 'level' (1-10)
+        // Level maps to mm: level 1 = 30mm, level 2 = 35mm, ..., level 10 = 75mm
+        if (resp.height > 0) {
+            return resp.height;
+        }
+        return resp.level * 5 + 25;
+    }
+}

--- a/bundles/org.openhab.binding.ecovacs/src/main/java/org/openhab/binding/ecovacs/internal/api/commands/GetLastTimeStatsCommand.java
+++ b/bundles/org.openhab.binding.ecovacs/src/main/java/org/openhab/binding/ecovacs/internal/api/commands/GetLastTimeStatsCommand.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.ecovacs.internal.api.commands;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.binding.ecovacs.internal.api.impl.ProtocolVersion;
+import org.openhab.binding.ecovacs.internal.api.impl.dto.response.deviceapi.json.LastTimeStatsReport;
+import org.openhab.binding.ecovacs.internal.api.impl.dto.response.portal.AbstractPortalIotCommandResponse;
+import org.openhab.binding.ecovacs.internal.api.impl.dto.response.portal.PortalIotCommandJsonResponse;
+import org.openhab.binding.ecovacs.internal.api.util.DataParsingException;
+
+import com.google.gson.Gson;
+
+/**
+ * Polls the GOAT mower for the last completed mowing session statistics.
+ * The response contains start time, duration (seconds), and area (cm²).
+ *
+ * @author Stefan Höhn - Initial contribution
+ */
+@NonNullByDefault
+public class GetLastTimeStatsCommand extends IotDeviceCommand<LastTimeStatsReport> {
+    @Override
+    public String getName(ProtocolVersion version) {
+        if (version == ProtocolVersion.XML) {
+            throw new IllegalStateException("Mower commands are not supported for XML");
+        }
+        return "getLastTimeStats";
+    }
+
+    @Override
+    public LastTimeStatsReport convertResponse(AbstractPortalIotCommandResponse response, ProtocolVersion version,
+            Gson gson) throws DataParsingException {
+        return ((PortalIotCommandJsonResponse) response).getResponsePayloadAs(gson, LastTimeStatsReport.class);
+    }
+}

--- a/bundles/org.openhab.binding.ecovacs/src/main/java/org/openhab/binding/ecovacs/internal/api/commands/GetMoveUpWarningCommand.java
+++ b/bundles/org.openhab.binding.ecovacs/src/main/java/org/openhab/binding/ecovacs/internal/api/commands/GetMoveUpWarningCommand.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.ecovacs.internal.api.commands;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.binding.ecovacs.internal.api.impl.ProtocolVersion;
+import org.openhab.binding.ecovacs.internal.api.impl.dto.response.deviceapi.json.EnabledStateReport;
+import org.openhab.binding.ecovacs.internal.api.impl.dto.response.portal.AbstractPortalIotCommandResponse;
+import org.openhab.binding.ecovacs.internal.api.impl.dto.response.portal.PortalIotCommandJsonResponse;
+import org.openhab.binding.ecovacs.internal.api.util.DataParsingException;
+
+import com.google.gson.Gson;
+
+/**
+ * @author Stefan Höhn - Initial contribution
+ */
+@NonNullByDefault
+public class GetMoveUpWarningCommand extends IotDeviceCommand<Boolean> {
+    @Override
+    public String getName(ProtocolVersion version) {
+        if (version == ProtocolVersion.XML) {
+            throw new IllegalStateException("Mower commands are not supported for XML");
+        }
+        return "getMoveUpWarning";
+    }
+
+    @Override
+    public Boolean convertResponse(AbstractPortalIotCommandResponse response, ProtocolVersion version, Gson gson)
+            throws DataParsingException {
+        EnabledStateReport resp = ((PortalIotCommandJsonResponse) response).getResponsePayloadAs(gson,
+                EnabledStateReport.class);
+        return resp.enabled != 0;
+    }
+}

--- a/bundles/org.openhab.binding.ecovacs/src/main/java/org/openhab/binding/ecovacs/internal/api/commands/GetMowerStateCommand.java
+++ b/bundles/org.openhab.binding.ecovacs/src/main/java/org/openhab/binding/ecovacs/internal/api/commands/GetMowerStateCommand.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.ecovacs.internal.api.commands;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.ecovacs.internal.api.impl.ProtocolVersion;
+import org.openhab.binding.ecovacs.internal.api.impl.dto.response.portal.AbstractPortalIotCommandResponse;
+import org.openhab.binding.ecovacs.internal.api.impl.dto.response.portal.PortalIotCommandJsonResponse;
+import org.openhab.binding.ecovacs.internal.api.model.CleanMode;
+import org.openhab.binding.ecovacs.internal.api.util.DataParsingException;
+
+import com.google.gson.Gson;
+
+/**
+ * Gets the current mower state via 'getCleanInfo'.
+ *
+ * @author Stefan Höhn - Initial contribution
+ */
+@NonNullByDefault
+public class GetMowerStateCommand extends IotDeviceCommand<CleanMode> {
+
+    private static class CleanStateDto {
+        public @Nullable String motionState;
+    }
+
+    private static class MowerStateDto {
+        public @Nullable String state;
+        public @Nullable CleanStateDto cleanState;
+    }
+
+    @Override
+    public String getName(ProtocolVersion version) {
+        if (version == ProtocolVersion.XML) {
+            throw new IllegalStateException("Mower commands are not supported for XML");
+        }
+        return "getCleanInfo";
+    }
+
+    @Override
+    public CleanMode convertResponse(AbstractPortalIotCommandResponse response, ProtocolVersion version, Gson gson)
+            throws DataParsingException {
+        MowerStateDto dto = ((PortalIotCommandJsonResponse) response).getResponsePayloadAs(gson, MowerStateDto.class);
+        if (dto == null) {
+            throw new DataParsingException("Null payload in getCleanInfo response");
+        }
+
+        if (dto.cleanState != null) {
+            String motionState = dto.cleanState.motionState;
+            if ("working".equals(motionState)) {
+                return CleanMode.AUTO;
+            } else if ("pause".equals(motionState)) {
+                return CleanMode.PAUSE;
+            } else if ("goCharging".equals(motionState)) {
+                return CleanMode.RETURNING;
+            }
+        }
+
+        if ("goCharging".equals(dto.state)) {
+            return CleanMode.RETURNING;
+        }
+
+        return CleanMode.IDLE;
+    }
+}

--- a/bundles/org.openhab.binding.ecovacs/src/main/java/org/openhab/binding/ecovacs/internal/api/commands/GetSafeProtectCommand.java
+++ b/bundles/org.openhab.binding.ecovacs/src/main/java/org/openhab/binding/ecovacs/internal/api/commands/GetSafeProtectCommand.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.ecovacs.internal.api.commands;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.binding.ecovacs.internal.api.impl.ProtocolVersion;
+import org.openhab.binding.ecovacs.internal.api.impl.dto.response.deviceapi.json.EnabledStateReport;
+import org.openhab.binding.ecovacs.internal.api.impl.dto.response.portal.AbstractPortalIotCommandResponse;
+import org.openhab.binding.ecovacs.internal.api.impl.dto.response.portal.PortalIotCommandJsonResponse;
+import org.openhab.binding.ecovacs.internal.api.util.DataParsingException;
+
+import com.google.gson.Gson;
+
+/**
+ * @author Stefan Höhn - Initial contribution
+ */
+@NonNullByDefault
+public class GetSafeProtectCommand extends IotDeviceCommand<Boolean> {
+    @Override
+    public String getName(ProtocolVersion version) {
+        if (version == ProtocolVersion.XML) {
+            throw new IllegalStateException("Mower commands are not supported for XML");
+        }
+        return "getSafeProtect";
+    }
+
+    @Override
+    public Boolean convertResponse(AbstractPortalIotCommandResponse response, ProtocolVersion version, Gson gson)
+            throws DataParsingException {
+        EnabledStateReport resp = ((PortalIotCommandJsonResponse) response).getResponsePayloadAs(gson,
+                EnabledStateReport.class);
+        return resp.enabled != 0;
+    }
+}

--- a/bundles/org.openhab.binding.ecovacs/src/main/java/org/openhab/binding/ecovacs/internal/api/commands/GetTotalStatsCommand.java
+++ b/bundles/org.openhab.binding.ecovacs/src/main/java/org/openhab/binding/ecovacs/internal/api/commands/GetTotalStatsCommand.java
@@ -43,9 +43,6 @@ public class GetTotalStatsCommand extends IotDeviceCommand<GetTotalStatsCommand.
         }
     }
 
-    public GetTotalStatsCommand() {
-    }
-
     @Override
     public String getName(ProtocolVersion version) {
         return version == ProtocolVersion.XML ? "GetCleanSum" : "getTotalStats";

--- a/bundles/org.openhab.binding.ecovacs/src/main/java/org/openhab/binding/ecovacs/internal/api/commands/IotDeviceCommand.java
+++ b/bundles/org.openhab.binding.ecovacs/src/main/java/org/openhab/binding/ecovacs/internal/api/commands/IotDeviceCommand.java
@@ -64,7 +64,7 @@ public abstract class IotDeviceCommand<RESPONSETYPE> {
 
     public final JsonElement getJsonPayload(ProtocolVersion version, Gson gson) {
         JsonObject result = new JsonObject();
-        result.add("header", gson.toJsonTree(new JsonPayloadHeader()));
+        result.add("header", gson.toJsonTree(new JsonPayloadHeader(getHeaderVersion())));
         @Nullable
         JsonElement args = getJsonPayloadArgs(version);
         if (args != null) {
@@ -73,6 +73,15 @@ public abstract class IotDeviceCommand<RESPONSETYPE> {
             result.add("body", body);
         }
         return result;
+    }
+
+    /**
+     * Returns the protocol header version to use for this command.
+     * Default is "0.0.50". GOAT mower commands override this to return "0.0.22"
+     * which is what the official app sends and the mower firmware requires.
+     */
+    protected String getHeaderVersion() {
+        return "0.0.50";
     }
 
     protected @Nullable JsonElement getJsonPayloadArgs(ProtocolVersion version) {

--- a/bundles/org.openhab.binding.ecovacs/src/main/java/org/openhab/binding/ecovacs/internal/api/commands/MowerCleanCommand.java
+++ b/bundles/org.openhab.binding.ecovacs/src/main/java/org/openhab/binding/ecovacs/internal/api/commands/MowerCleanCommand.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.ecovacs.internal.api.commands;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.ecovacs.internal.api.impl.ProtocolVersion;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+/**
+ * Generic mower clean command that uses 'clean' (not 'clean_V2') with V2-style content payload.
+ * Used for pause, resume, and stop actions on GOAT mowers.
+ *
+ * @author Stefan Höhn - Initial contribution
+ */
+@NonNullByDefault
+public class MowerCleanCommand extends AbstractMowerCommand {
+    private final String action;
+
+    public MowerCleanCommand(String action) {
+        this.action = action;
+    }
+
+    @Override
+    public String getName(ProtocolVersion version) {
+        if (version == ProtocolVersion.XML) {
+            throw new IllegalStateException("Mower commands are not supported for XML");
+        }
+        return "clean";
+    }
+
+    @Override
+    protected @Nullable JsonElement getJsonPayloadArgs(ProtocolVersion version) {
+        JsonObject args = new JsonObject();
+        args.addProperty("act", action);
+        JsonObject content = new JsonObject();
+        content.addProperty("type", "auto");
+        args.add("content", content);
+        return args;
+    }
+}

--- a/bundles/org.openhab.binding.ecovacs/src/main/java/org/openhab/binding/ecovacs/internal/api/commands/SetChildLockCommand.java
+++ b/bundles/org.openhab.binding.ecovacs/src/main/java/org/openhab/binding/ecovacs/internal/api/commands/SetChildLockCommand.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.ecovacs.internal.api.commands;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.ecovacs.internal.api.impl.ProtocolVersion;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+/**
+ * @author Stefan Höhn - Initial contribution
+ */
+@NonNullByDefault
+public class SetChildLockCommand extends AbstractNoResponseCommand {
+    private final boolean on;
+
+    public SetChildLockCommand(boolean on) {
+        this.on = on;
+    }
+
+    @Override
+    public String getName(ProtocolVersion version) {
+        if (version == ProtocolVersion.XML) {
+            throw new IllegalStateException("Mower commands are not supported for XML");
+        }
+        return "setChildLock";
+    }
+
+    @Override
+    protected @Nullable JsonElement getJsonPayloadArgs(ProtocolVersion version) {
+        JsonObject args = new JsonObject();
+        args.addProperty("on", on ? 1 : 0);
+        return args;
+    }
+}

--- a/bundles/org.openhab.binding.ecovacs/src/main/java/org/openhab/binding/ecovacs/internal/api/commands/SetCuttingHeightCommand.java
+++ b/bundles/org.openhab.binding.ecovacs/src/main/java/org/openhab/binding/ecovacs/internal/api/commands/SetCuttingHeightCommand.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.ecovacs.internal.api.commands;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.ecovacs.internal.api.impl.ProtocolVersion;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+/**
+ * @author Stefan Höhn - Initial contribution
+ */
+@NonNullByDefault
+public class SetCuttingHeightCommand extends AbstractNoResponseCommand {
+    private final int heightMm;
+
+    /**
+     * @param heightMm cutting height in millimeters (30-75)
+     */
+    public SetCuttingHeightCommand(int heightMm) {
+        this.heightMm = heightMm;
+    }
+
+    @Override
+    public String getName(ProtocolVersion version) {
+        if (version == ProtocolVersion.XML) {
+            throw new IllegalStateException("Mower commands are not supported for XML");
+        }
+        return "setCutHeight";
+    }
+
+    @Override
+    protected @Nullable JsonElement getJsonPayloadArgs(ProtocolVersion version) {
+        // Convert mm to level: level = (height - 25) / 5
+        // level 1 = 30mm, level 2 = 35mm, ..., level 10 = 75mm
+        int level = (heightMm - 25) / 5;
+        level = Math.max(1, Math.min(10, level));
+        JsonObject args = new JsonObject();
+        args.addProperty("level", level);
+        return args;
+    }
+}

--- a/bundles/org.openhab.binding.ecovacs/src/main/java/org/openhab/binding/ecovacs/internal/api/commands/SetMoveUpWarningCommand.java
+++ b/bundles/org.openhab.binding.ecovacs/src/main/java/org/openhab/binding/ecovacs/internal/api/commands/SetMoveUpWarningCommand.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.ecovacs.internal.api.commands;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.ecovacs.internal.api.impl.ProtocolVersion;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+/**
+ * @author Stefan Höhn - Initial contribution
+ */
+@NonNullByDefault
+public class SetMoveUpWarningCommand extends AbstractNoResponseCommand {
+    private final boolean on;
+
+    public SetMoveUpWarningCommand(boolean on) {
+        this.on = on;
+    }
+
+    @Override
+    public String getName(ProtocolVersion version) {
+        if (version == ProtocolVersion.XML) {
+            throw new IllegalStateException("Mower commands are not supported for XML");
+        }
+        return "setMoveUpWarning";
+    }
+
+    @Override
+    protected @Nullable JsonElement getJsonPayloadArgs(ProtocolVersion version) {
+        JsonObject args = new JsonObject();
+        args.addProperty("enable", on ? 1 : 0);
+        return args;
+    }
+}

--- a/bundles/org.openhab.binding.ecovacs/src/main/java/org/openhab/binding/ecovacs/internal/api/commands/SetSafeProtectCommand.java
+++ b/bundles/org.openhab.binding.ecovacs/src/main/java/org/openhab/binding/ecovacs/internal/api/commands/SetSafeProtectCommand.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.ecovacs.internal.api.commands;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.ecovacs.internal.api.impl.ProtocolVersion;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+/**
+ * @author Stefan Höhn - Initial contribution
+ */
+@NonNullByDefault
+public class SetSafeProtectCommand extends AbstractNoResponseCommand {
+    private final boolean on;
+
+    public SetSafeProtectCommand(boolean on) {
+        this.on = on;
+    }
+
+    @Override
+    public String getName(ProtocolVersion version) {
+        if (version == ProtocolVersion.XML) {
+            throw new IllegalStateException("Mower commands are not supported for XML");
+        }
+        return "setSafeProtect";
+    }
+
+    @Override
+    protected @Nullable JsonElement getJsonPayloadArgs(ProtocolVersion version) {
+        JsonObject args = new JsonObject();
+        args.addProperty("enable", on ? 1 : 0);
+        return args;
+    }
+}

--- a/bundles/org.openhab.binding.ecovacs/src/main/java/org/openhab/binding/ecovacs/internal/api/commands/StartEdgeCutCommand.java
+++ b/bundles/org.openhab.binding.ecovacs/src/main/java/org/openhab/binding/ecovacs/internal/api/commands/StartEdgeCutCommand.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.ecovacs.internal.api.commands;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.ecovacs.internal.api.impl.ProtocolVersion;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+/**
+ * Start edge cutting command for GOAT mowers. Sends a 'clean' command with border type
+ * to instruct the mower to cut along the boundary wire.
+ *
+ * @author Stefan Höhn - Initial contribution
+ */
+@NonNullByDefault
+public class StartEdgeCutCommand extends AbstractMowerCommand {
+    @Override
+    public String getName(ProtocolVersion version) {
+        if (version == ProtocolVersion.XML) {
+            throw new IllegalStateException("Mower commands are not supported for XML");
+        }
+        return "clean";
+    }
+
+    @Override
+    protected @Nullable JsonElement getJsonPayloadArgs(ProtocolVersion version) {
+        JsonObject args = new JsonObject();
+        args.addProperty("act", "start");
+        JsonObject content = new JsonObject();
+        content.addProperty("type", "border");
+        args.add("content", content);
+        return args;
+    }
+}

--- a/bundles/org.openhab.binding.ecovacs/src/main/java/org/openhab/binding/ecovacs/internal/api/commands/ZoneMowingCommand.java
+++ b/bundles/org.openhab.binding.ecovacs/src/main/java/org/openhab/binding/ecovacs/internal/api/commands/ZoneMowingCommand.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.ecovacs.internal.api.commands;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.ecovacs.internal.api.impl.ProtocolVersion;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+/**
+ * Zone mowing command for GOAT mowers. Sends a 'clean' command with specific zone IDs
+ * to instruct the mower to mow designated areas.
+ *
+ * @author Stefan Höhn - Initial contribution
+ */
+@NonNullByDefault
+public class ZoneMowingCommand extends AbstractMowerCommand {
+    private final String zoneIds;
+
+    public ZoneMowingCommand(String zoneIds) {
+        this.zoneIds = zoneIds;
+    }
+
+    @Override
+    public String getName(ProtocolVersion version) {
+        if (version == ProtocolVersion.XML) {
+            throw new IllegalStateException("Mower commands are not supported for XML");
+        }
+        return "clean";
+    }
+
+    @Override
+    protected @Nullable JsonElement getJsonPayloadArgs(ProtocolVersion version) {
+        JsonObject args = new JsonObject();
+        args.addProperty("act", "start");
+        JsonObject content = new JsonObject();
+        content.addProperty("type", "spotArea");
+        content.addProperty("value", zoneIds);
+        args.add("content", content);
+        return args;
+    }
+}

--- a/bundles/org.openhab.binding.ecovacs/src/main/java/org/openhab/binding/ecovacs/internal/api/impl/DeviceDescription.java
+++ b/bundles/org.openhab.binding.ecovacs/src/main/java/org/openhab/binding/ecovacs/internal/api/impl/DeviceDescription.java
@@ -17,6 +17,7 @@ import java.util.Set;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.ecovacs.internal.api.model.DeviceCapability;
+import org.openhab.binding.ecovacs.internal.api.model.DeviceType;
 
 /**
  * @author Danny Baumann - Initial contribution
@@ -26,22 +27,24 @@ public class DeviceDescription {
     public final String modelName;
     public final String deviceClass;
     public final @Nullable String deviceClassLink;
+    public final DeviceType deviceType;
     public final ProtocolVersion protoVersion;
     public final boolean usesMqtt;
     public final Set<DeviceCapability> capabilities;
 
     public DeviceDescription(String modelName, String deviceClass, @Nullable String deviceClassLink,
-            ProtocolVersion protoVersion, boolean usesMqtt, Set<DeviceCapability> capabilities) {
+            DeviceType deviceType, ProtocolVersion protoVersion, boolean usesMqtt, Set<DeviceCapability> capabilities) {
         this.modelName = modelName;
         this.capabilities = capabilities;
         this.deviceClass = deviceClass;
         this.deviceClassLink = deviceClassLink;
+        this.deviceType = deviceType;
         this.protoVersion = protoVersion;
         this.usesMqtt = usesMqtt;
     }
 
     public DeviceDescription resolveLinkWith(DeviceDescription other) {
-        return new DeviceDescription(modelName, deviceClass, null, other.protoVersion, other.usesMqtt,
+        return new DeviceDescription(modelName, deviceClass, null, other.deviceType, other.protoVersion, other.usesMqtt,
                 other.capabilities);
     }
 

--- a/bundles/org.openhab.binding.ecovacs/src/main/java/org/openhab/binding/ecovacs/internal/api/impl/EcovacsIotMqDevice.java
+++ b/bundles/org.openhab.binding.ecovacs/src/main/java/org/openhab/binding/ecovacs/internal/api/impl/EcovacsIotMqDevice.java
@@ -38,6 +38,7 @@ import org.openhab.binding.ecovacs.internal.api.impl.dto.response.portal.PortalC
 import org.openhab.binding.ecovacs.internal.api.impl.dto.response.portal.PortalLoginResponse;
 import org.openhab.binding.ecovacs.internal.api.model.CleanLogRecord;
 import org.openhab.binding.ecovacs.internal.api.model.DeviceCapability;
+import org.openhab.binding.ecovacs.internal.api.model.DeviceType;
 import org.openhab.core.io.net.http.TrustAllTrustManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -85,6 +86,11 @@ public class EcovacsIotMqDevice implements EcovacsDevice {
     @Override
     public String getModelName() {
         return desc.modelName;
+    }
+
+    @Override
+    public DeviceType getDeviceType() {
+        return desc.deviceType;
     }
 
     @Override

--- a/bundles/org.openhab.binding.ecovacs/src/main/java/org/openhab/binding/ecovacs/internal/api/impl/EcovacsXmppDevice.java
+++ b/bundles/org.openhab.binding.ecovacs/src/main/java/org/openhab/binding/ecovacs/internal/api/impl/EcovacsXmppDevice.java
@@ -61,6 +61,7 @@ import org.openhab.binding.ecovacs.internal.api.impl.dto.response.portal.PortalI
 import org.openhab.binding.ecovacs.internal.api.impl.dto.response.portal.PortalLoginResponse;
 import org.openhab.binding.ecovacs.internal.api.model.CleanLogRecord;
 import org.openhab.binding.ecovacs.internal.api.model.DeviceCapability;
+import org.openhab.binding.ecovacs.internal.api.model.DeviceType;
 import org.openhab.binding.ecovacs.internal.api.util.DataParsingException;
 import org.openhab.binding.ecovacs.internal.api.util.SchedulerTask;
 import org.openhab.binding.ecovacs.internal.api.util.XPathUtils;
@@ -102,6 +103,11 @@ public class EcovacsXmppDevice implements EcovacsDevice {
     @Override
     public String getModelName() {
         return desc.modelName;
+    }
+
+    @Override
+    public DeviceType getDeviceType() {
+        return desc.deviceType;
     }
 
     @Override

--- a/bundles/org.openhab.binding.ecovacs/src/main/java/org/openhab/binding/ecovacs/internal/api/impl/JsonReportParser.java
+++ b/bundles/org.openhab.binding.ecovacs/src/main/java/org/openhab/binding/ecovacs/internal/api/impl/JsonReportParser.java
@@ -32,6 +32,7 @@ import org.openhab.binding.ecovacs.internal.api.util.DataParsingException;
 import org.slf4j.Logger;
 
 import com.google.gson.Gson;
+import com.google.gson.JsonObject;
 import com.google.gson.JsonSyntaxException;
 
 /**
@@ -54,6 +55,13 @@ class JsonReportParser implements ReportParser {
 
     @Override
     public void handleMessage(String eventName, String payload) throws DataParsingException {
+        // Handle fwburypoint events separately - they have a different body structure
+        // (fields directly in body, not nested in body.data)
+        if (eventName.equals("onfwburypoint-bd_task-mow-auto-stop")) {
+            handleMowTaskStop(payload);
+            return;
+        }
+
         JsonResponsePayloadWrapper response;
         try {
             response = gson.fromJson(payload, JsonResponsePayloadWrapper.class);
@@ -93,7 +101,7 @@ class JsonReportParser implements ReportParser {
                 if (mode == null) {
                     throw new DataParsingException("Could not get clean mode from response " + payload);
                 }
-                String area = report.cleanState != null ? report.cleanState.areaDefinition : null;
+                String area = report.cleanState != null ? report.cleanState.getAreaDefinition() : null;
                 handleCleanModeChange(mode, area);
                 break;
             }
@@ -121,7 +129,11 @@ class JsonReportParser implements ReportParser {
             }
             case "stats": {
                 StatsReport report = payloadAs(response, StatsReport.class);
-                listener.onCleaningStatsUpdated(device, report.area, report.timeInSeconds);
+                if (report.mowedArea > 0) {
+                    listener.onMowingStatsUpdated(device, report.mowedArea, report.timeInSeconds);
+                } else {
+                    listener.onCleaningStatsUpdated(device, report.area, report.timeInSeconds);
+                }
                 break;
             }
             case "waterinfo": {
@@ -138,10 +150,9 @@ class JsonReportParser implements ReportParser {
                 handleCleanModeChange(mode, null);
                 break;
             }
-            // more possible events (unused for now):
-            // - "evt" -> EventReport
-            // - "lifespan" -> ComponentLifeSpanReport
-            // - "speed" -> SpeedReport
+            default:
+                logger.trace("{}: Ignoring unhandled event '{}': {}", device.getSerialNumber(), eventName, payload);
+                break;
         }
     }
 
@@ -160,5 +171,31 @@ class JsonReportParser implements ReportParser {
             throw new DataParsingException("Null payload in response " + response);
         }
         return payload;
+    }
+
+    private void handleMowTaskStop(String payload) {
+        try {
+            JsonObject root = gson.fromJson(payload, JsonObject.class);
+            if (root == null || !root.has("body")) {
+                return;
+            }
+            JsonObject body = root.getAsJsonObject("body");
+            if (body == null || !body.has("mowedArea")) {
+                return;
+            }
+            // mowedArea is in m² (float), time is in seconds (float), ts is epoch milliseconds (string)
+            double mowedAreaSqM = body.get("mowedArea").getAsDouble();
+            double timeSeconds = body.has("time") ? body.get("time").getAsDouble() : 0;
+            long startTimestampMs = body.has("ts") ? Long.parseLong(body.get("ts").getAsString()) : 0;
+            long startTimestamp = startTimestampMs / 1000;
+
+            // Convert area to cm² (int) and time to seconds (int) to match the existing callback signature
+            int areaSqCm = (int) Math.round(mowedAreaSqM * 10000);
+            int durationSeconds = (int) Math.round(timeSeconds);
+
+            listener.onMowingSessionFinished(device, startTimestamp, durationSeconds, areaSqCm);
+        } catch (Exception e) {
+            logger.debug("{}: Could not parse mow task stop event: {}", device.getSerialNumber(), e.getMessage());
+        }
     }
 }

--- a/bundles/org.openhab.binding.ecovacs/src/main/java/org/openhab/binding/ecovacs/internal/api/impl/dto/request/portal/PortalIotCommandRequest.java
+++ b/bundles/org.openhab.binding.ecovacs/src/main/java/org/openhab/binding/ecovacs/internal/api/impl/dto/request/portal/PortalIotCommandRequest.java
@@ -62,10 +62,15 @@ public class PortalIotCommandRequest {
         @SerializedName("tzm")
         public final int tzm = 480;
         @SerializedName("ver")
-        public final String version = "0.0.50";
+        public final String version;
 
         public JsonPayloadHeader() {
-            timestamp = System.currentTimeMillis();
+            this("0.0.50");
+        }
+
+        public JsonPayloadHeader(String version) {
+            this.timestamp = System.currentTimeMillis();
+            this.version = version;
         }
     }
 }

--- a/bundles/org.openhab.binding.ecovacs/src/main/java/org/openhab/binding/ecovacs/internal/api/impl/dto/response/deviceapi/json/CleanReport.java
+++ b/bundles/org.openhab.binding.ecovacs/src/main/java/org/openhab/binding/ecovacs/internal/api/impl/dto/response/deviceapi/json/CleanReport.java
@@ -12,9 +12,11 @@
  */
 package org.openhab.binding.ecovacs.internal.api.impl.dto.response.deviceapi.json;
 
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.ecovacs.internal.api.model.CleanMode;
 
 import com.google.gson.Gson;
+import com.google.gson.JsonElement;
 import com.google.gson.annotations.SerializedName;
 
 /**
@@ -26,7 +28,7 @@ public class CleanReport {
     @SerializedName("state")
     public String state;
     @SerializedName("cleanState")
-    public CleanStateReport cleanState;
+    public @Nullable CleanStateReport cleanState;
 
     public static class CleanStateReport {
         @SerializedName("router")
@@ -35,15 +37,22 @@ public class CleanReport {
         public String type;
         @SerializedName("motionState")
         public String motionState;
-        @SerializedName("content")
-        public String areaDefinition;
+        // content can be either a String (vacuum area definition) or a JSON object (mower content type)
+        public @Nullable JsonElement content;
+
+        public @Nullable String getAreaDefinition() {
+            if (content != null && content.isJsonPrimitive()) {
+                return content.getAsString();
+            }
+            return null;
+        }
     }
 
-    public CleanMode determineCleanMode(Gson gson) {
+    public @Nullable CleanMode determineCleanMode(Gson gson) {
         final String modeValue;
         if (cleanState != null) {
             if ("working".equals(cleanState.motionState)) {
-                modeValue = cleanState.type;
+                modeValue = cleanState.type != null ? cleanState.type : "auto";
             } else {
                 modeValue = cleanState.motionState;
             }

--- a/bundles/org.openhab.binding.ecovacs/src/main/java/org/openhab/binding/ecovacs/internal/api/impl/dto/response/deviceapi/json/LastTimeStatsReport.java
+++ b/bundles/org.openhab.binding.ecovacs/src/main/java/org/openhab/binding/ecovacs/internal/api/impl/dto/response/deviceapi/json/LastTimeStatsReport.java
@@ -12,22 +12,24 @@
  */
 package org.openhab.binding.ecovacs.internal.api.impl.dto.response.deviceapi.json;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
 import com.google.gson.annotations.SerializedName;
 
 /**
- * @author Danny Baumann - Initial contribution
+ * Represents the onLastTimeStats MQTT event from GOAT mowers, containing
+ * summary statistics about the last completed mowing session.
+ *
+ * @author Stefan Höhn - Initial contribution
  */
-public class StatsReport {
-    @SerializedName("area")
-    public int area;
-    @SerializedName("mowedArea")
-    public int mowedArea;
-    @SerializedName("time")
-    public int timeInSeconds;
-    @SerializedName("cid")
-    public String cid;
+@NonNullByDefault
+public class LastTimeStatsReport {
     @SerializedName("start")
-    public long startTimestamp;
-    @SerializedName("type")
-    public String type; // auto, ... ?
+    public String startTimestamp = "0";
+
+    @SerializedName("time")
+    public int durationSeconds;
+
+    @SerializedName("area")
+    public int areaSqCm;
 }

--- a/bundles/org.openhab.binding.ecovacs/src/main/java/org/openhab/binding/ecovacs/internal/api/model/Component.java
+++ b/bundles/org.openhab.binding.ecovacs/src/main/java/org/openhab/binding/ecovacs/internal/api/model/Component.java
@@ -23,7 +23,8 @@ public enum Component {
     SIDE_BRUSH("SideBrush", "sideBrush"),
     DUST_CASE_HEAP("DustCaseHeap", "heap"),
     UNIT_CARE("" /* not supported in XML */, "unitCare"),
-    ROUND_MOP("" /* not supported in XML */, "roundMop");
+    ROUND_MOP("" /* not supported in XML */, "roundMop"),
+    BLADE("" /* mower only, not supported in XML */, "blade");
 
     public final String xmlValue;
     public final String jsonValue;

--- a/bundles/org.openhab.binding.ecovacs/src/main/java/org/openhab/binding/ecovacs/internal/api/model/DeviceCapability.java
+++ b/bundles/org.openhab.binding.ecovacs/src/main/java/org/openhab/binding/ecovacs/internal/api/model/DeviceCapability.java
@@ -57,6 +57,24 @@ public enum DeviceCapability {
     AIR_DRYING,
     @SerializedName("custom_water_amount")
     CUSTOM_WATER_AMOUNT,
+    @SerializedName("mowing")
+    MOWING,
+    @SerializedName("zone_mowing")
+    ZONE_MOWING,
+    @SerializedName("edge_mowing")
+    EDGE_MOWING,
+    @SerializedName("cutting_height")
+    CUTTING_HEIGHT,
+    @SerializedName("remote_cutting_height")
+    REMOTE_CUTTING_HEIGHT,
+    @SerializedName("rain_detection")
+    RAIN_DETECTION,
+    @SerializedName("safe_protect")
+    SAFE_PROTECT,
+    @SerializedName("child_lock")
+    CHILD_LOCK,
+    @SerializedName("moveup_warning")
+    MOVEUP_WARNING,
     // implicit capabilities added in code
     EDGE_CLEANING,
     SPOT_CLEANING,

--- a/bundles/org.openhab.binding.ecovacs/src/main/java/org/openhab/binding/ecovacs/internal/api/model/DeviceType.java
+++ b/bundles/org.openhab.binding.ecovacs/src/main/java/org/openhab/binding/ecovacs/internal/api/model/DeviceType.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.ecovacs.internal.api.model;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * @author Stefan Höhn - Initial contribution
+ */
+@NonNullByDefault
+public enum DeviceType {
+    @SerializedName("vacuum")
+    VACUUM,
+    @SerializedName("mower")
+    MOWER
+}

--- a/bundles/org.openhab.binding.ecovacs/src/main/java/org/openhab/binding/ecovacs/internal/discovery/EcovacsDeviceDiscoveryService.java
+++ b/bundles/org.openhab.binding.ecovacs/src/main/java/org/openhab/binding/ecovacs/internal/discovery/EcovacsDeviceDiscoveryService.java
@@ -23,6 +23,7 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.binding.ecovacs.internal.api.EcovacsApi;
 import org.openhab.binding.ecovacs.internal.api.EcovacsApiException;
 import org.openhab.binding.ecovacs.internal.api.EcovacsDevice;
+import org.openhab.binding.ecovacs.internal.api.model.DeviceType;
 import org.openhab.binding.ecovacs.internal.api.util.SchedulerTask;
 import org.openhab.binding.ecovacs.internal.handler.EcovacsApiHandler;
 import org.openhab.core.config.discovery.AbstractThingHandlerDiscoveryService;
@@ -30,6 +31,7 @@ import org.openhab.core.config.discovery.DiscoveryResult;
 import org.openhab.core.config.discovery.DiscoveryResultBuilder;
 import org.openhab.core.config.discovery.DiscoveryService;
 import org.openhab.core.thing.Thing;
+import org.openhab.core.thing.ThingTypeUID;
 import org.openhab.core.thing.ThingUID;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.ServiceScope;
@@ -54,7 +56,7 @@ public class EcovacsDeviceDiscoveryService extends AbstractThingHandlerDiscovery
             this::scanForDevices);
 
     public EcovacsDeviceDiscoveryService() {
-        super(EcovacsApiHandler.class, Set.of(THING_TYPE_VACUUM), DISCOVER_TIMEOUT_SECONDS, true);
+        super(EcovacsApiHandler.class, Set.of(THING_TYPE_VACUUM, THING_TYPE_MOWER), DISCOVER_TIMEOUT_SECONDS, true);
     }
 
     @Override
@@ -120,7 +122,8 @@ public class EcovacsDeviceDiscoveryService extends AbstractThingHandlerDiscovery
     }
 
     private void deviceDiscovered(EcovacsDevice device) {
-        ThingUID thingUID = new ThingUID(THING_TYPE_VACUUM, thingHandler.getThing().getUID(), device.getSerialNumber());
+        ThingTypeUID thingType = device.getDeviceType() == DeviceType.MOWER ? THING_TYPE_MOWER : THING_TYPE_VACUUM;
+        ThingUID thingUID = new ThingUID(thingType, thingHandler.getThing().getUID(), device.getSerialNumber());
         DiscoveryResult discoveryResult = DiscoveryResultBuilder.create(thingUID)
                 .withBridge(thingHandler.getThing().getUID()).withLabel(device.getModelName())
                 .withProperty(Thing.PROPERTY_SERIAL_NUMBER, device.getSerialNumber())

--- a/bundles/org.openhab.binding.ecovacs/src/main/java/org/openhab/binding/ecovacs/internal/handler/AbstractEcovacsDeviceHandler.java
+++ b/bundles/org.openhab.binding.ecovacs/src/main/java/org/openhab/binding/ecovacs/internal/handler/AbstractEcovacsDeviceHandler.java
@@ -1,0 +1,254 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.ecovacs.internal.handler;
+
+import static org.openhab.binding.ecovacs.internal.EcovacsBindingConstants.*;
+
+import java.util.Optional;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.ecovacs.internal.api.EcovacsApi;
+import org.openhab.binding.ecovacs.internal.api.EcovacsApiException;
+import org.openhab.binding.ecovacs.internal.api.EcovacsDevice;
+import org.openhab.binding.ecovacs.internal.api.model.CleanMode;
+import org.openhab.binding.ecovacs.internal.api.util.SchedulerTask;
+import org.openhab.binding.ecovacs.internal.config.EcovacsVacuumConfiguration;
+import org.openhab.core.i18n.ConfigurationException;
+import org.openhab.core.i18n.LocaleProvider;
+import org.openhab.core.i18n.TranslationProvider;
+import org.openhab.core.library.types.DecimalType;
+import org.openhab.core.thing.Bridge;
+import org.openhab.core.thing.ChannelUID;
+import org.openhab.core.thing.Thing;
+import org.openhab.core.thing.ThingStatus;
+import org.openhab.core.thing.ThingStatusDetail;
+import org.openhab.core.thing.ThingStatusInfo;
+import org.openhab.core.thing.binding.BaseThingHandler;
+import org.openhab.core.thing.binding.builder.ThingBuilder;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link AbstractEcovacsDeviceHandler} provides shared functionality for Ecovacs device handlers.
+ *
+ * @author Danny Baumann - Initial contribution
+ * @author Stefan Höhn - Refactored from vacuum and mower handlers
+ */
+@NonNullByDefault
+public abstract class AbstractEcovacsDeviceHandler extends BaseThingHandler {
+
+    @FunctionalInterface
+    protected interface DeviceAction {
+        void run(EcovacsDevice device) throws EcovacsApiException, InterruptedException;
+    }
+
+    protected final Logger logger = LoggerFactory.getLogger(getClass());
+    protected final TranslationProvider i18Provider;
+    protected final LocaleProvider localeProvider;
+    protected final Bundle bundle;
+
+    protected final SchedulerTask initTask;
+    protected final SchedulerTask reconnectTask;
+    protected final SchedulerTask pollTask;
+
+    protected @Nullable EcovacsDevice device;
+    protected volatile @Nullable Boolean lastWasCharging;
+    protected volatile @Nullable CleanMode lastCleanMode;
+    protected long lastSuccessfulPollTimestamp;
+    protected String serialNumber = "<unset>";
+
+    protected AbstractEcovacsDeviceHandler(Thing thing, TranslationProvider i18Provider,
+            LocaleProvider localeProvider) {
+        super(thing);
+        this.i18Provider = i18Provider;
+        this.localeProvider = localeProvider;
+        this.bundle = FrameworkUtil.getBundle(getClass());
+
+        initTask = new SchedulerTask(scheduler, logger, "Init", this::initDevice);
+        reconnectTask = new SchedulerTask(scheduler, logger, "Connection", this::connectToDevice);
+        pollTask = new SchedulerTask(scheduler, logger, "Poll", this::pollData);
+    }
+
+    @Override
+    public void initialize() {
+        serialNumber = getConfigAs(EcovacsVacuumConfiguration.class).serialNumber;
+        if (serialNumber.isEmpty()) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
+                    "@text/offline.config-error-no-serial");
+        } else {
+            logger.debug("{}: Initializing {} handler", serialNumber, getLogPrefix());
+            updateStatus(ThingStatus.UNKNOWN);
+            initTask.setNamePrefix(serialNumber);
+            reconnectTask.setNamePrefix(serialNumber);
+            pollTask.setNamePrefix(serialNumber);
+            initTask.submit();
+        }
+    }
+
+    @Override
+    public void dispose() {
+        logger.debug("{}: Disposing {} handler", serialNumber, getLogPrefix());
+        teardown(false);
+    }
+
+    @Override
+    public void bridgeStatusChanged(ThingStatusInfo bridgeStatusInfo) {
+        logger.debug("{}: Bridge status changed to {}", serialNumber, bridgeStatusInfo);
+        if (bridgeStatusInfo.getStatus() == ThingStatus.ONLINE) {
+            initTask.submit();
+        } else if (bridgeStatusInfo.getStatus() == ThingStatus.OFFLINE) {
+            teardown(false);
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE);
+        }
+    }
+
+    public void onFirmwareVersionChanged(EcovacsDevice device, String fwVersion) {
+        updateProperty(Thing.PROPERTY_FIRMWARE_VERSION, fwVersion);
+    }
+
+    public void onBatteryLevelUpdated(EcovacsDevice device, int newLevelPercent) {
+        // Some devices report weird values (> 100%), so better clamp to supported range
+        int actualPercent = Math.max(0, Math.min(newLevelPercent, 100));
+        updateState(CHANNEL_ID_BATTERY_LEVEL, new DecimalType(actualPercent));
+    }
+
+    public void onEventStreamFailure(final EcovacsDevice device, Throwable error) {
+        logger.debug("{}: Device connection failed, reconnecting", serialNumber, error);
+        teardownAndScheduleReconnection();
+    }
+
+    protected void teardownAndScheduleReconnection() {
+        teardown(true);
+    }
+
+    protected synchronized void teardown(boolean scheduleReconnection) {
+        EcovacsDevice device = this.device;
+        if (device != null) {
+            device.disconnect(scheduler);
+        }
+
+        pollTask.cancel();
+        reconnectTask.cancel();
+        initTask.cancel();
+
+        if (scheduleReconnection) {
+            SchedulerTask connectTask = device != null ? reconnectTask : initTask;
+            connectTask.schedule(5);
+        }
+    }
+
+    protected synchronized void scheduleNextPoll(long initialDelaySeconds) {
+        final EcovacsVacuumConfiguration config = getConfigAs(EcovacsVacuumConfiguration.class);
+        final long delayUntilNextPoll;
+        if (initialDelaySeconds < 0) {
+            long intervalSeconds = config.refresh * 60;
+            long secondsSinceLastPoll = (System.currentTimeMillis() - lastSuccessfulPollTimestamp) / 1000;
+            long deltaRemaining = intervalSeconds - secondsSinceLastPoll;
+            delayUntilNextPoll = Math.max(0, deltaRemaining);
+        } else {
+            delayUntilNextPoll = initialDelaySeconds;
+        }
+        logger.debug("{}: Scheduling next poll in {}s, refresh interval {}min", serialNumber, delayUntilNextPoll,
+                config.refresh);
+        pollTask.cancel();
+        pollTask.schedule(delayUntilNextPoll);
+    }
+
+    protected @Nullable EcovacsApiHandler getApiHandler() {
+        final Bridge bridge = getBridge();
+        return bridge != null ? (EcovacsApiHandler) bridge.getHandler() : null;
+    }
+
+    protected boolean removeChannel(ThingBuilder builder, String channelId) {
+        ChannelUID channelUID = new ChannelUID(getThing().getUID(), channelId);
+        if (getThing().getChannel(channelUID) == null) {
+            return false;
+        }
+        logger.debug("{}: Removing unsupported channel {}", serialNumber, channelId);
+        builder.withoutChannel(channelUID);
+        return true;
+    }
+
+    protected void doWithDevice(DeviceAction action) {
+        final EcovacsDevice device = this.device;
+        if (device == null) {
+            return;
+        }
+        try {
+            action.run(device);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        } catch (EcovacsApiException e) {
+            logger.debug("{}: Device action failed: {}", serialNumber, e.getMessage(), e);
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, e.getMessage());
+            teardownAndScheduleReconnection();
+        }
+    }
+
+    private void initDevice() {
+        final EcovacsApiHandler handler = getApiHandler();
+        if (handler == null) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_UNINITIALIZED);
+            return;
+        }
+
+        try {
+            final EcovacsApi api = handler.createApiForDevice(serialNumber);
+            api.loginAndGetAccessToken();
+            Optional<EcovacsDevice> deviceOpt = api.getDevices().stream()
+                    .filter(d -> serialNumber.equals(d.getSerialNumber())).findFirst();
+            if (deviceOpt.isPresent()) {
+                EcovacsDevice device = deviceOpt.get();
+                this.device = device;
+                updateProperty(Thing.PROPERTY_MODEL_ID, device.getModelName());
+                updateProperty(Thing.PROPERTY_SERIAL_NUMBER, device.getSerialNumber());
+                afterDeviceFound(device);
+                connectToDevice();
+            } else {
+                logger.info("{}: Device not found in device list, setting offline", serialNumber);
+                updateStatus(ThingStatus.OFFLINE);
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        } catch (ConfigurationException e) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, e.getRawMessage());
+        } catch (EcovacsApiException e) {
+            logger.debug("API Exception: {}", e.getMessage(), e);
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, e.getMessage());
+        }
+    }
+
+    /**
+     * Called after the device has been found during initialization, before connecting.
+     * Subclasses use this to set up state options and remove unsupported channels.
+     */
+    protected abstract void afterDeviceFound(EcovacsDevice device);
+
+    /**
+     * Connect to the device and fetch initial state.
+     */
+    protected abstract void connectToDevice();
+
+    /**
+     * Poll device data.
+     */
+    protected abstract void pollData();
+
+    /**
+     * Returns a log prefix for this handler type (e.g. "mower" or "vacuum").
+     */
+    protected abstract String getLogPrefix();
+}

--- a/bundles/org.openhab.binding.ecovacs/src/main/java/org/openhab/binding/ecovacs/internal/handler/EcovacsMowerHandler.java
+++ b/bundles/org.openhab.binding.ecovacs/src/main/java/org/openhab/binding/ecovacs/internal/handler/EcovacsMowerHandler.java
@@ -1,0 +1,477 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.ecovacs.internal.handler;
+
+import static org.openhab.binding.ecovacs.internal.EcovacsBindingConstants.*;
+
+import java.time.Instant;
+import java.util.Locale;
+import java.util.Optional;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.ecovacs.internal.api.EcovacsApiException;
+import org.openhab.binding.ecovacs.internal.api.EcovacsDevice;
+import org.openhab.binding.ecovacs.internal.api.commands.GetBatteryInfoCommand;
+import org.openhab.binding.ecovacs.internal.api.commands.GetChargeStateCommand;
+import org.openhab.binding.ecovacs.internal.api.commands.GetChildLockCommand;
+import org.openhab.binding.ecovacs.internal.api.commands.GetComponentLifeSpanCommand;
+import org.openhab.binding.ecovacs.internal.api.commands.GetCuttingHeightCommand;
+import org.openhab.binding.ecovacs.internal.api.commands.GetMoveUpWarningCommand;
+import org.openhab.binding.ecovacs.internal.api.commands.GetMowerStateCommand;
+import org.openhab.binding.ecovacs.internal.api.commands.GetNetworkInfoCommand;
+import org.openhab.binding.ecovacs.internal.api.commands.GetSafeProtectCommand;
+import org.openhab.binding.ecovacs.internal.api.commands.GetTotalStatsCommand;
+import org.openhab.binding.ecovacs.internal.api.commands.GetTotalStatsCommand.TotalStats;
+import org.openhab.binding.ecovacs.internal.api.commands.GetTrueDetectCommand;
+import org.openhab.binding.ecovacs.internal.api.commands.GetVolumeCommand;
+import org.openhab.binding.ecovacs.internal.api.commands.GoChargingCommand;
+import org.openhab.binding.ecovacs.internal.api.commands.IotDeviceCommand;
+import org.openhab.binding.ecovacs.internal.api.commands.MowerCleanCommand;
+import org.openhab.binding.ecovacs.internal.api.commands.SetChildLockCommand;
+import org.openhab.binding.ecovacs.internal.api.commands.SetMoveUpWarningCommand;
+import org.openhab.binding.ecovacs.internal.api.commands.SetSafeProtectCommand;
+import org.openhab.binding.ecovacs.internal.api.commands.SetTrueDetectCommand;
+import org.openhab.binding.ecovacs.internal.api.commands.SetVolumeCommand;
+import org.openhab.binding.ecovacs.internal.api.commands.StartEdgeCutCommand;
+import org.openhab.binding.ecovacs.internal.api.commands.ZoneMowingCommand;
+import org.openhab.binding.ecovacs.internal.api.model.ChargeMode;
+import org.openhab.binding.ecovacs.internal.api.model.CleanMode;
+import org.openhab.binding.ecovacs.internal.api.model.Component;
+import org.openhab.binding.ecovacs.internal.api.model.DeviceCapability;
+import org.openhab.binding.ecovacs.internal.api.model.NetworkInfo;
+import org.openhab.core.i18n.LocaleProvider;
+import org.openhab.core.i18n.TranslationProvider;
+import org.openhab.core.library.types.DateTimeType;
+import org.openhab.core.library.types.DecimalType;
+import org.openhab.core.library.types.OnOffType;
+import org.openhab.core.library.types.PercentType;
+import org.openhab.core.library.types.QuantityType;
+import org.openhab.core.library.types.StringType;
+import org.openhab.core.library.unit.MetricPrefix;
+import org.openhab.core.library.unit.SIUnits;
+import org.openhab.core.library.unit.Units;
+import org.openhab.core.thing.ChannelUID;
+import org.openhab.core.thing.Thing;
+import org.openhab.core.thing.ThingStatus;
+import org.openhab.core.types.Command;
+import org.openhab.core.types.UnDefType;
+
+/**
+ * The {@link EcovacsMowerHandler} is responsible for handling data and commands from/to GOAT mowers.
+ *
+ * @author Stefan Höhn - Initial contribution
+ */
+@NonNullByDefault
+public class EcovacsMowerHandler extends AbstractEcovacsDeviceHandler implements EcovacsDevice.EventListener {
+
+    private volatile long mowingStartTimeMs;
+
+    public EcovacsMowerHandler(Thing thing, TranslationProvider i18Provider, LocaleProvider localeProvider) {
+        super(thing, i18Provider, localeProvider);
+    }
+
+    @Override
+    protected String getLogPrefix() {
+        return "mower";
+    }
+
+    @Override
+    protected void afterDeviceFound(EcovacsDevice device) {
+        removeUnsupportedChannels(device);
+    }
+
+    @Override
+    public void handleCommand(ChannelUID channelUID, Command command) {
+        final EcovacsDevice device = this.device;
+        if (device == null) {
+            logger.debug("{}: Ignoring command {}, no active connection", serialNumber, command);
+            return;
+        }
+        String channel = channelUID.getId();
+
+        try {
+            if (channel.equals(CHANNEL_ID_COMMAND) && command instanceof StringType) {
+                handleMowerCommand(device, command.toString());
+                // Schedule a quick poll to pick up state change in case MQTT event is delayed
+                scheduleNextPoll(5);
+                return;
+            } else if (channel.equals(CHANNEL_ID_VOICE_VOLUME) && command instanceof DecimalType volume) {
+                // Device uses 0-10 scale, openHAB uses 0-100 percent. Add 5 for rounding before integer division.
+                int volumePercent = volume.intValue();
+                device.sendCommand(new SetVolumeCommand((volumePercent + 5) / 10));
+                return;
+            } else if (channel.equals(CHANNEL_ID_TRUE_DETECT_3D) && command instanceof OnOffType) {
+                device.sendCommand(new SetTrueDetectCommand(command == OnOffType.ON));
+                return;
+            } else if (channel.equals(CHANNEL_ID_SAFE_PROTECT) && command instanceof OnOffType) {
+                device.sendCommand(new SetSafeProtectCommand(command == OnOffType.ON));
+                return;
+            } else if (channel.equals(CHANNEL_ID_CHILD_LOCK) && command instanceof OnOffType) {
+                device.sendCommand(new SetChildLockCommand(command == OnOffType.ON));
+                return;
+            } else if (channel.equals(CHANNEL_ID_MOVEUP_WARNING) && command instanceof OnOffType) {
+                device.sendCommand(new SetMoveUpWarningCommand(command == OnOffType.ON));
+                return;
+            }
+            logger.debug("{}: Ignoring unsupported command {} for channel {}", serialNumber, command, channel);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        } catch (EcovacsApiException e) {
+            logger.debug("{}: Handling device command {} failed", serialNumber, command, e);
+        }
+    }
+
+    private void handleMowerCommand(EcovacsDevice device, String command)
+            throws EcovacsApiException, InterruptedException {
+        switch (command) {
+            case CMD_MOW:
+                // If mower is paused, send resume instead of start (mower ignores start while paused).
+                // If mower is not paused, send start (mower ignores resume while idle).
+                if (lastCleanMode == CleanMode.PAUSE) {
+                    device.sendCommand(new MowerCleanCommand("resume"));
+                } else {
+                    device.sendCommand(new MowerCleanCommand("start"));
+                }
+                break;
+            case CMD_PAUSE:
+                device.sendCommand(new MowerCleanCommand("pause"));
+                break;
+            case CMD_RESUME:
+                device.sendCommand(new MowerCleanCommand("resume"));
+                break;
+            case CMD_STOP:
+                device.sendCommand(new MowerCleanCommand("stop"));
+                break;
+            case CMD_DOCK:
+                device.sendCommand(new GoChargingCommand());
+                break;
+            case CMD_EDGE_CUT:
+                device.sendCommand(new StartEdgeCutCommand());
+                break;
+            default:
+                if (command.startsWith("zone:") && device.hasCapability(DeviceCapability.ZONE_MOWING)) {
+                    String zones = command.substring(5);
+                    if (zones.isEmpty()) {
+                        logger.debug("{}: Zone mowing command requires zone IDs", serialNumber);
+                        return;
+                    }
+                    device.sendCommand(new ZoneMowingCommand(zones));
+                } else {
+                    logger.debug("{}: Unknown mower command: {}", serialNumber, command);
+                }
+                break;
+        }
+    }
+
+    // --- EcovacsDevice.EventListener implementation ---
+
+    @Override
+    public void onChargingStateUpdated(EcovacsDevice device, boolean charging) {
+        lastWasCharging = charging;
+        updateMowerStateChannel();
+    }
+
+    @Override
+    public void onCleaningModeUpdated(EcovacsDevice device, CleanMode newMode, Optional<String> areaDefinition) {
+        lastCleanMode = newMode;
+        updateMowerStateChannel();
+        if (newMode == CleanMode.RETURNING) {
+            scheduleNextPoll(30);
+        } else if (newMode.isIdle()) {
+            mowingStartTimeMs = 0;
+            updateState(CHANNEL_ID_MOWED_AREA, UnDefType.UNDEF);
+            updateState(CHANNEL_ID_MOWING_TIME, UnDefType.UNDEF);
+        } else if (!newMode.isIdle() && mowingStartTimeMs == 0) {
+            // Mowing started
+            mowingStartTimeMs = System.currentTimeMillis();
+        }
+    }
+
+    @Override
+    public void onCleaningStatsUpdated(EcovacsDevice device, int cleanedArea, int cleaningTimeSeconds) {
+    }
+
+    @Override
+    public void onMowingStatsUpdated(EcovacsDevice device, int mowedAreaSqCm, int timeSeconds) {
+        if (mowedAreaSqCm > 0) {
+            updateState(CHANNEL_ID_MOWED_AREA, new QuantityType<>(mowedAreaSqCm / 10000.0, SIUnits.SQUARE_METRE));
+        }
+        long startMs = mowingStartTimeMs;
+        if (startMs > 0) {
+            long elapsedSeconds = (System.currentTimeMillis() - startMs) / 1000;
+            updateState(CHANNEL_ID_MOWING_TIME, new QuantityType<>(elapsedSeconds, Units.SECOND));
+        }
+    }
+
+    @Override
+    public void onWaterSystemPresentUpdated(EcovacsDevice device, boolean present) {
+        // Not relevant for mowers, ignore
+    }
+
+    @Override
+    public void onErrorReported(EcovacsDevice device, int errorCode) {
+        // Error code 200 is sent on mow start and means "no error" — ignore it
+        if (errorCode == 200) {
+            return;
+        }
+        updateState(CHANNEL_ID_ERROR_CODE, new DecimalType(errorCode));
+        final Locale locale = localeProvider.getLocale();
+        String errorDesc = i18Provider.getText(bundle, "ecovacs.mower.error-code." + errorCode, null, locale);
+        if (errorDesc == null) {
+            errorDesc = i18Provider.getText(bundle, "ecovacs.mower.error-code.unknown", "", locale, errorCode);
+        }
+        updateState(CHANNEL_ID_ERROR_DESCRIPTION, new StringType(errorDesc));
+    }
+
+    @Override
+    public void onMowingSessionFinished(EcovacsDevice device, long startTimestamp, int durationSeconds, int areaSqCm) {
+        if (startTimestamp > 0) {
+            Instant startInstant = Instant.ofEpochSecond(startTimestamp);
+            updateState(CHANNEL_ID_LAST_MOW_START, new DateTimeType(startInstant));
+        }
+        updateState(CHANNEL_ID_LAST_MOW_DURATION, new QuantityType<>(durationSeconds, Units.SECOND));
+        updateState(CHANNEL_ID_LAST_MOW_AREA, new QuantityType<>(areaSqCm / 10000.0, SIUnits.SQUARE_METRE));
+    }
+
+    // --- State management ---
+
+    private void updateMowerStateChannel() {
+        Boolean charging = this.lastWasCharging;
+        CleanMode cleanMode = this.lastCleanMode;
+        if (charging == null || cleanMode == null) {
+            return;
+        }
+        String state = determineMowerState(charging, cleanMode);
+        updateState(CHANNEL_ID_MOWER_STATE, StringType.valueOf(state));
+    }
+
+    private String determineMowerState(boolean charging, CleanMode cleanMode) {
+        if (charging && cleanMode != CleanMode.RETURNING) {
+            return "charging";
+        }
+        if (cleanMode == CleanMode.RETURNING) {
+            return "returning";
+        }
+        if (cleanMode.isActive()) {
+            if (cleanMode == CleanMode.EDGE) {
+                return "edgeCutting";
+            }
+            return "mowing";
+        }
+        if (cleanMode == CleanMode.PAUSE) {
+            return "paused";
+        }
+        if (charging) {
+            return "docked";
+        }
+        return "idle";
+    }
+
+    // --- Connectivity ---
+
+    @Override
+    protected void connectToDevice() {
+        doWithDevice(device -> {
+            device.connect(this, scheduler);
+            // Fetch initial status
+            Integer batteryPercent = device.sendCommand(new GetBatteryInfoCommand());
+            onBatteryLevelUpdated(device, batteryPercent);
+            // Fetch initial charge and mowing state
+            try {
+                lastWasCharging = device.sendCommand(new GetChargeStateCommand()) == ChargeMode.CHARGING;
+                CleanMode mode = device.sendCommand(new GetMowerStateCommand());
+                lastCleanMode = mode;
+                updateMowerStateChannel();
+            } catch (EcovacsApiException e) {
+                logger.debug("{}: Could not fetch initial state: {}", serialNumber, e.getMessage());
+            }
+            scheduleNextPoll(-1);
+            logger.debug("{}: Mower connected", serialNumber);
+            updateStatus(ThingStatus.ONLINE);
+        });
+    }
+
+    // --- Polling ---
+
+    @Override
+    protected void pollData() {
+        logger.debug("{}: Polling mower data", serialNumber);
+        final EcovacsDevice device = this.device;
+        if (device == null) {
+            return;
+        }
+
+        Integer batteryPercent = pollCommand(device, new GetBatteryInfoCommand(), "battery");
+        if (batteryPercent == null || Thread.currentThread().isInterrupted()) {
+            return;
+        }
+        onBatteryLevelUpdated(device, batteryPercent);
+
+        ChargeMode chargeMode = pollCommand(device, new GetChargeStateCommand(), "charge state");
+        if (chargeMode == null || Thread.currentThread().isInterrupted()) {
+            return;
+        }
+        lastWasCharging = chargeMode == ChargeMode.CHARGING;
+
+        CleanMode mode = pollCommand(device, new GetMowerStateCommand(), "mower state");
+        if (mode == null || Thread.currentThread().isInterrupted()) {
+            return;
+        }
+        lastCleanMode = mode;
+        updateMowerStateChannel();
+
+        TotalStats totalStats = pollCommand(device, new GetTotalStatsCommand(), "total stats");
+        if (totalStats == null || Thread.currentThread().isInterrupted()) {
+            return;
+        }
+        updateState(CHANNEL_ID_TOTAL_MOWING_TIME, new QuantityType<>(totalStats.totalRuntime / 3600.0, Units.HOUR));
+        updateState(CHANNEL_ID_TOTAL_MOWED_AREA, new QuantityType<>(totalStats.totalArea, SIUnits.SQUARE_METRE));
+        updateState(CHANNEL_ID_TOTAL_MOW_RUNS, new DecimalType(totalStats.cleanRuns));
+
+        if (device.hasCapability(DeviceCapability.READ_NETWORK_INFO)) {
+            NetworkInfo netInfo = pollCommand(device, new GetNetworkInfoCommand(), "network info");
+            if (Thread.currentThread().isInterrupted()) {
+                return;
+            }
+            if (netInfo != null && netInfo.wifiRssi != 0) {
+                updateState(CHANNEL_ID_WIFI_RSSI, new QuantityType<>(netInfo.wifiRssi, Units.DECIBEL_MILLIWATTS));
+            }
+        }
+
+        Integer bladePercent = pollCommand(device, new GetComponentLifeSpanCommand(Component.BLADE), "blade lifespan");
+        if (bladePercent == null || Thread.currentThread().isInterrupted()) {
+            return;
+        }
+        updateState(CHANNEL_ID_BLADE_LIFETIME, new QuantityType<>(bladePercent, Units.PERCENT));
+
+        if (device.hasCapability(DeviceCapability.CUTTING_HEIGHT)) {
+            Integer heightMm = pollCommand(device, new GetCuttingHeightCommand(), "cutting height");
+            if (Thread.currentThread().isInterrupted()) {
+                return;
+            }
+            if (heightMm != null) {
+                updateState(CHANNEL_ID_CUTTING_HEIGHT, new QuantityType<>(heightMm, MetricPrefix.MILLI(SIUnits.METRE)));
+            }
+        }
+
+        if (device.hasCapability(DeviceCapability.VOICE_REPORTING)) {
+            Integer level = pollCommand(device, new GetVolumeCommand(), "volume");
+            if (Thread.currentThread().isInterrupted()) {
+                return;
+            }
+            if (level != null) {
+                updateState(CHANNEL_ID_VOICE_VOLUME, new PercentType(level * 10));
+            }
+        }
+
+        if (device.hasCapability(DeviceCapability.TRUE_DETECT_3D)) {
+            Boolean trueDetectEnabled = pollCommand(device, new GetTrueDetectCommand(), "TrueDetect state");
+            if (Thread.currentThread().isInterrupted()) {
+                return;
+            }
+            if (trueDetectEnabled != null) {
+                updateState(CHANNEL_ID_TRUE_DETECT_3D, OnOffType.from(trueDetectEnabled));
+            }
+        }
+
+        if (device.hasCapability(DeviceCapability.SAFE_PROTECT)) {
+            Boolean safeProtect = pollCommand(device, new GetSafeProtectCommand(), "SafeProtect state");
+            if (Thread.currentThread().isInterrupted()) {
+                return;
+            }
+            if (safeProtect != null) {
+                updateState(CHANNEL_ID_SAFE_PROTECT, OnOffType.from(safeProtect));
+            }
+        }
+
+        if (device.hasCapability(DeviceCapability.CHILD_LOCK)) {
+            Boolean childLock = pollCommand(device, new GetChildLockCommand(), "child lock state");
+            if (Thread.currentThread().isInterrupted()) {
+                return;
+            }
+            if (childLock != null) {
+                updateState(CHANNEL_ID_CHILD_LOCK, OnOffType.from(childLock));
+            }
+        }
+
+        if (device.hasCapability(DeviceCapability.MOVEUP_WARNING)) {
+            Boolean moveUpWarning = pollCommand(device, new GetMoveUpWarningCommand(), "move-up warning state");
+            if (Thread.currentThread().isInterrupted()) {
+                return;
+            }
+            if (moveUpWarning != null) {
+                updateState(CHANNEL_ID_MOVEUP_WARNING, OnOffType.from(moveUpWarning));
+            }
+        }
+
+        lastSuccessfulPollTimestamp = System.currentTimeMillis();
+        // Poll more frequently while mower is active (every 30s) to compensate for
+        // potentially dropped MQTT event subscriptions
+        CleanMode currentMode = lastCleanMode;
+        if (currentMode != null && (currentMode.isActive() || currentMode == CleanMode.RETURNING)) {
+            scheduleNextPoll(30);
+        } else {
+            scheduleNextPoll(-1);
+        }
+        logger.debug("{}: Mower data polling completed", serialNumber);
+    }
+
+    private <T> @Nullable T pollCommand(EcovacsDevice device, IotDeviceCommand<T> command, String name) {
+        try {
+            return device.sendCommand(command);
+        } catch (EcovacsApiException e) {
+            logger.debug("{}: Could not get {}: {}", serialNumber, name, e.getMessage());
+            return null;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return null;
+        }
+    }
+
+    // --- Channel management ---
+
+    private void removeUnsupportedChannels(EcovacsDevice device) {
+        var builder = editThing();
+        boolean hasChanges = false;
+
+        if (!device.hasCapability(DeviceCapability.CUTTING_HEIGHT)) {
+            hasChanges |= removeChannel(builder, CHANNEL_ID_CUTTING_HEIGHT);
+        }
+        if (!device.hasCapability(DeviceCapability.VOICE_REPORTING)) {
+            hasChanges |= removeChannel(builder, CHANNEL_ID_VOICE_VOLUME);
+        }
+        if (!device.hasCapability(DeviceCapability.TRUE_DETECT_3D)) {
+            hasChanges |= removeChannel(builder, CHANNEL_ID_TRUE_DETECT_3D);
+        }
+        if (!device.hasCapability(DeviceCapability.SAFE_PROTECT)) {
+            hasChanges |= removeChannel(builder, CHANNEL_ID_SAFE_PROTECT);
+        }
+        if (!device.hasCapability(DeviceCapability.CHILD_LOCK)) {
+            hasChanges |= removeChannel(builder, CHANNEL_ID_CHILD_LOCK);
+        }
+        if (!device.hasCapability(DeviceCapability.RAIN_DETECTION)) {
+            hasChanges |= removeChannel(builder, CHANNEL_ID_RAIN_DELAY);
+        }
+        if (!device.hasCapability(DeviceCapability.MOVEUP_WARNING)) {
+            hasChanges |= removeChannel(builder, CHANNEL_ID_MOVEUP_WARNING);
+        }
+        if (!device.hasCapability(DeviceCapability.READ_NETWORK_INFO)) {
+            hasChanges |= removeChannel(builder, CHANNEL_ID_WIFI_RSSI);
+        }
+
+        if (hasChanges) {
+            updateThing(builder.build());
+        }
+    }
+}

--- a/bundles/org.openhab.binding.ecovacs/src/main/java/org/openhab/binding/ecovacs/internal/handler/EcovacsVacuumHandler.java
+++ b/bundles/org.openhab.binding.ecovacs/src/main/java/org/openhab/binding/ecovacs/internal/handler/EcovacsVacuumHandler.java
@@ -29,7 +29,6 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.ecovacs.internal.EcovacsDynamicStateDescriptionProvider;
 import org.openhab.binding.ecovacs.internal.action.EcovacsVacuumActions;
-import org.openhab.binding.ecovacs.internal.api.EcovacsApi;
 import org.openhab.binding.ecovacs.internal.api.EcovacsApiException;
 import org.openhab.binding.ecovacs.internal.api.EcovacsDevice;
 import org.openhab.binding.ecovacs.internal.api.commands.AbstractNoResponseCommand;
@@ -76,11 +75,8 @@ import org.openhab.binding.ecovacs.internal.api.model.DeviceCapability;
 import org.openhab.binding.ecovacs.internal.api.model.MoppingWaterAmount;
 import org.openhab.binding.ecovacs.internal.api.model.NetworkInfo;
 import org.openhab.binding.ecovacs.internal.api.model.SuctionPower;
-import org.openhab.binding.ecovacs.internal.api.util.SchedulerTask;
-import org.openhab.binding.ecovacs.internal.config.EcovacsVacuumConfiguration;
 import org.openhab.binding.ecovacs.internal.util.StateOptionEntry;
 import org.openhab.binding.ecovacs.internal.util.StateOptionMapping;
-import org.openhab.core.i18n.ConfigurationException;
 import org.openhab.core.i18n.LocaleProvider;
 import org.openhab.core.i18n.TranslationProvider;
 import org.openhab.core.library.types.DateTimeType;
@@ -92,24 +88,17 @@ import org.openhab.core.library.types.RawType;
 import org.openhab.core.library.types.StringType;
 import org.openhab.core.library.unit.SIUnits;
 import org.openhab.core.library.unit.Units;
-import org.openhab.core.thing.Bridge;
 import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.Thing;
 import org.openhab.core.thing.ThingStatus;
 import org.openhab.core.thing.ThingStatusDetail;
-import org.openhab.core.thing.ThingStatusInfo;
 import org.openhab.core.thing.ThingUID;
-import org.openhab.core.thing.binding.BaseThingHandler;
 import org.openhab.core.thing.binding.ThingHandlerService;
 import org.openhab.core.thing.binding.builder.ThingBuilder;
 import org.openhab.core.types.Command;
 import org.openhab.core.types.State;
 import org.openhab.core.types.StateOption;
 import org.openhab.core.types.UnDefType;
-import org.osgi.framework.Bundle;
-import org.osgi.framework.FrameworkUtil;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * The {@link EcovacsVacuumHandler} is responsible for handling data and commands from/to vacuum cleaners.
@@ -117,44 +106,34 @@ import org.slf4j.LoggerFactory;
  * @author Danny Baumann - Initial contribution
  */
 @NonNullByDefault
-public class EcovacsVacuumHandler extends BaseThingHandler implements EcovacsDevice.EventListener {
+public class EcovacsVacuumHandler extends AbstractEcovacsDeviceHandler implements EcovacsDevice.EventListener {
 
-    private final Logger logger = LoggerFactory.getLogger(EcovacsVacuumHandler.class);
-
-    private final TranslationProvider i18Provider;
-    private final LocaleProvider localeProvider;
     private final EcovacsDynamicStateDescriptionProvider stateDescriptionProvider;
-    private final Bundle bundle;
 
-    private final SchedulerTask initTask;
-    private final SchedulerTask reconnectTask;
-    private final SchedulerTask pollTask;
-    private @Nullable EcovacsDevice device;
-
-    private @Nullable Boolean lastWasCharging;
-    private @Nullable CleanMode lastCleanMode;
     private @Nullable CleanMode lastActiveCleanMode;
     private Optional<String> lastDownloadedCleanMapUrl = Optional.empty();
-    private long lastSuccessfulPollTimestamp;
     private int lastDefaultCleaningPasses = 1;
-    private String serialNumber = "<unset>";
 
     public EcovacsVacuumHandler(Thing thing, TranslationProvider i18Provider, LocaleProvider localeProvider,
             EcovacsDynamicStateDescriptionProvider stateDescriptionProvider) {
-        super(thing);
-        this.i18Provider = i18Provider;
-        this.localeProvider = localeProvider;
+        super(thing, i18Provider, localeProvider);
         this.stateDescriptionProvider = stateDescriptionProvider;
-        bundle = FrameworkUtil.getBundle(getClass());
+    }
 
-        initTask = new SchedulerTask(scheduler, logger, "Init", this::initDevice);
-        reconnectTask = new SchedulerTask(scheduler, logger, "Connection", this::connectToDevice);
-        pollTask = new SchedulerTask(scheduler, logger, "Poll", this::pollData);
+    @Override
+    protected String getLogPrefix() {
+        return "vacuum";
     }
 
     @Override
     public Collection<Class<? extends ThingHandlerService>> getServices() {
         return Set.of(EcovacsVacuumActions.class);
+    }
+
+    @Override
+    protected void afterDeviceFound(EcovacsDevice device) {
+        updateStateOptions(device);
+        removeUnsupportedChannels(device);
     }
 
     @Override
@@ -209,7 +188,7 @@ public class EcovacsVacuumHandler extends BaseThingHandler implements EcovacsDev
             } else if (channel.equals(CHANNEL_ID_CLEANING_PASSES) && command instanceof DecimalType type) {
                 int passes = type.intValue();
                 device.sendCommand(new SetDefaultCleanPassesCommand(passes));
-                lastDefaultCleaningPasses = passes; // if we get here, the command was executed successfully
+                lastDefaultCleaningPasses = passes;
                 return;
             }
             logger.debug("{}: Ignoring unsupported device command {} for channel {}", serialNumber, command, channel);
@@ -218,28 +197,6 @@ public class EcovacsVacuumHandler extends BaseThingHandler implements EcovacsDev
         } catch (EcovacsApiException e) {
             logger.debug("{}: Handling device command {} failed", serialNumber, command, e);
         }
-    }
-
-    @Override
-    public void initialize() {
-        serialNumber = getConfigAs(EcovacsVacuumConfiguration.class).serialNumber;
-        if (serialNumber.isEmpty()) {
-            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
-                    "@text/offline.config-error-no-serial");
-        } else {
-            logger.debug("{}: Initializing handler", serialNumber);
-            updateStatus(ThingStatus.UNKNOWN);
-            initTask.setNamePrefix(serialNumber);
-            reconnectTask.setNamePrefix(serialNumber);
-            pollTask.setNamePrefix(serialNumber);
-            initTask.submit();
-        }
-    }
-
-    @Override
-    public void dispose() {
-        logger.debug("{}: Disposing handler", serialNumber);
-        teardown(false);
     }
 
     @Override
@@ -266,7 +223,7 @@ public class EcovacsVacuumHandler extends BaseThingHandler implements EcovacsDev
                 case CHANNEL_ID_ERROR_DESCRIPTION:
                     fetchInitialErrorCode(device);
                 default:
-                    scheduleNextPoll(5); // add some delay in case multiple channels are linked at once
+                    scheduleNextPoll(5);
                     break;
             }
         } catch (InterruptedException e) {
@@ -276,23 +233,7 @@ public class EcovacsVacuumHandler extends BaseThingHandler implements EcovacsDev
         }
     }
 
-    @Override
-    public void bridgeStatusChanged(ThingStatusInfo bridgeStatusInfo) {
-        logger.debug("{}: Bridge status changed to {}", serialNumber, bridgeStatusInfo);
-        if (bridgeStatusInfo.getStatus() == ThingStatus.ONLINE) {
-            initTask.submit();
-        } else if (bridgeStatusInfo.getStatus() == ThingStatus.OFFLINE) {
-            teardown(false);
-            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE);
-        }
-    }
-
-    @Override
-    public void onBatteryLevelUpdated(EcovacsDevice device, int newLevelPercent) {
-        // Some devices report weird values (> 100%), so better clamp to supported range
-        int actualPercent = Math.max(0, Math.min(newLevelPercent, 100));
-        updateState(CHANNEL_ID_BATTERY_LEVEL, new DecimalType(actualPercent));
-    }
+    // --- EcovacsDevice.EventListener callbacks ---
 
     @Override
     public void onChargingStateUpdated(EcovacsDevice device, boolean charging) {
@@ -311,7 +252,6 @@ public class EcovacsVacuumHandler extends BaseThingHandler implements EcovacsDev
         updateStateAndCommandChannels();
         Optional<State> areaDefState = areaDefinition.map(def -> {
             if (newMode == CleanMode.SPOT_AREA) {
-                // Map indices back to letters as shown in the app
                 def = Arrays.stream(def.split(",")).map(item -> {
                     try {
                         int index = Integer.parseInt(item);
@@ -321,7 +261,6 @@ public class EcovacsVacuumHandler extends BaseThingHandler implements EcovacsDev
                     }
                 }).collect(Collectors.joining(";"));
             } else if (newMode == CleanMode.CUSTOM_AREA) {
-                // Map the separator from comma to semicolon to allow using the output as command input
                 def = def.replace(',', ';');
             }
             return new StringType(def);
@@ -342,6 +281,10 @@ public class EcovacsVacuumHandler extends BaseThingHandler implements EcovacsDev
     }
 
     @Override
+    public void onMowingStatsUpdated(EcovacsDevice device, int mowedAreaSqCm, int timeSeconds) {
+    }
+
+    @Override
     public void onWaterSystemPresentUpdated(EcovacsDevice device, boolean present) {
         updateState(CHANNEL_ID_WATER_PLATE_PRESENT, OnOffType.from(present));
     }
@@ -358,15 +301,10 @@ public class EcovacsVacuumHandler extends BaseThingHandler implements EcovacsDev
     }
 
     @Override
-    public void onEventStreamFailure(final EcovacsDevice device, Throwable error) {
-        logger.debug("{}: Device connection failed, reconnecting", serialNumber, error);
-        teardownAndScheduleReconnection();
+    public void onMowingSessionFinished(EcovacsDevice device, long startTimestamp, int durationSeconds, int areaSqCm) {
     }
 
-    @Override
-    public void onFirmwareVersionChanged(EcovacsDevice device, String fwVersion) {
-        updateProperty(Thing.PROPERTY_FIRMWARE_VERSION, fwVersion);
-    }
+    // --- playSound action ---
 
     public void playSound(PlaySoundCommand command) {
         doWithDevice(device -> {
@@ -377,6 +315,51 @@ public class EcovacsVacuumHandler extends BaseThingHandler implements EcovacsDev
             }
         });
     }
+
+    // --- doWithDevice override with auth failure handling ---
+
+    @Override
+    protected void doWithDevice(DeviceAction action) {
+        EcovacsDevice device = this.device;
+        if (device == null) {
+            return;
+        }
+        try {
+            action.run(device);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        } catch (EcovacsApiException e) {
+            logger.debug("{}: Failed communicating to device, reconnecting", serialNumber, e);
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, e.getMessage());
+            if (e.isAuthFailure) {
+                EcovacsApiHandler apiHandler = getApiHandler();
+                if (apiHandler != null) {
+                    apiHandler.onLoginExpired();
+                }
+                device.disconnect(scheduler);
+                this.device = null;
+            }
+            teardownAndScheduleReconnection();
+        }
+    }
+
+    // --- Connectivity ---
+
+    @Override
+    protected void connectToDevice() {
+        doWithDevice(device -> {
+            device.connect(this, scheduler);
+            fetchInitialBatteryStatus(device);
+            fetchInitialStateAndCommandValues(device);
+            fetchInitialWaterSystemPresentState(device);
+            fetchInitialErrorCode(device);
+            scheduleNextPoll(-1);
+            logger.debug("{}: Device connected", serialNumber);
+            updateStatus(ThingStatus.ONLINE);
+        });
+    }
+
+    // --- Fetch methods ---
 
     private void fetchInitialBatteryStatus(EcovacsDevice device) throws EcovacsApiException, InterruptedException {
         Integer batteryPercent = device.sendCommand(new GetBatteryInfoCommand());
@@ -410,183 +393,10 @@ public class EcovacsVacuumHandler extends BaseThingHandler implements EcovacsDev
         }
     }
 
-    private void removeUnsupportedChannels(EcovacsDevice device) {
-        ThingBuilder builder = editThing();
-        boolean hasChanges = false;
+    // --- Polling ---
 
-        if (!device.hasCapability(DeviceCapability.MOPPING_SYSTEM)) {
-            hasChanges |= removeUnsupportedChannel(builder, CHANNEL_ID_WATER_AMOUNT);
-            hasChanges |= removeUnsupportedChannel(builder, CHANNEL_ID_WATER_AMOUNT_PERCENT);
-            hasChanges |= removeUnsupportedChannel(builder, CHANNEL_ID_WATER_PLATE_PRESENT);
-        } else if (device.hasCapability(DeviceCapability.CUSTOM_WATER_AMOUNT)) {
-            hasChanges |= removeUnsupportedChannel(builder, CHANNEL_ID_WATER_AMOUNT);
-        } else {
-            hasChanges |= removeUnsupportedChannel(builder, CHANNEL_ID_WATER_AMOUNT_PERCENT);
-        }
-        if (!device.hasCapability(DeviceCapability.CLEAN_SPEED_CONTROL)) {
-            hasChanges |= removeUnsupportedChannel(builder, CHANNEL_ID_SUCTION_POWER);
-        }
-        if (!device.hasCapability(DeviceCapability.MAIN_BRUSH)) {
-            hasChanges |= removeUnsupportedChannel(builder, CHANNEL_ID_MAIN_BRUSH_LIFETIME);
-        }
-        if (!device.hasCapability(DeviceCapability.VOICE_REPORTING)) {
-            hasChanges |= removeUnsupportedChannel(builder, CHANNEL_ID_VOICE_VOLUME);
-        }
-        if (!device.hasCapability(DeviceCapability.EXTENDED_CLEAN_LOG_RECORD)) {
-            hasChanges |= removeUnsupportedChannel(builder, CHANNEL_ID_LAST_CLEAN_MODE);
-        }
-        if (!device.hasCapability(DeviceCapability.MAPPING)
-                || !device.hasCapability(DeviceCapability.EXTENDED_CLEAN_LOG_RECORD)) {
-            hasChanges |= removeUnsupportedChannel(builder, CHANNEL_ID_LAST_CLEAN_MAP);
-        }
-        if (!device.hasCapability(DeviceCapability.READ_NETWORK_INFO)) {
-            hasChanges |= removeUnsupportedChannel(builder, CHANNEL_ID_WIFI_RSSI);
-        }
-        if (!device.hasCapability(DeviceCapability.AUTO_EMPTY_STATION)) {
-            hasChanges |= removeUnsupportedChannel(builder, CHANNEL_ID_AUTO_EMPTY);
-        }
-        if (!device.hasCapability(DeviceCapability.TRUE_DETECT_3D)) {
-            hasChanges |= removeUnsupportedChannel(builder, CHANNEL_ID_TRUE_DETECT_3D);
-        }
-        if (!device.hasCapability(DeviceCapability.DEFAULT_CLEAN_COUNT_SETTING)) {
-            hasChanges |= removeUnsupportedChannel(builder, CHANNEL_ID_CLEANING_PASSES);
-        }
-        if (!device.hasCapability(DeviceCapability.UNIT_CARE_LIFESPAN)) {
-            hasChanges |= removeUnsupportedChannel(builder, CHANNEL_ID_OTHER_COMPONENT_LIFETIME);
-        }
-        if (!device.hasCapability(DeviceCapability.ROUND_MOP_LIFESPAN)) {
-            hasChanges |= removeUnsupportedChannel(builder, CHANNEL_ID_ROUND_MOP_LIFETIME);
-        }
-
-        if (hasChanges) {
-            updateThing(builder.build());
-        }
-    }
-
-    private boolean removeUnsupportedChannel(ThingBuilder builder, String channelId) {
-        ChannelUID channelUID = new ChannelUID(getThing().getUID(), channelId);
-        if (getThing().getChannel(channelUID) == null) {
-            return false;
-        }
-        logger.debug("{}: Removing unsupported channel {}", serialNumber, channelId);
-        builder.withoutChannel(channelUID);
-        return true;
-    }
-
-    private void updateStateOptions(EcovacsDevice device) {
-        List<StateOption> modeChannelOptions = createChannelOptions(device, CleanMode.values(), CLEAN_MODE_MAPPING,
-                m -> m.enumValue.isActive());
-        ThingUID thingUID = getThing().getUID();
-
-        stateDescriptionProvider.setStateOptions(new ChannelUID(thingUID, CHANNEL_ID_CLEANING_MODE),
-                modeChannelOptions);
-        stateDescriptionProvider.setStateOptions(new ChannelUID(thingUID, CHANNEL_ID_LAST_CLEAN_MODE),
-                modeChannelOptions);
-        stateDescriptionProvider.setStateOptions(new ChannelUID(thingUID, CHANNEL_ID_SUCTION_POWER),
-                createChannelOptions(device, SuctionPower.values(), SUCTION_POWER_MAPPING, null));
-        stateDescriptionProvider.setStateOptions(new ChannelUID(thingUID, CHANNEL_ID_WATER_AMOUNT),
-                createChannelOptions(device, MoppingWaterAmount.values(), WATER_AMOUNT_MAPPING, null));
-    }
-
-    private <T extends Enum<T>> List<StateOption> createChannelOptions(EcovacsDevice device, T[] values,
-            StateOptionMapping<T> mapping, @Nullable Predicate<StateOptionEntry<T>> filter) {
-        return Arrays.stream(values).map(v -> Optional.ofNullable(mapping.get(v)))
-                // ensure we have a mapping (should always be the case)
-                .filter(Optional::isPresent).map(opt -> opt.get())
-                // apply supplied filter
-                .filter(mv -> filter == null || filter.test(mv))
-                // apply capability filter
-                .filter(mv -> mv.capability.isEmpty() || device.hasCapability(mv.capability.get()))
-                // map to actual option
-                .map(mv -> new StateOption(mv.value, mv.value)).collect(Collectors.toList());
-    }
-
-    private synchronized void scheduleNextPoll(long initialDelaySeconds) {
-        final EcovacsVacuumConfiguration config = getConfigAs(EcovacsVacuumConfiguration.class);
-        final long delayUntilNextPoll;
-        if (initialDelaySeconds < 0) {
-            long intervalSeconds = config.refresh * 60;
-            long secondsSinceLastPoll = (System.currentTimeMillis() - lastSuccessfulPollTimestamp) / 1000;
-            long deltaRemaining = intervalSeconds - secondsSinceLastPoll;
-            delayUntilNextPoll = Math.max(0, deltaRemaining);
-        } else {
-            delayUntilNextPoll = initialDelaySeconds;
-        }
-        logger.debug("{}: Scheduling next poll in {}s, refresh interval {}min", serialNumber, delayUntilNextPoll,
-                config.refresh);
-        pollTask.cancel();
-        pollTask.schedule(delayUntilNextPoll);
-    }
-
-    private void initDevice() {
-        final EcovacsApiHandler handler = getApiHandler();
-        if (handler == null) {
-            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_UNINITIALIZED);
-            return;
-        }
-
-        try {
-            final EcovacsApi api = handler.createApiForDevice(serialNumber);
-            api.loginAndGetAccessToken();
-            Optional<EcovacsDevice> deviceOpt = api.getDevices().stream()
-                    .filter(d -> serialNumber.equals(d.getSerialNumber())).findFirst();
-            if (deviceOpt.isPresent()) {
-                EcovacsDevice device = deviceOpt.get();
-                this.device = device;
-                updateProperty(Thing.PROPERTY_MODEL_ID, device.getModelName());
-                updateProperty(Thing.PROPERTY_SERIAL_NUMBER, device.getSerialNumber());
-                updateStateOptions(device);
-                removeUnsupportedChannels(device);
-                connectToDevice();
-            } else {
-                logger.info("{}: Device not found in device list, setting offline", serialNumber);
-                updateStatus(ThingStatus.OFFLINE);
-            }
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-        } catch (ConfigurationException e) {
-            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, e.getRawMessage());
-        } catch (EcovacsApiException e) {
-            logger.debug("API Exception: {}", e.getMessage(), e);
-            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, e.getMessage());
-        }
-    }
-
-    private void teardownAndScheduleReconnection() {
-        teardown(true);
-    }
-
-    private synchronized void teardown(boolean scheduleReconnection) {
-        EcovacsDevice device = this.device;
-        if (device != null) {
-            device.disconnect(scheduler);
-        }
-
-        pollTask.cancel();
-
-        reconnectTask.cancel();
-        initTask.cancel();
-
-        if (scheduleReconnection) {
-            SchedulerTask connectTask = device != null ? reconnectTask : initTask;
-            connectTask.schedule(5);
-        }
-    }
-
-    private void connectToDevice() {
-        doWithDevice(device -> {
-            device.connect(this, scheduler);
-            fetchInitialBatteryStatus(device);
-            fetchInitialStateAndCommandValues(device);
-            fetchInitialWaterSystemPresentState(device); // nop if unsupported
-            fetchInitialErrorCode(device);
-            scheduleNextPoll(-1);
-            logger.debug("{}: Device connected", serialNumber);
-            updateStatus(ThingStatus.ONLINE);
-        });
-    }
-
-    private void pollData() {
+    @Override
+    protected void pollData() {
         logger.debug("{}: Polling data", serialNumber);
         doWithDevice(device -> {
             TotalStats totalStats = device.sendCommand(new GetTotalStatsCommand());
@@ -683,6 +493,8 @@ public class EcovacsVacuumHandler extends BaseThingHandler implements EcovacsDev
         logger.debug("{}: Data polling completed", serialNumber);
     }
 
+    // --- State and command channel helpers ---
+
     private void updateStateAndCommandChannels() {
         Boolean charging = this.lastWasCharging;
         CleanMode cleanMode = this.lastCleanMode;
@@ -698,9 +510,6 @@ public class EcovacsVacuumHandler extends BaseThingHandler implements EcovacsDev
 
     private String determineStateChannelValue(boolean charging, CleanMode cleanMode) {
         if (charging) {
-            // Some devices already report charging state while returning to charging station, make sure to not report
-            // charging in that case. The same applies for models with pad washing/drying station, as those states imply
-            // the device being charging.
             if (cleanMode != CleanMode.RETURNING && cleanMode != CleanMode.WASHING && cleanMode != CleanMode.DRYING
                     && cleanMode != CleanMode.EMPTYING) {
                 return "charging";
@@ -766,7 +575,6 @@ public class EcovacsVacuumHandler extends BaseThingHandler implements EcovacsDev
                 int passes = splitted.length == 3 && "x2".equals(splitted[2]) ? 2 : lastDefaultCleaningPasses;
                 List<String> roomIds = new ArrayList<>();
                 for (String id : splitted[1].split(";")) {
-                    // We let the user pass in letters as in Ecovacs' app, but the API wants indices
                     if (id.length() == 1 && id.charAt(0) >= 'A' && id.charAt(0) <= 'Z') {
                         roomIds.add(String.valueOf(id.charAt(0) - 'A'));
                     } else {
@@ -799,7 +607,6 @@ public class EcovacsVacuumHandler extends BaseThingHandler implements EcovacsDev
             String[] splitted = command.split(":");
             if (splitted.length == 2) {
                 String scenarioId = splitted[1];
-                // Setting passes > 1 does not seem to have any effect (tested on T30).
                 return new SceneCleaningCommand(scenarioId, 1);
             }
             logger.warn("{}: {} command needs to have the form {}:<scenarioId>", serialNumber, CMD_SCENE_CLEAN,
@@ -809,38 +616,83 @@ public class EcovacsVacuumHandler extends BaseThingHandler implements EcovacsDev
         return null;
     }
 
-    private interface WithDeviceAction {
-        void run(EcovacsDevice device) throws EcovacsApiException, InterruptedException;
+    // --- State options ---
+
+    private void updateStateOptions(EcovacsDevice device) {
+        List<StateOption> modeChannelOptions = createChannelOptions(device, CleanMode.values(), CLEAN_MODE_MAPPING,
+                m -> m.enumValue.isActive());
+        ThingUID thingUID = getThing().getUID();
+
+        stateDescriptionProvider.setStateOptions(new ChannelUID(thingUID, CHANNEL_ID_CLEANING_MODE),
+                modeChannelOptions);
+        stateDescriptionProvider.setStateOptions(new ChannelUID(thingUID, CHANNEL_ID_LAST_CLEAN_MODE),
+                modeChannelOptions);
+        stateDescriptionProvider.setStateOptions(new ChannelUID(thingUID, CHANNEL_ID_SUCTION_POWER),
+                createChannelOptions(device, SuctionPower.values(), SUCTION_POWER_MAPPING, null));
+        stateDescriptionProvider.setStateOptions(new ChannelUID(thingUID, CHANNEL_ID_WATER_AMOUNT),
+                createChannelOptions(device, MoppingWaterAmount.values(), WATER_AMOUNT_MAPPING, null));
     }
 
-    private void doWithDevice(WithDeviceAction action) {
-        EcovacsDevice device = this.device;
-        if (device == null) {
-            return;
-        }
-        try {
-            action.run(device);
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-        } catch (EcovacsApiException e) {
-            logger.debug("{}: Failed communicating to device, reconnecting", serialNumber, e);
-            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, e.getMessage());
-            if (e.isAuthFailure) {
-                EcovacsApiHandler apiHandler = getApiHandler();
-                if (apiHandler != null) {
-                    apiHandler.onLoginExpired();
-                }
-                // Drop our device instance to make sure we run a full init cycle,
-                // including an API re-login, on reconnection
-                device.disconnect(scheduler);
-                this.device = null;
-            }
-            teardownAndScheduleReconnection();
-        }
+    private <T extends Enum<T>> List<StateOption> createChannelOptions(EcovacsDevice device, T[] values,
+            StateOptionMapping<T> mapping, @Nullable Predicate<StateOptionEntry<T>> filter) {
+        return Arrays.stream(values).map(v -> Optional.ofNullable(mapping.get(v))).filter(Optional::isPresent)
+                .map(opt -> opt.get()).filter(mv -> filter == null || filter.test(mv))
+                .filter(mv -> mv.capability.isEmpty() || device.hasCapability(mv.capability.get()))
+                .map(mv -> new StateOption(mv.value, mv.value)).collect(Collectors.toList());
     }
 
-    private @Nullable EcovacsApiHandler getApiHandler() {
-        final Bridge bridge = getBridge();
-        return bridge != null ? (EcovacsApiHandler) bridge.getHandler() : null;
+    // --- Channel management ---
+
+    private void removeUnsupportedChannels(EcovacsDevice device) {
+        ThingBuilder builder = editThing();
+        boolean hasChanges = false;
+
+        if (!device.hasCapability(DeviceCapability.MOPPING_SYSTEM)) {
+            hasChanges |= removeChannel(builder, CHANNEL_ID_WATER_AMOUNT);
+            hasChanges |= removeChannel(builder, CHANNEL_ID_WATER_AMOUNT_PERCENT);
+            hasChanges |= removeChannel(builder, CHANNEL_ID_WATER_PLATE_PRESENT);
+        } else if (device.hasCapability(DeviceCapability.CUSTOM_WATER_AMOUNT)) {
+            hasChanges |= removeChannel(builder, CHANNEL_ID_WATER_AMOUNT);
+        } else {
+            hasChanges |= removeChannel(builder, CHANNEL_ID_WATER_AMOUNT_PERCENT);
+        }
+        if (!device.hasCapability(DeviceCapability.CLEAN_SPEED_CONTROL)) {
+            hasChanges |= removeChannel(builder, CHANNEL_ID_SUCTION_POWER);
+        }
+        if (!device.hasCapability(DeviceCapability.MAIN_BRUSH)) {
+            hasChanges |= removeChannel(builder, CHANNEL_ID_MAIN_BRUSH_LIFETIME);
+        }
+        if (!device.hasCapability(DeviceCapability.VOICE_REPORTING)) {
+            hasChanges |= removeChannel(builder, CHANNEL_ID_VOICE_VOLUME);
+        }
+        if (!device.hasCapability(DeviceCapability.EXTENDED_CLEAN_LOG_RECORD)) {
+            hasChanges |= removeChannel(builder, CHANNEL_ID_LAST_CLEAN_MODE);
+        }
+        if (!device.hasCapability(DeviceCapability.MAPPING)
+                || !device.hasCapability(DeviceCapability.EXTENDED_CLEAN_LOG_RECORD)) {
+            hasChanges |= removeChannel(builder, CHANNEL_ID_LAST_CLEAN_MAP);
+        }
+        if (!device.hasCapability(DeviceCapability.READ_NETWORK_INFO)) {
+            hasChanges |= removeChannel(builder, CHANNEL_ID_WIFI_RSSI);
+        }
+        if (!device.hasCapability(DeviceCapability.AUTO_EMPTY_STATION)) {
+            hasChanges |= removeChannel(builder, CHANNEL_ID_AUTO_EMPTY);
+        }
+        if (!device.hasCapability(DeviceCapability.TRUE_DETECT_3D)) {
+            hasChanges |= removeChannel(builder, CHANNEL_ID_TRUE_DETECT_3D);
+        }
+        if (!device.hasCapability(DeviceCapability.DEFAULT_CLEAN_COUNT_SETTING)) {
+            hasChanges |= removeChannel(builder, CHANNEL_ID_CLEANING_PASSES);
+        }
+        if (!device.hasCapability(DeviceCapability.UNIT_CARE_LIFESPAN)) {
+            hasChanges |= removeChannel(builder, CHANNEL_ID_OTHER_COMPONENT_LIFETIME);
+        }
+        if (!device.hasCapability(DeviceCapability.ROUND_MOP_LIFESPAN)) {
+            hasChanges |= removeChannel(builder, CHANNEL_ID_ROUND_MOP_LIFETIME);
+        }
+
+        if (hasChanges) {
+            updateThing(builder.build());
+        }
     }
 }

--- a/bundles/org.openhab.binding.ecovacs/src/main/resources/OH-INF/i18n/ecovacs.properties
+++ b/bundles/org.openhab.binding.ecovacs/src/main/resources/OH-INF/i18n/ecovacs.properties
@@ -1,7 +1,7 @@
 # add-on
 
 addon.ecovacs.name = Ecovacs Binding
-addon.ecovacs.description = This is the binding for Ecovacs Deebot vacuum cleaners.
+addon.ecovacs.description = This is the binding for Ecovacs Deebot vacuum cleaners and GOAT robotic lawn mowers.
 
 # thing types
 
@@ -9,6 +9,8 @@ thing-type.ecovacs.ecovacsapi.label = Ecovacs API Account
 thing-type.ecovacs.ecovacsapi.description = The API account
 thing-type.ecovacs.vacuum.label = Ecovacs Vacuum Cleaner
 thing-type.ecovacs.vacuum.description = Represents an Ecovacs vacuum cleaner
+thing-type.ecovacs.mower.label = Ecovacs GOAT Mower
+thing-type.ecovacs.mower.description = Represents an Ecovacs GOAT robotic lawn mower
 
 # thing types config
 
@@ -25,6 +27,9 @@ thing-type.config.ecovacs.ecovacsapi.password.description = Password for logging
 thing-type.config.ecovacs.vacuum.refresh.label = Refresh Interval
 thing-type.config.ecovacs.vacuum.refresh.description = Specifies the refresh interval in minutes.
 thing-type.config.ecovacs.vacuum.serialNumber.label = Device Serial Number
+thing-type.config.ecovacs.mower.refresh.label = Refresh Interval
+thing-type.config.ecovacs.mower.refresh.description = Specifies the refresh interval in minutes.
+thing-type.config.ecovacs.mower.serialNumber.label = Device Serial Number
 
 # channel group types
 
@@ -34,6 +39,12 @@ channel-group-type.ecovacs.last-clean.label = Last Clean Run
 channel-group-type.ecovacs.settings.label = Settings
 channel-group-type.ecovacs.status.label = Status
 channel-group-type.ecovacs.total-stats.label = Device Lifetime Statistics
+channel-group-type.ecovacs.mower-actions.label = Actions
+channel-group-type.ecovacs.mower-consumables.label = Consumables
+channel-group-type.ecovacs.mower-settings.label = Settings
+channel-group-type.ecovacs.mower-status.label = Status
+channel-group-type.ecovacs.mower-total-stats.label = Device Lifetime Statistics
+channel-group-type.ecovacs.last-mow.label = Last Mow Run
 
 # channel types
 
@@ -119,6 +130,55 @@ channel-type.ecovacs.water-system-present.description = Water plate with mop att
 channel-type.ecovacs.wifi-rssi.label = Wi-Fi Signal Strength
 channel-type.ecovacs.wifi-rssi.description = Received signal strength indicator for Wi-Fi
 
+# mower channel types
+
+channel-type.ecovacs.mower-state.label = Mower State
+channel-type.ecovacs.mower-state.description = Current operational state of the mower
+channel-type.ecovacs.mower-state.state.option.mowing = Mowing
+channel-type.ecovacs.mower-state.state.option.paused = Paused
+channel-type.ecovacs.mower-state.state.option.returning = Returning to dock
+channel-type.ecovacs.mower-state.state.option.charging = Charging
+channel-type.ecovacs.mower-state.state.option.idle = Idle
+channel-type.ecovacs.mower-state.state.option.docked = Docked
+channel-type.ecovacs.mower-state.state.option.error = Error
+channel-type.ecovacs.mower-state.state.option.edgeCutting = Edge cutting
+channel-type.ecovacs.mower-command.label = Command
+channel-type.ecovacs.mower-command.description = Command to execute
+channel-type.ecovacs.mower-command.state.option.mow = Start mowing
+channel-type.ecovacs.mower-command.state.option.pause = Pause mowing
+channel-type.ecovacs.mower-command.state.option.resume = Resume mowing
+channel-type.ecovacs.mower-command.state.option.stop = Stop
+channel-type.ecovacs.mower-command.state.option.dock = Return to dock
+channel-type.ecovacs.mower-command.state.option.edgeCut = Start edge cutting
+channel-type.ecovacs.current-mowing-time.label = Current Mowing Time
+channel-type.ecovacs.current-mowing-time.description = Mowing time in current session
+channel-type.ecovacs.current-mowed-area.label = Current Mowed Area
+channel-type.ecovacs.current-mowed-area.description = Mowed area in current session
+channel-type.ecovacs.total-mowing-time.label = Total Mowing Time
+channel-type.ecovacs.total-mowing-time.description = Total mowing time in device life time
+channel-type.ecovacs.total-mowed-area.label = Total Mowed Area
+channel-type.ecovacs.total-mowed-area.description = Total mowed area in device life time
+channel-type.ecovacs.total-mow-runs.label = Total Mow Runs
+channel-type.ecovacs.total-mow-runs.description = Number of mowing runs in device life time
+channel-type.ecovacs.last-mow-start.label = Last Mow Start
+channel-type.ecovacs.last-mow-start.description = Start time of last completed mowing run
+channel-type.ecovacs.last-mow-duration.label = Last Mow Duration
+channel-type.ecovacs.last-mow-duration.description = Duration of last completed mowing run
+channel-type.ecovacs.last-mow-area.label = Last Mowed Area
+channel-type.ecovacs.last-mow-area.description = Mowed area in last completed mowing run
+channel-type.ecovacs.blade-lifetime.label = Blade Lifetime
+channel-type.ecovacs.blade-lifetime.description = Remaining life time of cutting blades in percent
+channel-type.ecovacs.cutting-height.label = Cutting Height
+channel-type.ecovacs.cutting-height.description = Cutting height of the mower blades
+channel-type.ecovacs.safe-protect.label = SafeProtect
+channel-type.ecovacs.safe-protect.description = Stop mower when an obstacle or unsafe condition is detected
+channel-type.ecovacs.child-lock.label = Child Lock
+channel-type.ecovacs.child-lock.description = Lock the mower to prevent unintended operation
+channel-type.ecovacs.rain-delay.label = Rain Delay
+channel-type.ecovacs.rain-delay.description = Rain detected, mowing delayed
+channel-type.ecovacs.moveup-warning.label = Move-Up Warning
+channel-type.ecovacs.moveup-warning.description = Trigger alarm when the mower is lifted off the ground
+
 # cleaning modes
 
 ecovacs.cleaning-mode.auto = Automatic
@@ -167,6 +227,10 @@ ecovacs.vacuum.error-code.500 = Request timeout
 ecovacs.vacuum.error-code.601 = AIVI side error
 ecovacs.vacuum.error-code.602 = AIVI roll error
 ecovacs.vacuum.error-code.unknown = Unknown error ({0})
+
+# mower error codes
+ecovacs.mower.error-code.0 = No error
+ecovacs.mower.error-code.unknown = Unknown error ({0})
 
 # thing status descriptions
 

--- a/bundles/org.openhab.binding.ecovacs/src/main/resources/OH-INF/thing/mower-thing-types.xml
+++ b/bundles/org.openhab.binding.ecovacs/src/main/resources/OH-INF/thing/mower-thing-types.xml
@@ -1,0 +1,269 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="ecovacs"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
+
+	<thing-type id="mower">
+		<supported-bridge-type-refs>
+			<bridge-type-ref id="ecovacsapi"/>
+		</supported-bridge-type-refs>
+
+		<label>Ecovacs GOAT Mower</label>
+		<description>Represents an Ecovacs GOAT robotic lawn mower</description>
+		<category>LawnMower</category>
+		<semantic-equipment-tag>CleaningRobot</semantic-equipment-tag>
+
+		<channel-groups>
+			<channel-group id="actions" typeId="mower-actions"/>
+			<channel-group id="status" typeId="mower-status"/>
+			<channel-group id="last-mow" typeId="last-mow"/>
+			<channel-group id="total-stats" typeId="mower-total-stats"/>
+			<channel-group id="consumables" typeId="mower-consumables"/>
+			<channel-group id="settings" typeId="mower-settings"/>
+		</channel-groups>
+
+		<properties>
+			<property name="thingTypeVersion">1</property>
+		</properties>
+
+		<config-description>
+			<parameter name="serialNumber" type="text" required="true">
+				<label>Device Serial Number</label>
+			</parameter>
+			<parameter name="refresh" type="integer" unit="min" min="1" required="false">
+				<label>Refresh Interval</label>
+				<advanced>true</advanced>
+				<description>Specifies the refresh interval in minutes.</description>
+				<unitLabel>Minutes</unitLabel>
+				<default>5</default>
+			</parameter>
+		</config-description>
+	</thing-type>
+
+	<!-- Channel Group Types -->
+
+	<channel-group-type id="mower-actions">
+		<label>Actions</label>
+		<channels>
+			<channel id="command" typeId="mower-command"/>
+		</channels>
+	</channel-group-type>
+
+	<channel-group-type id="mower-status">
+		<label>Status</label>
+		<channels>
+			<channel id="state" typeId="mower-state"/>
+			<channel id="battery" typeId="system.battery-level"/>
+			<channel id="current-mowing-time" typeId="current-mowing-time"/>
+			<channel id="current-mowed-area" typeId="current-mowed-area"/>
+			<channel id="wifi-rssi" typeId="wifi-rssi"/>
+			<channel id="error-code" typeId="error-code"/>
+			<channel id="error-description" typeId="error-description"/>
+		</channels>
+	</channel-group-type>
+
+	<channel-group-type id="last-mow">
+		<label>Last Mow Run</label>
+		<channels>
+			<channel id="last-mow-start" typeId="last-mow-start"/>
+			<channel id="last-mow-duration" typeId="last-mow-duration"/>
+			<channel id="last-mow-area" typeId="last-mow-area"/>
+		</channels>
+	</channel-group-type>
+
+	<channel-group-type id="mower-total-stats">
+		<label>Device Lifetime Statistics</label>
+		<channels>
+			<channel id="total-mowing-time" typeId="total-mowing-time"/>
+			<channel id="total-mowed-area" typeId="total-mowed-area"/>
+			<channel id="total-mow-runs" typeId="total-mow-runs"/>
+		</channels>
+	</channel-group-type>
+
+	<channel-group-type id="mower-consumables">
+		<label>Consumables</label>
+		<channels>
+			<channel id="blade-lifetime" typeId="blade-lifetime"/>
+		</channels>
+	</channel-group-type>
+
+	<channel-group-type id="mower-settings">
+		<label>Settings</label>
+		<channels>
+			<channel id="cutting-height" typeId="cutting-height"/>
+			<channel id="voice-volume" typeId="voice-volume"/>
+			<channel id="true-detect-3d" typeId="true-detect-3d"/>
+			<channel id="safe-protect" typeId="safe-protect"/>
+			<channel id="child-lock" typeId="child-lock"/>
+			<channel id="rain-delay" typeId="rain-delay"/>
+			<channel id="moveup-warning" typeId="moveup-warning"/>
+		</channels>
+	</channel-group-type>
+
+	<!-- Channel Types -->
+
+	<channel-type id="mower-state">
+		<item-type>String</item-type>
+		<label>Mower State</label>
+		<description>Current operational state of the mower</description>
+		<state readOnly="true">
+			<options>
+				<option value="mowing">Mowing</option>
+				<option value="paused">Paused</option>
+				<option value="returning">Returning to dock</option>
+				<option value="charging">Charging</option>
+				<option value="idle">Idle</option>
+				<option value="docked">Docked</option>
+				<option value="error">Error</option>
+				<option value="edgeCutting">Edge cutting</option>
+			</options>
+		</state>
+	</channel-type>
+
+	<channel-type id="mower-command">
+		<item-type>String</item-type>
+		<label>Command</label>
+		<description>Command to execute</description>
+		<state>
+			<options>
+				<option value="mow">Start mowing</option>
+				<option value="pause">Pause mowing</option>
+				<option value="resume">Resume mowing</option>
+				<option value="stop">Stop</option>
+				<option value="dock">Return to dock</option>
+				<option value="edgeCut">Start edge cutting</option>
+			</options>
+		</state>
+	</channel-type>
+
+	<channel-type id="current-mowing-time">
+		<item-type>Number:Time</item-type>
+		<label>Current Mowing Time</label>
+		<description>Mowing time in current session</description>
+		<tags>
+			<tag>Status</tag>
+			<tag>Duration</tag>
+		</tags>
+		<state pattern="%d %unit%" readOnly="true"></state>
+	</channel-type>
+
+	<channel-type id="current-mowed-area">
+		<item-type>Number:Area</item-type>
+		<label>Current Mowed Area</label>
+		<description>Mowed area in current session</description>
+		<state pattern="%d %unit%" readOnly="true"></state>
+	</channel-type>
+
+	<channel-type id="total-mowing-time">
+		<item-type unitHint="h">Number:Time</item-type>
+		<label>Total Mowing Time</label>
+		<description>Total mowing time in device life time</description>
+		<tags>
+			<tag>Status</tag>
+			<tag>Duration</tag>
+		</tags>
+		<state pattern="%.1f %unit%" readOnly="true"></state>
+	</channel-type>
+
+	<channel-type id="total-mowed-area">
+		<item-type>Number:Area</item-type>
+		<label>Total Mowed Area</label>
+		<description>Total mowed area in device life time</description>
+		<state pattern="%d %unit%" readOnly="true"></state>
+	</channel-type>
+
+	<channel-type id="total-mow-runs">
+		<item-type>Number</item-type>
+		<label>Total Mow Runs</label>
+		<description>Number of mowing runs in device life time</description>
+		<state readOnly="true"/>
+	</channel-type>
+
+	<channel-type id="last-mow-start">
+		<item-type>DateTime</item-type>
+		<label>Last Mow Start</label>
+		<description>Start time of the last completed mowing run</description>
+		<category>Time</category>
+		<tags>
+			<tag>Status</tag>
+			<tag>Timestamp</tag>
+		</tags>
+		<state readOnly="true"/>
+	</channel-type>
+
+	<channel-type id="last-mow-duration">
+		<item-type unitHint="min">Number:Time</item-type>
+		<label>Last Mow Duration</label>
+		<description>Duration of the last completed mowing run</description>
+		<category>Time</category>
+		<state pattern="%.1f %unit%" readOnly="true"/>
+	</channel-type>
+
+	<channel-type id="last-mow-area">
+		<item-type>Number:Area</item-type>
+		<label>Last Mowed Area</label>
+		<description>Area mowed in the last completed mowing run</description>
+		<state pattern="%d %unit%" readOnly="true"/>
+	</channel-type>
+
+	<channel-type id="blade-lifetime">
+		<item-type>Number:Dimensionless</item-type>
+		<label>Blade Lifetime</label>
+		<description>Remaining life time of cutting blades in percent</description>
+		<state pattern="%d %unit%" readOnly="true"></state>
+	</channel-type>
+
+	<channel-type id="cutting-height">
+		<item-type unitHint="mm">Number:Length</item-type>
+		<label>Cutting Height</label>
+		<description>Cutting height of the mower blades</description>
+		<tags>
+			<tag>Control</tag>
+			<tag>Level</tag>
+		</tags>
+		<state min="30" max="75" step="5" pattern="%d %unit%" readOnly="true"></state>
+	</channel-type>
+
+	<channel-type id="safe-protect">
+		<item-type>Switch</item-type>
+		<label>SafeProtect</label>
+		<description>Stop mower when an obstacle or unsafe condition is detected</description>
+		<tags>
+			<tag>Switch</tag>
+			<tag>Mode</tag>
+		</tags>
+	</channel-type>
+
+	<channel-type id="child-lock">
+		<item-type>Switch</item-type>
+		<label>Child Lock</label>
+		<description>Lock the mower to prevent unintended operation</description>
+		<tags>
+			<tag>Switch</tag>
+			<tag>Mode</tag>
+		</tags>
+	</channel-type>
+
+	<channel-type id="rain-delay" advanced="true">
+		<item-type>Switch</item-type>
+		<label>Rain Delay</label>
+		<description>Rain detected, mowing delayed</description>
+		<tags>
+			<tag>Status</tag>
+			<tag>Info</tag>
+		</tags>
+		<state readOnly="true"/>
+	</channel-type>
+
+	<channel-type id="moveup-warning">
+		<item-type>Switch</item-type>
+		<label>Move-Up Warning</label>
+		<description>Trigger alarm when the mower is lifted off the ground</description>
+		<tags>
+			<tag>Switch</tag>
+			<tag>Mode</tag>
+		</tags>
+	</channel-type>
+
+</thing:thing-descriptions>

--- a/bundles/org.openhab.binding.ecovacs/src/main/resources/devices/supported_device_list.json
+++ b/bundles/org.openhab.binding.ecovacs/src/main/resources/devices/supported_device_list.json
@@ -8,7 +8,8 @@
             "mopping_system",
             "main_brush",
             "clean_speed_control"
-        ]
+        ],
+        "deviceType": "vacuum"
     },
     {
         "modelName": "DEEBOT OZMO 601",
@@ -20,7 +21,6 @@
         "deviceClass": "16wdph",
         "deviceClassLink": "dl8fht"
     },
-
     {
         "modelName": "DEEBOT OZMO 610 Series",
         "deviceClass": "130",
@@ -30,9 +30,9 @@
             "mopping_system",
             "main_brush",
             "single_room_cleaning"
-        ]
+        ],
+        "deviceType": "vacuum"
     },
-
     {
         "modelName": "DEEBOT 710",
         "deviceClass": "uv242z",
@@ -41,7 +41,8 @@
         "capabilities": [
             "main_brush",
             "clean_speed_control"
-        ]
+        ],
+        "deviceType": "vacuum"
     },
     {
         "modelName": "DEEBOT 711",
@@ -58,7 +59,6 @@
         "deviceClass": "eyi9jv",
         "deviceClassLink": "uv242z"
     },
-
     {
         "modelName": "DEEBOT 900 Series",
         "deviceClass": "ls1ok3",
@@ -70,9 +70,9 @@
             "custom_area_cleaning",
             "clean_speed_control",
             "mapping"
-        ]
+        ],
+        "deviceType": "vacuum"
     },
-
     {
         "modelName": "DEEBOT OZMO 900 Series",
         "deviceClass": "y79a7u",
@@ -85,14 +85,14 @@
             "custom_area_cleaning",
             "clean_speed_control",
             "mapping"
-        ]
+        ],
+        "deviceType": "vacuum"
     },
     {
         "modelName": "DEEBOT OZMO 905",
         "deviceClass": "2pv572",
         "deviceClassLink": "y79a7u"
     },
-
     {
         "modelName": "DEEBOT OZMO/PRO 930 Series",
         "deviceClass": "115",
@@ -104,18 +104,17 @@
             "spot_area_cleaning",
             "custom_area_cleaning",
             "mapping"
-        ]
+        ],
+        "deviceType": "vacuum"
     },
-
     {
         "modelName": "DEEBOT Slim2 Series",
         "deviceClass": "123",
         "protoVersion": "xml",
         "usesMqtt": false,
-        "capabilities": [
-        ]
+        "capabilities": [],
+        "deviceType": "vacuum"
     },
-
     {
         "modelName": "DEEBOT OZMO Slim10 Series",
         "deviceClass": "02uwxm",
@@ -124,9 +123,9 @@
         "capabilities": [
             "mopping_system",
             "clean_speed_control"
-        ]
+        ],
+        "deviceType": "vacuum"
     },
-
     {
         "modelName": "DEEBOT OZMO 950 Series",
         "deviceClass": "yna5xi",
@@ -141,7 +140,8 @@
             "voice_reporting",
             "read_network_info",
             "mapping"
-        ]
+        ],
+        "deviceType": "vacuum"
     },
     {
         "modelName": "DEEBOT OZMO 920",
@@ -153,7 +153,6 @@
         "deviceClass": "9rft3c",
         "deviceClassLink": "yna5xi"
     },
-
     {
         "modelName": "DEEBOT N8",
         "deviceClass": "n6cwdb",
@@ -169,7 +168,8 @@
             "read_network_info",
             "unit_care_lifespan",
             "mapping"
-        ]
+        ],
+        "deviceType": "vacuum"
     },
     {
         "modelName": "DEEBOT N3 MAX",
@@ -201,7 +201,6 @@
         "deviceClass": "z0gd1j",
         "deviceClassLink": "n6cwdb"
     },
-
     {
         "modelName": "DEEBOT N8+",
         "deviceClass": "b2jqs4",
@@ -218,14 +217,14 @@
             "unit_care_lifespan",
             "auto_empty_station",
             "mapping"
-        ]
+        ],
+        "deviceType": "vacuum"
     },
     {
         "modelName": "DEEBOT N8+",
         "deviceClass": "7bryc5",
         "deviceClassLink": "b2jqs4"
     },
-
     {
         "modelName": "DEEBOT OZMO T8",
         "deviceClass": "h18jkh",
@@ -242,7 +241,8 @@
             "unit_care_lifespan",
             "true_detect_3d",
             "mapping"
-        ]
+        ],
+        "deviceType": "vacuum"
     },
     {
         "modelName": "DEEBOT OZMO T8",
@@ -309,7 +309,6 @@
         "deviceClass": "s1f8g7",
         "deviceClassLink": "h18jkh"
     },
-
     {
         "modelName": "DEEBOT OZMO T8+",
         "deviceClass": "fqxoiu",
@@ -327,7 +326,8 @@
             "true_detect_3d",
             "mapping",
             "auto_empty_station"
-        ]
+        ],
+        "deviceType": "vacuum"
     },
     {
         "modelName": "DEEBOT OZMO T8+",
@@ -364,7 +364,6 @@
         "deviceClass": "ifbw08",
         "deviceClassLink": "fqxoiu"
     },
-
     {
         "modelName": "DEEBOT T9+",
         "deviceClass": "lhbd50",
@@ -383,7 +382,8 @@
             "mapping",
             "auto_empty_station",
             "uses_clean_results_log_api"
-        ]
+        ],
+        "deviceType": "vacuum"
     },
     {
         "modelName": "DEEBOT T9+",
@@ -415,7 +415,6 @@
         "deviceClass": "c2of2s",
         "deviceClassLink": "lhbd50"
     },
-
     {
         "modelName": "DEEBOT T10",
         "deviceClass": "jtmf04",
@@ -433,14 +432,14 @@
             "true_detect_3d",
             "mapping",
             "uses_clean_results_log_api"
-        ]
+        ],
+        "deviceType": "vacuum"
     },
     {
         "modelName": "DEEBOT N10",
         "deviceClass": "m1wkuw",
         "deviceClassLink": "jtmf04"
     },
-
     {
         "modelName": "DEEBOT T10 PLUS",
         "deviceClass": "rss8xk",
@@ -459,7 +458,8 @@
             "mapping",
             "auto_empty_station",
             "uses_clean_results_log_api"
-        ]
+        ],
+        "deviceType": "vacuum"
     },
     {
         "modelName": "DEEBOT T10 PLUS",
@@ -476,7 +476,6 @@
         "deviceClass": "clojes",
         "deviceClassLink": "rss8xk"
     },
-
     {
         "modelName": "DEEBOT T10 TURBO",
         "deviceClass": "9s1s80",
@@ -495,7 +494,8 @@
             "true_detect_3d",
             "mapping",
             "uses_clean_results_log_api"
-        ]
+        ],
+        "deviceType": "vacuum"
     },
     {
         "modelName": "DEEBOT T10 TURBO",
@@ -522,7 +522,6 @@
         "deviceClass": "s523z1",
         "deviceClassLink": "9s1s80"
     },
-
     {
         "modelName": "DEEBOT T10 OMNI",
         "deviceClass": "lx3j7m",
@@ -543,7 +542,8 @@
             "auto_empty_station",
             "air_drying",
             "uses_clean_results_log_api"
-        ]
+        ],
+        "deviceType": "vacuum"
     },
     {
         "modelName": "DEEBOT X1 OMNI",
@@ -565,7 +565,6 @@
         "deviceClass": "bro5wu",
         "deviceClassLink": "lx3j7m"
     },
-
     {
         "modelName": "DEEBOT X1 PLUS",
         "deviceClass": "n4gstt",
@@ -584,9 +583,9 @@
             "mapping",
             "auto_empty_station",
             "uses_clean_results_log_api"
-        ]
+        ],
+        "deviceType": "vacuum"
     },
-
     {
         "modelName": "DEEBOT T20 OMNI",
         "deviceClass": "p1jij8",
@@ -606,7 +605,8 @@
             "air_drying",
             "true_detect_3d",
             "mapping"
-        ]
+        ],
+        "deviceType": "vacuum"
     },
     {
         "modelName": "DEEBOT T20 OMNI",
@@ -668,7 +668,6 @@
         "deviceClass": "py3qif",
         "deviceClassLink": "p1jij8"
     },
-
     {
         "modelName": "DEEBOT U2",
         "deviceClass": "ipzjy0",
@@ -680,7 +679,8 @@
             "clean_speed_control",
             "voice_reporting",
             "read_network_info"
-        ]
+        ],
+        "deviceType": "vacuum"
     },
     {
         "modelName": "DEEBOT U2",
@@ -752,7 +752,6 @@
         "deviceClass": "zjna8m",
         "deviceClassLink": "ipzjy0"
     },
-
     {
         "modelName": "DEEBOT X2",
         "deviceClass": "e6ofmn",
@@ -774,7 +773,8 @@
             "auto_empty_station",
             "air_drying",
             "uses_clean_results_log_api"
-        ]
+        ],
+        "deviceType": "vacuum"
     },
     {
         "modelName": "DEEBOT X2 OMNI",
@@ -791,7 +791,6 @@
         "deviceClass": "ip3mmy",
         "deviceClassLink": "e6ofmn"
     },
-
     {
         "modelName": "DEEBOT T30 OMNI",
         "deviceClass": "z4lvk7",
@@ -813,7 +812,8 @@
             "auto_empty_station",
             "air_drying",
             "uses_clean_results_log_api"
-        ]
+        ],
+        "deviceType": "vacuum"
     },
     {
         "modelName": "DEEBOT T30 OMNI",
@@ -945,7 +945,6 @@
         "deviceClass": "87swps",
         "deviceClassLink": "z4lvk7"
     },
-
     {
         "modelName": "DEEBOT T50 PRO OMNI",
         "deviceClass": "czjwet",
@@ -968,9 +967,9 @@
             "air_drying",
             "uses_clean_results_log_api",
             "custom_water_amount"
-        ]
+        ],
+        "deviceType": "vacuum"
     },
-
     {
         "modelName": "DEEBOT X8 PRO OMNI",
         "deviceClass": "n0vyif",
@@ -994,11 +993,118 @@
             "air_drying",
             "uses_clean_results_log_api",
             "custom_water_amount"
-        ]
+        ],
+        "deviceType": "vacuum"
     },
     {
         "modelName": "DEEBOT X8 OMNI",
         "deviceClass": "4bx3w9",
         "deviceClassLink": "n0vyif"
+    },
+    {
+        "modelName": "GOAT O500 Panorama",
+        "deviceClass": "300lc5",
+        "deviceType": "mower",
+        "protocolVersion": "JSON_V2",
+        "usesMqtt": true,
+        "capabilities": [
+            "edge_mowing",
+            "zone_mowing",
+            "mowing",
+            "cutting_height",
+            "voice_reporting",
+            "true_detect_3d",
+            "safe_protect",
+            "child_lock",
+            "moveup_warning",
+            "read_network_info"
+        ]
+    },
+    {
+        "modelName": "GOAT G1-800",
+        "deviceClass": "guzput",
+        "deviceType": "mower",
+        "protocolVersion": "JSON_V2",
+        "usesMqtt": true,
+        "capabilities": [
+            "edge_mowing",
+            "zone_mowing",
+            "mowing",
+            "cutting_height",
+            "voice_reporting",
+            "true_detect_3d",
+            "safe_protect",
+            "child_lock",
+            "read_network_info"
+        ]
+    },
+    {
+        "modelName": "GOAT O800 RTK",
+        "deviceClass": "2px96q",
+        "deviceType": "mower",
+        "protocolVersion": "JSON_V2",
+        "usesMqtt": true,
+        "capabilities": [
+            "edge_mowing",
+            "zone_mowing",
+            "mowing",
+            "cutting_height",
+            "voice_reporting",
+            "true_detect_3d",
+            "safe_protect",
+            "child_lock",
+            "moveup_warning",
+            "read_network_info"
+        ]
+    },
+    {
+        "modelName": "GOAT G1",
+        "deviceClass": "77atlz",
+        "deviceClassLink": "guzput"
+    },
+    {
+        "modelName": "GOAT G1",
+        "deviceClass": "5xu9h3",
+        "deviceClassLink": "guzput"
+    },
+    {
+        "modelName": "GOAT G1",
+        "deviceClass": "itk04l",
+        "deviceClassLink": "guzput"
+    },
+    {
+        "modelName": "GOAT G1",
+        "deviceClass": "s69g6z",
+        "deviceClassLink": "guzput"
+    },
+    {
+        "modelName": "GOAT G1",
+        "deviceClass": "2ap5uq",
+        "deviceClassLink": "guzput"
+    },
+    {
+        "modelName": "GOAT O600 RTK",
+        "deviceClass": "6n9pcz",
+        "deviceClassLink": "2px96q"
+    },
+    {
+        "modelName": "GOAT O1200 LiDAR Pro",
+        "deviceClass": "2i0fns",
+        "deviceClassLink": "2px96q"
+    },
+    {
+        "modelName": "GOAT A1600 RTK",
+        "deviceClass": "xmp9ds",
+        "deviceClassLink": "2px96q"
+    },
+    {
+        "modelName": "GOAT A3000 LiDAR Pro",
+        "deviceClass": "51rcxt",
+        "deviceClassLink": "2px96q"
+    },
+    {
+        "modelName": "GOAT A3000 LiDAR",
+        "deviceClass": "cr0e4u",
+        "deviceClassLink": "2px96q"
     }
 ]

--- a/bundles/org.openhab.binding.ecovacs/src/test/java/org/openhab/binding/ecovacs/internal/CleanReportMowerTest.java
+++ b/bundles/org.openhab.binding.ecovacs/src/test/java/org/openhab/binding/ecovacs/internal/CleanReportMowerTest.java
@@ -1,0 +1,258 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.ecovacs.internal;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+import org.openhab.binding.ecovacs.internal.api.impl.dto.response.deviceapi.json.CleanReport;
+import org.openhab.binding.ecovacs.internal.api.impl.dto.response.deviceapi.json.LastTimeStatsReport;
+import org.openhab.binding.ecovacs.internal.api.impl.dto.response.deviceapi.json.StatsReport;
+import org.openhab.binding.ecovacs.internal.api.model.CleanMode;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonParser;
+
+/**
+ * Tests for CleanReport mower-specific behavior, including the determineCleanMode logic,
+ * StatsReport mowedArea deserialization, and LastTimeStatsReport deserialization.
+ *
+ * @author Stefan Höhn - Initial contribution
+ */
+class CleanReportMowerTest {
+
+    private final Gson gson = new Gson();
+
+    // --- CleanReport.determineCleanMode tests ---
+
+    @Test
+    void testDetermineCleanModeWorkingWithTypeAuto() {
+        CleanReport report = new CleanReport();
+        CleanReport.CleanStateReport cleanState = new CleanReport.CleanStateReport();
+        cleanState.motionState = "working";
+        cleanState.type = "auto";
+        report.cleanState = cleanState;
+
+        CleanMode mode = report.determineCleanMode(gson);
+        assertEquals(CleanMode.AUTO, mode);
+    }
+
+    @Test
+    void testDetermineCleanModeWorkingWithTypeNull() {
+        // Bug fix: mowers may send type=null when working, should default to AUTO
+        CleanReport report = new CleanReport();
+        CleanReport.CleanStateReport cleanState = new CleanReport.CleanStateReport();
+        cleanState.motionState = "working";
+        cleanState.type = null;
+        report.cleanState = cleanState;
+
+        CleanMode mode = report.determineCleanMode(gson);
+        assertEquals(CleanMode.AUTO, mode);
+    }
+
+    @Test
+    void testDetermineCleanModePause() {
+        CleanReport report = new CleanReport();
+        CleanReport.CleanStateReport cleanState = new CleanReport.CleanStateReport();
+        cleanState.motionState = "pause";
+        cleanState.type = "auto";
+        report.cleanState = cleanState;
+
+        CleanMode mode = report.determineCleanMode(gson);
+        assertEquals(CleanMode.PAUSE, mode);
+    }
+
+    @Test
+    void testDetermineCleanModeGoCharging() {
+        CleanReport report = new CleanReport();
+        CleanReport.CleanStateReport cleanState = new CleanReport.CleanStateReport();
+        cleanState.motionState = "goCharging";
+        cleanState.type = "auto";
+        report.cleanState = cleanState;
+
+        CleanMode mode = report.determineCleanMode(gson);
+        assertEquals(CleanMode.RETURNING, mode);
+    }
+
+    @Test
+    void testDetermineCleanModeIdleNoCleanState() {
+        CleanReport report = new CleanReport();
+        report.state = "idle";
+        report.cleanState = null;
+
+        CleanMode mode = report.determineCleanMode(gson);
+        assertEquals(CleanMode.IDLE, mode);
+    }
+
+    @Test
+    void testDetermineCleanModeContentAsJsonObject() {
+        // Mowers send content as a JSON object, not a string
+        CleanReport report = new CleanReport();
+        CleanReport.CleanStateReport cleanState = new CleanReport.CleanStateReport();
+        cleanState.motionState = "working";
+        cleanState.type = "auto";
+        cleanState.content = JsonParser.parseString("{\"type\":\"auto\",\"value\":\"zone1\"}");
+        report.cleanState = cleanState;
+
+        CleanMode mode = report.determineCleanMode(gson);
+        assertEquals(CleanMode.AUTO, mode);
+        // getAreaDefinition should return null for JSON object content
+        assertNull(cleanState.getAreaDefinition());
+    }
+
+    @Test
+    void testGetAreaDefinitionWithStringContent() {
+        CleanReport.CleanStateReport cleanState = new CleanReport.CleanStateReport();
+        cleanState.content = JsonParser.parseString("\"1,2,3,4\"");
+
+        assertEquals("1,2,3,4", cleanState.getAreaDefinition());
+    }
+
+    @Test
+    void testGetAreaDefinitionWithNullContent() {
+        CleanReport.CleanStateReport cleanState = new CleanReport.CleanStateReport();
+        cleanState.content = null;
+
+        assertNull(cleanState.getAreaDefinition());
+    }
+
+    @Test
+    void testDetermineCleanModeWorkingWithTypeBorder() {
+        CleanReport report = new CleanReport();
+        CleanReport.CleanStateReport cleanState = new CleanReport.CleanStateReport();
+        cleanState.motionState = "working";
+        cleanState.type = "border";
+        report.cleanState = cleanState;
+
+        CleanMode mode = report.determineCleanMode(gson);
+        assertEquals(CleanMode.EDGE, mode);
+    }
+
+    // --- CleanReport deserialization from JSON (simulating GetMowerStateCommand response) ---
+
+    @Test
+    void testCleanReportDeserializationWorkingAuto() {
+        String json = "{\"trigger\":\"app\",\"state\":\"clean\","
+                + "\"cleanState\":{\"router\":\"plan\",\"type\":\"auto\",\"motionState\":\"working\"}}";
+        CleanReport report = gson.fromJson(json, CleanReport.class);
+
+        assertNotNull(report.cleanState);
+        assertEquals("working", report.cleanState.motionState);
+        assertEquals(CleanMode.AUTO, report.determineCleanMode(gson));
+    }
+
+    @Test
+    void testCleanReportDeserializationPause() {
+        String json = "{\"trigger\":\"app\",\"state\":\"clean\","
+                + "\"cleanState\":{\"router\":\"plan\",\"type\":\"auto\",\"motionState\":\"pause\"}}";
+        CleanReport report = gson.fromJson(json, CleanReport.class);
+
+        assertNotNull(report.cleanState);
+        assertEquals("pause", report.cleanState.motionState);
+        assertEquals(CleanMode.PAUSE, report.determineCleanMode(gson));
+    }
+
+    @Test
+    void testCleanReportDeserializationGoCharging() {
+        String json = "{\"trigger\":\"workComplete\",\"state\":\"clean\","
+                + "\"cleanState\":{\"router\":\"plan\",\"type\":\"auto\",\"motionState\":\"goCharging\"}}";
+        CleanReport report = gson.fromJson(json, CleanReport.class);
+
+        assertNotNull(report.cleanState);
+        assertEquals("goCharging", report.cleanState.motionState);
+        assertEquals(CleanMode.RETURNING, report.determineCleanMode(gson));
+    }
+
+    @Test
+    void testCleanReportDeserializationIdleNoCleanState() {
+        String json = "{\"trigger\":\"app\",\"state\":\"idle\"}";
+        CleanReport report = gson.fromJson(json, CleanReport.class);
+
+        assertNull(report.cleanState);
+        assertEquals("idle", report.state);
+        assertEquals(CleanMode.IDLE, report.determineCleanMode(gson));
+    }
+
+    @Test
+    void testCleanReportDeserializationWithObjectContent() {
+        // Mowers send content as a JSON object rather than a string
+        String json = "{\"trigger\":\"app\",\"state\":\"clean\","
+                + "\"cleanState\":{\"router\":\"plan\",\"type\":\"auto\",\"motionState\":\"working\","
+                + "\"content\":{\"type\":\"auto\",\"value\":\"zone1\"}}}";
+        CleanReport report = gson.fromJson(json, CleanReport.class);
+
+        assertNotNull(report.cleanState);
+        assertNotNull(report.cleanState.content);
+        assertTrue(report.cleanState.content.isJsonObject());
+        assertNull(report.cleanState.getAreaDefinition());
+        assertEquals(CleanMode.AUTO, report.determineCleanMode(gson));
+    }
+
+    // --- StatsReport tests ---
+
+    @Test
+    void testStatsReportMowedAreaDeserialization() {
+        String json = "{\"area\":150,\"mowedArea\":120,\"time\":3600,\"cid\":\"session123\","
+                + "\"start\":1700000000,\"type\":\"auto\"}";
+        StatsReport report = gson.fromJson(json, StatsReport.class);
+
+        assertEquals(150, report.area);
+        assertEquals(120, report.mowedArea);
+        assertEquals(3600, report.timeInSeconds);
+        assertEquals("session123", report.cid);
+        assertEquals(1700000000L, report.startTimestamp);
+        assertEquals("auto", report.type);
+    }
+
+    @Test
+    void testStatsReportMowedAreaZero() {
+        String json = "{\"area\":0,\"mowedArea\":0,\"time\":0,\"cid\":\"abc\",\"start\":0,\"type\":\"auto\"}";
+        StatsReport report = gson.fromJson(json, StatsReport.class);
+
+        assertEquals(0, report.mowedArea);
+    }
+
+    // --- LastTimeStatsReport tests ---
+
+    @Test
+    void testLastTimeStatsReportDeserialization() {
+        String json = "{\"start\":\"1700000000\",\"time\":1800,\"area\":250}";
+        LastTimeStatsReport report = gson.fromJson(json, LastTimeStatsReport.class);
+
+        assertEquals("1700000000", report.startTimestamp);
+        assertEquals(1800, report.durationSeconds);
+        assertEquals(250, report.areaSqCm);
+    }
+
+    @Test
+    void testLastTimeStatsReportDefaultValues() {
+        String json = "{}";
+        LastTimeStatsReport report = gson.fromJson(json, LastTimeStatsReport.class);
+
+        // Gson will not use the field initializer for missing fields when deserializing to an existing class,
+        // but startTimestamp has a default of "0" in the class definition
+        assertEquals(0, report.durationSeconds);
+        assertEquals(0, report.areaSqCm);
+    }
+
+    @Test
+    void testLastTimeStatsReportWithMowerData() {
+        // Simulates typical GOAT mower last time stats
+        String json = "{\"start\":\"1720000000\",\"time\":4500,\"area\":800}";
+        LastTimeStatsReport report = gson.fromJson(json, LastTimeStatsReport.class);
+
+        assertEquals("1720000000", report.startTimestamp);
+        assertEquals(4500, report.durationSeconds);
+        assertEquals(800, report.areaSqCm);
+    }
+}

--- a/bundles/org.openhab.binding.ecovacs/src/test/java/org/openhab/binding/ecovacs/internal/DeviceDescriptionTest.java
+++ b/bundles/org.openhab.binding.ecovacs/src/test/java/org/openhab/binding/ecovacs/internal/DeviceDescriptionTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.ecovacs.internal;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.InputStreamReader;
+import java.lang.reflect.Type;
+import java.util.List;
+import java.util.Objects;
+
+import org.junit.jupiter.api.Test;
+import org.openhab.binding.ecovacs.internal.api.impl.DeviceDescription;
+import org.openhab.binding.ecovacs.internal.api.model.DeviceCapability;
+import org.openhab.binding.ecovacs.internal.api.model.DeviceType;
+
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+import com.google.gson.stream.JsonReader;
+
+/**
+ * Tests for device description parsing and device type detection.
+ *
+ * @author Stefan Höhn - Initial contribution
+ */
+class DeviceDescriptionTest {
+
+    private final Gson gson = new Gson();
+
+    @Test
+    void testDeviceTypeDefaultsToVacuum() {
+        DeviceDescription desc = new DeviceDescription("Deebot Test", "abc123", null, DeviceType.VACUUM,
+                org.openhab.binding.ecovacs.internal.api.impl.ProtocolVersion.JSON_V2, true, new java.util.HashSet<>());
+        assertEquals(DeviceType.VACUUM, desc.deviceType);
+    }
+
+    @Test
+    void testDeviceTypeSetToMower() {
+        DeviceDescription desc = new DeviceDescription("GOAT Test", "xyz789", null, DeviceType.MOWER,
+                org.openhab.binding.ecovacs.internal.api.impl.ProtocolVersion.JSON_V2, true, new java.util.HashSet<>());
+        assertEquals(DeviceType.MOWER, desc.deviceType);
+    }
+
+    @Test
+    void testSupportedDeviceListContainsGoatO500() {
+        List<DeviceDescription> devices = loadSupportedDeviceList();
+        assertTrue(devices.stream().anyMatch(d -> "300lc5".equals(d.deviceClass)),
+                "GOAT O500 Panorama (300lc5) should be in supported device list");
+    }
+
+    @Test
+    void testGoatO500IsMowerType() {
+        List<DeviceDescription> devices = loadSupportedDeviceList();
+        DeviceDescription goat = devices.stream().filter(d -> "300lc5".equals(d.deviceClass)).findFirst().orElse(null);
+        assertNotNull(goat);
+        assertEquals(DeviceType.MOWER, goat.deviceType);
+        assertEquals("GOAT O500 Panorama", goat.modelName);
+    }
+
+    @Test
+    void testGoatO500HasMowingCapability() {
+        List<DeviceDescription> devices = loadSupportedDeviceList();
+        DeviceDescription goat = devices.stream().filter(d -> "300lc5".equals(d.deviceClass)).findFirst().orElse(null);
+        assertNotNull(goat);
+        assertTrue(goat.capabilities.contains(DeviceCapability.MOWING));
+        assertTrue(goat.capabilities.contains(DeviceCapability.CUTTING_HEIGHT));
+        assertTrue(goat.capabilities.contains(DeviceCapability.ZONE_MOWING));
+        assertTrue(goat.capabilities.contains(DeviceCapability.EDGE_MOWING));
+    }
+
+    @Test
+    void testExistingVacuumsRemainVacuumType() {
+        List<DeviceDescription> devices = loadSupportedDeviceList();
+        // Deebot OZMO 950 (class ls1ok3 or similar) should be VACUUM
+        DeviceDescription vacuum = devices.stream().filter(d -> d.modelName.contains("DEEBOT")).findFirst()
+                .orElse(null);
+        assertNotNull(vacuum);
+        assertEquals(DeviceType.VACUUM, vacuum.deviceType);
+    }
+
+    @Test
+    void testDeviceClassLinkResolvesDeviceType() {
+        // Verify that linked GOAT devices in the supported list resolve to MOWER type
+        List<DeviceDescription> devices = loadSupportedDeviceList();
+
+        // Find a linked GOAT device (e.g., "77atlz" links to "guzput")
+        DeviceDescription linked = devices.stream().filter(d -> "77atlz".equals(d.deviceClass)).findFirst()
+                .orElse(null);
+        assertNotNull(linked, "GOAT G1 variant (77atlz) should be in supported device list");
+        assertNotNull(linked.deviceClassLink, "Should have a deviceClassLink");
+
+        // Find the target
+        DeviceDescription target = devices.stream().filter(d -> linked.deviceClassLink.equals(d.deviceClass))
+                .findFirst().orElse(null);
+        assertNotNull(target, "Target device (guzput) should be in supported device list");
+        assertEquals(DeviceType.MOWER, target.deviceType);
+
+        // Resolve the link
+        DeviceDescription resolved = linked.resolveLinkWith(target);
+        assertEquals(DeviceType.MOWER, resolved.deviceType);
+        assertTrue(resolved.capabilities.contains(DeviceCapability.MOWING));
+    }
+
+    private List<DeviceDescription> loadSupportedDeviceList() {
+        ClassLoader cl = Objects.requireNonNull(getClass().getClassLoader());
+        JsonReader reader = new JsonReader(new InputStreamReader(
+                Objects.requireNonNull(cl.getResourceAsStream("devices/supported_device_list.json"))));
+        Type listType = new TypeToken<List<DeviceDescription>>() {
+        }.getType();
+        return gson.fromJson(reader, listType);
+    }
+}

--- a/bundles/org.openhab.binding.ecovacs/src/test/java/org/openhab/binding/ecovacs/internal/MowerCommandTest.java
+++ b/bundles/org.openhab.binding.ecovacs/src/test/java/org/openhab/binding/ecovacs/internal/MowerCommandTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.ecovacs.internal;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+import org.openhab.binding.ecovacs.internal.api.commands.GetCuttingHeightCommand;
+import org.openhab.binding.ecovacs.internal.api.commands.MowerCleanCommand;
+import org.openhab.binding.ecovacs.internal.api.commands.SetCuttingHeightCommand;
+import org.openhab.binding.ecovacs.internal.api.commands.SetSafeProtectCommand;
+import org.openhab.binding.ecovacs.internal.api.commands.StartEdgeCutCommand;
+import org.openhab.binding.ecovacs.internal.api.commands.ZoneMowingCommand;
+import org.openhab.binding.ecovacs.internal.api.impl.ProtocolVersion;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+/**
+ * Tests for mower command JSON serialization.
+ *
+ * @author Stefan Höhn - Initial contribution
+ */
+class MowerCommandTest {
+
+    private final Gson gson = new Gson();
+
+    @Test
+    void testMowerCleanCommandName() {
+        MowerCleanCommand cmd = new MowerCleanCommand("start");
+        assertEquals("clean", cmd.getName(ProtocolVersion.JSON_V2));
+        assertEquals("clean", cmd.getName(ProtocolVersion.JSON));
+    }
+
+    @Test
+    void testMowerCleanStartPayload() {
+        MowerCleanCommand cmd = new MowerCleanCommand("start");
+        JsonElement payload = cmd.getJsonPayload(ProtocolVersion.JSON_V2, gson);
+        JsonObject header = payload.getAsJsonObject().get("header").getAsJsonObject();
+        assertEquals("0.0.22", header.get("ver").getAsString());
+        JsonObject body = payload.getAsJsonObject().get("body").getAsJsonObject();
+        JsonObject data = body.get("data").getAsJsonObject();
+        assertEquals("start", data.get("act").getAsString());
+        JsonObject content = data.get("content").getAsJsonObject();
+        assertEquals("auto", content.get("type").getAsString());
+    }
+
+    @Test
+    void testMowerCleanPausePayload() {
+        MowerCleanCommand cmd = new MowerCleanCommand("pause");
+        JsonElement payload = cmd.getJsonPayload(ProtocolVersion.JSON_V2, gson);
+        JsonObject body = payload.getAsJsonObject().get("body").getAsJsonObject();
+        JsonObject data = body.get("data").getAsJsonObject();
+        assertEquals("pause", data.get("act").getAsString());
+        JsonObject content = data.get("content").getAsJsonObject();
+        assertEquals("auto", content.get("type").getAsString());
+    }
+
+    @Test
+    void testMowerCleanHeaderVersion() {
+        MowerCleanCommand cmd = new MowerCleanCommand("stop");
+        JsonElement payload = cmd.getJsonPayload(ProtocolVersion.JSON_V2, gson);
+        JsonObject header = payload.getAsJsonObject().get("header").getAsJsonObject();
+        assertEquals("0.0.22", header.get("ver").getAsString());
+    }
+
+    @Test
+    void testStartEdgeCutCommandPayload() {
+        StartEdgeCutCommand cmd = new StartEdgeCutCommand();
+        JsonElement payload = cmd.getJsonPayload(ProtocolVersion.JSON_V2, gson);
+        JsonObject header = payload.getAsJsonObject().get("header").getAsJsonObject();
+        assertEquals("0.0.22", header.get("ver").getAsString());
+        JsonObject body = payload.getAsJsonObject().get("body").getAsJsonObject();
+        JsonObject data = body.get("data").getAsJsonObject();
+        assertEquals("start", data.get("act").getAsString());
+        JsonObject content = data.get("content").getAsJsonObject();
+        assertEquals("border", content.get("type").getAsString());
+    }
+
+    @Test
+    void testZoneMowingCommandPayload() {
+        ZoneMowingCommand cmd = new ZoneMowingCommand("1;2;3");
+        JsonElement payload = cmd.getJsonPayload(ProtocolVersion.JSON_V2, gson);
+        JsonObject header = payload.getAsJsonObject().get("header").getAsJsonObject();
+        assertEquals("0.0.22", header.get("ver").getAsString());
+        JsonObject body = payload.getAsJsonObject().get("body").getAsJsonObject();
+        JsonObject data = body.get("data").getAsJsonObject();
+        assertEquals("start", data.get("act").getAsString());
+        JsonObject content = data.get("content").getAsJsonObject();
+        assertEquals("spotArea", content.get("type").getAsString());
+        assertEquals("1;2;3", content.get("value").getAsString());
+    }
+
+    @Test
+    void testSetCuttingHeightCommandName() {
+        SetCuttingHeightCommand cmd = new SetCuttingHeightCommand(50);
+        assertEquals("setCutHeight", cmd.getName(ProtocolVersion.JSON_V2));
+    }
+
+    @Test
+    void testSetCuttingHeightCommandPayload() {
+        SetCuttingHeightCommand cmd = new SetCuttingHeightCommand(50);
+        JsonElement payload = cmd.getJsonPayload(ProtocolVersion.JSON_V2, gson);
+        JsonObject body = payload.getAsJsonObject().get("body").getAsJsonObject();
+        JsonObject data = body.get("data").getAsJsonObject();
+        assertEquals(5, data.get("level").getAsInt());
+    }
+
+    @Test
+    void testGetCuttingHeightCommandName() {
+        GetCuttingHeightCommand cmd = new GetCuttingHeightCommand();
+        assertEquals("getCutHeight", cmd.getName(ProtocolVersion.JSON_V2));
+    }
+
+    @Test
+    void testSetSafeProtectCommandPayload() {
+        SetSafeProtectCommand cmdOn = new SetSafeProtectCommand(true);
+        JsonElement payloadOn = cmdOn.getJsonPayload(ProtocolVersion.JSON_V2, gson);
+        JsonObject dataOn = payloadOn.getAsJsonObject().get("body").getAsJsonObject().get("data").getAsJsonObject();
+        assertEquals(1, dataOn.get("enable").getAsInt());
+
+        SetSafeProtectCommand cmdOff = new SetSafeProtectCommand(false);
+        JsonElement payloadOff = cmdOff.getJsonPayload(ProtocolVersion.JSON_V2, gson);
+        JsonObject dataOff = payloadOff.getAsJsonObject().get("body").getAsJsonObject().get("data").getAsJsonObject();
+        assertEquals(0, dataOff.get("enable").getAsInt());
+    }
+
+    @Test
+    void testMowerCleanCommandThrowsForXml() {
+        MowerCleanCommand cmd = new MowerCleanCommand("start");
+        assertThrows(IllegalStateException.class, () -> cmd.getName(ProtocolVersion.XML));
+    }
+}


### PR DESCRIPTION
Adds support for Ecovacs GOAT series robotic lawn mowers to the existing Ecovacs binding.
  
  ## Summary
  
  - New `mower` thing type with channels for state, battery, mowing time/area, blade lifetime, cutting height, volume, WiFi RSSI, error reporting, total/last-mow stats
  - Commands: `mow` (smart resume when paused), `pause`, `resume`, `stop`, `dock`, `edgeCut`, `zone:<ids>`
  - Settings: cutting height, voice volume, TrueDetect 3D, SafeProtect, child lock, move-up warning
  - Real-time MQTT event stream (onCleanInfo, onStats, onLastTimeStats)
  - HTTP command API using `ver:"0.0.22"` header required by GOAT firmware
  - Automatic device discovery with mower/vacuum type differentiation
  
  ### Supported Models
  
  GOAT O500 Panorama, G1/G1-800, O600 RTK, O800 RTK, O1200 LiDAR Pro, A1600 RTK, A3000 LiDAR/LiDAR Pro

It should be highlighted that even the O500 works well on my side (this is currently an open issue in the other projects - see below).
  
  ## Tested
  
  Verified on real hardware (GOAT O500 Panorama) — start/stop/pause/resume/dock commands, real-time monitoring, polling, and MQTT events all working correctly and regression tested on the vacuum cleaner Deebot Osmo T8 AIVI.
  
  ## Acknowledgments
  
  The protocol details for GOAT mowers are based on the the excellent reverse-engineering work of:
  - [bmartin5692/sucks](https://github.com/bmartin5692/sucks) — Ecovacs protocol documentation
  - [DeebotUniverse/client.py](https://github.com/DeebotUniverse/client.py) — Python Ecovacs library with GOAT mower support
  - [nicoh88/ecovacs-mqtt](https://github.com/nicoh88/ecovacs-mqtt) — MQTT integration research for GOAT devices
  
Thank you to these communities for making the mower integration possible.

Full disclosure: This PR was iteratively developed together with AI support. However, I supervised the whole development process and reviewed all code by myself and adapted the code and documentation multiple times until all channels were detected and processed correctly.

During the development many incremental changes were done until I arrived at the final binding that I tested thoroughly based on my own Ecovacs devices Goat O500 Panorama and the vacuum cleaner Deebot Osmo T8 AIVI.

Note:  I am running 5.2 at home. openHAB main branch uses bnd 7.3.0 which generates DS 1.4 (Declarative Services) SCR descriptors in the compiled JAR. But my openHAB 5.2.0 production server runs Felix SCR which only supports up to DS
  1.3 descriptors. So I have "only" tested this on 5.2. based on the 5.1.5 branch and not on the latest main branch. This should't be a problem and I wanted to mention this.
  
