### PR TITLE
[zwavejs] Fix boolean value type bug in multicast messages

### DIFF
--- a/bundles/org.openhab.binding.zwavejs/src/main/java/org/openhab/binding/zwavejs/internal/handler/ZwaveJSBridgeHandler.java
+++ b/bundles/org.openhab.binding.zwavejs/src/main/java/org/openhab/binding/zwavejs/internal/handler/ZwaveJSBridgeHandler.java
@@ -424,7 +424,7 @@ public class ZwaveJSBridgeHandler extends BaseBridgeHandler implements ZwaveEven
         try {
             return Double.parseDouble(trimmed);
         } catch (NumberFormatException e) {
-            return value;
+            return trimmed;
         }
     }
 }

--- a/bundles/org.openhab.binding.zwavejs/src/main/java/org/openhab/binding/zwavejs/internal/handler/ZwaveJSBridgeHandler.java
+++ b/bundles/org.openhab.binding.zwavejs/src/main/java/org/openhab/binding/zwavejs/internal/handler/ZwaveJSBridgeHandler.java
@@ -410,9 +410,19 @@ public class ZwaveJSBridgeHandler extends BaseBridgeHandler implements ZwaveEven
                 .toArray();
     }
 
-    private static Object convertValueType(String value) {
+    /**
+     * Converts a string value to a Boolean, Double or String, in that order of precedence.
+     * Package-private (rather than private) so it can be unit tested directly.
+     */
+    static Object convertValueType(String value) {
+        String trimmed = value.trim();
+
+        if ("true".equalsIgnoreCase(trimmed) || "false".equalsIgnoreCase(trimmed)) {
+            return Boolean.parseBoolean(trimmed);
+        }
+
         try {
-            return Double.parseDouble(value.trim());
+            return Double.parseDouble(trimmed);
         } catch (NumberFormatException e) {
             return value;
         }

--- a/bundles/org.openhab.binding.zwavejs/src/test/java/org/openhab/binding/zwavejs/internal/handler/ZwaveJSBridgeHandlerTest.java
+++ b/bundles/org.openhab.binding.zwavejs/src/test/java/org/openhab/binding/zwavejs/internal/handler/ZwaveJSBridgeHandlerTest.java
@@ -12,6 +12,8 @@
  */
 package org.openhab.binding.zwavejs.internal.handler;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
@@ -26,6 +28,9 @@ import java.util.List;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.openhab.binding.zwavejs.internal.DataUtil;
 import org.openhab.binding.zwavejs.internal.api.dto.Event;
 import org.openhab.binding.zwavejs.internal.api.dto.Node;
@@ -194,6 +199,30 @@ public class ZwaveJSBridgeHandlerTest {
         } finally {
             handler.dispose();
         }
+    }
+
+    @ParameterizedTest
+    @CsvSource({ "true, true", "false, false", "TRUE, true", "False, false", "  true  , true" })
+    public void testConvertValueTypeBoolean(String input, boolean expected) {
+        Object result = ZwaveJSBridgeHandler.convertValueType(input);
+        assertInstanceOf(Boolean.class, result);
+        assertEquals(expected, result);
+    }
+
+    @ParameterizedTest
+    @CsvSource({ "42, 42.0", "42.5, 42.5", "-3.14, -3.14", "0, 0.0", "  7  , 7.0", "1, 1.0" })
+    public void testConvertValueTypeNumber(String input, double expected) {
+        Object result = ZwaveJSBridgeHandler.convertValueType(input);
+        assertInstanceOf(Double.class, result);
+        assertEquals(expected, result);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "hello", "on", "off", "yes", "no", "3abc" })
+    public void testConvertValueTypeString(String input) {
+        Object result = ZwaveJSBridgeHandler.convertValueType(input);
+        assertInstanceOf(String.class, result);
+        assertEquals(input, result);
     }
 
     @Test

--- a/bundles/org.openhab.binding.zwavejs/src/test/java/org/openhab/binding/zwavejs/internal/handler/ZwaveJSBridgeHandlerTest.java
+++ b/bundles/org.openhab.binding.zwavejs/src/test/java/org/openhab/binding/zwavejs/internal/handler/ZwaveJSBridgeHandlerTest.java
@@ -202,7 +202,7 @@ public class ZwaveJSBridgeHandlerTest {
     }
 
     @ParameterizedTest
-    @CsvSource({ "true, true", "false, false", "TRUE, true", "False, false", "  true  , true" })
+    @CsvSource({ "true, true", "false, false", "TRUE, true", "False, false", "'  true  ', true" })
     public void testConvertValueTypeBoolean(String input, boolean expected) {
         Object result = ZwaveJSBridgeHandler.convertValueType(input);
         assertInstanceOf(Boolean.class, result);
@@ -210,7 +210,7 @@ public class ZwaveJSBridgeHandlerTest {
     }
 
     @ParameterizedTest
-    @CsvSource({ "42, 42.0", "42.5, 42.5", "-3.14, -3.14", "0, 0.0", "  7  , 7.0", "1, 1.0" })
+    @CsvSource({ "42, 42.0", "42.5, 42.5", "-3.14, -3.14", "0, 0.0", "'  7  ', 7.0", "1, 1.0" })
     public void testConvertValueTypeNumber(String input, double expected) {
         Object result = ZwaveJSBridgeHandler.convertValueType(input);
         assertInstanceOf(Double.class, result);
@@ -218,11 +218,11 @@ public class ZwaveJSBridgeHandlerTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = { "hello", "on", "off", "yes", "no", "3abc" })
+    @ValueSource(strings = { "hello", "on", "off", "yes", "no", "3abc", "   trimme   " })
     public void testConvertValueTypeString(String input) {
         Object result = ZwaveJSBridgeHandler.convertValueType(input);
         assertInstanceOf(String.class, result);
-        assertEquals(input, result);
+        assertEquals(input.trim(), result);
     }
 
     @Test


### PR DESCRIPTION
# Description

For ZWave properties that are only 2 state, ZWaveJS maps the acceptable values to the booleans true and false.  As an example, this can be seen [here](https://github.com/zwave-js/zwave-js/blob/master/packages/cc/src/cc/MultilevelSwitchCC.ts#L144) for the "multilevel switch" class and command "perform a level change up."  ZWaveJS is strict and will not execute the command if the value sent does not match one of it's expected states exactly.  There is no coercion or conversion of strings supported in ZWaveJS.  This PR addresses an issue where the openhab binding is sending the strings "true" and "false" for the value when executing a multicast message.

# Testing

I've tested this in my local setup to confirm the fix works.  I've also added some unit tests in this PR.