### PR TITLE
[verisure] Fix login failures caused by Verisure API changes

### DIFF
--- a/bundles/org.openhab.binding.verisure/src/main/java/org/openhab/binding/verisure/internal/VerisureHandlerFactory.java
+++ b/bundles/org.openhab.binding.verisure/src/main/java/org/openhab/binding/verisure/internal/VerisureHandlerFactory.java
@@ -72,12 +72,7 @@ public class VerisureHandlerFactory extends BaseThingHandlerFactory {
     private final Logger logger = LoggerFactory.getLogger(VerisureHandlerFactory.class);
     private final HttpClient httpClient;
 
-    /**
-     * Verisure sends large WAF and JWT session cookies that together exceed Jetty's
-     * default 4 kB request buffer, causing "Request header too large" on login. Use a
-     * dedicated HTTP client with a larger request buffer. A dedicated client is also
-     * needed because {@link VerisureSession} temporarily replaces the cookie store.
-     */
+    // Verisure's WAF and JWT session cookies exceed Jetty's default 4 kB request buffer
     private static final int REQUEST_BUFFER_SIZE = 16 * 1024;
 
     @Activate
@@ -87,7 +82,7 @@ public class VerisureHandlerFactory extends BaseThingHandlerFactory {
         try {
             this.httpClient.start();
         } catch (Exception e) {
-            logger.warn("Failed to start Verisure HTTP client: {}", e.getMessage());
+            throw new IllegalStateException("Failed to start HTTP client", e);
         }
     }
 

--- a/bundles/org.openhab.binding.verisure/src/main/java/org/openhab/binding/verisure/internal/VerisureHandlerFactory.java
+++ b/bundles/org.openhab.binding.verisure/src/main/java/org/openhab/binding/verisure/internal/VerisureHandlerFactory.java
@@ -36,6 +36,7 @@ import org.openhab.core.thing.ThingTypeUID;
 import org.openhab.core.thing.binding.BaseThingHandlerFactory;
 import org.openhab.core.thing.binding.ThingHandler;
 import org.openhab.core.thing.binding.ThingHandlerFactory;
+import org.osgi.service.component.ComponentContext;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -71,9 +72,33 @@ public class VerisureHandlerFactory extends BaseThingHandlerFactory {
     private final Logger logger = LoggerFactory.getLogger(VerisureHandlerFactory.class);
     private final HttpClient httpClient;
 
+    /**
+     * Verisure sends large WAF and JWT session cookies that together exceed Jetty's
+     * default 4 kB request buffer, causing "Request header too large" on login. Use a
+     * dedicated HTTP client with a larger request buffer. A dedicated client is also
+     * needed because {@link VerisureSession} temporarily replaces the cookie store.
+     */
+    private static final int REQUEST_BUFFER_SIZE = 16 * 1024;
+
     @Activate
     public VerisureHandlerFactory(@Reference HttpClientFactory httpClientFactory) {
-        this.httpClient = httpClientFactory.getCommonHttpClient();
+        this.httpClient = httpClientFactory.createHttpClient(VerisureBindingConstants.BINDING_ID);
+        this.httpClient.setRequestBufferSize(REQUEST_BUFFER_SIZE);
+        try {
+            this.httpClient.start();
+        } catch (Exception e) {
+            logger.warn("Failed to start Verisure HTTP client: {}", e.getMessage());
+        }
+    }
+
+    @Override
+    protected void deactivate(ComponentContext componentContext) {
+        try {
+            httpClient.stop();
+        } catch (Exception e) {
+            logger.debug("Failed to stop Verisure HTTP client: {}", e.getMessage());
+        }
+        super.deactivate(componentContext);
     }
 
     @Override

--- a/bundles/org.openhab.binding.verisure/src/main/java/org/openhab/binding/verisure/internal/VerisureSession.java
+++ b/bundles/org.openhab.binding.verisure/src/main/java/org/openhab/binding/verisure/internal/VerisureSession.java
@@ -674,8 +674,8 @@ public class VerisureSession {
                     logger.warn("MFA is activated on this user! Not supported by binding!");
                     return false;
                 }
-                String vsAccess = this.vsAccess;
-                if (httpStatusCode != HttpStatus.OK_200 || vsAccess == null || vsAccess.isEmpty()) {
+                String accessToken = vsAccess;
+                if (httpStatusCode != HttpStatus.OK_200 || accessToken == null || accessToken.isEmpty()) {
                     logger.debug("Failed to login, /auth/login HTTP status code: {}", httpStatusCode);
                     return false;
                 }
@@ -692,9 +692,8 @@ public class VerisureSession {
                     logger.debug("Failed to add username cookie: {}", e.getMessage());
                 }
 
-                // Step 4: Call j_spring_security_check to establish the legacy session. Verisure
-                // has started to remove this endpoint (it returns 404); the vs-access token from
-                // /auth/login is then sufficient, so a failure here is not fatal.
+                // Step 4: Legacy login, endpoint removed by Verisure (404); non-fatal since the
+                // vs-access token suffices
                 url = LOGON_SUF;
                 logger.debug("Login URL: {}", url);
                 httpStatusCode = postVerisureAPI(url, authstring);

--- a/bundles/org.openhab.binding.verisure/src/main/java/org/openhab/binding/verisure/internal/VerisureSession.java
+++ b/bundles/org.openhab.binding.verisure/src/main/java/org/openhab/binding/verisure/internal/VerisureSession.java
@@ -674,6 +674,11 @@ public class VerisureSession {
                     logger.warn("MFA is activated on this user! Not supported by binding!");
                     return false;
                 }
+                String vsAccess = this.vsAccess;
+                if (httpStatusCode != HttpStatus.OK_200 || vsAccess == null || vsAccess.isEmpty()) {
+                    logger.debug("Failed to login, /auth/login HTTP status code: {}", httpStatusCode);
+                    return false;
+                }
 
                 // Step 3: Add the username cookie (required by j_spring_security_check)
                 try {
@@ -687,13 +692,16 @@ public class VerisureSession {
                     logger.debug("Failed to add username cookie: {}", e.getMessage());
                 }
 
-                // Step 4: Call j_spring_security_check
+                // Step 4: Call j_spring_security_check to establish the legacy session. Verisure
+                // has started to remove this endpoint (it returns 404); the vs-access token from
+                // /auth/login is then sufficient, so a failure here is not fatal.
                 url = LOGON_SUF;
                 logger.debug("Login URL: {}", url);
                 httpStatusCode = postVerisureAPI(url, authstring);
                 if (httpStatusCode != HttpStatus.OK_200) {
-                    logger.debug("Failed to login, HTTP status code: {}", httpStatusCode);
-                    return false;
+                    logger.debug("Legacy login failed with HTTP status code: {}, continuing with token based session",
+                            httpStatusCode);
+                    return true;
                 }
 
                 // Step 5: Verify login by accessing status page


### PR DESCRIPTION
Fixes #21141

Verisure has made two backend changes (early July 2026) that break the binding's login, leaving the bridge ONLINE but all things frozen with `Please check that you have configured correct deviceId for thing!` warnings:

1. **Large WAF/JWT cookies exceed Jetty's default 4 kB request buffer.** The login POST fails client-side with `org.eclipse.jetty.http.BadMessageException: 500: Request header too large`. Fixed by using a dedicated HTTP client with a 16 kB request buffer instead of the common HTTP client (same approach as e.g. the remehaheating binding). A dedicated client is also cleaner since `VerisureSession` temporarily replaces the cookie store, which previously affected the shared common client.

2. **The legacy `j_spring_security_check` endpoint has been removed (returns 404).** The `vs-access` token from `/auth/login` is sufficient for the GraphQL API, so a legacy login failure is now treated as non-fatal. Instead, a successful `/auth/login` (valid `vs-access` token) is required.

Verified on a live installation (openHAB 5.1.4, two installations/sites, Yale Doorman smart lock): data polling for all thing types works again and commands (door lock/unlock) work via the token-based session.
