### PR TITLE
[WIP] [persistence] Store the time of the update not the time the store occurred

### DIFF
--- a/bundles/org.openhab.persistence.dynamodb/src/main/java/org/openhab/persistence/dynamodb/internal/DynamoDBPersistenceService.java
+++ b/bundles/org.openhab.persistence.dynamodb/src/main/java/org/openhab/persistence/dynamodb/internal/DynamoDBPersistenceService.java
@@ -496,7 +496,8 @@ public class DynamoDBPersistenceService implements QueryablePersistenceService {
     @Override
     public void store(Item item, @Nullable String alias) {
         // Timestamp and capture state immediately as rest of the store is asynchronous (state might change in between)
-        ZonedDateTime time = ZonedDateTime.now();
+        ZonedDateTime lastStateUpdate = item.getLastStateUpdate();
+        ZonedDateTime time = (lastStateUpdate != null ? lastStateUpdate : ZonedDateTime.now());
 
         logIfManyQueuedTasks();
         if (!(item instanceof GenericItem)) {

--- a/bundles/org.openhab.persistence.dynamodb/src/main/java/org/openhab/persistence/dynamodb/internal/DynamoDBQueryUtils.java
+++ b/bundles/org.openhab.persistence.dynamodb/src/main/java/org/openhab/persistence/dynamodb/internal/DynamoDBQueryUtils.java
@@ -194,15 +194,15 @@ public class DynamoDBQueryUtils {
             // No need to place time filter, but we do filter by partition
             queryBuilder.queryConditional(QueryConditional.keyEqualTo(k -> k.partitionValue(partition)));
         } else if (begin != null && end == null) {
-            queryBuilder.queryConditional(QueryConditional
-                    .sortGreaterThan(k -> k.partitionValue(partition).sortValue(timeConverter.transformFrom(begin))));
+            queryBuilder.queryConditional(QueryConditional.sortGreaterThanOrEqualTo(
+                    k -> k.partitionValue(partition).sortValue(timeConverter.transformFrom(begin))));
         } else if (begin == null && end != null) {
-            queryBuilder.queryConditional(QueryConditional
-                    .sortLessThan(k -> k.partitionValue(partition).sortValue(timeConverter.transformFrom(end))));
+            queryBuilder.queryConditional(QueryConditional.sortLessThanOrEqualTo(
+                    k -> k.partitionValue(partition).sortValue(timeConverter.transformFrom(end))));
         } else if (begin != null && end != null) {
             queryBuilder.queryConditional(QueryConditional.sortBetween(
-                    k -> k.partitionValue(partition).sortValue(timeConverter.transformFrom(begin)),
-                    k -> k.partitionValue(partition).sortValue(timeConverter.transformFrom(end))));
+                    k -> k.partitionValue(partition).sortValue(timeConverter.transformFrom(begin.minusNanos(1))),
+                    k -> k.partitionValue(partition).sortValue(timeConverter.transformFrom(end.plusNanos(1)))));
         }
     }
 

--- a/bundles/org.openhab.persistence.dynamodb/src/main/java/org/openhab/persistence/dynamodb/internal/DynamoDBQueryUtils.java
+++ b/bundles/org.openhab.persistence.dynamodb/src/main/java/org/openhab/persistence/dynamodb/internal/DynamoDBQueryUtils.java
@@ -14,6 +14,7 @@ package org.openhab.persistence.dynamodb.internal;
 
 import java.lang.reflect.InvocationTargetException;
 import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
@@ -201,8 +202,10 @@ public class DynamoDBQueryUtils {
                     k -> k.partitionValue(partition).sortValue(timeConverter.transformFrom(end))));
         } else if (begin != null && end != null) {
             queryBuilder.queryConditional(QueryConditional.sortBetween(
-                    k -> k.partitionValue(partition).sortValue(timeConverter.transformFrom(begin.minusNanos(1))),
-                    k -> k.partitionValue(partition).sortValue(timeConverter.transformFrom(end.plusNanos(1)))));
+                    k -> k.partitionValue(partition)
+                            .sortValue(timeConverter.transformFrom(begin.truncatedTo(ChronoUnit.MILLIS).minusNanos(1))),
+                    k -> k.partitionValue(partition)
+                            .sortValue(timeConverter.transformFrom(end.truncatedTo(ChronoUnit.MILLIS).plusNanos(1)))));
         }
     }
 

--- a/bundles/org.openhab.persistence.dynamodb/src/test/java/org/openhab/persistence/dynamodb/internal/AbstractTwoItemIntegrationTest.java
+++ b/bundles/org.openhab.persistence.dynamodb/src/test/java/org/openhab/persistence/dynamodb/internal/AbstractTwoItemIntegrationTest.java
@@ -110,12 +110,12 @@ public abstract class AbstractTwoItemIntegrationTest extends BaseIntegrationTest
         }
 
         assertStateEquals(getFirstItemState(), storedFirst.getState());
-        assertTrue(storedFirst.getTimestamp().toInstant().isBefore(afterStore1.toInstant()));
-        assertTrue(storedFirst.getTimestamp().toInstant().isAfter(beforeStore.toInstant()));
+        assertTrue(!storedFirst.getTimestamp().toInstant().isAfter(afterStore1.toInstant()));
+        assertTrue(!storedFirst.getTimestamp().toInstant().isBefore(beforeStore.toInstant()));
 
         assertStateEquals(getSecondItemState(), storedSecond.getState());
-        assertTrue(storedSecond.getTimestamp().toInstant().isBefore(afterStore2.toInstant()));
-        assertTrue(storedSecond.getTimestamp().toInstant().isAfter(afterStore1.toInstant()));
+        assertTrue(!storedSecond.getTimestamp().toInstant().isAfter(afterStore2.toInstant()));
+        assertTrue(!storedSecond.getTimestamp().toInstant().isBefore(afterStore1.toInstant()));
     }
 
     @Test
@@ -225,8 +225,8 @@ public abstract class AbstractTwoItemIntegrationTest extends BaseIntegrationTest
             HistoricItem actual1 = iterator.next();
             assertFalse(iterator.hasNext());
             assertStateEquals(getFirstItemState(), actual1.getState());
-            assertTrue(actual1.getInstant().isBefore(afterStore1.toInstant()));
-            assertTrue(actual1.getInstant().isAfter(beforeStore.toInstant()));
+            assertTrue(!actual1.getInstant().isAfter(afterStore1.toInstant()));
+            assertTrue(!actual1.getInstant().isBefore(beforeStore.toInstant()));
         });
     }
 
@@ -246,8 +246,8 @@ public abstract class AbstractTwoItemIntegrationTest extends BaseIntegrationTest
             HistoricItem actual1 = iterator.next();
             assertFalse(iterator.hasNext());
             assertStateEquals(getFirstItemState(), actual1.getState());
-            assertTrue(actual1.getInstant().isBefore(afterStore1.toInstant()));
-            assertTrue(actual1.getInstant().isAfter(beforeStore.toInstant()));
+            assertTrue(!actual1.getInstant().isAfter(afterStore1.toInstant()));
+            assertTrue(!actual1.getInstant().isBefore(beforeStore.toInstant()));
         });
     }
 
@@ -267,8 +267,8 @@ public abstract class AbstractTwoItemIntegrationTest extends BaseIntegrationTest
             HistoricItem actual1 = iterator.next();
             assertFalse(iterator.hasNext());
             assertStateEquals(getFirstItemState(), actual1.getState());
-            assertTrue(actual1.getInstant().isBefore(afterStore1.toInstant()));
-            assertTrue(actual1.getInstant().isAfter(beforeStore.toInstant()));
+            assertTrue(!actual1.getInstant().isAfter(afterStore1.toInstant()));
+            assertTrue(!actual1.getInstant().isBefore(beforeStore.toInstant()));
         });
     }
 
@@ -304,8 +304,8 @@ public abstract class AbstractTwoItemIntegrationTest extends BaseIntegrationTest
             HistoricItem actual1 = iterator.next();
             assertFalse(iterator.hasNext());
             assertStateEquals(getFirstItemState(), actual1.getState());
-            assertTrue(actual1.getInstant().isBefore(afterStore1.toInstant()));
-            assertTrue(actual1.getInstant().isAfter(beforeStore.toInstant()));
+            assertTrue(!actual1.getInstant().isAfter(afterStore1.toInstant()));
+            assertTrue(!actual1.getInstant().isBefore(beforeStore.toInstant()));
         });
     }
 
@@ -331,8 +331,8 @@ public abstract class AbstractTwoItemIntegrationTest extends BaseIntegrationTest
             HistoricItem actual1 = iterator.next();
             assertFalse(iterator.hasNext());
             assertStateEquals(getSecondItemState(), actual1.getState());
-            assertTrue(actual1.getTimestamp().toInstant().isBefore(afterStore2.toInstant()));
-            assertTrue(actual1.getTimestamp().toInstant().isAfter(afterStore1.toInstant()));
+            assertTrue(!actual1.getTimestamp().toInstant().isAfter(afterStore2.toInstant()));
+            assertTrue(!actual1.getTimestamp().toInstant().isBefore(afterStore1.toInstant()));
         });
     }
 
@@ -368,8 +368,8 @@ public abstract class AbstractTwoItemIntegrationTest extends BaseIntegrationTest
             HistoricItem actual1 = iterator.next();
             assertFalse(iterator.hasNext());
             assertStateEquals(getSecondItemState(), actual1.getState());
-            assertTrue(actual1.getTimestamp().toInstant().isBefore(afterStore2.toInstant()));
-            assertTrue(actual1.getTimestamp().toInstant().isAfter(afterStore1.toInstant()));
+            assertTrue(!actual1.getTimestamp().toInstant().isAfter(afterStore2.toInstant()));
+            assertTrue(!actual1.getTimestamp().toInstant().isBefore(afterStore1.toInstant()));
         });
     }
 
@@ -389,8 +389,8 @@ public abstract class AbstractTwoItemIntegrationTest extends BaseIntegrationTest
             HistoricItem actual1 = iterator.next();
             assertFalse(iterator.hasNext());
             assertStateEquals(getFirstItemState(), actual1.getState());
-            assertTrue(actual1.getTimestamp().toInstant().isBefore(afterStore1.toInstant()));
-            assertTrue(actual1.getTimestamp().toInstant().isAfter(beforeStore.toInstant()));
+            assertTrue(!actual1.getTimestamp().toInstant().isAfter(afterStore1.toInstant()));
+            assertTrue(!actual1.getTimestamp().toInstant().isBefore(beforeStore.toInstant()));
         });
     }
 

--- a/bundles/org.openhab.persistence.dynamodb/src/test/java/org/openhab/persistence/dynamodb/internal/CallItemIntegrationTest.java
+++ b/bundles/org.openhab.persistence.dynamodb/src/test/java/org/openhab/persistence/dynamodb/internal/CallItemIntegrationTest.java
@@ -15,6 +15,7 @@ package org.openhab.persistence.dynamodb.internal;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
@@ -43,16 +44,17 @@ public class CallItemIntegrationTest extends AbstractTwoItemIntegrationTest {
     @BeforeAll
     public static void storeData() throws InterruptedException {
         CallItem item = (CallItem) ITEMS.get(NAME);
+        beforeStore = ZonedDateTime.now().truncatedTo(ChronoUnit.MILLIS);
+        Thread.sleep(1);
         item.setState(STATE1);
-        beforeStore = ZonedDateTime.now();
         Thread.sleep(10);
         service.store(item);
-        afterStore1 = ZonedDateTime.now();
+        afterStore1 = ZonedDateTime.now().truncatedTo(ChronoUnit.MILLIS);
         Thread.sleep(10);
         item.setState(STATE2);
         service.store(item);
         Thread.sleep(10);
-        afterStore2 = ZonedDateTime.now();
+        afterStore2 = ZonedDateTime.now().truncatedTo(ChronoUnit.MILLIS);
 
         LOGGER.info("Created item between {} and {}", AbstractDynamoDBItem.DATEFORMATTER.format(beforeStore),
                 AbstractDynamoDBItem.DATEFORMATTER.format(afterStore1));

--- a/bundles/org.openhab.persistence.dynamodb/src/test/java/org/openhab/persistence/dynamodb/internal/ColorItemIntegrationTest.java
+++ b/bundles/org.openhab.persistence.dynamodb/src/test/java/org/openhab/persistence/dynamodb/internal/ColorItemIntegrationTest.java
@@ -14,6 +14,7 @@ package org.openhab.persistence.dynamodb.internal;
 
 import java.math.BigDecimal;
 import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
@@ -54,16 +55,17 @@ public class ColorItemIntegrationTest extends AbstractTwoItemIntegrationTest {
     @BeforeAll
     public static void storeData() throws InterruptedException {
         ColorItem item = (ColorItem) ITEMS.get(NAME);
+        beforeStore = ZonedDateTime.now().truncatedTo(ChronoUnit.MILLIS);
+        Thread.sleep(1);
         item.setState(STATE1);
-        beforeStore = ZonedDateTime.now();
         Thread.sleep(10);
         service.store(item);
-        afterStore1 = ZonedDateTime.now();
+        afterStore1 = ZonedDateTime.now().truncatedTo(ChronoUnit.MILLIS);
         Thread.sleep(10);
         item.setState(STATE2);
         service.store(item);
         Thread.sleep(10);
-        afterStore2 = ZonedDateTime.now();
+        afterStore2 = ZonedDateTime.now().truncatedTo(ChronoUnit.MILLIS);
 
         LOGGER.info("Created item between {} and {}", AbstractDynamoDBItem.DATEFORMATTER.format(beforeStore),
                 AbstractDynamoDBItem.DATEFORMATTER.format(afterStore1));

--- a/bundles/org.openhab.persistence.dynamodb/src/test/java/org/openhab/persistence/dynamodb/internal/ContactItemIntegrationTest.java
+++ b/bundles/org.openhab.persistence.dynamodb/src/test/java/org/openhab/persistence/dynamodb/internal/ContactItemIntegrationTest.java
@@ -13,6 +13,7 @@
 package org.openhab.persistence.dynamodb.internal;
 
 import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
@@ -41,16 +42,17 @@ public class ContactItemIntegrationTest extends AbstractTwoItemIntegrationTest {
     @BeforeAll
     public static void storeData() throws InterruptedException {
         ContactItem item = (ContactItem) ITEMS.get(NAME);
+        beforeStore = ZonedDateTime.now().truncatedTo(ChronoUnit.MILLIS);
+        Thread.sleep(1);
         item.setState(STATE1);
-        beforeStore = ZonedDateTime.now();
         Thread.sleep(10);
         service.store(item);
-        afterStore1 = ZonedDateTime.now();
+        afterStore1 = ZonedDateTime.now().truncatedTo(ChronoUnit.MILLIS);
         Thread.sleep(10);
         item.setState(STATE2);
         service.store(item);
         Thread.sleep(10);
-        afterStore2 = ZonedDateTime.now();
+        afterStore2 = ZonedDateTime.now().truncatedTo(ChronoUnit.MILLIS);
 
         LOGGER.info("Created item between {} and {}", AbstractDynamoDBItem.DATEFORMATTER.format(beforeStore),
                 AbstractDynamoDBItem.DATEFORMATTER.format(afterStore1));

--- a/bundles/org.openhab.persistence.dynamodb/src/test/java/org/openhab/persistence/dynamodb/internal/DateTimeItemIntegrationTest.java
+++ b/bundles/org.openhab.persistence.dynamodb/src/test/java/org/openhab/persistence/dynamodb/internal/DateTimeItemIntegrationTest.java
@@ -14,6 +14,7 @@ package org.openhab.persistence.dynamodb.internal;
 
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
@@ -47,17 +48,17 @@ public class DateTimeItemIntegrationTest extends AbstractTwoItemIntegrationTest 
     public static void storeData() throws InterruptedException {
         DateTimeItem item = (DateTimeItem) ITEMS.get(NAME);
 
+        beforeStore = ZonedDateTime.now().truncatedTo(ChronoUnit.MILLIS);
+        Thread.sleep(1);
         item.setState(STATE1);
-
-        beforeStore = ZonedDateTime.now();
         Thread.sleep(10);
         service.store(item);
-        afterStore1 = ZonedDateTime.now();
+        afterStore1 = ZonedDateTime.now().truncatedTo(ChronoUnit.MILLIS);
         Thread.sleep(10);
         item.setState(STATE2);
         service.store(item);
         Thread.sleep(10);
-        afterStore2 = ZonedDateTime.now();
+        afterStore2 = ZonedDateTime.now().truncatedTo(ChronoUnit.MILLIS);
         LOGGER.info("Created item between {} and {}", AbstractDynamoDBItem.DATEFORMATTER.format(beforeStore),
                 AbstractDynamoDBItem.DATEFORMATTER.format(afterStore1));
     }

--- a/bundles/org.openhab.persistence.dynamodb/src/test/java/org/openhab/persistence/dynamodb/internal/DimmerItemIntegrationTest.java
+++ b/bundles/org.openhab.persistence.dynamodb/src/test/java/org/openhab/persistence/dynamodb/internal/DimmerItemIntegrationTest.java
@@ -13,6 +13,7 @@
 package org.openhab.persistence.dynamodb.internal;
 
 import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
@@ -40,17 +41,17 @@ public class DimmerItemIntegrationTest extends AbstractTwoItemIntegrationTest {
     public static void storeData() throws InterruptedException {
         DimmerItem item = (DimmerItem) ITEMS.get(NAME);
 
+        beforeStore = ZonedDateTime.now().truncatedTo(ChronoUnit.MILLIS);
+        Thread.sleep(1);
         item.setState(STATE1);
-
-        beforeStore = ZonedDateTime.now();
         Thread.sleep(10);
         service.store(item);
-        afterStore1 = ZonedDateTime.now();
+        afterStore1 = ZonedDateTime.now().truncatedTo(ChronoUnit.MILLIS);
         Thread.sleep(10);
         item.setState(STATE2);
         service.store(item);
         Thread.sleep(10);
-        afterStore2 = ZonedDateTime.now();
+        afterStore2 = ZonedDateTime.now().truncatedTo(ChronoUnit.MILLIS);
         LOGGER.info("Created item between {} and {}", AbstractDynamoDBItem.DATEFORMATTER.format(beforeStore),
                 AbstractDynamoDBItem.DATEFORMATTER.format(afterStore1));
     }

--- a/bundles/org.openhab.persistence.dynamodb/src/test/java/org/openhab/persistence/dynamodb/internal/LocationItemIntegrationTest.java
+++ b/bundles/org.openhab.persistence.dynamodb/src/test/java/org/openhab/persistence/dynamodb/internal/LocationItemIntegrationTest.java
@@ -13,6 +13,7 @@
 package org.openhab.persistence.dynamodb.internal;
 
 import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
@@ -43,16 +44,17 @@ public class LocationItemIntegrationTest extends AbstractTwoItemIntegrationTest 
     @BeforeAll
     public static void storeData() throws InterruptedException {
         LocationItem item = (LocationItem) ITEMS.get(NAME);
+        beforeStore = ZonedDateTime.now().truncatedTo(ChronoUnit.MILLIS);
+        Thread.sleep(1);
         item.setState(STATE1);
-        beforeStore = ZonedDateTime.now();
         Thread.sleep(10);
         service.store(item);
-        afterStore1 = ZonedDateTime.now();
+        afterStore1 = ZonedDateTime.now().truncatedTo(ChronoUnit.MILLIS);
         Thread.sleep(10);
         item.setState(STATE2);
         service.store(item);
         Thread.sleep(10);
-        afterStore2 = ZonedDateTime.now();
+        afterStore2 = ZonedDateTime.now().truncatedTo(ChronoUnit.MILLIS);
 
         LOGGER.info("Created item between {} and {}", AbstractDynamoDBItem.DATEFORMATTER.format(beforeStore),
                 AbstractDynamoDBItem.DATEFORMATTER.format(afterStore1));

--- a/bundles/org.openhab.persistence.dynamodb/src/test/java/org/openhab/persistence/dynamodb/internal/NumberItemIntegrationTest.java
+++ b/bundles/org.openhab.persistence.dynamodb/src/test/java/org/openhab/persistence/dynamodb/internal/NumberItemIntegrationTest.java
@@ -16,6 +16,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.math.BigDecimal;
 import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
@@ -45,17 +46,17 @@ public class NumberItemIntegrationTest extends AbstractTwoItemIntegrationTest {
     public static void storeData() throws InterruptedException {
         NumberItem item = (NumberItem) ITEMS.get(NAME);
 
+        beforeStore = ZonedDateTime.now().truncatedTo(ChronoUnit.MILLIS);
+        Thread.sleep(1);
         item.setState(STATE1);
-
-        beforeStore = ZonedDateTime.now();
         Thread.sleep(10);
         service.store(item);
-        afterStore1 = ZonedDateTime.now();
+        afterStore1 = ZonedDateTime.now().truncatedTo(ChronoUnit.MILLIS);
         Thread.sleep(10);
         item.setState(STATE2);
         service.store(item);
         Thread.sleep(10);
-        afterStore2 = ZonedDateTime.now();
+        afterStore2 = ZonedDateTime.now().truncatedTo(ChronoUnit.MILLIS);
 
         LOGGER.info("Created item between {} and {}", AbstractDynamoDBItem.DATEFORMATTER.format(beforeStore),
                 AbstractDynamoDBItem.DATEFORMATTER.format(afterStore1));

--- a/bundles/org.openhab.persistence.dynamodb/src/test/java/org/openhab/persistence/dynamodb/internal/PagingIntegrationTest.java
+++ b/bundles/org.openhab.persistence.dynamodb/src/test/java/org/openhab/persistence/dynamodb/internal/PagingIntegrationTest.java
@@ -16,6 +16,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import java.math.BigDecimal;
 import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -49,7 +50,11 @@ public class PagingIntegrationTest extends BaseIntegrationTest {
     @SuppressWarnings("null")
     @BeforeAll
     public static void populateData() {
-        storeStart = ZonedDateTime.now();
+        storeStart = ZonedDateTime.now().truncatedTo(ChronoUnit.MILLIS);
+        try {
+            Thread.sleep(1);
+        } catch (InterruptedException e) {
+        }
 
         NumberItem item = (NumberItem) ITEMS.get(NAME);
         for (int i = 0; i < STATE_COUNT; i++) {

--- a/bundles/org.openhab.persistence.dynamodb/src/test/java/org/openhab/persistence/dynamodb/internal/PlayerItemPlayPauseIntegrationTest.java
+++ b/bundles/org.openhab.persistence.dynamodb/src/test/java/org/openhab/persistence/dynamodb/internal/PlayerItemPlayPauseIntegrationTest.java
@@ -13,6 +13,7 @@
 package org.openhab.persistence.dynamodb.internal;
 
 import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
@@ -40,17 +41,17 @@ public class PlayerItemPlayPauseIntegrationTest extends AbstractTwoItemIntegrati
     public static void storeData() throws InterruptedException {
         PlayerItem item = (PlayerItem) ITEMS.get(NAME);
 
+        beforeStore = ZonedDateTime.now().truncatedTo(ChronoUnit.MILLIS);
+        Thread.sleep(1);
         item.setState(STATE1);
-
-        beforeStore = ZonedDateTime.now();
         Thread.sleep(10);
         service.store(item);
-        afterStore1 = ZonedDateTime.now();
+        afterStore1 = ZonedDateTime.now().truncatedTo(ChronoUnit.MILLIS);
         Thread.sleep(10);
         item.setState(STATE2);
         service.store(item);
         Thread.sleep(10);
-        afterStore2 = ZonedDateTime.now();
+        afterStore2 = ZonedDateTime.now().truncatedTo(ChronoUnit.MILLIS);
 
         LOGGER.info("Created item between {} and {}", AbstractDynamoDBItem.DATEFORMATTER.format(beforeStore),
                 AbstractDynamoDBItem.DATEFORMATTER.format(afterStore1));

--- a/bundles/org.openhab.persistence.dynamodb/src/test/java/org/openhab/persistence/dynamodb/internal/PlayerItemRewindFastForwardIntegrationTest.java
+++ b/bundles/org.openhab.persistence.dynamodb/src/test/java/org/openhab/persistence/dynamodb/internal/PlayerItemRewindFastForwardIntegrationTest.java
@@ -13,6 +13,7 @@
 package org.openhab.persistence.dynamodb.internal;
 
 import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
 
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -58,17 +59,17 @@ public class PlayerItemRewindFastForwardIntegrationTest extends AbstractTwoItemI
 
         PlayerItem item = (PlayerItem) ITEMS.get(NAME);
 
+        beforeStore = ZonedDateTime.now().truncatedTo(ChronoUnit.MILLIS);
+        Thread.sleep(1);
         item.setState(localState1);
-
-        beforeStore = ZonedDateTime.now();
         Thread.sleep(10);
         service.store(item);
-        afterStore1 = ZonedDateTime.now();
+        afterStore1 = ZonedDateTime.now().truncatedTo(ChronoUnit.MILLIS);
         Thread.sleep(10);
         item.setState(localState2);
         service.store(item);
         Thread.sleep(10);
-        afterStore2 = ZonedDateTime.now();
+        afterStore2 = ZonedDateTime.now().truncatedTo(ChronoUnit.MILLIS);
 
         LOGGER.info("Created item between {} and {}", AbstractDynamoDBItem.DATEFORMATTER.format(beforeStore),
                 AbstractDynamoDBItem.DATEFORMATTER.format(afterStore1));

--- a/bundles/org.openhab.persistence.dynamodb/src/test/java/org/openhab/persistence/dynamodb/internal/RollershutterItemIntegrationTest.java
+++ b/bundles/org.openhab.persistence.dynamodb/src/test/java/org/openhab/persistence/dynamodb/internal/RollershutterItemIntegrationTest.java
@@ -16,6 +16,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.math.BigDecimal;
 import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
@@ -43,16 +44,17 @@ public class RollershutterItemIntegrationTest extends AbstractTwoItemIntegration
     @BeforeAll
     public static void storeData() throws InterruptedException {
         RollershutterItem item = (RollershutterItem) ITEMS.get(NAME);
+        beforeStore = ZonedDateTime.now().truncatedTo(ChronoUnit.MILLIS);
+        Thread.sleep(1);
         item.setState(STATE1);
-        beforeStore = ZonedDateTime.now();
         Thread.sleep(10);
         service.store(item);
-        afterStore1 = ZonedDateTime.now();
+        afterStore1 = ZonedDateTime.now().truncatedTo(ChronoUnit.MILLIS);
         Thread.sleep(10);
         item.setState(STATE2);
         service.store(item);
         Thread.sleep(10);
-        afterStore2 = ZonedDateTime.now();
+        afterStore2 = ZonedDateTime.now().truncatedTo(ChronoUnit.MILLIS);
 
         LOGGER.info("Created item between {} and {}", AbstractDynamoDBItem.DATEFORMATTER.format(beforeStore),
                 AbstractDynamoDBItem.DATEFORMATTER.format(afterStore1));

--- a/bundles/org.openhab.persistence.dynamodb/src/test/java/org/openhab/persistence/dynamodb/internal/StringItemIntegrationTest.java
+++ b/bundles/org.openhab.persistence.dynamodb/src/test/java/org/openhab/persistence/dynamodb/internal/StringItemIntegrationTest.java
@@ -13,6 +13,7 @@
 package org.openhab.persistence.dynamodb.internal;
 
 import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
@@ -39,16 +40,17 @@ public class StringItemIntegrationTest extends AbstractTwoItemIntegrationTest {
     @BeforeAll
     public static void storeData() throws InterruptedException {
         StringItem item = (StringItem) ITEMS.get(NAME);
+        beforeStore = ZonedDateTime.now().truncatedTo(ChronoUnit.MILLIS);
+        Thread.sleep(1);
         item.setState(STATE1);
-        beforeStore = ZonedDateTime.now();
         Thread.sleep(10);
         service.store(item);
-        afterStore1 = ZonedDateTime.now();
+        afterStore1 = ZonedDateTime.now().truncatedTo(ChronoUnit.MILLIS);
         Thread.sleep(10);
         item.setState(STATE2);
         service.store(item);
         Thread.sleep(10);
-        afterStore2 = ZonedDateTime.now();
+        afterStore2 = ZonedDateTime.now().truncatedTo(ChronoUnit.MILLIS);
 
         LOGGER.info("Created item between {} and {}", AbstractDynamoDBItem.DATEFORMATTER.format(beforeStore),
                 AbstractDynamoDBItem.DATEFORMATTER.format(afterStore1));

--- a/bundles/org.openhab.persistence.dynamodb/src/test/java/org/openhab/persistence/dynamodb/internal/SwitchItemIntegrationTest.java
+++ b/bundles/org.openhab.persistence.dynamodb/src/test/java/org/openhab/persistence/dynamodb/internal/SwitchItemIntegrationTest.java
@@ -13,6 +13,7 @@
 package org.openhab.persistence.dynamodb.internal;
 
 import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
@@ -41,16 +42,17 @@ public class SwitchItemIntegrationTest extends AbstractTwoItemIntegrationTest {
     @BeforeAll
     public static void storeData() throws InterruptedException {
         SwitchItem item = (SwitchItem) ITEMS.get(NAME);
+        beforeStore = ZonedDateTime.now().truncatedTo(ChronoUnit.MILLIS);
+        Thread.sleep(1);
         item.setState(STATE1);
-        beforeStore = ZonedDateTime.now();
         Thread.sleep(10);
         service.store(item);
-        afterStore1 = ZonedDateTime.now();
+        afterStore1 = ZonedDateTime.now().truncatedTo(ChronoUnit.MILLIS);
         Thread.sleep(10);
         item.setState(STATE2);
         service.store(item);
         Thread.sleep(10);
-        afterStore2 = ZonedDateTime.now();
+        afterStore2 = ZonedDateTime.now().truncatedTo(ChronoUnit.MILLIS);
 
         LOGGER.info("Created item between {} and {}", AbstractDynamoDBItem.DATEFORMATTER.format(beforeStore),
                 AbstractDynamoDBItem.DATEFORMATTER.format(afterStore1));

--- a/bundles/org.openhab.persistence.inmemory/src/main/java/org/openhab/persistence/inmemory/internal/InMemoryPersistenceService.java
+++ b/bundles/org.openhab.persistence.inmemory/src/main/java/org/openhab/persistence/inmemory/internal/InMemoryPersistenceService.java
@@ -127,13 +127,13 @@ public class InMemoryPersistenceService implements ModifiablePersistenceService 
 
     @Override
     public void store(Item item) {
-        internalStore(item.getName(), ZonedDateTime.now(), item.getState());
+        store(item, null);
     }
 
     @Override
     public void store(Item item, @Nullable String alias) {
-        String finalName = Objects.requireNonNullElse(alias, item.getName());
-        internalStore(finalName, ZonedDateTime.now(), item.getState());
+        ZonedDateTime lastStateUpdate = Objects.requireNonNullElse(item.getLastStateUpdate(), ZonedDateTime.now());
+        store(item, lastStateUpdate, item.getState(), alias);
     }
 
     @Override

--- a/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/internal/JdbcPersistenceService.java
+++ b/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/internal/JdbcPersistenceService.java
@@ -137,17 +137,21 @@ public class JdbcPersistenceService extends JdbcMapper implements ModifiablePers
 
     @Override
     public void store(Item item) {
-        scheduler.execute(() -> internalStore(item, null, item.getState(), null));
+        store(item, null);
     }
 
     @Override
     public void store(Item item, @Nullable String alias) {
-        scheduler.execute(() -> internalStore(item, null, item.getState(), alias));
+        ZonedDateTime lastStateUpdate = item.getLastStateUpdate();
+        if (lastStateUpdate == null) {
+            lastStateUpdate = ZonedDateTime.now();
+        }
+        store(item, lastStateUpdate, item.getState(), alias);
     }
 
     @Override
     public void store(Item item, ZonedDateTime date, State state) {
-        scheduler.execute(() -> internalStore(item, date, state, null));
+        store(item, date, state, null);
     }
 
     @Override

--- a/bundles/org.openhab.persistence.jpa/src/main/java/org/openhab/persistence/jpa/internal/JpaPersistenceService.java
+++ b/bundles/org.openhab.persistence.jpa/src/main/java/org/openhab/persistence/jpa/internal/JpaPersistenceService.java
@@ -12,6 +12,7 @@
  */
 package org.openhab.persistence.jpa.internal;
 
+import java.time.ZonedDateTime;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -153,7 +154,8 @@ public class JpaPersistenceService implements QueryablePersistenceService {
         }
         pItem.setName(name);
         pItem.setRealName(item.getName());
-        pItem.setTimestamp(new Date());
+        ZonedDateTime lastStateUpdate = item.getLastStateUpdate();
+        pItem.setTimestamp(lastStateUpdate != null ? Date.from(lastStateUpdate.toInstant()) : new Date());
 
         EntityManager em = getEntityManagerFactory().createEntityManager();
         try {

--- a/bundles/org.openhab.persistence.mongodb/src/main/java/org/openhab/persistence/mongodb/internal/MongoDBPersistenceService.java
+++ b/bundles/org.openhab.persistence.mongodb/src/main/java/org/openhab/persistence/mongodb/internal/MongoDBPersistenceService.java
@@ -312,13 +312,14 @@ public class MongoDBPersistenceService implements ModifiablePersistenceService {
     }
 
     @Override
-    public void store(Item item, @Nullable String alias) {
-        store(item, new Date(), item.getState(), alias);
+    public void store(Item item) {
+        store(item, null);
     }
 
     @Override
-    public void store(Item item) {
-        store(item, null);
+    public void store(Item item, @Nullable String alias) {
+        ZonedDateTime lastStateUpdate = item.getLastStateUpdate();
+        store(item, (lastStateUpdate != null ? lastStateUpdate : ZonedDateTime.now()), item.getState(), alias);
     }
 
     @Override

--- a/bundles/org.openhab.persistence.rrd4j/src/main/java/org/openhab/persistence/rrd4j/internal/RRD4jPersistenceService.java
+++ b/bundles/org.openhab.persistence.rrd4j/src/main/java/org/openhab/persistence/rrd4j/internal/RRD4jPersistenceService.java
@@ -288,6 +288,11 @@ public class RRD4jPersistenceService implements QueryablePersistenceService {
     }
 
     @Override
+    public void store(Item item) {
+        store(item, null);
+    }
+
+    @Override
     public void store(final Item item, @Nullable final String alias) {
         if (!active) {
             logger.warn("Tried to store {} but service is not yet ready (or shutting down).", item);
@@ -331,12 +336,13 @@ public class RRD4jPersistenceService implements QueryablePersistenceService {
             return;
         }
 
-        long now = System.currentTimeMillis() / 1000;
-        Double oldValue = storageMap.put(new Key(now, name), value);
+        long lastStateUpdate = Objects.requireNonNullElse(item.getLastStateUpdate(), ZonedDateTime.now())
+                .toEpochSecond();
+        Double oldValue = storageMap.put(new Key(lastStateUpdate, name), value);
         if (oldValue != null && !oldValue.equals(value)) {
             logger.debug(
                     "Discarding value {} for item {} with timestamp {} because a new value ({}) arrived with the same timestamp.",
-                    oldValue, item.getName(), now, value);
+                    oldValue, item.getName(), lastStateUpdate, value);
         }
     }
 
@@ -405,11 +411,6 @@ public class RRD4jPersistenceService implements QueryablePersistenceService {
         } catch (IOException e) {
             logger.debug("Error closing rrd4j database: {}", e.getMessage());
         }
-    }
-
-    @Override
-    public void store(Item item) {
-        store(item, null);
     }
 
     @Override

--- a/bundles/org.openhab.persistence.timescaledb/src/main/java/org/openhab/persistence/timescaledb/internal/TimescaleDBPersistenceService.java
+++ b/bundles/org.openhab.persistence.timescaledb/src/main/java/org/openhab/persistence/timescaledb/internal/TimescaleDBPersistenceService.java
@@ -232,7 +232,8 @@ public class TimescaleDBPersistenceService implements ModifiablePersistenceServi
 
     @Override
     public void store(Item item, @Nullable String alias) {
-        store(item, ZonedDateTime.now(), item.getState(), alias);
+        ZonedDateTime lastStateUpdate = item.getLastStateUpdate();
+        store(item, (lastStateUpdate != null ? lastStateUpdate : ZonedDateTime.now()), item.getState(), alias);
     }
 
     // -------------------------------------------------------------------------


### PR DESCRIPTION
Only mapdb has it right. The rest... :-(

Using now instead of the update time means (a) different persistence services disagree about when state update occurred and (b) roll-forward of forecast time series introduces bogus entries in persistence.