### PR TITLE
[unifi] Include userStatus and door name in Access log payloads

### DIFF
--- a/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/access/handler/UnifiAccessLogPayloadBuilder.java
+++ b/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/access/handler/UnifiAccessLogPayloadBuilder.java
@@ -80,6 +80,11 @@ public class UnifiAccessLogPayloadBuilder {
         if (data.source.actor != null) {
             putIfNonNull(logMap, "actorName", data.source.actor.displayName);
         }
+        if (data.source.authentication != null) {
+            putIfNonNull(logMap, "credentialProvider", data.source.authentication.credentialProvider);
+        }
+        putIfNonNull(logMap, "doorName", targetDisplayName(data, "door"));
+        putIfNonNull(logMap, "userStatus", targetDisplayName(data, "user_status"));
         return gson.toJson(logMap);
     }
 
@@ -100,8 +105,29 @@ public class UnifiAccessLogPayloadBuilder {
         }
         if (data.source.event != null) {
             putIfNonNull(accessMap, "message", data.source.event.displayMessage);
+            putIfNonNull(accessMap, "result", data.source.event.result);
+            putIfNonNull(accessMap, "published", data.source.event.published);
         }
+        putIfNonNull(accessMap, "doorName", targetDisplayName(data, "door"));
+        putIfNonNull(accessMap, "userStatus", targetDisplayName(data, "user_status"));
         return gson.toJson(accessMap);
+    }
+
+    /**
+     * Extracts the {@code displayName} of the first {@code _source.target} entry matching the given
+     * {@code type} (e.g. {@code "door"} or {@code "user_status"}). The UniFi Access log event carries
+     * these as typed references in the target array rather than as dedicated fields.
+     *
+     * @param data the log data
+     * @param type the target {@code type} to look for
+     * @return the matching non-empty display name, or {@code null} if absent
+     */
+    private static @Nullable String targetDisplayName(LogsAddData data, String type) {
+        if (data.source.target == null) {
+            return null;
+        }
+        return data.source.target.stream().filter(t -> type.equalsIgnoreCase(t.type)).map(t -> t.displayName)
+                .filter(v -> v != null && !v.isEmpty()).findFirst().orElse(null);
     }
 
     private static void putIfNonNull(Map<String, Object> map, String key, @Nullable Object value) {


### PR DESCRIPTION
The Access `access.logs.add` event already carries the acting user's status and the door display name in its `_source.target[]` array (alongside `credentialProvider`), but the `log` and `access-attempt-success/failure` trigger payloads never surfaced them.

This extracts `userStatus` and `doorName` (plus `result`/`published` on the access-attempt payload) using the same target lookup the router already does for the door id — so a rule can react to *who* opened *which* door and whether that user's access is still `ACTIVE` (e.g. a card a reader honoured from its offline cache after the user was revoked) without a second API round-trip.

Verified against live events from a UA-G2-PRO reader on a UDM.
