### PR TITLE
[unifi] Fix Access insight-log parsing when an event has multiple devices

### DIFF
--- a/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/access/dto/Notification.java
+++ b/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/access/dto/Notification.java
@@ -427,7 +427,8 @@ public class Notification {
             public Authentication authentication;
             public BaseReference building;
             public List<CameraCaptureReference> cameraCapture;
-            public BaseReference device;
+            // The Access API sends `device` as an array (e.g. hub + reader), not a single object.
+            public List<BaseReference> device;
             public BaseReference deviceConfig;
             public BaseReference deviceUaHub;
             public BaseReference door;

--- a/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/access/handler/UnifiAccessLogPayloadBuilder.java
+++ b/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/access/handler/UnifiAccessLogPayloadBuilder.java
@@ -53,9 +53,8 @@ public class UnifiAccessLogPayloadBuilder {
         putIfNonNull(insight, "doorId", doorId);
         String doorName = (data.metadata != null && data.metadata.door != null) ? data.metadata.door.displayName : null;
         putIfNonNull(insight, "doorName", doorName);
-        String deviceId = (data.metadata != null && data.metadata.device != null && !data.metadata.device.isEmpty())
-                ? data.metadata.device.get(0).id
-                : null;
+        String deviceId = (data.metadata != null && data.metadata.device != null && !data.metadata.device.isEmpty()
+                && data.metadata.device.get(0) != null) ? data.metadata.device.get(0).id : null;
         putIfNonNull(insight, "deviceId", deviceId);
         putIfNonNull(insight, "cameraId", cameraId);
         return gson.toJson(insight);

--- a/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/access/handler/UnifiAccessLogPayloadBuilder.java
+++ b/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/access/handler/UnifiAccessLogPayloadBuilder.java
@@ -53,7 +53,9 @@ public class UnifiAccessLogPayloadBuilder {
         putIfNonNull(insight, "doorId", doorId);
         String doorName = (data.metadata != null && data.metadata.door != null) ? data.metadata.door.displayName : null;
         putIfNonNull(insight, "doorName", doorName);
-        String deviceId = (data.metadata != null && data.metadata.device != null) ? data.metadata.device.id : null;
+        String deviceId = (data.metadata != null && data.metadata.device != null && !data.metadata.device.isEmpty())
+                ? data.metadata.device.get(0).id
+                : null;
         putIfNonNull(insight, "deviceId", deviceId);
         putIfNonNull(insight, "cameraId", cameraId);
         return gson.toJson(insight);

--- a/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/access/handler/UnifiAccessNotificationRouter.java
+++ b/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/access/handler/UnifiAccessNotificationRouter.java
@@ -224,7 +224,7 @@ public class UnifiAccessNotificationRouter {
         // route to each referenced device (the event lists e.g. the hub and the reader)
         if (data.metadata != null && data.metadata.device != null) {
             for (Notification.BaseReference dev : data.metadata.device) {
-                String deviceId = dev.id;
+                String deviceId = dev != null ? dev.id : null;
                 if (deviceId != null) {
                     UnifiAccessDeviceHandler d = bridgeHandler.getDeviceHandler(deviceId);
                     if (d != null) {

--- a/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/access/handler/UnifiAccessNotificationRouter.java
+++ b/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/access/handler/UnifiAccessNotificationRouter.java
@@ -221,12 +221,16 @@ public class UnifiAccessNotificationRouter {
                 dh.triggerLogInsight(payload);
             }
         }
-        // route to specific device if referenced
-        String deviceId = data.metadata != null && data.metadata.device != null ? data.metadata.device.id : null;
-        if (deviceId != null) {
-            UnifiAccessDeviceHandler d = bridgeHandler.getDeviceHandler(deviceId);
-            if (d != null) {
-                d.triggerLogInsight(payload);
+        // route to each referenced device (the event lists e.g. the hub and the reader)
+        if (data.metadata != null && data.metadata.device != null) {
+            for (Notification.BaseReference dev : data.metadata.device) {
+                String deviceId = dev.id;
+                if (deviceId != null) {
+                    UnifiAccessDeviceHandler d = bridgeHandler.getDeviceHandler(deviceId);
+                    if (d != null) {
+                        d.triggerLogInsight(payload);
+                    }
+                }
             }
         }
     }

--- a/bundles/org.openhab.binding.unifi/src/test/java/org/openhab/binding/unifi/internal/access/dto/NotificationDeserializationTest.java
+++ b/bundles/org.openhab.binding.unifi/src/test/java/org/openhab/binding/unifi/internal/access/dto/NotificationDeserializationTest.java
@@ -168,4 +168,75 @@ class NotificationDeserializationTest {
         assertEquals(Notification.RemoteViewChangeData.Reason.ADMIN_UNLOCK_SUCCEEDED, data.reason);
         assertEquals("call-456", data.remoteCallRequestId);
     }
+
+    // --- Full Notification with access.logs.insights.add (metadata.device is an ARRAY) ---
+
+    @Test
+    void insightsAddNotificationWithMultipleDevicesDeserialization() {
+        // Regression: the Access API sends metadata.device as an array (e.g. the hub plus the
+        // reader). It used to be modelled as a single object, so deserialization failed with
+        // "Expected BEGIN_OBJECT but was BEGIN_ARRAY at path $.metadata.device" and no insight
+        // event was ever routed.
+        String json = """
+                {
+                    "event": "access.logs.insights.add",
+                    "receiver_id": "recv-003",
+                    "event_object_id": "obj-003",
+                    "save_to_history": true,
+                    "data": {
+                        "log_key": "dashboard.access.door.unlock.success",
+                        "event_type": "access.door.unlock",
+                        "message": "Front Door unlocked",
+                        "published": 1700000000000,
+                        "result": "ACCESS",
+                        "metadata": {
+                            "actor": {
+                                "display_name": "Jane Doe"
+                            },
+                            "door": {
+                                "id": "door-1",
+                                "type": "door",
+                                "display_name": "Front Door"
+                            },
+                            "device": [
+                                {
+                                    "id": "hub-1",
+                                    "type": "UAH",
+                                    "display_name": "Front Door Hub"
+                                },
+                                {
+                                    "id": "reader-1",
+                                    "type": "UA-G2-PRO",
+                                    "display_name": "Front Door Reader"
+                                }
+                            ]
+                        }
+                    }
+                }
+                """;
+
+        Notification notification = gson.fromJson(json, Notification.class);
+
+        assertNotNull(notification);
+        assertEquals("access.logs.insights.add", notification.event);
+
+        Notification.InsightLogsAddData data = notification.dataAsInsightLogsAdd(gson);
+        assertNotNull(data);
+        assertEquals("dashboard.access.door.unlock.success", data.logKey);
+        assertEquals("access.door.unlock", data.eventType);
+        assertEquals("ACCESS", data.result);
+        assertEquals(Long.valueOf(1700000000000L), data.published);
+
+        assertNotNull(data.metadata);
+        assertNotNull(data.metadata.door);
+        assertEquals("Front Door", data.metadata.door.displayName);
+
+        // the array must deserialize into a list, preserving order
+        assertNotNull(data.metadata.device);
+        assertEquals(2, data.metadata.device.size());
+        assertEquals("hub-1", data.metadata.device.get(0).id);
+        assertEquals("UAH", data.metadata.device.get(0).type);
+        assertEquals("reader-1", data.metadata.device.get(1).id);
+        assertEquals("Front Door Reader", data.metadata.device.get(1).displayName);
+    }
 }


### PR DESCRIPTION
`metadata.device` on the `access.logs.insights.add` event is a JSON array (e.g. the hub and the reader), but it was modelled as a single object, so every insight event failed to deserialize (`Expected BEGIN_OBJECT but was BEGIN_ARRAY at path $.metadata.device`) and the `log-insight` trigger channel never fired.

Model it as a list: the payload reports the first device's id, and the router routes the trigger to each referenced device.

Observed live on a UDM with a UA-G2-PRO reader.
