### PR TITLE
[doorbird] Upgrade dependency and fix warnings

### DIFF
--- a/bundles/org.openhab.binding.doorbird/pom.xml
+++ b/bundles/org.openhab.binding.doorbird/pom.xml
@@ -20,16 +20,28 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.goterl.lazycode</groupId>
+      <groupId>com.goterl</groupId>
       <artifactId>lazysodium-java</artifactId>
-      <version>4.2.5</version>
+      <version>5.2.0</version>
       <scope>compile</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
-      <groupId>co.libly</groupId>
+      <groupId>com.goterl</groupId>
       <artifactId>resource-loader</artifactId>
-      <version>1.3.7</version>
+      <version>2.1.0</version>
       <scope>compile</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>net.java.dev.jna</groupId>

--- a/bundles/org.openhab.binding.doorbird/src/main/java/org/openhab/binding/doorbird/internal/api/DoorbirdAPI.java
+++ b/bundles/org.openhab.binding.doorbird/src/main/java/org/openhab/binding/doorbird/internal/api/DoorbirdAPI.java
@@ -74,7 +74,7 @@ public final class DoorbirdAPI {
         return (GSON);
     }
 
-    public static <T> T fromJson(String json, Class<T> dataClass) {
+    public static <T> @Nullable T fromJson(String json, Class<T> dataClass) {
         return GSON.fromJson(json, dataClass);
     }
 

--- a/bundles/org.openhab.binding.doorbird/src/main/java/org/openhab/binding/doorbird/internal/listener/DoorbirdEvent.java
+++ b/bundles/org.openhab.binding.doorbird/src/main/java/org/openhab/binding/doorbird/internal/listener/DoorbirdEvent.java
@@ -24,10 +24,10 @@ import org.openhab.core.util.HexUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.goterl.lazycode.lazysodium.LazySodiumJava;
-import com.goterl.lazycode.lazysodium.SodiumJava;
-import com.goterl.lazycode.lazysodium.exceptions.SodiumException;
-import com.goterl.lazycode.lazysodium.interfaces.PwHash;
+import com.goterl.lazysodium.LazySodiumJava;
+import com.goterl.lazysodium.SodiumJava;
+import com.goterl.lazysodium.exceptions.SodiumException;
+import com.goterl.lazysodium.interfaces.PwHash;
 import com.sun.jna.NativeLong;
 
 /**

--- a/bundles/org.openhab.binding.doorbird/src/main/java/org/openhab/binding/doorbird/internal/listener/DoorbirdUdpListener.java
+++ b/bundles/org.openhab.binding.doorbird/src/main/java/org/openhab/binding/doorbird/internal/listener/DoorbirdUdpListener.java
@@ -52,7 +52,7 @@ public class DoorbirdUdpListener extends Thread {
     private final DoorbellHandler thingHandler;
 
     // UDP socket used to receive status events from doorbell
-    private @Nullable DatagramSocket socket;
+    private volatile @Nullable DatagramSocket socket;
 
     private byte @Nullable [] lastData;
     private int lastDataLength;
@@ -93,7 +93,11 @@ public class DoorbirdUdpListener extends Thread {
         }
 
         DatagramPacket packet = new DatagramPacket(new byte[BUFFER_SIZE], BUFFER_SIZE);
-        while (socket != null) {
+        while (true) {
+            DatagramSocket socket = this.socket;
+            if (socket == null) {
+                break;
+            }
             try {
                 socket.receive(packet);
                 processPacket(packet);
@@ -101,7 +105,7 @@ public class DoorbirdUdpListener extends Thread {
                 // Nothing to do on socket timeout
             } catch (IOException e) {
                 logger.debug("Listener got IOException waiting for datagram: {}", e.getMessage());
-                socket = null;
+                this.socket = null;
             }
         }
         logger.debug("Listener exiting");

--- a/bundles/org.openhab.binding.doorbird/src/main/java/org/openhab/binding/doorbird/internal/listener/DoorbirdUdpListener.java
+++ b/bundles/org.openhab.binding.doorbird/src/main/java/org/openhab/binding/doorbird/internal/listener/DoorbirdUdpListener.java
@@ -104,7 +104,8 @@ public class DoorbirdUdpListener extends Thread {
             } catch (SocketTimeoutException e) {
                 // Nothing to do on socket timeout
             } catch (IOException e) {
-                logger.debug("Listener got IOException waiting for datagram: {}", e.getMessage());
+                logger.debug("Listener got IOException waiting for datagram: {}", e.getMessage(), e);
+                socket.close();
                 this.socket = null;
             }
         }


### PR DESCRIPTION
- Fixes some build warnings
    - Some warnings from the code in the binding itself
    - One warning regarding the pom for com.goterl.lazycode:lazysodium-java is missing dependency information (can;t find the related issue, but i remember @wborn generated the poms and prepared them for upload to jfrog)
- Upgrades lazysodium to 5.2.0
- changes `socket` to be volatile because shutdown() accesses it from another thread
- Fixed race condition that might lead to a resource leak by not closing the socket