### PR TITLE
[icloud] Fix HTTP 409 handling in 2FA/SMS auth flow

### DIFF
--- a/bundles/org.openhab.binding.icloud/src/main/java/org/openhab/binding/icloud/internal/ICloudService.java
+++ b/bundles/org.openhab.binding.icloud/src/main/java/org/openhab/binding/icloud/internal/ICloudService.java
@@ -135,8 +135,22 @@ public class ICloudService {
         List<Pair<String, String>> headers = ListUtil.replaceEntries(getAuthHeaders(),
                 List.of(Pair.of("Accept", "application/json")));
         addSessionHeaders(headers);
+        String responseBody;
+        try {
+            responseBody = session.get(AUTH_ENDPOINT, headers);
+        } catch (ICloudApiAuthenticationException ex) {
+            // Apple responds with HTTP 409 (2FA_REQUIRED) here as part of the normal 2-FA
+            // challenge flow; the body already contains the phoneNumberVerification data we
+            // need. Without this, the exception propagates and canRequestSmsCode()/
+            // requestSmsCode() below is never reached, so 2-FA accounts can never authenticate.
+            if (ex.getStatusCode() == 409) {
+                responseBody = ex.body;
+            } else {
+                throw ex;
+            }
+        }
         @Nullable
-        Map<String, Object> localSessionData = JsonUtils.toMap(session.get(AUTH_ENDPOINT, headers));
+        Map<String, Object> localSessionData = JsonUtils.toMap(responseBody);
         if (localSessionData != null) {
             data = localSessionData;
         }
@@ -226,7 +240,15 @@ public class ICloudService {
                 List.of(Pair.of("Accept", "application/json")));
         addSessionHeaders(headers);
 
-        session.put(AUTH_ENDPOINT + "/verify/phone", JsonUtils.toJson(requestBody), headers);
+        try {
+            session.put(AUTH_ENDPOINT + "/verify/phone", JsonUtils.toJson(requestBody), headers);
+        } catch (ICloudApiAuthenticationException ex) {
+            // Apple responds with HTTP 409 here too even though the SMS/iMessage code is actually
+            // sent (verified empirically). Treat 409 as expected here, same as in getMfaAuthOptions().
+            if (ex.getStatusCode() != 409) {
+                throw ex;
+            }
+        }
 
         // Cache the phone payload for later validation
         cachedSmsPhoneNumber = phonePayload;


### PR DESCRIPTION
Apple's `idmsa.apple.com` auth endpoints reply with HTTP 409 on two calls that are actually part of a *successful* 2-FA flow, not a real error — confirmed against a live account with HSA2/2FA enabled:

- `GET /appleauth/auth` (in `getMfaAuthOptions()`) returns 409 together with the `phoneNumberVerification`/`trustedPhoneNumbers` challenge data needed to request an SMS/iMessage code.
- `PUT /appleauth/auth/verify/phone` (in `requestSmsCode()`) also returns 409, even though the SMS/iMessage code *is* sent successfully.

`ICloudApiAuthenticationException.isAuthError()` classifies 409 as an auth error unconditionally, so both calls throw before `canRequestSmsCode()`/`requestSmsCode()` — and the `WAIT_FOR_CODE` state machine in `ICloudAccountBridgeHandler` — are ever reached. This means 2-FA/HSA2 accounts can never authenticate regardless of the `code` thing configuration, and the account thing ends up `OFFLINE (CONFIGURATION_ERROR)` with a generic `"Request ... failed with 409."` message instead of prompting for a 2-FA code.

This PR catches the 409 case in both methods and treats it as expected: `getMfaAuthOptions()` uses the exception body (which already carries the challenge JSON), and `requestSmsCode()` treats the 409 as a completed request.

Verified end-to-end on a live account with 2FA/HSA2 enabled (TRACE log evidence, personal details redacted): the flow now completes through `accountLogin` and the thing reaches `ONLINE`.

Fixes #20425