### PR TITLE
[zwavejs] Add unit mappings for kVar and kVarh

### DIFF
--- a/bundles/org.openhab.binding.zwavejs/src/main/java/org/openhab/binding/zwavejs/internal/conversion/BaseMetadata.java
+++ b/bundles/org.openhab.binding.zwavejs/src/main/java/org/openhab/binding/zwavejs/internal/conversion/BaseMetadata.java
@@ -71,6 +71,8 @@ public abstract class BaseMetadata {
             Map.entry("Minutes", "min"), //
             Map.entry("seconds", "s"), //
             Map.entry("Seconds", "s"), //
+            Map.entry("kVar", "kvar"), //
+            Map.entry("kVarh", "kvarh"), //
             Map.entry("fahrenheit", "°F"), //
             Map.entry("min/sec", ""), // special case ZUI sends min/sec as unit, but is actually dimensionless
             Map.entry("°(C/F)", ""), // special case where Zwave JS sends °F/C as unit, but is actually dimensionless


### PR DESCRIPTION
ZUI does not use a strict unit declaration. Like this PR, we sometimes need to manually correct those units to map it to openHAB's UoM system.

Should be backported to 5.2.1