### PR TITLE
[tuya] Handle UDP discovery bind failures gracefully

### DIFF
--- a/bundles/org.openhab.binding.tuya/src/main/java/org/openhab/binding/tuya/internal/local/UdpDiscoveryListener.java
+++ b/bundles/org.openhab.binding.tuya/src/main/java/org/openhab/binding/tuya/internal/local/UdpDiscoveryListener.java
@@ -60,9 +60,9 @@ public class UdpDiscoveryListener implements ChannelFutureListener {
     private List<Channel> channels = List.of();
 
     private static final List<PortVersion> PORTS = List.of( //
-            new PortVersion(6666, ProtocolVersion.V3_1), //
-            new PortVersion(6667, ProtocolVersion.V3_1), //
-            new PortVersion(7000, ProtocolVersion.V3_5) //
+            new PortVersion(6666, ProtocolVersion.V3_1), // Raw channel
+            new PortVersion(6667, ProtocolVersion.V3_1), // Encrypted channel
+            new PortVersion(7000, ProtocolVersion.V3_5) // Encrypted channel V3.5
     );
 
     private final EventLoopGroup group;

--- a/bundles/org.openhab.binding.tuya/src/main/java/org/openhab/binding/tuya/internal/local/UdpDiscoveryListener.java
+++ b/bundles/org.openhab.binding.tuya/src/main/java/org/openhab/binding/tuya/internal/local/UdpDiscoveryListener.java
@@ -14,6 +14,7 @@ package org.openhab.binding.tuya.internal.local;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -102,7 +103,7 @@ public class UdpDiscoveryListener implements ChannelFutureListener {
                 logger.warn("Error starting Tuya UDP listener on port {}: {}", portVersion.port(), e.getMessage());
             }
             return null;
-        }).filter(channel -> channel != null).toList();
+        }).filter(Objects::nonNull).toList();
     }
 
     public void deactivate() {

--- a/bundles/org.openhab.binding.tuya/src/main/java/org/openhab/binding/tuya/internal/local/UdpDiscoveryListener.java
+++ b/bundles/org.openhab.binding.tuya/src/main/java/org/openhab/binding/tuya/internal/local/UdpDiscoveryListener.java
@@ -80,30 +80,48 @@ public class UdpDiscoveryListener implements ChannelFutureListener {
                     }
                 });
 
-        ChannelFuture futureEncrypted35 = b.bind(7000).addListener(this).sync();
-        encryptedChannel35 = futureEncrypted35.channel();
-        encryptedChannel35.attr(TuyaDevice.DEVICE_ID_ATTR).set("udpListener");
-        encryptedChannel35.attr(TuyaDevice.PROTOCOL_ATTR).set(ProtocolVersion.V3_5);
-        encryptedChannel35.attr(TuyaDevice.SESSION_KEY_ATTR).set(TUYA_UDP_KEY);
+        try {
+            ChannelFuture futureEncrypted35 = b.bind(7000).addListener(this).sync();
+            encryptedChannel35 = futureEncrypted35.channel();
+            encryptedChannel35.attr(TuyaDevice.DEVICE_ID_ATTR).set("udpListener");
+            encryptedChannel35.attr(TuyaDevice.PROTOCOL_ATTR).set(ProtocolVersion.V3_5);
+            encryptedChannel35.attr(TuyaDevice.SESSION_KEY_ATTR).set(TUYA_UDP_KEY);
+        } catch (Exception e) {
+            logger.warn("Error starting Tuya UDP listener on port 7000: {}", e.getMessage());
+        }
 
-        ChannelFuture futureEncrypted = b.bind(6667).addListener(this).sync();
-        encryptedChannel = futureEncrypted.channel();
-        encryptedChannel.attr(TuyaDevice.DEVICE_ID_ATTR).set("udpListener");
-        encryptedChannel.attr(TuyaDevice.PROTOCOL_ATTR).set(ProtocolVersion.V3_1);
-        encryptedChannel.attr(TuyaDevice.SESSION_KEY_ATTR).set(TUYA_UDP_KEY);
+        try {
+            ChannelFuture futureEncrypted = b.bind(6667).addListener(this).sync();
+            encryptedChannel = futureEncrypted.channel();
+            encryptedChannel.attr(TuyaDevice.DEVICE_ID_ATTR).set("udpListener");
+            encryptedChannel.attr(TuyaDevice.PROTOCOL_ATTR).set(ProtocolVersion.V3_1);
+            encryptedChannel.attr(TuyaDevice.SESSION_KEY_ATTR).set(TUYA_UDP_KEY);
+        } catch (Exception e) {
+            logger.warn("Error starting Tuya UDP listener on port 6667: {}", e.getMessage());
+        }
 
-        ChannelFuture futureRaw = b.bind(6666).addListener(this).sync();
-        rawChannel = futureRaw.channel();
-        rawChannel.attr(TuyaDevice.DEVICE_ID_ATTR).set("udpListener");
-        rawChannel.attr(TuyaDevice.PROTOCOL_ATTR).set(ProtocolVersion.V3_1);
-        rawChannel.attr(TuyaDevice.SESSION_KEY_ATTR).set(TUYA_UDP_KEY);
+        try {
+            ChannelFuture futureRaw = b.bind(6666).addListener(this).sync();
+            rawChannel = futureRaw.channel();
+            rawChannel.attr(TuyaDevice.DEVICE_ID_ATTR).set("udpListener");
+            rawChannel.attr(TuyaDevice.PROTOCOL_ATTR).set(ProtocolVersion.V3_1);
+            rawChannel.attr(TuyaDevice.SESSION_KEY_ATTR).set(TUYA_UDP_KEY);
+        } catch (Exception e) {
+            logger.warn("Error starting Tuya UDP listener on port 6666: {}", e.getMessage());
+        }
     }
 
     public void deactivate() {
         deactivate = true;
-        encryptedChannel.close();
-        encryptedChannel35.close();
-        rawChannel.close();
+        if (encryptedChannel != null) {
+            encryptedChannel.close();
+        }
+        if (encryptedChannel35 != null) {
+            encryptedChannel35.close();
+        }
+        if (rawChannel != null) {
+            rawChannel.close();
+        }
     }
 
     public void registerListener(String deviceId, DeviceInfoSubscriber subscriber) {

--- a/bundles/org.openhab.binding.tuya/src/main/java/org/openhab/binding/tuya/internal/local/UdpDiscoveryListener.java
+++ b/bundles/org.openhab.binding.tuya/src/main/java/org/openhab/binding/tuya/internal/local/UdpDiscoveryListener.java
@@ -12,6 +12,7 @@
  */
 package org.openhab.binding.tuya.internal.local;
 
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -55,9 +56,14 @@ public class UdpDiscoveryListener implements ChannelFutureListener {
     private final Map<String, DeviceInfo> deviceInfos = new ConcurrentHashMap<>();
     private final Map<String, DeviceInfoSubscriber> deviceListeners = new ConcurrentHashMap<>();
 
-    private @NonNullByDefault({}) Channel encryptedChannel;
-    private @NonNullByDefault({}) Channel encryptedChannel35;
-    private @NonNullByDefault({}) Channel rawChannel;
+    private List<Channel> channels = List.of();
+
+    private static final List<PortVersion> PORTS = List.of( //
+            new PortVersion(6666, ProtocolVersion.V3_1), //
+            new PortVersion(6667, ProtocolVersion.V3_1), //
+            new PortVersion(7000, ProtocolVersion.V3_5) //
+    );
+
     private final EventLoopGroup group;
     private boolean deactivate = false;
 
@@ -80,48 +86,28 @@ public class UdpDiscoveryListener implements ChannelFutureListener {
                     }
                 });
 
-        try {
-            ChannelFuture futureEncrypted35 = b.bind(7000).addListener(this).sync();
-            encryptedChannel35 = futureEncrypted35.channel();
-            encryptedChannel35.attr(TuyaDevice.DEVICE_ID_ATTR).set("udpListener");
-            encryptedChannel35.attr(TuyaDevice.PROTOCOL_ATTR).set(ProtocolVersion.V3_5);
-            encryptedChannel35.attr(TuyaDevice.SESSION_KEY_ATTR).set(TUYA_UDP_KEY);
-        } catch (Exception e) {
-            logger.warn("Error starting Tuya UDP listener on port 7000: {}", e.getMessage());
-        }
-
-        try {
-            ChannelFuture futureEncrypted = b.bind(6667).addListener(this).sync();
-            encryptedChannel = futureEncrypted.channel();
-            encryptedChannel.attr(TuyaDevice.DEVICE_ID_ATTR).set("udpListener");
-            encryptedChannel.attr(TuyaDevice.PROTOCOL_ATTR).set(ProtocolVersion.V3_1);
-            encryptedChannel.attr(TuyaDevice.SESSION_KEY_ATTR).set(TUYA_UDP_KEY);
-        } catch (Exception e) {
-            logger.warn("Error starting Tuya UDP listener on port 6667: {}", e.getMessage());
-        }
-
-        try {
-            ChannelFuture futureRaw = b.bind(6666).addListener(this).sync();
-            rawChannel = futureRaw.channel();
-            rawChannel.attr(TuyaDevice.DEVICE_ID_ATTR).set("udpListener");
-            rawChannel.attr(TuyaDevice.PROTOCOL_ATTR).set(ProtocolVersion.V3_1);
-            rawChannel.attr(TuyaDevice.SESSION_KEY_ATTR).set(TUYA_UDP_KEY);
-        } catch (Exception e) {
-            logger.warn("Error starting Tuya UDP listener on port 6666: {}", e.getMessage());
-        }
+        channels = PORTS.stream().map(portVersion -> {
+            try {
+                ChannelFuture future = b.bind(portVersion.port()).addListener(this).sync();
+                Channel channel = future.channel();
+                channel.attr(TuyaDevice.DEVICE_ID_ATTR).set("udpListener");
+                channel.attr(TuyaDevice.PROTOCOL_ATTR).set(portVersion.version());
+                channel.attr(TuyaDevice.SESSION_KEY_ATTR).set(TUYA_UDP_KEY);
+                return channel;
+            } catch (InterruptedException e) {
+                logger.warn("Interrupted while starting Tuya UDP listener on port {}: {}", portVersion.port(),
+                        e.getMessage());
+                Thread.currentThread().interrupt();
+            } catch (Exception e) {
+                logger.warn("Error starting Tuya UDP listener on port {}: {}", portVersion.port(), e.getMessage());
+            }
+            return null;
+        }).filter(channel -> channel != null).toList();
     }
 
     public void deactivate() {
         deactivate = true;
-        if (encryptedChannel != null) {
-            encryptedChannel.close();
-        }
-        if (encryptedChannel35 != null) {
-            encryptedChannel35.close();
-        }
-        if (rawChannel != null) {
-            rawChannel.close();
-        }
+        channels.forEach(Channel::close);
     }
 
     public void registerListener(String deviceId, DeviceInfoSubscriber subscriber) {
@@ -145,5 +131,8 @@ public class UdpDiscoveryListener implements ChannelFutureListener {
             deactivate();
             activate();
         }
+    }
+
+    private static record PortVersion(int port, ProtocolVersion version) {
     }
 }


### PR DESCRIPTION
Suppress exceptions when the UDP discovery listener cannot bind to its ports, allowing the binding to start normally and Things to load. The failure is now logged as a warning so users are informed without blocking activation.

This seems to fix the issue - confirmed here https://community.openhab.org/t/openhab-5-2-release-discussion/169691/143

This may not be a comprehensive fix to the problem, e.g. a retry might want to be implemented, but if the user doesn't intervene to release the ports, retrying is pointless. Or perhaps a better way to register this "health" issue, but that needs a mechanism from core to facilitate it.

This is good enough for now.

Should be backported to 5.2
