### PR TITLE
[unifi] Reconnect Protect WebSockets when the connection dies silently

### DIFF
--- a/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/protect/UnifiProtectBindingConstants.java
+++ b/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/protect/UnifiProtectBindingConstants.java
@@ -27,10 +27,6 @@ public class UnifiProtectBindingConstants {
     public static final String BINDING_ID = "unifi";
     public static final String SERVICE_ID = "org.openhab.unifiprotect";
 
-    /**
-     * How long a Protect WebSocket may go without receiving a frame before it is treated as dead
-     * and closed so the reconnect logic runs. Shared by the private and public clients.
-     */
     public static final long WEBSOCKET_IDLE_TIMEOUT_MS = 150_000L;
 
     // List of all Thing Type UIDs (canonical unifi:* used for discovery and new things)

--- a/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/protect/UnifiProtectBindingConstants.java
+++ b/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/protect/UnifiProtectBindingConstants.java
@@ -27,6 +27,12 @@ public class UnifiProtectBindingConstants {
     public static final String BINDING_ID = "unifi";
     public static final String SERVICE_ID = "org.openhab.unifiprotect";
 
+    /**
+     * How long a Protect WebSocket may go without receiving a frame before it is treated as dead
+     * and closed so the reconnect logic runs. Shared by the private and public clients.
+     */
+    public static final long WEBSOCKET_IDLE_TIMEOUT_MS = 150_000L;
+
     // List of all Thing Type UIDs (canonical unifi:* used for discovery and new things)
     public static final ThingTypeUID THING_TYPE_NVR = new ThingTypeUID(BINDING_ID, "nvr");
     public static final ThingTypeUID THING_TYPE_CAMERA = new ThingTypeUID(BINDING_ID, "camera");

--- a/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/protect/api/priv/client/UniFiProtectPrivateClient.java
+++ b/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/protect/api/priv/client/UniFiProtectPrivateClient.java
@@ -196,15 +196,16 @@ public class UniFiProtectPrivateClient {
     /**
      * Enable WebSocket for real-time updates
      */
-    public CompletableFuture<Void> enableWebSocket(
-            Consumer<UniFiProtectPrivateWebSocket.WebSocketUpdate> updateHandler) {
-        return ensureAuthenticated().thenCompose(v -> connectWebSocket(updateHandler, true));
+    public CompletableFuture<Void> enableWebSocket(Consumer<UniFiProtectPrivateWebSocket.WebSocketUpdate> updateHandler,
+            Runnable onReconnected) {
+        return ensureAuthenticated().thenCompose(v -> connectWebSocket(updateHandler, onReconnected, true));
     }
 
     // A null cookie is fine: the shared HttpClient's CookieStore supplies it on the upgrade (as for REST), and a
     // genuine 401 is re-authenticated and retried below.
     private CompletableFuture<Void> connectWebSocket(
-            Consumer<UniFiProtectPrivateWebSocket.WebSocketUpdate> updateHandler, boolean allowReauth) {
+            Consumer<UniFiProtectPrivateWebSocket.WebSocketUpdate> updateHandler, Runnable onReconnected,
+            boolean allowReauth) {
         if (webSocket != null) {
             logger.debug("WebSocket already enabled");
             return CompletableFuture.completedFuture(null);
@@ -212,8 +213,8 @@ public class UniFiProtectPrivateClient {
 
         String wsUrl = baseUrl.replace("https://", "wss://").replace("http://", "ws://") + "/proxy/protect/ws/updates";
         String cookie = authenticator.getAuthCookie();
-        UniFiProtectPrivateWebSocket ws = new UniFiProtectPrivateWebSocket(wsUrl, cookie, updateHandler, this,
-                httpClient);
+        UniFiProtectPrivateWebSocket ws = new UniFiProtectPrivateWebSocket(wsUrl, cookie, updateHandler, onReconnected,
+                this, httpClient);
         return ws.connect().handle((connected, ex) -> ex).thenCompose(ex -> {
             if (ex == null) {
                 webSocket = ws;
@@ -222,7 +223,7 @@ public class UniFiProtectPrivateClient {
             ws.disconnect();
             if (allowReauth && UniFiWebSocketUtil.isUnauthorizedUpgrade(ex)) {
                 logger.debug("WebSocket upgrade rejected (401); re-authenticating and retrying");
-                return reauthenticateSession().thenCompose(v -> connectWebSocket(updateHandler, false));
+                return reauthenticateSession().thenCompose(v -> connectWebSocket(updateHandler, onReconnected, false));
             }
             return CompletableFuture.<Void> failedFuture(ex);
         });

--- a/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/protect/api/priv/client/UniFiProtectPrivateWebSocket.java
+++ b/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/protect/api/priv/client/UniFiProtectPrivateWebSocket.java
@@ -91,6 +91,10 @@ public class UniFiProtectPrivateWebSocket {
         this.wsClient = new WebSocketClient(httpClient);
         // Prevent wsClient.stop() from stopping the shared HttpClient instance
         this.wsClient.unmanage(httpClient);
+        // Detect a silently dead / half-open connection: Jetty closes the session
+        // when no frame is read within the window -> onWebSocketClose -> reconnect.
+        // Without this a dropped socket stays "ONLINE" and updates stop forever.
+        this.wsClient.setMaxIdleTimeout(150_000L);
 
         try {
             wsClient.start();

--- a/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/protect/api/priv/client/UniFiProtectPrivateWebSocket.java
+++ b/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/protect/api/priv/client/UniFiProtectPrivateWebSocket.java
@@ -100,8 +100,6 @@ public class UniFiProtectPrivateWebSocket {
         this.wsClient = new WebSocketClient(httpClient);
         // Prevent wsClient.stop() from stopping the shared HttpClient instance
         this.wsClient.unmanage(httpClient);
-        // Halves Jetty's 300 s default so a half-open socket is closed, and reconnected, sooner.
-        // Also applies to the injected HttpClient, which is shared per bridge.
         this.wsClient.setMaxIdleTimeout(UnifiProtectBindingConstants.WEBSOCKET_IDLE_TIMEOUT_MS);
 
         try {

--- a/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/protect/api/priv/client/UniFiProtectPrivateWebSocket.java
+++ b/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/protect/api/priv/client/UniFiProtectPrivateWebSocket.java
@@ -61,6 +61,7 @@ public class UniFiProtectPrivateWebSocket {
     private final String wsUrl;
     private final @Nullable String authCookie;
     private final Consumer<WebSocketUpdate> updateHandler;
+    private final Runnable onReconnected;
     private final UniFiProtectPrivateClient client;
     private final WebSocketClient wsClient;
 
@@ -86,10 +87,12 @@ public class UniFiProtectPrivateWebSocket {
      * @param httpClient HTTP client to use (shared from main client)
      */
     public UniFiProtectPrivateWebSocket(String wsUrl, @Nullable String authCookie,
-            Consumer<WebSocketUpdate> updateHandler, UniFiProtectPrivateClient client, HttpClient httpClient) {
+            Consumer<WebSocketUpdate> updateHandler, Runnable onReconnected, UniFiProtectPrivateClient client,
+            HttpClient httpClient) {
         this.wsUrl = wsUrl;
         this.authCookie = authCookie;
         this.updateHandler = updateHandler;
+        this.onReconnected = onReconnected;
         this.client = client;
 
         this.wsClient = new WebSocketClient(httpClient);
@@ -153,12 +156,15 @@ public class UniFiProtectPrivateWebSocket {
     }
 
     /**
-     * Refresh the bootstrap after an established session was re-established.
+     * Resynchronise after an established session was re-established.
      *
      * Reconnecting only restores the stream of new updates: Protect does not replay what happened
      * while the socket was down, and {@code /ws/updates} is opened without the cached
-     * {@code lastUpdateId}. Without this, anything that changed during the outage stays stale until
-     * the next periodic bootstrap refresh, which can be up to 15 minutes later.
+     * {@code lastUpdateId}. Refreshing the bootstrap alone is not enough either, because that only
+     * replaces the client's cached copy — the Thing channels are written from it by the NVR
+     * handler's device sync, which otherwise runs only when the public event socket reopens. A
+     * private-only stall leaves that socket connected, so nothing would push the recovered state
+     * out. Hence: refresh the bootstrap, then notify the handler to sync devices from it.
      */
     private void resyncIfReconnected() {
         if (!resyncAfterConnect) {
@@ -169,8 +175,13 @@ public class UniFiProtectPrivateWebSocket {
         logger.debug("Refreshing bootstrap after WebSocket reconnect to pick up missed updates");
         client.refreshBootstrap().whenComplete((bootstrap, ex) -> {
             if (ex != null) {
-                // Not fatal: the stream is live again and the periodic refresh remains a backstop.
                 logger.debug("Bootstrap refresh after reconnect failed", ex);
+                return;
+            }
+            try {
+                onReconnected.run();
+            } catch (RuntimeException e) {
+                logger.debug("Device sync after reconnect failed", e);
             }
         });
     }

--- a/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/protect/api/priv/client/UniFiProtectPrivateWebSocket.java
+++ b/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/protect/api/priv/client/UniFiProtectPrivateWebSocket.java
@@ -98,9 +98,11 @@ public class UniFiProtectPrivateWebSocket {
         this.wsClient = new WebSocketClient(httpClient);
         // Prevent wsClient.stop() from stopping the shared HttpClient instance
         this.wsClient.unmanage(httpClient);
-        // Detect a silently dead / half-open connection: Jetty closes the session
-        // when no frame is read within the window -> onWebSocketClose -> reconnect.
-        // Without this a dropped socket stays "ONLINE" and updates stop forever.
+        // Detect a silently dead / half-open connection: Jetty closes the session when no frame is
+        // read within the window -> onWebSocketClose -> reconnect. Jetty's own default already
+        // expired the session, but only after 300 s; this halves that so updates resume sooner.
+        // Note setMaxIdleTimeout also applies the value to the injected HttpClient, which is shared
+        // per bridge, so keep it comfortably above any request timeout used on that client.
         this.wsClient.setMaxIdleTimeout(UnifiProtectBindingConstants.WEBSOCKET_IDLE_TIMEOUT_MS);
 
         try {
@@ -171,13 +173,15 @@ public class UniFiProtectPrivateWebSocket {
             // First connect of this socket: the caller has just bootstrapped, nothing to catch up on.
             return;
         }
-        resyncAfterConnect = false;
         logger.debug("Refreshing bootstrap after WebSocket reconnect to pick up missed updates");
         client.refreshBootstrap().whenComplete((bootstrap, ex) -> {
             if (ex != null) {
-                logger.debug("Bootstrap refresh after reconnect failed", ex);
+                // Leave the flag set so the next successful connect tries again. Clearing it on the
+                // attempt would let a single failed refresh drop the recovery entirely.
+                logger.debug("Bootstrap refresh after reconnect failed, will retry on next connect", ex);
                 return;
             }
+            resyncAfterConnect = false;
             try {
                 onReconnected.run();
             } catch (RuntimeException e) {

--- a/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/protect/api/priv/client/UniFiProtectPrivateWebSocket.java
+++ b/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/protect/api/priv/client/UniFiProtectPrivateWebSocket.java
@@ -27,6 +27,7 @@ import org.eclipse.jetty.websocket.api.Session;
 import org.eclipse.jetty.websocket.api.WebSocketAdapter;
 import org.eclipse.jetty.websocket.client.ClientUpgradeRequest;
 import org.eclipse.jetty.websocket.client.WebSocketClient;
+import org.openhab.binding.unifi.internal.protect.UnifiProtectBindingConstants;
 import org.openhab.binding.unifi.internal.protect.api.priv.dto.devices.Bridge;
 import org.openhab.binding.unifi.internal.protect.api.priv.dto.devices.Camera;
 import org.openhab.binding.unifi.internal.protect.api.priv.dto.devices.Chime;
@@ -94,7 +95,7 @@ public class UniFiProtectPrivateWebSocket {
         // Detect a silently dead / half-open connection: Jetty closes the session
         // when no frame is read within the window -> onWebSocketClose -> reconnect.
         // Without this a dropped socket stays "ONLINE" and updates stop forever.
-        this.wsClient.setMaxIdleTimeout(150_000L);
+        this.wsClient.setMaxIdleTimeout(UnifiProtectBindingConstants.WEBSOCKET_IDLE_TIMEOUT_MS);
 
         try {
             wsClient.start();

--- a/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/protect/api/priv/client/UniFiProtectPrivateWebSocket.java
+++ b/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/protect/api/priv/client/UniFiProtectPrivateWebSocket.java
@@ -70,8 +70,7 @@ public class UniFiProtectPrivateWebSocket {
     private volatile @Nullable Session session;
     private volatile @Nullable CompletableFuture<Void> connectFuture;
     private volatile boolean shouldReconnect = true;
-    // Set when an established session drops, so the next successful connect knows it has to
-    // resynchronise. Updates sent while the socket was down are not replayed by Protect.
+    // Protect does not replay what was missed, so a dropped session has to resynchronise.
     private volatile boolean resyncAfterConnect = false;
     private final AtomicInteger reconnectAttempts = new AtomicInteger(0);
     private static final int MAX_RECONNECT_ATTEMPTS = 10;
@@ -101,11 +100,8 @@ public class UniFiProtectPrivateWebSocket {
         this.wsClient = new WebSocketClient(httpClient);
         // Prevent wsClient.stop() from stopping the shared HttpClient instance
         this.wsClient.unmanage(httpClient);
-        // Detect a silently dead / half-open connection: Jetty closes the session when no frame is
-        // read within the window -> onWebSocketClose -> reconnect. Jetty's own default already
-        // expired the session, but only after 300 s; this halves that so updates resume sooner.
-        // Note setMaxIdleTimeout also applies the value to the injected HttpClient, which is shared
-        // per bridge, so keep it comfortably above any request timeout used on that client.
+        // Halves Jetty's 300 s default so a half-open socket is closed, and reconnected, sooner.
+        // Also applies to the injected HttpClient, which is shared per bridge.
         this.wsClient.setMaxIdleTimeout(UnifiProtectBindingConstants.WEBSOCKET_IDLE_TIMEOUT_MS);
 
         try {
@@ -138,11 +134,8 @@ public class UniFiProtectPrivateWebSocket {
 
             CompletableFuture.runAsync(() -> {
                 try {
-                    // Catch up on what was missed BEFORE the socket is opened. Doing it afterwards
-                    // let a live update arrive first and then be overwritten by the older bootstrap
-                    // snapshot, and a failed refresh had no way to be retried while the new socket
-                    // stayed healthy. As part of the connect, a failure fails the attempt and
-                    // scheduleReconnect tries the whole sequence again.
+                    // Before the socket opens, so a live update cannot be overwritten by the
+                    // older snapshot, and so a failure is retried by scheduleReconnect.
                     resyncBeforeConnect();
 
                     Future<Session> future = wsClient.connect(adapter, uri, request);
@@ -166,26 +159,18 @@ public class UniFiProtectPrivateWebSocket {
     }
 
     /**
-     * Resynchronise after an established session was re-established.
-     *
-     * Reconnecting only restores the stream of new updates: Protect does not replay what happened
-     * while the socket was down, and {@code /ws/updates} is opened without the cached
-     * {@code lastUpdateId}. Refreshing the bootstrap alone is not enough either, because that only
-     * replaces the client's cached copy — the Thing channels are written from it by the NVR
-     * handler's device sync, which otherwise runs only when the public event socket reopens. A
-     * private-only stall leaves that socket connected, so nothing would push the recovered state
-     * out. Hence: refresh the bootstrap, then notify the handler to sync devices from it.
+     * Refresh the bootstrap and push it onto the Thing channels before the socket reopens. The
+     * device sync is needed because a refresh only replaces the client's cached copy.
      */
     private void resyncBeforeConnect() throws ExecutionException, InterruptedException, TimeoutException {
         if (!resyncAfterConnect) {
-            // First connect of this socket: the caller has just bootstrapped, nothing to catch up on.
+            // First connect: the caller has just bootstrapped.
             return;
         }
         logger.debug("Refreshing bootstrap before reopening the WebSocket to pick up missed updates");
         client.refreshBootstrap().get(BOOTSTRAP_REFRESH_TIMEOUT_SECONDS, TimeUnit.SECONDS);
         onReconnected.run();
-        // Only now: if either step threw, the connect attempt fails and is retried with the flag
-        // still set, rather than the recovery being quietly abandoned.
+        // Only now: a throw above leaves the flag set so the retry repeats the whole sequence.
         resyncAfterConnect = false;
     }
 

--- a/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/protect/api/priv/client/UniFiProtectPrivateWebSocket.java
+++ b/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/protect/api/priv/client/UniFiProtectPrivateWebSocket.java
@@ -67,6 +67,9 @@ public class UniFiProtectPrivateWebSocket {
     private volatile @Nullable Session session;
     private volatile @Nullable CompletableFuture<Void> connectFuture;
     private volatile boolean shouldReconnect = true;
+    // Set when an established session drops, so the next successful connect knows it has to
+    // resynchronise. Updates sent while the socket was down are not replayed by Protect.
+    private volatile boolean resyncAfterConnect = false;
     private final AtomicInteger reconnectAttempts = new AtomicInteger(0);
     private static final int MAX_RECONNECT_ATTEMPTS = 10;
     private static final int INITIAL_RECONNECT_DELAY_MS = 1_000;
@@ -133,6 +136,7 @@ public class UniFiProtectPrivateWebSocket {
                     reconnectAttempts.set(0);
                     logger.debug("WebSocket connected");
                     newFuture.complete(null);
+                    resyncIfReconnected();
                 } catch (Exception ex) {
                     logger.debug("WebSocket connection failed", ex);
                     newFuture.completeExceptionally(ex);
@@ -146,6 +150,29 @@ public class UniFiProtectPrivateWebSocket {
         }
 
         return newFuture;
+    }
+
+    /**
+     * Refresh the bootstrap after an established session was re-established.
+     *
+     * Reconnecting only restores the stream of new updates: Protect does not replay what happened
+     * while the socket was down, and {@code /ws/updates} is opened without the cached
+     * {@code lastUpdateId}. Without this, anything that changed during the outage stays stale until
+     * the next periodic bootstrap refresh, which can be up to 15 minutes later.
+     */
+    private void resyncIfReconnected() {
+        if (!resyncAfterConnect) {
+            // First connect of this socket: the caller has just bootstrapped, nothing to catch up on.
+            return;
+        }
+        resyncAfterConnect = false;
+        logger.debug("Refreshing bootstrap after WebSocket reconnect to pick up missed updates");
+        client.refreshBootstrap().whenComplete((bootstrap, ex) -> {
+            if (ex != null) {
+                // Not fatal: the stream is live again and the periodic refresh remains a backstop.
+                logger.debug("Bootstrap refresh after reconnect failed", ex);
+            }
+        });
     }
 
     /**
@@ -278,6 +305,7 @@ public class UniFiProtectPrivateWebSocket {
         public void onWebSocketClose(int statusCode, String reason) {
             logger.debug("WebSocket closed: {} - {}", statusCode, reason);
             if (shouldReconnect) {
+                resyncAfterConnect = true;
                 scheduleReconnect();
             }
         }

--- a/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/protect/api/priv/client/UniFiProtectPrivateWebSocket.java
+++ b/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/protect/api/priv/client/UniFiProtectPrivateWebSocket.java
@@ -16,8 +16,10 @@ import java.net.URI;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 
@@ -76,6 +78,7 @@ public class UniFiProtectPrivateWebSocket {
     private static final int INITIAL_RECONNECT_DELAY_MS = 1_000;
     private static final int MAX_RECONNECT_DELAY_MS = 60_000;
     private static final int CIRCUIT_BREAKER_DELAY_MS = 60_000;
+    private static final int BOOTSTRAP_REFRESH_TIMEOUT_SECONDS = 30;
 
     /**
      * Create UniFi Protect WebSocket client
@@ -133,15 +136,20 @@ public class UniFiProtectPrivateWebSocket {
                 request.setHeader("Cookie", authCookie);
             }
 
-            Future<Session> future = wsClient.connect(adapter, uri, request);
-
             CompletableFuture.runAsync(() -> {
                 try {
+                    // Catch up on what was missed BEFORE the socket is opened. Doing it afterwards
+                    // let a live update arrive first and then be overwritten by the older bootstrap
+                    // snapshot, and a failed refresh had no way to be retried while the new socket
+                    // stayed healthy. As part of the connect, a failure fails the attempt and
+                    // scheduleReconnect tries the whole sequence again.
+                    resyncBeforeConnect();
+
+                    Future<Session> future = wsClient.connect(adapter, uri, request);
                     session = future.get(10, TimeUnit.SECONDS);
                     reconnectAttempts.set(0);
                     logger.debug("WebSocket connected");
                     newFuture.complete(null);
-                    resyncIfReconnected();
                 } catch (Exception ex) {
                     logger.debug("WebSocket connection failed", ex);
                     newFuture.completeExceptionally(ex);
@@ -168,26 +176,17 @@ public class UniFiProtectPrivateWebSocket {
      * private-only stall leaves that socket connected, so nothing would push the recovered state
      * out. Hence: refresh the bootstrap, then notify the handler to sync devices from it.
      */
-    private void resyncIfReconnected() {
+    private void resyncBeforeConnect() throws ExecutionException, InterruptedException, TimeoutException {
         if (!resyncAfterConnect) {
             // First connect of this socket: the caller has just bootstrapped, nothing to catch up on.
             return;
         }
-        logger.debug("Refreshing bootstrap after WebSocket reconnect to pick up missed updates");
-        client.refreshBootstrap().whenComplete((bootstrap, ex) -> {
-            if (ex != null) {
-                // Leave the flag set so the next successful connect tries again. Clearing it on the
-                // attempt would let a single failed refresh drop the recovery entirely.
-                logger.debug("Bootstrap refresh after reconnect failed, will retry on next connect", ex);
-                return;
-            }
-            resyncAfterConnect = false;
-            try {
-                onReconnected.run();
-            } catch (RuntimeException e) {
-                logger.debug("Device sync after reconnect failed", e);
-            }
-        });
+        logger.debug("Refreshing bootstrap before reopening the WebSocket to pick up missed updates");
+        client.refreshBootstrap().get(BOOTSTRAP_REFRESH_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        onReconnected.run();
+        // Only now: if either step threw, the connect attempt fails and is retried with the flag
+        // still set, rather than the recovery being quietly abandoned.
+        resyncAfterConnect = false;
     }
 
     /**

--- a/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/protect/api/pub/client/UniFiProtectPublicClient.java
+++ b/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/protect/api/pub/client/UniFiProtectPublicClient.java
@@ -46,6 +46,7 @@ import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpMethod;
 import org.eclipse.jetty.websocket.api.Session;
 import org.eclipse.jetty.websocket.api.WebSocketAdapter;
+import org.eclipse.jetty.websocket.api.WebSocketPingPongListener;
 import org.eclipse.jetty.websocket.client.ClientUpgradeRequest;
 import org.eclipse.jetty.websocket.client.WebSocketClient;
 import org.openhab.binding.unifi.internal.protect.api.pub.dto.ApiValueEnum;
@@ -508,8 +509,9 @@ public class UniFiProtectPublicClient implements Closeable {
                 upgrade.setHeader(h.getKey(), h.getValue());
             }
 
-            future.complete(wsClient.connect(new WebSocketAdapter() {
+            class WsAdapter extends WebSocketAdapter implements WebSocketPingPongListener {
                 private @Nullable ScheduledFuture<?> heartbeatTask;
+                private volatile long lastActivityMs;
 
                 @Override
                 public void onWebSocketConnect(@Nullable Session session) {
@@ -518,17 +520,28 @@ public class UniFiProtectPublicClient implements Closeable {
                         return;
                     }
                     super.onWebSocketConnect(session);
-                    // Schedule periodic ping frames as heartbeat
+                    lastActivityMs = System.currentTimeMillis();
+                    // Heartbeat: ping to keep the link warm, and - since a write-only
+                    // ping does NOT fail on a half-open socket - close the session when
+                    // no frame has been *received* within the window so onWebSocketClose
+                    // -> reconnect runs. Without this a dead socket stays "ONLINE" and
+                    // real-time updates stop indefinitely.
                     heartbeatTask = executorService.scheduleWithFixedDelay(() -> {
+                        Session s = getSession();
+                        if (s == null || !s.isOpen()) {
+                            return;
+                        }
+                        long silentMs = System.currentTimeMillis() - lastActivityMs;
+                        if (silentMs > 150_000L) {
+                            logger.debug("No WebSocket frames received in {} ms; closing to reconnect", silentMs);
+                            s.close(1001, "No data received");
+                            return;
+                        }
                         try {
-                            Session s = getSession();
-                            if (s != null && s.isOpen()) {
-                                s.getRemote().sendPing(ByteBuffer.allocate(0));
-                            }
+                            s.getRemote().sendPing(ByteBuffer.allocate(0));
                         } catch (IOException e) {
                             logger.debug("WebSocket heartbeat ping failed", e);
-                            session.close(1000, "WebSocket heartbeat ping failed");
-                            throw new IllegalStateException("WebSocket heartbeat ping failed", e);
+                            s.close(1000, "WebSocket heartbeat ping failed");
                         }
                     }, 30, 30, TimeUnit.SECONDS);
                     logger.debug("WebSocket connected: {}", wsUri);
@@ -538,6 +551,7 @@ public class UniFiProtectPublicClient implements Closeable {
 
                 @Override
                 public void onWebSocketText(@Nullable String message) {
+                    lastActivityMs = System.currentTimeMillis();
                     if (message != null) {
                         onText.accept(message);
                     }
@@ -562,7 +576,21 @@ public class UniFiProtectPublicClient implements Closeable {
                     onClosed.accept(statusCode, reason != null ? reason : "");
                     super.onWebSocketClose(statusCode, reason);
                 }
-            }, wsUri, upgrade).get());
+
+                @Override
+                public void onWebSocketPong(@Nullable ByteBuffer payload) {
+                    // Pong for our keepalive ping: proof the peer is still alive, so a
+                    // healthy-but-quiet link (the integration WS is sparse) is not
+                    // mistaken for dead by the received-frame staleness check.
+                    lastActivityMs = System.currentTimeMillis();
+                }
+
+                @Override
+                public void onWebSocketPing(@Nullable ByteBuffer payload) {
+                    // Jetty auto-replies with a pong; nothing to do here.
+                }
+            }
+            future.complete(wsClient.connect(new WsAdapter(), wsUri, upgrade).get());
         } catch (Exception e) {
             future.completeExceptionally(e);
         }

--- a/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/protect/api/pub/client/UniFiProtectPublicClient.java
+++ b/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/protect/api/pub/client/UniFiProtectPublicClient.java
@@ -587,7 +587,11 @@ public class UniFiProtectPublicClient implements Closeable {
 
                 @Override
                 public void onWebSocketPing(@Nullable ByteBuffer payload) {
-                    // Jetty auto-replies with a pong; nothing to do here.
+                    // An inbound ping is a received frame - proof the peer is alive - so
+                    // count it as activity too (mirrors onWebSocketPong), so a quiet-but-
+                    // alive peer is not mistaken for dead by the staleness check. Jetty
+                    // still auto-replies with the pong itself.
+                    lastActivityMs = System.currentTimeMillis();
                 }
             }
             future.complete(wsClient.connect(new WsAdapter(), wsUri, upgrade).get());

--- a/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/protect/api/pub/client/UniFiProtectPublicClient.java
+++ b/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/protect/api/pub/client/UniFiProtectPublicClient.java
@@ -49,6 +49,7 @@ import org.eclipse.jetty.websocket.api.WebSocketAdapter;
 import org.eclipse.jetty.websocket.api.WebSocketPingPongListener;
 import org.eclipse.jetty.websocket.client.ClientUpgradeRequest;
 import org.eclipse.jetty.websocket.client.WebSocketClient;
+import org.openhab.binding.unifi.internal.protect.UnifiProtectBindingConstants;
 import org.openhab.binding.unifi.internal.protect.api.pub.dto.ApiValueEnum;
 import org.openhab.binding.unifi.internal.protect.api.pub.dto.AssetFileType;
 import org.openhab.binding.unifi.internal.protect.api.pub.dto.Camera;
@@ -532,7 +533,7 @@ public class UniFiProtectPublicClient implements Closeable {
                             return;
                         }
                         long silentMs = System.currentTimeMillis() - lastActivityMs;
-                        if (silentMs > 150_000L) {
+                        if (silentMs > UnifiProtectBindingConstants.WEBSOCKET_IDLE_TIMEOUT_MS) {
                             logger.debug("No WebSocket frames received in {} ms; closing to reconnect", silentMs);
                             s.close(1001, "No data received");
                             return;

--- a/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/protect/api/pub/client/UniFiProtectPublicClient.java
+++ b/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/protect/api/pub/client/UniFiProtectPublicClient.java
@@ -522,11 +522,8 @@ public class UniFiProtectPublicClient implements Closeable {
                     }
                     super.onWebSocketConnect(session);
                     lastActivityMs = System.currentTimeMillis();
-                    // Heartbeat: ping to keep the link warm, and - since a write-only
-                    // ping does NOT fail on a half-open socket - close the session when
-                    // no frame has been *received* within the window so onWebSocketClose
-                    // -> reconnect runs. Without this a dead socket stays "ONLINE" and
-                    // real-time updates stop indefinitely.
+                    // A write-only ping does not fail on a half-open socket, so liveness is
+                    // judged on frames *received*, not on the ping succeeding.
                     heartbeatTask = executorService.scheduleWithFixedDelay(() -> {
                         Session s = getSession();
                         if (s == null || !s.isOpen()) {
@@ -580,18 +577,13 @@ public class UniFiProtectPublicClient implements Closeable {
 
                 @Override
                 public void onWebSocketPong(@Nullable ByteBuffer payload) {
-                    // Pong for our keepalive ping: proof the peer is still alive, so a
-                    // healthy-but-quiet link (the integration WS is sparse) is not
-                    // mistaken for dead by the received-frame staleness check.
+                    // Counts as activity: this WS is sparse, so quiet is not dead.
                     lastActivityMs = System.currentTimeMillis();
                 }
 
                 @Override
                 public void onWebSocketPing(@Nullable ByteBuffer payload) {
-                    // An inbound ping is a received frame - proof the peer is alive - so
-                    // count it as activity too (mirrors onWebSocketPong), so a quiet-but-
-                    // alive peer is not mistaken for dead by the staleness check. Jetty
-                    // still auto-replies with the pong itself.
+                    // Also activity; Jetty still sends the pong reply itself.
                     lastActivityMs = System.currentTimeMillis();
                 }
             }

--- a/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/protect/api/pub/client/UniFiProtectPublicClient.java
+++ b/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/protect/api/pub/client/UniFiProtectPublicClient.java
@@ -523,7 +523,7 @@ public class UniFiProtectPublicClient implements Closeable {
                     super.onWebSocketConnect(session);
                     lastActivityMs = System.currentTimeMillis();
                     // A write-only ping does not fail on a half-open socket, so liveness is
-                    // judged on frames *received*, not on the ping succeeding.
+                    // judged on frames *received*.
                     heartbeatTask = executorService.scheduleWithFixedDelay(() -> {
                         Session s = getSession();
                         if (s == null || !s.isOpen()) {
@@ -577,13 +577,11 @@ public class UniFiProtectPublicClient implements Closeable {
 
                 @Override
                 public void onWebSocketPong(@Nullable ByteBuffer payload) {
-                    // Counts as activity: this WS is sparse, so quiet is not dead.
                     lastActivityMs = System.currentTimeMillis();
                 }
 
                 @Override
                 public void onWebSocketPing(@Nullable ByteBuffer payload) {
-                    // Also activity; Jetty still sends the pong reply itself.
                     lastActivityMs = System.currentTimeMillis();
                 }
             }

--- a/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/protect/handler/UnifiProtectNVRHandler.java
+++ b/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/protect/handler/UnifiProtectNVRHandler.java
@@ -276,12 +276,15 @@ public class UnifiProtectNVRHandler extends BaseBridgeHandler {
                     routePrivateApiUpdate(update);
                 });
             }, () -> {
-                // The private socket came back after a stall. Its bootstrap has just been refreshed,
-                // but only the device sync writes that state onto the Thing channels, and it normally
-                // runs from the public event socket's onOpen -- which does not fire when only the
-                // private socket dropped.
+                // Runs before /ws/updates is reopened. Only the device sync writes the refreshed
+                // bootstrap onto the Thing channels, and it normally runs from the public event
+                // socket's onOpen, which does not fire when only the private socket dropped.
+                // Synchronous on purpose: handing it to the scheduler would return immediately and
+                // let the socket reopen while the sync was still writing, so a live update could be
+                // overwritten by the older snapshot. syncDevices logs and swallows its own failures,
+                // so a partial sync does not block the socket from coming back.
                 logger.debug("Private API WebSocket reconnected, syncing devices from refreshed bootstrap");
-                scheduler.execute(this::syncDevices);
+                syncDevices();
             }).whenComplete((result, ex) -> {
                 if (ex != null) {
                     logger.debug("Failed to enable Private API WebSocket", ex);

--- a/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/protect/handler/UnifiProtectNVRHandler.java
+++ b/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/protect/handler/UnifiProtectNVRHandler.java
@@ -276,13 +276,8 @@ public class UnifiProtectNVRHandler extends BaseBridgeHandler {
                     routePrivateApiUpdate(update);
                 });
             }, () -> {
-                // Runs before /ws/updates is reopened. Only the device sync writes the refreshed
-                // bootstrap onto the Thing channels, and it normally runs from the public event
-                // socket's onOpen, which does not fire when only the private socket dropped.
-                // Synchronous on purpose: handing it to the scheduler would return immediately and
-                // let the socket reopen while the sync was still writing, so a live update could be
-                // overwritten by the older snapshot. syncDevices logs and swallows its own failures,
-                // so a partial sync does not block the socket from coming back.
+                // Inline on purpose: the socket must not reopen until the sync has finished
+                // writing. syncDevices logs and swallows its own failures.
                 logger.debug("Private API WebSocket reconnected, syncing devices from refreshed bootstrap");
                 syncDevices();
             }).whenComplete((result, ex) -> {

--- a/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/protect/handler/UnifiProtectNVRHandler.java
+++ b/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/protect/handler/UnifiProtectNVRHandler.java
@@ -276,8 +276,7 @@ public class UnifiProtectNVRHandler extends BaseBridgeHandler {
                     routePrivateApiUpdate(update);
                 });
             }, () -> {
-                // Inline on purpose: the socket must not reopen until the sync has finished
-                // writing. syncDevices logs and swallows its own failures.
+                // The socket must not reopen until the sync has finished writing.
                 logger.debug("Private API WebSocket reconnected, syncing devices from refreshed bootstrap");
                 syncDevices();
             }).whenComplete((result, ex) -> {

--- a/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/protect/handler/UnifiProtectNVRHandler.java
+++ b/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/protect/handler/UnifiProtectNVRHandler.java
@@ -275,6 +275,13 @@ public class UnifiProtectNVRHandler extends BaseBridgeHandler {
                     logger.trace("Private API WebSocket update: action={}, model={}", update.action, update.modelType);
                     routePrivateApiUpdate(update);
                 });
+            }, () -> {
+                // The private socket came back after a stall. Its bootstrap has just been refreshed,
+                // but only the device sync writes that state onto the Thing channels, and it normally
+                // runs from the public event socket's onOpen -- which does not fire when only the
+                // private socket dropped.
+                logger.debug("Private API WebSocket reconnected, syncing devices from refreshed bootstrap");
+                scheduler.execute(this::syncDevices);
             }).whenComplete((result, ex) -> {
                 if (ex != null) {
                     logger.debug("Failed to enable Private API WebSocket", ex);


### PR DESCRIPTION
A UniFi Protect WebSocket can drop silently — the TCP socket stays half-open
(established, but no data and no close/error event). When that happens the
binding never notices: the camera Things stay ONLINE while real-time updates
(motion / smart-detect events and device state) stop until the binding is
restarted.

Both Protect WebSocket clients now detect this so the existing reconnect logic
can recover on its own:

- **Private client** (device updates): set a client idle timeout, so Jetty
  closes the session when no frame is read within the window.
- **Public integration client** (events): its 30s keepalive ping is a *write*
  and does not fail on a half-open socket, so it now closes the session when no
  frame has been *received* within the window. Pong replies are tracked
  (`WebSocketPingPongListener`) so a healthy but idle link — the integration
  stream can be quiet for minutes — is not treated as dead.

Verified by black-holing the controller mid-stream (`ip route add blackhole`):
without the change the sockets sit half-open indefinitely; with it both clients
close and reconnect within ~150 s, with no spurious reconnects while the link
is healthy but quiet.
