### PR TITLE
[zwavejs] Handle value notification events for stateless CCs

### DIFF
--- a/bundles/org.openhab.binding.zwavejs/src/main/java/org/openhab/binding/zwavejs/internal/api/dto/Args.java
+++ b/bundles/org.openhab.binding.zwavejs/src/main/java/org/openhab/binding/zwavejs/internal/api/dto/Args.java
@@ -22,6 +22,10 @@ public class Args {
     public int endpoint;
     public Object newValue;
     public Object prevValue;
+    /**
+     * See {@link org.openhab.binding.zwavejs.internal.handler.ZwaveJSBridgeHandler#normalizeValueNotification}.
+     */
+    public Object value;
     public String propertyName;
     public Object propertyKey;
 

--- a/bundles/org.openhab.binding.zwavejs/src/main/java/org/openhab/binding/zwavejs/internal/handler/ZwaveJSBridgeHandler.java
+++ b/bundles/org.openhab.binding.zwavejs/src/main/java/org/openhab/binding/zwavejs/internal/handler/ZwaveJSBridgeHandler.java
@@ -177,9 +177,13 @@ public class ZwaveJSBridgeHandler extends BaseBridgeHandler implements ZwaveEven
                     }
                     break;
                 case "value updated":
-                case "value notification":
                     if (nodeListener != null) {
                         nodeListener.onNodeStateChanged(eventMsg.event);
+                    }
+                    break;
+                case "value notification":
+                    if (nodeListener != null) {
+                        nodeListener.onNodeStateChanged(normalizeValueNotification(eventMsg.event));
                     }
                     break;
                 case "alive":
@@ -225,6 +229,21 @@ public class ZwaveJSBridgeHandler extends BaseBridgeHandler implements ZwaveEven
         normalizedEvent.args.newValue = new Gson().toJson(event.args);
         normalizedEvent.nodeId = event.nodeId;
         return normalizedEvent;
+    }
+
+    /**
+     * "value notification" events report stateless CC values (e.g. Central Scene or Scene Activation).
+     * Unlike "value updated" events they carry the datum in {@code args.value}; copy it to
+     * {@code args.newValue} so downstream handling is identical for both event types.
+     *
+     * @param event the incoming value notification event
+     * @return the same event with {@code args.newValue} populated
+     */
+    static Event normalizeValueNotification(Event event) {
+        if (event.args != null && event.args.newValue == null) {
+            event.args.newValue = event.args.value;
+        }
+        return event;
     }
 
     private @Nullable Event createEventFromMessageId(String messageId, @Nullable Object value) {

--- a/bundles/org.openhab.binding.zwavejs/src/test/java/org/openhab/binding/zwavejs/internal/handler/ZwaveJSBridgeHandlerTest.java
+++ b/bundles/org.openhab.binding.zwavejs/src/test/java/org/openhab/binding/zwavejs/internal/handler/ZwaveJSBridgeHandlerTest.java
@@ -31,7 +31,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
 import org.openhab.binding.zwavejs.internal.DataUtil;
+import org.openhab.binding.zwavejs.internal.api.dto.Args;
 import org.openhab.binding.zwavejs.internal.api.dto.Event;
 import org.openhab.binding.zwavejs.internal.api.dto.Node;
 import org.openhab.binding.zwavejs.internal.api.dto.Result;
@@ -199,6 +201,53 @@ public class ZwaveJSBridgeHandlerTest {
         } finally {
             handler.dispose();
         }
+    }
+
+    @Test
+    public void testOnEventWithEventMessageValueNotification() throws IOException {
+        final Bridge thing = ZwaveJSBridgeHandlerMock.mockBridge("localhost");
+        final ThingHandlerCallback callback = mock(ThingHandlerCallback.class);
+        final ZwaveJSBridgeHandlerMock handler = ZwaveJSBridgeHandlerMock.createAndInitHandler(callback, thing);
+
+        ZwaveNodeListener nodeListener = mock(ZwaveNodeListener.class);
+        when(nodeListener.getId()).thenReturn(60);
+        handler.registerNodeListener(nodeListener);
+
+        EventMessage eventMessage = DataUtil.fromJson("event_node_60_scene_activation_notification.json",
+                EventMessage.class);
+
+        handler.onEvent(eventMessage);
+
+        try {
+            ArgumentCaptor<Event> eventCaptor = ArgumentCaptor.forClass(Event.class);
+            verify(nodeListener).onNodeStateChanged(eventCaptor.capture());
+            assertEquals(16L, eventCaptor.getValue().args.newValue);
+        } finally {
+            handler.dispose();
+        }
+    }
+
+    @Test
+    public void testNormalizeValueNotificationCopiesValueToNewValue() {
+        Event event = new Event();
+        event.args = new Args();
+        event.args.value = 16;
+
+        Event result = ZwaveJSBridgeHandler.normalizeValueNotification(event);
+
+        assertEquals(16, result.args.newValue);
+    }
+
+    @Test
+    public void testNormalizeValueNotificationKeepsExistingNewValue() {
+        Event event = new Event();
+        event.args = new Args();
+        event.args.newValue = 42;
+        event.args.value = 16;
+
+        Event result = ZwaveJSBridgeHandler.normalizeValueNotification(event);
+
+        assertEquals(42, result.args.newValue);
     }
 
     @ParameterizedTest

--- a/bundles/org.openhab.binding.zwavejs/src/test/java/org/openhab/binding/zwavejs/internal/handler/ZwaveJSNodeHandlerTest.java
+++ b/bundles/org.openhab.binding.zwavejs/src/test/java/org/openhab/binding/zwavejs/internal/handler/ZwaveJSNodeHandlerTest.java
@@ -31,6 +31,7 @@ import org.openhab.binding.zwavejs.internal.api.dto.commands.NodeSetValueCommand
 import org.openhab.binding.zwavejs.internal.api.dto.messages.EventMessage;
 import org.openhab.binding.zwavejs.internal.handler.mock.ZwaveJSNodeHandlerMock;
 import org.openhab.core.config.core.Configuration;
+import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.library.types.HSBType;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.library.types.PercentType;
@@ -297,6 +298,25 @@ public class ZwaveJSNodeHandlerTest {
                     argThat(arg -> arg.getStatus().equals(ThingStatus.ONLINE)));
             verify(callback, times(1)).stateUpdated(eq(channelIdDimmer), eq(new PercentType(52)));
             verify(callback, times(1)).stateUpdated(eq(channelIdRollerShutter), eq(new PercentType(52)));
+        } finally {
+            handler.dispose();
+        }
+    }
+
+    @Test
+    public void testNode37CentralSceneValueNotificationUpdate() throws IOException {
+        final Thing thing = ZwaveJSNodeHandlerMock.mockThing(37);
+        final ThingHandlerCallback callback = mock(ThingHandlerCallback.class);
+        final ZwaveJSNodeHandlerMock handler = ZwaveJSNodeHandlerMock.createAndInitHandler(callback, thing,
+                "store_4.json");
+
+        EventMessage eventMessage = DataUtil.fromJson("event_node_37_central_scene_notification.json",
+                EventMessage.class);
+        handler.onNodeStateChanged(ZwaveJSBridgeHandler.normalizeValueNotification(eventMessage.event));
+
+        ChannelUID channelId = new ChannelUID("zwavejs:test-bridge:test-thing:central-scene-scene-001");
+        try {
+            verify(callback, times(1)).stateUpdated(eq(channelId), eq(new DecimalType(2)));
         } finally {
             handler.dispose();
         }

--- a/bundles/org.openhab.binding.zwavejs/src/test/resources/json/event_node_37_central_scene_notification.json
+++ b/bundles/org.openhab.binding.zwavejs/src/test/resources/json/event_node_37_central_scene_notification.json
@@ -1,0 +1,18 @@
+{
+    "type": "event",
+    "event": {
+        "source": "node",
+        "event": "value notification",
+        "nodeId": 37,
+        "args": {
+            "commandClassName": "Central Scene",
+            "commandClass": 91,
+            "property": "scene",
+            "propertyKey": "001",
+            "endpoint": 0,
+            "value": 2,
+            "propertyName": "scene",
+            "ccVersion": 3
+        }
+    }
+}

--- a/bundles/org.openhab.binding.zwavejs/src/test/resources/json/event_node_60_scene_activation_notification.json
+++ b/bundles/org.openhab.binding.zwavejs/src/test/resources/json/event_node_60_scene_activation_notification.json
@@ -1,0 +1,17 @@
+{
+    "type": "event",
+    "event": {
+        "source": "node",
+        "event": "value notification",
+        "nodeId": 60,
+        "args": {
+            "commandClassName": "Scene Activation",
+            "commandClass": 43,
+            "property": "sceneId",
+            "endpoint": 0,
+            "value": 16,
+            "propertyName": "sceneId",
+            "ccVersion": 1
+        }
+    }
+}


### PR DESCRIPTION
Fixes #21199.

**Classification:** Bugfix.

**Problem:** `"value notification"` events (stateless CC values: Central Scene `scene`, Scene Activation `sceneId`, …) carry their datum in `args.value`, which the `Args` DTO did not map. Every such event reached `onNodeStateChanged` with `newValue == null` and was silently dropped — so central-scene channels never updated from physical presses (details and root-cause analysis in the linked issue).

**Fix (minimal, two touch points):**
- `Args` gains the `value` field.
- The bridge dispatch normalizes value-notification events via a package-private `normalizeValueNotification` (copies `value` → `newValue` when `newValue` is absent), so downstream handling is identical for both event types. `value updated` handling is untouched.

**Tests:** two direct unit tests for the normalization helper, a bridge-level dispatch test and a fixture-driven handler test (`event_node_37_central_scene_notification.json`, node 37 of the existing `store_4.json`, asserting the `central-scene-scene-001` channel receives the state).

**Verified on real hardware:** after deploying this fix on an affected network (Z-Wave JS UI 11.16.2 / openHAB 5.1.4), physical scene presses update the linked items immediately; before the fix the driver decoded the presses but no item ever changed.

This PR was developed with AI assistance (Claude); the change and tests were reviewed and hardware-verified by the author.
