### PR TITLE
[zwavejs] Add channel support for Scene Activation CC (0x2B)

### DIFF
--- a/bundles/org.openhab.binding.zwavejs/README.md
+++ b/bundles/org.openhab.binding.zwavejs/README.md
@@ -65,6 +65,13 @@ It provides the event payload in JSON as a string value.
 A common scenario is using this JSON to determine the userId that unlocked a door lock.
 This channel is added automatically; no manual configuration is required.
 
+### Scene-Activation Channel
+
+The binding automatically adds a `scene-activation-scene-id` channel (or `scene-activation-scene-id-N` per endpoint) for endpoints that support Scene Activation (Command Class 0x2B).
+Scene Activation is a stateless command class, so its values are not part of the static Z-Wave JS node snapshot; the channel is pre-created so the binding can post the activated scene id (`Number`) when the device sends a Scene Activation Set.
+This is useful for devices like the Fibaro FGD212 / FGS222, which expose Scene Activation but not Central Scene.
+This channel is added automatically; no manual configuration is required.
+
 ## Channel Configuration and Inversion
 
 Channels in the `zwavejs` binding support an **inversion** configuration option.

--- a/bundles/org.openhab.binding.zwavejs/src/main/java/org/openhab/binding/zwavejs/internal/BindingConstants.java
+++ b/bundles/org.openhab.binding.zwavejs/src/main/java/org/openhab/binding/zwavejs/internal/BindingConstants.java
@@ -96,4 +96,10 @@ public class BindingConstants {
     public static final String VIRTUAL_NOTIFICATION_PROPERTY = "virtual";
     public static final String VIRTUAL_NOTIFICATION_CHANNEL_ID = String.format("%s-%s",
             VIRTUAL_COMMAND_CLASS_NOTIFICATION, VIRTUAL_NOTIFICATION_PROPERTY);
+
+    // Scene Activation CC (0x2B) is event-only: zwave-js does not include it in the static
+    // node.values snapshot, so a channel must be synthesized at interview time using these names
+    // to match the metadata id derived from runtime "value notification" events.
+    public static final String SCENE_ACTIVATION_CHANNEL_COMMAND_CLASS_NAME = "Scene Activation";
+    public static final String SCENE_ACTIVATION_CHANNEL_PROPERTY_NAME = "sceneId";
 }

--- a/bundles/org.openhab.binding.zwavejs/src/main/java/org/openhab/binding/zwavejs/internal/handler/ZwaveJSNodeHandler.java
+++ b/bundles/org.openhab.binding.zwavejs/src/main/java/org/openhab/binding/zwavejs/internal/handler/ZwaveJSNodeHandler.java
@@ -783,6 +783,31 @@ public class ZwaveJSNodeHandler extends BaseThingHandler implements ZwaveNodeLis
         }
     }
 
+    /**
+     * Re-injects channels that the eager generator pass cannot rediscover (because the device's
+     * interview omits the CC) but which were legitimately attached earlier via the lazy path and
+     * persisted to Thing.json.
+     *
+     * Currently scoped to CC 0x2B (Scene Activation): only channels whose configuration
+     * commandClassId equals COMMAND_CLASS_SCENE_ACTIVATION are preserved; all other "missing
+     * from result" channels still go through the normal removal path in updateChannels().
+     *
+     * @param result the type generator result that updateChannels will consume
+     */
+    private void rePrimePersistentLazyChannels(ZwaveJSTypeGeneratorResult result) {
+        for (Channel existing : thing.getChannels()) {
+            String id = existing.getUID().getId();
+            if (result.channels.containsKey(id)) {
+                continue;
+            }
+            ZwaveJSChannelConfiguration cfg = getChannelConfiguration(existing);
+            if (cfg.commandClassId == COMMAND_CLASS_SCENE_ACTIVATION) {
+                logger.debug("Node {}. Preserving lazy Scene Activation channel {} across setupThing", config.id, id);
+                result.channels.put(id, existing);
+            }
+        }
+    }
+
     private boolean setupThing(Node node) {
         logger.debug("Node {}. Building channels and configuration, containing {} values", node.nodeId,
                 node.values.size());
@@ -804,6 +829,12 @@ public class ZwaveJSNodeHandler extends BaseThingHandler implements ZwaveNodeLis
         if (!result.location.equals(getThing().getLocation()) && !result.location.isBlank()) {
             builder.withLocation(result.location);
         }
+
+        // Preserve channels previously attached via the lazy CC 0x2B path (Fibaro
+        // FGD212 and similar devices whose interview omits CC 0x2B). Without this,
+        // updateChannels would treat them as "no longer part of the result" and
+        // strip them on every setupThing(), causing the lazy add to repeat each event.
+        rePrimePersistentLazyChannels(result);
 
         // Update channels
         builder = updateChannels(builder, result);

--- a/bundles/org.openhab.binding.zwavejs/src/main/java/org/openhab/binding/zwavejs/internal/handler/ZwaveJSNodeHandler.java
+++ b/bundles/org.openhab.binding.zwavejs/src/main/java/org/openhab/binding/zwavejs/internal/handler/ZwaveJSNodeHandler.java
@@ -13,6 +13,7 @@
 package org.openhab.binding.zwavejs.internal.handler;
 
 import static org.openhab.binding.zwavejs.internal.BindingConstants.*;
+import static org.openhab.binding.zwavejs.internal.CommandClassConstants.COMMAND_CLASS_SCENE_ACTIVATION;
 import static org.openhab.binding.zwavejs.internal.CommandClassConstants.EQUIPMENT_MAP;
 import static org.openhab.core.thing.Thing.*;
 
@@ -535,8 +536,16 @@ public class ZwaveJSNodeHandler extends BaseThingHandler implements ZwaveNodeLis
         logger.trace("Getting the configuration for linked channel {}", metadata.id);
         Channel channel = thing.getChannel(metadata.id);
         if (channel == null) {
-            logger.debug("Node {}. Channel {} not found, ignoring event", config.id, channelId);
-            return false;
+            // Some Fibaro dimmers (e.g. FGD212) emit Scene Activation (CC 0x2B) events but do not
+            // list the CC in their endpoint commandClasses, so the eager generator cannot create
+            // the channel up front. Fall back to lazy creation here on first event arrival.
+            if (event.args.commandClass == COMMAND_CLASS_SCENE_ACTIVATION) {
+                channel = lazilyAddSceneActivationChannel(event.args.endpoint);
+            }
+            if (channel == null) {
+                logger.debug("Node {}. Channel {} not found, ignoring event", config.id, channelId);
+                return false;
+            }
         }
 
         ZwaveJSChannelConfiguration channelConfig = getChannelConfiguration(channel);
@@ -741,6 +750,37 @@ public class ZwaveJSNodeHandler extends BaseThingHandler implements ZwaveNodeLis
     @Override
     public Integer getId() {
         return this.config.id;
+    }
+
+    /**
+     * Lazy fallback for nodes whose interview did not list CC 0x2B (Scene Activation) in their
+     * endpoint commandClasses. When a Scene Activation event arrives and no channel exists yet,
+     * synthesize one, attach it to the Thing, and return it so the caller can dispatch the event
+     * normally.
+     *
+     * @param endpoint the endpoint index reported in the incoming event
+     * @return the freshly attached Channel, or {@code null} if attaching failed
+     */
+    private @Nullable Channel lazilyAddSceneActivationChannel(int endpoint) {
+        try {
+            Channel channel = typeGenerator.createSceneActivationChannel(thing.getUID(), config.id, endpoint);
+            String newChannelId = channel.getUID().getId();
+
+            // Re-check under the lock-free fast path: another event may have created it concurrently.
+            Channel existing = thing.getChannel(newChannelId);
+            if (existing != null) {
+                return existing;
+            }
+
+            logger.debug("Node {}. Lazily adding Scene Activation channel {} on first event", config.id, newChannelId);
+            ThingBuilder builder = editThing().withChannel(channel);
+            updateThing(builder.build());
+            return thing.getChannel(newChannelId);
+        } catch (RuntimeException e) {
+            logger.warn("Node {}. Failed to lazily add Scene Activation channel for endpoint {}", config.id, endpoint,
+                    e);
+            return null;
+        }
     }
 
     private boolean setupThing(Node node) {

--- a/bundles/org.openhab.binding.zwavejs/src/main/java/org/openhab/binding/zwavejs/internal/type/ZwaveJSTypeGenerator.java
+++ b/bundles/org.openhab.binding.zwavejs/src/main/java/org/openhab/binding/zwavejs/internal/type/ZwaveJSTypeGenerator.java
@@ -14,6 +14,7 @@ package org.openhab.binding.zwavejs.internal.type;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.binding.zwavejs.internal.api.dto.Node;
+import org.openhab.core.thing.Channel;
 import org.openhab.core.thing.ThingUID;
 
 /**
@@ -36,4 +37,20 @@ public interface ZwaveJSTypeGenerator {
      * @return a ZwaveJSTypeGeneratorResult containing the generated type information
      */
     ZwaveJSTypeGeneratorResult generate(ThingUID thingUID, Node node, boolean configurationAsChannels);
+
+    /*
+     * Builds a Scene Activation (CC 0x2B) channel for the given endpoint and registers its
+     * ChannelType. Used to lazily add the channel on first incoming "value notification" event
+     * for nodes whose interview did not list CC 0x2B in the endpoint's commandClasses (some Fibaro
+     * dimmers, e.g. FGD212).
+     *
+     * @param thingUID the ThingUID of the node
+     * 
+     * @param nodeId the Z-Wave node id (used only for log context)
+     * 
+     * @param endpoint the endpoint index that received the Scene Activation event
+     * 
+     * @return the created Channel
+     */
+    Channel createSceneActivationChannel(ThingUID thingUID, int nodeId, int endpoint);
 }

--- a/bundles/org.openhab.binding.zwavejs/src/main/java/org/openhab/binding/zwavejs/internal/type/ZwaveJSTypeGeneratorImpl.java
+++ b/bundles/org.openhab.binding.zwavejs/src/main/java/org/openhab/binding/zwavejs/internal/type/ZwaveJSTypeGeneratorImpl.java
@@ -278,14 +278,18 @@ public class ZwaveJSTypeGeneratorImpl implements ZwaveJSTypeGenerator {
         if (node.endpoints == null) {
             return;
         }
-        node.endpoints.stream()
-                .filter(ep -> ep.commandClasses != null && ep.commandClasses.stream()
-                        .anyMatch(cc -> cc != null && COMMAND_CLASS_SCENE_ACTIVATION == cc.id))
-                .forEach(ep -> createSceneActivationChannel(thingUID, node, result, ep.index));
+        node.endpoints.stream().filter(ep -> ep.commandClasses != null
+                && ep.commandClasses.stream().anyMatch(cc -> cc != null && COMMAND_CLASS_SCENE_ACTIVATION == cc.id))
+                .forEach(ep -> {
+                    Channel channel = createSceneActivationChannel(thingUID, node.nodeId, ep.index);
+                    if (!result.channels.containsKey(channel.getUID().getId())) {
+                        result.channels.put(channel.getUID().getId(), channel);
+                    }
+                });
     }
 
-    private void createSceneActivationChannel(ThingUID thingUID, Node node, ZwaveJSTypeGeneratorResult result,
-            int endpoint) {
+    @Override
+    public Channel createSceneActivationChannel(ThingUID thingUID, int nodeId, int endpoint) {
         Value value = new Value();
         value.endpoint = endpoint;
         value.commandClass = COMMAND_CLASS_SCENE_ACTIVATION;
@@ -299,21 +303,15 @@ public class ZwaveJSTypeGeneratorImpl implements ZwaveJSTypeGenerator {
         value.metadata.label = "Scene Activation";
         value.metadata.description = "Last received scene id (CC 0x2B Scene Activation)";
 
-        ChannelMetadata details = new ChannelMetadata(node.nodeId, value);
-        if (result.channels.containsKey(details.id)) {
-            return;
-        }
-
+        ChannelMetadata details = new ChannelMetadata(nodeId, value);
         logger.trace("Node {} building Scene Activation channel with Id: {}", details.nodeId, details.id);
 
         ChannelTypeUID channelTypeUID = generateChannelTypeUID(details);
-        ChannelType type = getOrGenerate(channelTypeUID, details);
-        if (type == null) {
-            return;
-        }
+        ChannelType type = Objects.requireNonNull(getOrGenerate(channelTypeUID, details),
+                "Scene Activation ChannelType could not be generated");
         Configuration config = buildChannelConfiguration(details);
 
-        Channel channel = ChannelBuilder.create(new ChannelUID(thingUID, details.id), CoreItemFactory.NUMBER)
+        return ChannelBuilder.create(new ChannelUID(thingUID, details.id), CoreItemFactory.NUMBER)
                 .withType(type.getUID()) //
                 .withDefaultTags(type.getTags()) //
                 .withKind(type.getKind()) //
@@ -322,8 +320,6 @@ public class ZwaveJSTypeGeneratorImpl implements ZwaveJSTypeGenerator {
                 .withAutoUpdatePolicy(type.getAutoUpdatePolicy()) //
                 .withConfiguration(config) //
                 .build();
-
-        result.channels.put(details.id, channel);
     }
 
     private ConfigDescriptionParameter createConfigDescription(ConfigMetadata details) {

--- a/bundles/org.openhab.binding.zwavejs/src/main/java/org/openhab/binding/zwavejs/internal/type/ZwaveJSTypeGeneratorImpl.java
+++ b/bundles/org.openhab.binding.zwavejs/src/main/java/org/openhab/binding/zwavejs/internal/type/ZwaveJSTypeGeneratorImpl.java
@@ -15,6 +15,7 @@ package org.openhab.binding.zwavejs.internal.type;
 import static org.openhab.binding.zwavejs.internal.BindingConstants.*;
 import static org.openhab.binding.zwavejs.internal.CommandClassConstants.COMMAND_CLASS_ALARM;
 import static org.openhab.binding.zwavejs.internal.CommandClassConstants.COMMAND_CLASS_DOOR_LOCK;
+import static org.openhab.binding.zwavejs.internal.CommandClassConstants.COMMAND_CLASS_SCENE_ACTIVATION;
 import static org.openhab.binding.zwavejs.internal.CommandClassConstants.COMMAND_CLASS_SWITCH_COLOR;
 
 import java.net.URI;
@@ -187,6 +188,9 @@ public class ZwaveJSTypeGeneratorImpl implements ZwaveJSTypeGenerator {
         // add raw notification channel if necessary
         addRawNotificationChannel(thingUID, node, result);
 
+        // add Scene Activation (CC 0x2B) channels if necessary
+        addSceneActivationChannels(thingUID, node, result);
+
         logger.debug("Node {}. Generated {} channels and {} configDescriptions with URI {}", node.nodeId,
                 result.channels.size(), configDescriptions.size(), uri);
 
@@ -255,6 +259,71 @@ public class ZwaveJSTypeGeneratorImpl implements ZwaveJSTypeGenerator {
 
             result.channels.put(details.id, channel);
         }
+    }
+
+    /**
+     * Synthesize a Scene Activation channel for every endpoint that supports CC 0x2B.
+     *
+     * Scene Activation is a stateless command class: zwave-js does not surface it in the static
+     * {@code node.values} snapshot, so the value-driven generator never creates a channel for it.
+     * Without a channel, the runtime "value notification" events that carry the activated scene id
+     * are silently dropped by {@code ZwaveJSNodeHandler.onNodeStateChanged}. We pre-create the
+     * channel here so those events have a destination.
+     *
+     * @param thingUID the ThingUID
+     * @param node the Node
+     * @param result the ZwaveJSTypeGeneratorResult that receives the channels
+     */
+    private void addSceneActivationChannels(ThingUID thingUID, Node node, ZwaveJSTypeGeneratorResult result) {
+        if (node.endpoints == null) {
+            return;
+        }
+        node.endpoints.stream()
+                .filter(ep -> ep.commandClasses != null && ep.commandClasses.stream()
+                        .anyMatch(cc -> cc != null && COMMAND_CLASS_SCENE_ACTIVATION == cc.id))
+                .forEach(ep -> createSceneActivationChannel(thingUID, node, result, ep.index));
+    }
+
+    private void createSceneActivationChannel(ThingUID thingUID, Node node, ZwaveJSTypeGeneratorResult result,
+            int endpoint) {
+        Value value = new Value();
+        value.endpoint = endpoint;
+        value.commandClass = COMMAND_CLASS_SCENE_ACTIVATION;
+        value.commandClassName = SCENE_ACTIVATION_CHANNEL_COMMAND_CLASS_NAME;
+        value.property = SCENE_ACTIVATION_CHANNEL_PROPERTY_NAME;
+        value.propertyName = SCENE_ACTIVATION_CHANNEL_PROPERTY_NAME;
+        value.metadata = new Metadata();
+        value.metadata.type = MetadataType.NUMBER;
+        value.metadata.writeable = false;
+        value.metadata.readable = true;
+        value.metadata.label = "Scene Activation";
+        value.metadata.description = "Last received scene id (CC 0x2B Scene Activation)";
+
+        ChannelMetadata details = new ChannelMetadata(node.nodeId, value);
+        if (result.channels.containsKey(details.id)) {
+            return;
+        }
+
+        logger.trace("Node {} building Scene Activation channel with Id: {}", details.nodeId, details.id);
+
+        ChannelTypeUID channelTypeUID = generateChannelTypeUID(details);
+        ChannelType type = getOrGenerate(channelTypeUID, details);
+        if (type == null) {
+            return;
+        }
+        Configuration config = buildChannelConfiguration(details);
+
+        Channel channel = ChannelBuilder.create(new ChannelUID(thingUID, details.id), CoreItemFactory.NUMBER)
+                .withType(type.getUID()) //
+                .withDefaultTags(type.getTags()) //
+                .withKind(type.getKind()) //
+                .withLabel(details.label) //
+                .withDescription(Objects.requireNonNull(details.description)) //
+                .withAutoUpdatePolicy(type.getAutoUpdatePolicy()) //
+                .withConfiguration(config) //
+                .build();
+
+        result.channels.put(details.id, channel);
     }
 
     private ConfigDescriptionParameter createConfigDescription(ConfigMetadata details) {

--- a/bundles/org.openhab.binding.zwavejs/src/test/java/org/openhab/binding/zwavejs/internal/handler/ZwaveJSNodeHandlerTest.java
+++ b/bundles/org.openhab.binding.zwavejs/src/test/java/org/openhab/binding/zwavejs/internal/handler/ZwaveJSNodeHandlerTest.java
@@ -304,6 +304,25 @@ public class ZwaveJSNodeHandlerTest {
     }
 
     @Test
+    public void testNode60SceneActivationValueNotificationLazyChannel() throws IOException {
+        final Thing thing = ZwaveJSNodeHandlerMock.mockThing(60);
+        final ThingHandlerCallback callback = mock(ThingHandlerCallback.class);
+        final ZwaveJSNodeHandlerMock handler = ZwaveJSNodeHandlerMock.createAndInitHandler(callback, thing,
+                "store_4.json");
+
+        EventMessage eventMessage = DataUtil.fromJson("event_node_60_scene_activation_notification.json",
+                EventMessage.class);
+        handler.onNodeStateChanged(ZwaveJSBridgeHandler.normalizeValueNotification(eventMessage.event));
+
+        ChannelUID channelId = new ChannelUID("zwavejs:test-bridge:test-thing:scene-activation-scene-id");
+        try {
+            verify(callback, times(1)).stateUpdated(eq(channelId), eq(new DecimalType(16)));
+        } finally {
+            handler.dispose();
+        }
+    }
+
+    @Test
     public void testNode37CentralSceneValueNotificationUpdate() throws IOException {
         final Thing thing = ZwaveJSNodeHandlerMock.mockThing(37);
         final ThingHandlerCallback callback = mock(ThingHandlerCallback.class);

--- a/bundles/org.openhab.binding.zwavejs/src/test/java/org/openhab/binding/zwavejs/internal/type/ZwaveJSTypeGeneratorTest.java
+++ b/bundles/org.openhab.binding.zwavejs/src/test/java/org/openhab/binding/zwavejs/internal/type/ZwaveJSTypeGeneratorTest.java
@@ -19,7 +19,9 @@ import static org.openhab.binding.zwavejs.internal.BindingConstants.BINDING_ID;
 
 import java.io.IOException;
 import java.math.BigDecimal;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
@@ -29,6 +31,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openhab.binding.zwavejs.internal.BindingConstants;
 import org.openhab.binding.zwavejs.internal.DataUtil;
+import org.openhab.binding.zwavejs.internal.api.dto.CommandClass;
+import org.openhab.binding.zwavejs.internal.api.dto.Endpoint;
 import org.openhab.binding.zwavejs.internal.api.dto.Node;
 import org.openhab.binding.zwavejs.internal.api.dto.messages.ResultMessage;
 import org.openhab.binding.zwavejs.internal.handler.mock.ZwaveJSChannelTypeInMemmoryProvider;
@@ -423,5 +427,78 @@ public class ZwaveJSTypeGeneratorTest {
 
         assertEquals(47, channels.values().stream().map(f -> f.getChannelTypeUID()).distinct().count());
         assertTrue(channels.containsKey("color-switch-color-temperature"));
+    }
+
+    @Test
+    public void testSceneActivationChannelCreatedFromEndpointCommandClassList() {
+        // Synthetic node: endpoint 0 lists CC 0x2B (Scene Activation) but has no value entry for it
+        // (this matches what zwave-js exposes for stateless CCs). We expect a Number channel to be
+        // synthesized so that runtime "value notification" events have a destination.
+        Node node = new Node();
+        node.nodeId = 99;
+        node.values = new ArrayList<>();
+        Endpoint ep = new Endpoint();
+        ep.index = 0;
+        ep.commandClasses = new ArrayList<>();
+        CommandClass sceneActivation = new CommandClass();
+        sceneActivation.id = 0x2B;
+        sceneActivation.name = "Scene Activation";
+        sceneActivation.version = 1;
+        ep.commandClasses.add(sceneActivation);
+        node.endpoints = List.of(ep);
+
+        ZwaveJSTypeGeneratorResult results = Objects.requireNonNull(provider)
+                .generate(new ThingUID(BINDING_ID, "test-bridge", "test-thing"), node, false);
+
+        Channel channel = results.channels.get("scene-activation-scene-id");
+        assertNotNull(channel);
+        assertEquals(CoreItemFactory.NUMBER, channel.getAcceptedItemType());
+        assertEquals("Scene Activation", channel.getLabel());
+
+        Configuration config = channel.getConfiguration();
+        assertEquals("Scene Activation", config.get(BindingConstants.CONFIG_CHANNEL_COMMANDCLASS_NAME));
+    }
+
+    @Test
+    public void testSceneActivationChannelPerEndpoint() {
+        // Two endpoints both listing CC 0x2B should produce two channels with the -N suffix.
+        Node node = new Node();
+        node.nodeId = 100;
+        node.values = new ArrayList<>();
+        node.endpoints = new ArrayList<>();
+        for (int idx : new int[] { 0, 1 }) {
+            Endpoint ep = new Endpoint();
+            ep.index = idx;
+            ep.commandClasses = new ArrayList<>();
+            CommandClass cc = new CommandClass();
+            cc.id = 0x2B;
+            cc.name = "Scene Activation";
+            cc.version = 1;
+            ep.commandClasses.add(cc);
+            node.endpoints.add(ep);
+        }
+
+        ZwaveJSTypeGeneratorResult results = Objects.requireNonNull(provider)
+                .generate(new ThingUID(BINDING_ID, "test-bridge", "test-thing"), node, false);
+
+        assertNotNull(results.channels.get("scene-activation-scene-id"));
+        assertNotNull(results.channels.get("scene-activation-scene-id-1"));
+    }
+
+    @Test
+    public void testSceneActivationChannelNotCreatedWhenCcAbsent() {
+        // No endpoint lists CC 0x2B, so no Scene Activation channel should be created.
+        Node node = new Node();
+        node.nodeId = 101;
+        node.values = new ArrayList<>();
+        Endpoint ep = new Endpoint();
+        ep.index = 0;
+        ep.commandClasses = new ArrayList<>();
+        node.endpoints = List.of(ep);
+
+        ZwaveJSTypeGeneratorResult results = Objects.requireNonNull(provider)
+                .generate(new ThingUID(BINDING_ID, "test-bridge", "test-thing"), node, false);
+
+        assertNull(results.channels.get("scene-activation-scene-id"));
     }
 }


### PR DESCRIPTION
Depends on #21200 (its commit is included; will rebase once merged).

**Classification:** Enhancement.

**Motivation:** an entire generation of devices (e.g. Fibaro FGD212 Dimmer 2 / FGS222) predates Central Scene CC and reports wall-switch presses (S1/S2 single/double/triple) via Scene Activation CC (0x2B) `SCENE_ACTIVATION_SET`. The legacy OH1/OH2 zwave binding exposed this as `scene_number`; the zwavejs binding has no channel for it, because CC 0x2B is event-only — zwave-js never includes it in the static `node.values` snapshot, so the value-driven channel generator never sees it. For these devices every wall press is currently lost.

**Design (three commits):**
1. **Eager:** `addSceneActivationChannels` creates a read-only Number channel (`scene-activation-scene-id`, one per endpoint) at interview time when an endpoint lists CC 0x2B in `commandClasses`.
2. **Lazy fallback:** many such devices only *control* (send) 0x2B without listing it as supported — nothing to detect at interview time. On the first incoming Scene Activation value notification with no matching channel, the channel is synthesized on the fly.
3. **Persistence:** lazily created channels are preserved across `setupThing()` re-runs (`rePrimePersistentLazyChannels`) — the eager generator can never rediscover them, and without this they would be removed on every re-interview/reconnect.

**Tests:** generator-level tests for eager creation/absence (`scene-activation-scene-id`, endpoint suffixing), and a handler-level fixture test for the lazy path (node without CC 0x2B in its CC list receives a Scene Activation value notification → channel created and state updated).

**Verified on real hardware** with multiple FGD212 dimmers on Z-Wave JS UI 11.16.2 / openHAB 5.1.4 (both the eager-listed and the lazy/controlled-only cases, before and after a 500→800-series controller migration).

This PR was developed with AI assistance (Claude); the change and tests were reviewed and hardware-verified by the author.
