### PR TITLE
[govee] Reduce discovery log noise from Bluetooth-only devices

### DIFF
--- a/bundles/org.openhab.binding.govee/src/main/java/org/openhab/binding/govee/internal/GoveeDiscoveryService.java
+++ b/bundles/org.openhab.binding.govee/src/main/java/org/openhab/binding/govee/internal/GoveeDiscoveryService.java
@@ -131,7 +131,9 @@ public class GoveeDiscoveryService extends AbstractDiscoveryService implements G
 
         final String ipAddress = data.ip();
         if (ipAddress == null || ipAddress.isEmpty()) {
-            logger.warn("Missing IP address received during discovery - ignoring {}", response);
+            // Bluetooth-only Govee devices reply to the LAN discovery scan without an IP address; they cannot be
+            // controlled over the LAN API and reappear on every background scan, so log at debug to avoid noise.
+            logger.debug("Ignoring scan response without IP address (device not reachable over LAN) - {}", response);
             return null;
         }
 

--- a/bundles/org.openhab.binding.govee/src/main/java/org/openhab/binding/govee/internal/GoveeDiscoveryService.java
+++ b/bundles/org.openhab.binding.govee/src/main/java/org/openhab/binding/govee/internal/GoveeDiscoveryService.java
@@ -131,8 +131,6 @@ public class GoveeDiscoveryService extends AbstractDiscoveryService implements G
 
         final String ipAddress = data.ip();
         if (ipAddress == null || ipAddress.isEmpty()) {
-            // Bluetooth-only Govee devices reply to the LAN discovery scan without an IP address; they cannot be
-            // controlled over the LAN API and reappear on every background scan, so log at debug to avoid noise.
             logger.debug("Ignoring scan response without IP address (device not reachable over LAN) - {}", response);
             return null;
         }


### PR DESCRIPTION
## Description

Follow-up to #20984.

Bluetooth-only Govee devices (models without a usable Wi-Fi/LAN control interface) reply to the LAN discovery multicast with a valid `cmd:"scan"` message that has no `ip` field. Such a device cannot be added as a LAN Thing, and because background discovery runs on a fixed 300s interval it re-appears on every scan. Today this is logged at `WARN`:

```
[WARN ] [govee.internal.GoveeDiscoveryService] - Missing IP address received during discovery - ignoring DiscoveryResponse[msg=DiscoveryMsg[cmd=scan, data=DiscoveryData[ip=null, device=0C:DE:..., sku=H6093, ...]]]
```

which turns into a steady stream of warnings on an otherwise healthy installation (observed at roughly 8–10/hour from a single BLE-only device that shares the discovery port).

This is an expected, non-actionable condition, so it is now logged at `DEBUG` instead. The missing-MAC and missing-SKU branches are intentionally left at `WARN`, since those indicate genuinely malformed scan responses rather than a normal device type.

## Testing done

No behaviour change: the response is still ignored and no `Thing` is created. The existing `GoveeDiscoveryTest.testScanMessageWithoutIpIsIgnored` still passes — only the log level differs, so no new/changed test is needed.
