### PR TITLE
[yamlcomposer] Upgrade to Jinjava 2.8.3

### DIFF
--- a/bom/openhab-addons/pom.xml
+++ b/bom/openhab-addons/pom.xml
@@ -2368,6 +2368,11 @@
     </dependency>
     <dependency>
       <groupId>org.openhab.addons.bundles</groupId>
+      <artifactId>org.openhab.io.yamlcomposer</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.openhab.addons.bundles</groupId>
       <artifactId>org.openhab.persistence.dynamodb</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/bundles/org.openhab.io.yamlcomposer/pom.xml
+++ b/bundles/org.openhab.io.yamlcomposer/pom.xml
@@ -16,6 +16,7 @@
 
   <properties>
     <bnd.importpackage>com.sun.jdi;resolution:=optional,com.sun.jdi.connect;resolution:=optional,com.sun.jdi.event;resolution:=optional,com.sun.jdi.request;resolution:=optional,com.sun.tools.attach;resolution:=optional,jdk.internal.module;resolution:=optional,org.jspecify.annotations;resolution:=optional,sun.misc;resolution:=optional,*</bnd.importpackage>
+    <dep.noembedding>com.hubspot.jinjava.jinjava</dep.noembedding>
   </properties>
 
   <dependencies>
@@ -23,78 +24,13 @@
       <groupId>org.snakeyaml</groupId>
       <artifactId>snakeyaml-engine</artifactId>
       <version>3.0.1</version>
+      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.openhab.osgiify</groupId>
       <artifactId>com.hubspot.jinjava.jinjava</artifactId>
-      <version>2.7.4</version>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.google.re2j</groupId>
-      <artifactId>re2j</artifactId>
-      <version>1.2</version>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>33.5.0-jre</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.openhab.osgiify</groupId>
-      <artifactId>com.hubspot.immutables.immutables-exceptions</artifactId>
-      <version>1.9</version>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-lang3</artifactId>
-      <version>3.20.0</version>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.jsoup</groupId>
-      <artifactId>jsoup</artifactId>
-      <version>1.22.2</version>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>commons-net</groupId>
-      <artifactId>commons-net</artifactId>
-      <version>${commons.net.version}</version>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>ch.obermuhlner</groupId>
-      <artifactId>big-math</artifactId>
-      <version>2.3.2</version>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.googlecode.java-ipv6</groupId>
-      <artifactId>java-ipv6</artifactId>
-      <version>0.17</version>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.google.code.findbugs</groupId>
-      <artifactId>jsr305</artifactId>
-      <version>3.0.2</version>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.javassist</groupId>
-      <artifactId>javassist</artifactId>
-      <version>3.30.2-GA</version>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.fasterxml.jackson.datatype</groupId>
-      <artifactId>jackson-datatype-jdk8</artifactId>
-      <version>${jackson.version}</version>
-      <scope>compile</scope>
+      <version>2.8.3</version>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
 </project>

--- a/bundles/org.openhab.io.yamlcomposer/pom.xml
+++ b/bundles/org.openhab.io.yamlcomposer/pom.xml
@@ -32,5 +32,17 @@
       <version>2.8.3</version>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jdk8</artifactId>
+      <version>${jackson.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.re2j</groupId>
+      <artifactId>re2j</artifactId>
+      <version>1.2</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/bundles/org.openhab.io.yamlcomposer/src/main/feature/feature.xml
+++ b/bundles/org.openhab.io.yamlcomposer/src/main/feature/feature.xml
@@ -5,10 +5,11 @@
 	<feature name="openhab-misc-yamlcomposer" description="YAML Composer" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
 		<feature dependency="true">openhab.tp-commons-net</feature>
-		<bundle dependency="true">mvn:org.openhab.osgiify/com.hubspot.jinjava.jinjava/2.7.4</bundle>
-		<bundle dependency="true">mvn:org.openhab.osgiify/com.google.re2j.re2j/1.2</bundle>
-		<bundle dependency="true">mvn:ch.obermuhlner/big-math/2.3.2</bundle>
-		<bundle dependency="true">mvn:org.openhab.osgiify/com.hubspot.immutables.immutables-exceptions/1.9</bundle>
+		<feature dependency="true">openhab.tp-jackson</feature>
+		<bundle dependency="true" start-level="70">mvn:ch.obermuhlner/big-math/2.3.2</bundle>
+		<bundle dependency="true" start-level="70">mvn:org.javassist/javassist/3.30.2-GA</bundle>
+		<bundle dependency="true" start-level="70">mvn:org.openhab.osgiify/com.google.re2j.re2j/1.2</bundle>
+		<bundle dependency="true" start-level="75">mvn:org.openhab.osgiify/com.hubspot.jinjava.jinjava/2.8.3</bundle>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.io.yamlcomposer/${project.version}</bundle>
 	</feature>
 </features>

--- a/bundles/org.openhab.io.yamlcomposer/src/main/feature/feature.xml
+++ b/bundles/org.openhab.io.yamlcomposer/src/main/feature/feature.xml
@@ -7,6 +7,7 @@
 		<feature dependency="true">openhab.tp-commons-net</feature>
 		<feature dependency="true">openhab.tp-jackson</feature>
 		<bundle dependency="true" start-level="70">mvn:ch.obermuhlner/big-math/2.3.2</bundle>
+		<bundle dependency="true" start-level="70">mvn:com.fasterxml.jackson.datatype/jackson-datatype-jdk8/${jackson.version}</bundle>
 		<bundle dependency="true" start-level="70">mvn:org.javassist/javassist/3.30.2-GA</bundle>
 		<bundle dependency="true" start-level="70">mvn:org.openhab.osgiify/com.google.re2j.re2j/1.2</bundle>
 		<bundle dependency="true" start-level="75">mvn:org.openhab.osgiify/com.hubspot.jinjava.jinjava/2.8.3</bundle>

--- a/itests/org.openhab.io.yamlcomposer.tests/itest.bndrun
+++ b/itests/org.openhab.io.yamlcomposer.tests/itest.bndrun
@@ -20,8 +20,6 @@ Fragment-Host: org.openhab.io.yamlcomposer
 	ch.qos.logback.core;version='[1.5.32,1.5.33)',\
 	com.fasterxml.jackson.core.jackson-annotations;version='[2.21.0,2.21.1)',\
 	com.google.gson;version='[2.13.2,2.13.3)',\
-	com.google.guava;version='[33.6.0,33.6.1)',\
-	com.google.guava.failureaccess;version='[1.0.3,1.0.4)',\
 	com.sun.jna;version='[5.18.1,5.18.2)',\
 	com.sun.xml.bind.jaxb-osgi;version='[2.3.9,2.3.10)',\
 	io.methvin.directory-watcher;version='[0.19.1,0.19.2)',\
@@ -73,4 +71,11 @@ Fragment-Host: org.openhab.io.yamlcomposer
 	com.fasterxml.jackson.core.jackson-core;version='[2.21.4,2.21.5)',\
 	com.fasterxml.jackson.core.jackson-databind;version='[2.21.4,2.21.5)',\
 	com.fasterxml.jackson.dataformat.jackson-dataformat-yaml;version='[2.21.4,2.21.5)',\
-	org.osgi.service.cm;version='[1.6.1,1.6.2)'
+	ch.obermuhlner.math.big;version='[2.3.2,2.3.3)',\
+	com.fasterxml.jackson.datatype.jackson-datatype-jdk8;version='[2.21.4,2.21.5)',\
+	com.google.re2j.re2j;version='[1.2.0,1.2.1)',\
+	com.hubspot.jinjava.jinjava;version='[2.8.3,2.8.4)',\
+	javassist;version='[3.30.2,3.30.3)',\
+	org.apache.commons.commons-io;version='[2.22.0,2.22.1)',\
+	org.apache.commons.commons-net;version='[3.13.0,3.13.1)',\
+	org.apache.commons.lang3;version='[3.20.0,3.20.1)'

--- a/itests/org.openhab.io.yamlcomposer.tests/pom.xml
+++ b/itests/org.openhab.io.yamlcomposer.tests/pom.xml
@@ -20,6 +20,31 @@
       <artifactId>org.openhab.io.yamlcomposer</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.snakeyaml</groupId>
+      <artifactId>snakeyaml-engine</artifactId>
+      <version>3.0.1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.openhab.osgiify</groupId>
+      <artifactId>com.hubspot.jinjava.jinjava</artifactId>
+      <version>2.8.3</version>
+    </dependency>
+    <dependency>
+      <groupId>ch.obermuhlner</groupId>
+      <artifactId>big-math</artifactId>
+      <version>2.3.2</version>
+    </dependency>
+    <dependency>
+      <groupId>org.openhab.osgiify</groupId>
+      <artifactId>com.google.re2j.re2j</artifactId>
+      <version>1.2</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jdk8</artifactId>
+      <version>${jackson.version}</version>
+    </dependency>
   </dependencies>
 
 </project>


### PR DESCRIPTION
Depends on https://github.com/openhab/openhab-osgiify/pull/126

Previously, the whole jinjava + all its dependencies were embedded into the yamlcomposer jar. It didn't actually require the osgiified jinjava bundle at runtime despite requiring it in feature.xml. As a result, we had two copies of the classes + dependencies loaded.

Now Jinjava's osgiified bundle will include its own dependencies, so that we don't even need to list them in pom.xml.
We  load the few bundles that the Jinjava bundle needs inside feature.xml before starting it, relying on start-level order.