### PR TITLE
[opentelemetry] Add OTLP metrics and traces

### DIFF
--- a/bundles/org.openhab.io.opentelemetry/NOTICE
+++ b/bundles/org.openhab.io.opentelemetry/NOTICE
@@ -18,3 +18,18 @@ OpenTelemetry Java SDK
 * License: Apache License 2.0
 * Project: https://opentelemetry.io/
 * Source:  https://github.com/open-telemetry/opentelemetry-java
+
+Micrometer
+* License: Apache License 2.0
+* Project: https://micrometer.io/
+* Source:  https://github.com/micrometer-metrics/micrometer
+
+OpenTelemetry Proto
+* License: Apache License 2.0
+* Project: https://opentelemetry.io/
+* Source:  https://github.com/open-telemetry/opentelemetry-proto
+
+protobuf-java
+* License: BSD License
+* Project: https://developers.google.com/protocol-buffers
+* Source:  https://github.com/protocolbuffers/protobuf

--- a/bundles/org.openhab.io.opentelemetry/README.md
+++ b/bundles/org.openhab.io.opentelemetry/README.md
@@ -7,36 +7,95 @@ children:
 # OpenTelemetry Service
 
 The OpenTelemetry service integrates openHAB with the [OpenTelemetry](https://opentelemetry.io/) observability framework.
-It captures log messages generated within openHAB and exports them to an OpenTelemetry-compatible collector or backend using the OTLP/HTTP protocol.
+It captures openHAB's **logs**, **metrics**, and **traces** (event-bus spans) and exports them to any OpenTelemetry-compatible collector or backend using the OTLP/HTTP protocol.
 
 :::tip OpenTelemetry
 OpenTelemetry (also referred to as OTel) is a high-quality, industry-standard observability framework for cloud-native software.
-It provides a vendor-neutral set of APIs, SDKs, and tools to generate, collect, and export telemetry data (metrics, logs, and traces) to monitoring backends (such as Prometheus, Grafana Loki, etc.) for analyzing application performance and health.
+It provides a vendor-neutral set of APIs, SDKs, and tools to generate, collect, and export telemetry data (metrics, logs, and traces) to monitoring backends (such as Prometheus, Grafana, Dynatrace, etc.) for analyzing application performance and health.
 :::
 
-This add-on hooks into openHAB's internal logging framework.
-Every log entry emitted by openHAB is intercepted and pushed to the configured OpenTelemetry Collector.
+All three signals share a single OTLP endpoint (`otlpURL`) and a common set of resource attributes so they correlate to a single service entity in your observability backend.
 
-## Global Resource Attributes (Application & Environment)
+## Global Resource Attributes
 
-The service attaches resource attributes to identify the source of the logs:
+The service attaches the following resource attributes to all exported signals:
 
-- `service.name`: `openHAB`
-- `service.namespace`: `org.openhab`
-- `service.version`: The running openHAB version.
-- `os.name`: The host Operating System name.
-- `os.version`: The host Operating System version.
-- `host.name`: The system hostname.
+| Attribute | Value |
+|:---|:---|
+| `service.name` | `openHAB` |
+| `service.namespace` | `org.openhab` |
+| `service.version` | The running openHAB version |
+| `service.instance.id` | A stable UUID generated once per JVM lifetime (preserved across reconfigurations) |
+| `os.name` | The host Operating System name |
+| `os.version` | The host Operating System version |
+| `host.name` | The system hostname |
 
-## Exported Log Attributes
+## Exported Logs
 
-Each log entry is sent with detailed metadata:
+Every log entry emitted by openHAB is intercepted and pushed to the configured log endpoint.
 
-- `log.logger.name`: The class name or logging namespace that generated the log.
-- `thread.name`: The name of the thread executing the log.
-- `exception.type`: The Java exception class name (if an exception was thrown).
-- `exception.message`: The exception's message (if applicable).
-- `exception.stacktrace`: The complete Java stack trace (if applicable).
+Each log record carries the following attributes:
+
+| Attribute | Description |
+|:---|:---|
+| `log.logger.name` | The class name or logging namespace that produced the entry |
+| `thread.name` | The name of the thread that produced the entry |
+| `exception.type` | Java exception class name (when an exception was thrown) |
+| `exception.message` | The exception's message (when applicable) |
+| `exception.stacktrace` | The complete Java stack trace (when applicable) |
+
+:::note
+Logs emitted by the OpenTelemetry service itself and the OTLP exporter are intentionally suppressed to prevent an export-failure feedback loop (for example, a transient HTTP 403 being re-ingested and re-exported indefinitely).
+:::
+
+## Exported Metrics
+
+The service attaches an OTLP push registry to openHAB's internal [Micrometer](https://micrometer.io/) composite registry.
+All meters registered by openHAB core are automatically included; meters from unrelated add-ons are excluded by a name-prefix filter.
+
+Exported meter prefixes:
+
+| Prefix | Coverage |
+|:---|:---|
+| `openhab.*` | openHAB domain meters: thing state, rule executions, item events, … |
+| `jvm.*` | JVM memory, garbage collection, threads |
+| `process.*` | Process CPU, file descriptors |
+| `system.*` | System CPU usage |
+| `executor.*` | Thread pool metrics |
+| `logback.*` | Log event counts by level |
+| `http.*` | HTTP server request metrics |
+
+:::note
+The metrics pipeline uses Micrometer's naming conventions (snake_case with `.` separators), not the OTel semantic conventions for metrics.
+Use `CUMULATIVE` (the default) for most backends and when routing through an OTel Collector.
+Use `DELTA` when pushing directly to a backend whose data model requires delta-encoded metrics — consult your backend's documentation.
+:::
+
+## Exported Traces (Event-Bus Spans)
+
+The service subscribes to the entire openHAB event bus and emits one span per event, providing a complete activity timeline of your openHAB instance: item state changes, thing status transitions, rule executions, channel link events, and more.
+
+Each span carries the following attributes:
+
+| Attribute | Description |
+|:---|:---|
+| `event.type` | The openHAB event class name (e.g. `ItemStateChangedEvent`) |
+| `event.topic` | The event bus topic (e.g. `openhab/items/MyLight/statechanged`) |
+| `event.source` | The event source identifier |
+
+Use `tracesSamplingRatio` to limit the exported volume on busy instances (e.g. `0.1` to export 10% of events).
+
+## Deployment
+
+The add-on supports two deployment patterns:
+
+**Direct to backend** — set `otlpURL` to your observability backend's OTLP ingest URL and `otlpHeaders` to the required authentication header.
+Simple to set up; backend credentials are stored in openHAB's configuration.
+
+**Via an OTel Collector** — set `otlpURL` to the collector's HTTP endpoint (e.g. `http://localhost:4318`) and leave `otlpHeaders` empty.
+The collector receives all three signals from openHAB and forwards them to one or more backends.
+This keeps backend credentials out of openHAB, allows fan-out to multiple backends, and handles metric temporality conversion.
+See the [OTel Collector example](doc/otel-collector.md) for a ready-to-use configuration.
 
 ## Configuration
 
@@ -44,34 +103,104 @@ The OpenTelemetry service can be configured via Main UI (_Settings_ → _Add-on 
 
 ### Configuration Parameters
 
-| Configuration Parameter | Description                                                                                                                                | Default Value           |
-|:------------------------|:-------------------------------------------------------------------------------------------------------------------------------------------|:------------------------|
-| `otlpURL`               | **OpenTelemetry Collector URL**: The base URL of the OpenTelemetry Collector instance (using HTTP transport)                               | `http://localhost:4318` |
-| `otlpHeaders`           | **OTLP Headers**: Optional comma-separated headers for authentication or routing (e.g., `Authorization=Bearer token,X-Tenant-Id=openhab`). |                         |
-| `logsEnabled`           | **Export Logs**: Enable/disable exporting openHAB logs to OpenTelemetry.                                                                   | `false`                 |
-| `logsEndpoint`          | **Log Endpoint**: The endpoint path to send logs to (resolved against `otlpURL`).                                                          | `/v1/logs`              |
+#### Connection
 
-The OpenTelemetry service supports the use of environment variables in the configuration parameters using the `${ENV:MY_ENV_VAR}` syntax.
+| Parameter | Description | Default |
+|:---|:---|:---|
+| `otlpURL` | OTLP endpoint to push telemetry to. Set to a local OTel Collector (e.g. `http://localhost:4318`) or directly to a backend ingest URL. All per-signal endpoints are resolved against this base URL. | `http://localhost:4318` |
+| `otlpHeaders` | Comma-separated authentication headers, e.g. `Authorization=Bearer token`. Only needed for direct-to-backend deployments — leave empty when using a collector. Stored as a masked secret. | |
+
+:::warning Cleartext HTTP
+If `otlpURL` uses `http://`, a warning is logged at startup. Use HTTPS in production to protect credentials in transit.
+:::
+
+The service supports environment variable substitution in all parameters using the `${ENV:MY_ENV_VAR}` syntax.
+
+#### Logs
+
+| Parameter | Description | Default |
+|:---|:---|:---|
+| `logsEnabled` | Enable exporting openHAB logs to the OTLP endpoint | `true` |
+| `logsEndpoint` | Endpoint path, resolved against `otlpURL` | `/v1/logs` |
+
+#### Metrics
+
+| Parameter | Description | Default |
+|:---|:---|:---|
+| `metricsEnabled` | Enable exporting openHAB metrics to the OTLP endpoint | `true` |
+| `metricsEndpoint` | Endpoint path, resolved against `otlpURL` | `/v1/metrics` |
+| `metricsInterval` | Push interval as an ISO 8601 duration (e.g. `PT60S` for 60 seconds) | `PT60S` |
+| `metricsAggregationTemporality` | Aggregation temporality: `CUMULATIVE` for most backends; `DELTA` when your backend requires delta-encoded metrics | `CUMULATIVE` |
+
+#### Traces
+
+| Parameter | Description | Default |
+|:---|:---|:---|
+| `tracesEnabled` | Enable exporting event-bus spans to the OTLP endpoint | `true` |
+| `tracesEndpoint` | Endpoint path, resolved against `otlpURL` | `/v1/traces` |
+| `tracesSamplingRatio` | Fraction of event-bus spans to export (0.0 = none, 1.0 = all) | `1.0` |
 
 ### Configuration File Example
 
-To configure the service via file, create or modify `$OPENHAB_CONF/services/opentelemetry.cfg`:
+To configure the service via file, create or modify `$OPENHAB_CONF/services/org.openhab.opentelemetry.cfg`:
 
 ```ini
-# The URL of the OpenTelemetry Collector instance
+# Base URL of your OTLP endpoint or collector
 otlpURL=http://localhost:4318
 
-# Optional headers for authentication/routing (e.g., header=value,header2=value2)
+# Optional authentication headers (comma-separated key=value pairs)
 # otlpHeaders=Authorization=Bearer mySecretToken
 
-# Enable exporting logs
+# --- Logs ---
 logsEnabled=true
-
-# The endpoint path to send logs to
 logsEndpoint=/v1/logs
+
+# --- Metrics ---
+metricsEnabled=true
+metricsEndpoint=/v1/metrics
+metricsInterval=PT60S
+# CUMULATIVE works for most backends. Use DELTA if your backend requires delta-encoded metrics.
+metricsAggregationTemporality=CUMULATIVE
+
+# --- Traces (event-bus spans) ---
+tracesEnabled=true
+tracesEndpoint=/v1/traces
+tracesSamplingRatio=1.0
 ```
 
-## Limitations
+## Scope and Limitations
 
-Please note that the OpenTelemetry service is not able to capture all logs during openHAB startup and shutdown,
-as the OpenTelemetry service starts and stops after or before the openHAB runtime.
+This bundle uses openHAB's OSGi seams (log service, Micrometer registry, event bus) to export telemetry without requiring a JVM agent.
+This approach is clean and OSGi-native, but has inherent coverage limits compared to bytecode-instrumentation agents:
+
+- **No automatic library instrumentation.** Only openHAB's own signals are exported: its logs, its Micrometer meters, and its event-bus activity. HTTP/REST calls to external services, persistence layer operations, MQTT broker interactions, and binding-internal operations are not automatically traced.
+- **No automatic context propagation.** openHAB's event bus is asynchronous and fire-and-forget. Spans emitted by this bundle are flat per-event spans — a useful activity timeline — not distributed call trees. There is no W3C `traceparent` injected across thread or network boundaries.
+- **Late-start blind window.** The bundle activates after openHAB core and bindings are already running. Log entries, events, and metric changes produced during the bootstrap phase before activation are not captured.
+- **Metrics use Micrometer semantics.** Micrometer naming conventions apply (not OTel semantic conventions for metrics). Trace–metric exemplar linking is not produced.
+- **Event-bus spans are `internal`-kind.** Observability backends that derive request-level RED metrics (request rate, error rate, response time) from `server`-kind root spans will not compute them for this service. This is expected: openHAB is an event-driven system, not an HTTP request-response service.
+
+## Coexistence with the OTel Java Agent
+
+The [OTel Java agent](https://opentelemetry.io/docs/zero-code/java/agent/) can complement this bundle by providing automatic HTTP server instrumentation (which adds `server`-kind root spans and enables RED metrics in observability backends), JDBC tracing, and other library-level coverage that the bundle cannot provide.
+
+When the agent is detected at startup, this bundle routes its event-bus spans through the agent's already-registered `GlobalOpenTelemetry` pipeline rather than starting its own tracer provider, so both sources land in the same service entity in the backend.
+
+To run the agent alongside openHAB, add to `/etc/default/openhab` (or the equivalent for your installation):
+
+```bash
+EXTRA_JAVA_OPTS="-javaagent:/path/to/opentelemetry-javaagent.jar \
+  -Dotel.service.name=openHAB \
+  -Dotel.exporter.otlp.protocol=http/protobuf \
+  -Dotel.exporter.otlp.endpoint=http://localhost:4318 \
+  -Dotel.metrics.exporter=none"
+```
+
+Set `-Dotel.exporter.otlp.protocol` explicitly and make sure it matches your endpoint's port — `http/protobuf` typically listens on `4318`, `grpc` on `4317`. A protocol/port mismatch fails silently at the transport layer with no data arriving and no obvious error.
+
+The agent's own JVM metrics instrumentation overlaps with this bundle's Micrometer-based `jvm.*` meters, so running both without `-Dotel.metrics.exporter=none` produces two independently-sourced series for the same JVM. Disable the agent's metrics exporter to avoid that duplication, or leave it enabled if your backend deduplicates by resource identity.
+
+When running both, consider disabling `logsEnabled` (the agent exports logs) while keeping `metricsEnabled` and `tracesEnabled` (the agent does not see openHAB's Micrometer meters or event-bus events).
+
+:::note
+The OTel Java agent must be present at JVM launch time and cannot be attached to a running instance. A full openHAB restart is required after adding the `-javaagent` argument.
+:::

--- a/bundles/org.openhab.io.opentelemetry/README.md
+++ b/bundles/org.openhab.io.opentelemetry/README.md
@@ -26,7 +26,7 @@ The service attaches the following resource attributes to all exported signals:
 | `service.name` | `openHAB` |
 | `service.namespace` | `org.openhab` |
 | `service.version` | The running openHAB version |
-| `service.instance.id` | A stable UUID generated once per JVM lifetime (preserved across reconfigurations) |
+| `service.instance.id` | openHAB's persistent per-installation UUID (survives restarts) |
 | `os.name` | The host Operating System name |
 | `os.version` | The host Operating System version |
 | `host.name` | The system hostname |
@@ -45,7 +45,7 @@ Each log record carries the following attributes:
 | `exception.message` | The exception's message (when applicable) |
 | `exception.stacktrace` | The complete Java stack trace (when applicable) |
 
-:::note
+:::tip Note
 Logs emitted by the OpenTelemetry service itself and the OTLP exporter are intentionally suppressed to prevent an export-failure feedback loop (for example, a transient HTTP 403 being re-ingested and re-exported indefinitely).
 :::
 
@@ -56,7 +56,7 @@ Meters are included when they carry the `openhab_core_metric=true` tag, which op
 This covers openHAB domain meters (thing state, rule executions, item events), JVM metrics, processor and thread-pool metrics.
 Meters from unrelated add-ons or third-party libraries are excluded regardless of their name.
 
-:::note
+:::tip Note
 The metrics pipeline uses Micrometer's naming conventions (snake_case with `.` separators), not the OTel semantic conventions for metrics.
 Use `CUMULATIVE` (the default) for most backends and when routing through an OTel Collector.
 Use `DELTA` when pushing directly to a backend whose data model requires delta-encoded metrics — consult your backend's documentation.
@@ -101,8 +101,8 @@ The OpenTelemetry service can be configured via Main UI (_Settings_ → _Add-on 
 | `otlpURL` | OTLP endpoint to push telemetry to. Set to a local OTel Collector (e.g. `http://localhost:4318`) or directly to a backend ingest URL. All per-signal endpoints are resolved against this base URL. | `http://localhost:4318` |
 | `otlpHeaders` | Comma-separated authentication headers, e.g. `Authorization=Bearer token`. Only needed for direct-to-backend deployments — leave empty when using a collector. Stored as a masked secret. | |
 
-:::warning Cleartext HTTP
-If `otlpURL` uses `http://`, a warning is logged at startup. Use HTTPS in production to protect credentials in transit.
+:::tip Note
+If `otlpURL` uses `http://`, this is logged at startup. Use HTTPS in production to protect credentials in transit.
 :::
 
 The service supports environment variable substitution in all parameters using the `${ENV:MY_ENV_VAR}` syntax.
@@ -133,7 +133,7 @@ The service supports environment variable substitution in all parameters using t
 
 ### Configuration File Example
 
-To configure the service via file, create or modify `$OPENHAB_CONF/services/org.openhab.opentelemetry.cfg`:
+To configure the service via file, create or modify `$OPENHAB_CONF/services/opentelemetry.cfg`:
 
 ```ini
 # Base URL of your OTLP endpoint or collector
@@ -192,6 +192,6 @@ The agent's own JVM metrics instrumentation overlaps with this bundle's Micromet
 
 When running both, consider disabling `logsEnabled` (the agent exports logs) while keeping `metricsEnabled` and `tracesEnabled` (the agent does not see openHAB's Micrometer meters or event-bus events).
 
-:::note
+:::tip Note
 The OTel Java agent must be present at JVM launch time and cannot be attached to a running instance. A full openHAB restart is required after adding the `-javaagent` argument.
 :::

--- a/bundles/org.openhab.io.opentelemetry/README.md
+++ b/bundles/org.openhab.io.opentelemetry/README.md
@@ -1,5 +1,6 @@
 ---
 children:
+
   - ["doc/lgtm-stack", "LGTM Stack Example"]
   - ["doc/otel-collector", "OpenTelemetry Collector Example"]
 ---
@@ -120,14 +121,14 @@ The service supports environment variable substitution in all parameters using t
 
 | Parameter | Description | Default |
 |:---|:---|:---|
-| `logsEnabled` | Enable exporting openHAB logs to the OTLP endpoint | `true` |
+| `logsEnabled` | Enable exporting openHAB logs to the OTLP endpoint | `false` |
 | `logsEndpoint` | Endpoint path, resolved against `otlpURL` | `/v1/logs` |
 
 #### Metrics
 
 | Parameter | Description | Default |
 |:---|:---|:---|
-| `metricsEnabled` | Enable exporting openHAB metrics to the OTLP endpoint | `true` |
+| `metricsEnabled` | Enable exporting openHAB metrics to the OTLP endpoint | `false` |
 | `metricsEndpoint` | Endpoint path, resolved against `otlpURL` | `/v1/metrics` |
 | `metricsInterval` | Push interval as an ISO 8601 duration (e.g. `PT60S` for 60 seconds) | `PT60S` |
 | `metricsAggregationTemporality` | Aggregation temporality: `CUMULATIVE` for most backends; `DELTA` when your backend requires delta-encoded metrics | `CUMULATIVE` |
@@ -136,7 +137,7 @@ The service supports environment variable substitution in all parameters using t
 
 | Parameter | Description | Default |
 |:---|:---|:---|
-| `tracesEnabled` | Enable exporting event-bus spans to the OTLP endpoint | `true` |
+| `tracesEnabled` | Enable exporting event-bus spans to the OTLP endpoint | `false` |
 | `tracesEndpoint` | Endpoint path, resolved against `otlpURL` | `/v1/traces` |
 | `tracesSamplingRatio` | Fraction of event-bus spans to export (0.0 = none, 1.0 = all) | `1.0` |
 

--- a/bundles/org.openhab.io.opentelemetry/README.md
+++ b/bundles/org.openhab.io.opentelemetry/README.md
@@ -80,7 +80,7 @@ Use `tracesSamplingRatio` to limit the exported volume on busy instances (e.g. `
 
 The add-on supports two deployment patterns:
 
-**Direct to backend** — set `otlpURL` to your observability backend's OTLP ingest URL and `otlpHeaders` to the required authentication header.
+- **Direct to backend**: Set `otlpURL` to your observability backend's OTLP ingest URL and `otlpHeaders` to the required authentication header.
 Simple to set up; backend credentials are stored in openHAB's configuration.
 
 **Via an OTel Collector** — set `otlpURL` to the collector's HTTP endpoint (e.g. `http://localhost:4318`) and leave `otlpHeaders` empty.

--- a/bundles/org.openhab.io.opentelemetry/README.md
+++ b/bundles/org.openhab.io.opentelemetry/README.md
@@ -1,6 +1,5 @@
 ---
 children:
-
   - ["doc/lgtm-stack", "LGTM Stack Example"]
   - ["doc/otel-collector", "OpenTelemetry Collector Example"]
 ---
@@ -81,12 +80,11 @@ Use `tracesSamplingRatio` to limit the exported volume on busy instances (e.g. `
 The add-on supports two deployment patterns:
 
 - **Direct to backend**: Set `otlpURL` to your observability backend's OTLP ingest URL and `otlpHeaders` to the required authentication header.
-Simple to set up; backend credentials are stored in openHAB's configuration.
-
-**Via an OTel Collector** — set `otlpURL` to the collector's HTTP endpoint (e.g. `http://localhost:4318`) and leave `otlpHeaders` empty.
-The collector receives all three signals from openHAB and forwards them to one or more backends.
+  Simple to set up; backend credentials are stored in openHAB's configuration.
+- **Via an OTel Collector**: Set `otlpURL` to the collector's HTTP endpoint (e.g. `http://localhost:4318`) and leave `otlpHeaders` empty.
+  The collector receives all three signals from openHAB and forwards them to one or more backends.
   This keeps backend credentials out of openHAB, allows fan-out to multiple backends, and handles metric temporality conversion.
-See the [OTel Collector example](doc/otel-collector.md) for a ready-to-use configuration.
+  See the [OTel Collector example](doc/otel-collector.md) for a ready-to-use configuration.
 
 ## Configuration
 
@@ -102,7 +100,7 @@ The OpenTelemetry service can be configured via Main UI (_Settings_ → _Add-on 
 | `otlpHeaders` | Comma-separated authentication headers, e.g. `Authorization=Bearer token`. Only needed for direct-to-backend deployments — leave empty when using a collector. Stored as a masked secret. | |
 
 :::tip Note
-If `otlpURL` uses `http://`, this is logged at startup. Use HTTPS in production to protect credentials in transit.
+If `otlpURL` uses `http://`, this is logged at startup. Use HTTPS to protect credentials in transit.
 :::
 
 The service supports environment variable substitution in all parameters using the `${ENV:MY_ENV_VAR}` syntax.
@@ -161,20 +159,28 @@ tracesSamplingRatio=1.0
 
 ## Scope and Limitations
 
-This bundle uses openHAB's OSGi seams (log service, Micrometer registry, event bus) to export telemetry without requiring a JVM agent.
-This approach is clean and OSGi-native, but has inherent coverage limits compared to bytecode-instrumentation agents:
+The bundle reads telemetry from three places openHAB already offers: the OSGi log service, the Micrometer registry and the event bus.
+No JVM agent is needed, but that also means it only sees what those three sources expose:
 
-- **No automatic library instrumentation.** Only openHAB's own signals are exported: its logs, its Micrometer meters, and its event-bus activity. HTTP/REST calls to external services, persistence layer operations, MQTT broker interactions, and binding-internal operations are not automatically traced.
-- **No automatic context propagation.** openHAB's event bus is asynchronous and fire-and-forget. Spans emitted by this bundle are flat per-event spans — a useful activity timeline — not distributed call trees. There is no W3C `traceparent` injected across thread or network boundaries.
-- **Late-start blind window.** The bundle activates after openHAB core and bindings are already running. Log entries, events, and metric changes produced during the bootstrap phase before activation are not captured.
-- **Metrics use Micrometer semantics.** Micrometer naming conventions apply (not OTel semantic conventions for metrics). Trace–metric exemplar linking is not produced.
-- **Event-bus spans are `internal`-kind.** Observability backends that derive request-level RED metrics (request rate, error rate, response time) from `server`-kind root spans will not compute them for this service. This is expected: openHAB is an event-driven system, not an HTTP request-response service.
+- Only openHAB's own logs, meters and events are exported.
+  Calls a binding makes to a device or a REST API, persistence writes and MQTT traffic are not traced.
+- Event-bus spans are flat.
+  Each event gets its own root span, so you get a timeline of activity rather than call trees.
+  No `traceparent` is passed between threads or over the network.
+- Nothing is captured before the bundle starts.
+  openHAB core and the bindings are already up by then, so early log entries, events and metric changes are lost.
+- Metric names follow Micrometer, not the OTel semantic conventions.
+  There are no exemplars linking metrics to traces.
+- Event-bus spans have kind `internal`.
+  Backends that build RED metrics from `server` spans will show nothing for openHAB, which is an event-driven system and not an HTTP service.
 
 ## Coexistence with the OTel Java Agent
 
-The [OTel Java agent](https://opentelemetry.io/docs/zero-code/java/agent/) can complement this bundle by providing automatic HTTP server instrumentation (which adds `server`-kind root spans and enables RED metrics in observability backends), JDBC tracing, and other library-level coverage that the bundle cannot provide.
+The [OTel Java agent](https://opentelemetry.io/docs/zero-code/java/agent/) covers what this bundle cannot: HTTP server instrumentation, JDBC and other libraries.
+Its HTTP spans have kind `server`, so backends can build RED metrics from them.
 
-When the agent is detected at startup, this bundle routes its event-bus spans through the agent's already-registered `GlobalOpenTelemetry` pipeline rather than starting its own tracer provider, so both sources land in the same service entity in the backend.
+If the agent is present at startup, the bundle sends its event-bus spans through the agent's `GlobalOpenTelemetry` instead of setting up its own tracer provider.
+Both then appear under the same service in the backend.
 
 To run the agent alongside openHAB, add to `/etc/default/openhab` (or the equivalent for your installation):
 
@@ -189,7 +195,9 @@ EXTRA_JAVA_OPTS="-javaagent:/path/to/opentelemetry-javaagent.jar \
 Set `-Dotel.exporter.otlp.protocol` explicitly and make sure it matches your endpoint's port — `http/protobuf` typically listens on `4318`, `grpc` on `4317`.
 A protocol/port mismatch fails silently at the transport layer with no data arriving and no obvious error.
 
-The agent's own JVM metrics instrumentation overlaps with this bundle's Micrometer-based `jvm.*` meters, so running both without `-Dotel.metrics.exporter=none` produces two independently-sourced series for the same JVM. Disable the agent's metrics exporter to avoid that duplication, or leave it enabled if your backend deduplicates by resource identity.
+The agent collects JVM metrics of its own, which overlap with the `jvm.*` meters this bundle exports through Micrometer.
+Without `-Dotel.metrics.exporter=none` you end up with the same JVM reported twice.
+Leave the agent's metrics exporter on only if your backend deduplicates by resource identity.
 
 When running both, consider disabling `logsEnabled` (the agent exports logs) while keeping `metricsEnabled` and `tracesEnabled` (the agent does not see openHAB's Micrometer meters or event-bus events).
 

--- a/bundles/org.openhab.io.opentelemetry/README.md
+++ b/bundles/org.openhab.io.opentelemetry/README.md
@@ -74,6 +74,7 @@ Each span carries the following attributes:
 | `event.source` | The event source identifier |
 
 Use `tracesSamplingRatio` to limit the exported volume on busy instances (e.g. `0.1` to export 10% of events).
+This setting has no effect when the OTel Java agent supplies the tracer, see [Coexistence with the OTel Java Agent](#coexistence-with-the-otel-java-agent).
 
 ## Deployment
 
@@ -181,6 +182,10 @@ Its HTTP spans have kind `server`, so backends can build RED metrics from them.
 
 If the agent is present at startup, the bundle sends its event-bus spans through the agent's `GlobalOpenTelemetry` instead of setting up its own tracer provider.
 Both then appear under the same service in the backend.
+
+`tracesSamplingRatio` is ignored in this mode.
+Sampling is controlled by the agent's own `SdkTracerProvider`.
+Set `-Dotel.traces.sampler=traceidratio -Dotel.traces.sampler.arg=0.1` on the agent for 10% sampling.
 
 To run the agent alongside openHAB, add to `/etc/default/openhab` (or the equivalent for your installation):
 

--- a/bundles/org.openhab.io.opentelemetry/README.md
+++ b/bundles/org.openhab.io.opentelemetry/README.md
@@ -52,19 +52,9 @@ Logs emitted by the OpenTelemetry service itself and the OTLP exporter are inten
 ## Exported Metrics
 
 The service attaches an OTLP push registry to openHAB's internal [Micrometer](https://micrometer.io/) composite registry.
-All meters registered by openHAB core are automatically included; meters from unrelated add-ons are excluded by a name-prefix filter.
-
-Exported meter prefixes:
-
-| Prefix | Coverage |
-|:---|:---|
-| `openhab.*` | openHAB domain meters: thing state, rule executions, item events, … |
-| `jvm.*` | JVM memory, garbage collection, threads |
-| `process.*` | Process CPU, file descriptors |
-| `system.*` | System CPU usage |
-| `executor.*` | Thread pool metrics |
-| `logback.*` | Log event counts by level |
-| `http.*` | HTTP server request metrics |
+Meters are included when they carry the `openhab_core_metric=true` tag, which openHAB core's `DefaultMetricsRegistration` attaches to every core meter binder.
+This covers openHAB domain meters (thing state, rule executions, item events), JVM metrics, processor and thread-pool metrics.
+Meters from unrelated add-ons or third-party libraries are excluded regardless of their name.
 
 :::note
 The metrics pipeline uses Micrometer's naming conventions (snake_case with `.` separators), not the OTel semantic conventions for metrics.

--- a/bundles/org.openhab.io.opentelemetry/README.md
+++ b/bundles/org.openhab.io.opentelemetry/README.md
@@ -167,7 +167,7 @@ No JVM agent is needed, but that also means it only sees what those three source
 - Event-bus spans are flat.
   Each event gets its own root span, so you get a timeline of activity rather than call trees.
   No `traceparent` is passed between threads or over the network.
-- Nothing is captured before the bundle starts.
+- Nothing is captured before the add-on starts.
   openHAB core and the bindings are already up by then, so early log entries, events and metric changes are lost.
 - Metric names follow Micrometer, not the OTel semantic conventions.
   There are no exemplars linking metrics to traces.

--- a/bundles/org.openhab.io.opentelemetry/README.md
+++ b/bundles/org.openhab.io.opentelemetry/README.md
@@ -159,7 +159,7 @@ tracesSamplingRatio=1.0
 
 ## Scope and Limitations
 
-The bundle reads telemetry from three places openHAB already offers: the OSGi log service, the Micrometer registry and the event bus.
+The add-on reads telemetry from three places openHAB already offers: the OSGi log service, the Micrometer metrics registry and the event bus.
 No JVM agent is needed, but that also means it only sees what those three sources expose:
 
 - Only openHAB's own logs, meters and events are exported.

--- a/bundles/org.openhab.io.opentelemetry/README.md
+++ b/bundles/org.openhab.io.opentelemetry/README.md
@@ -186,7 +186,8 @@ EXTRA_JAVA_OPTS="-javaagent:/path/to/opentelemetry-javaagent.jar \
   -Dotel.metrics.exporter=none"
 ```
 
-Set `-Dotel.exporter.otlp.protocol` explicitly and make sure it matches your endpoint's port — `http/protobuf` typically listens on `4318`, `grpc` on `4317`. A protocol/port mismatch fails silently at the transport layer with no data arriving and no obvious error.
+Set `-Dotel.exporter.otlp.protocol` explicitly and make sure it matches your endpoint's port — `http/protobuf` typically listens on `4318`, `grpc` on `4317`.
+A protocol/port mismatch fails silently at the transport layer with no data arriving and no obvious error.
 
 The agent's own JVM metrics instrumentation overlaps with this bundle's Micrometer-based `jvm.*` meters, so running both without `-Dotel.metrics.exporter=none` produces two independently-sourced series for the same JVM. Disable the agent's metrics exporter to avoid that duplication, or leave it enabled if your backend deduplicates by resource identity.
 

--- a/bundles/org.openhab.io.opentelemetry/README.md
+++ b/bundles/org.openhab.io.opentelemetry/README.md
@@ -85,7 +85,7 @@ Simple to set up; backend credentials are stored in openHAB's configuration.
 
 **Via an OTel Collector** — set `otlpURL` to the collector's HTTP endpoint (e.g. `http://localhost:4318`) and leave `otlpHeaders` empty.
 The collector receives all three signals from openHAB and forwards them to one or more backends.
-This keeps backend credentials out of openHAB, allows fan-out to multiple backends, and handles metric temporality conversion.
+  This keeps backend credentials out of openHAB, allows fan-out to multiple backends, and handles metric temporality conversion.
 See the [OTel Collector example](doc/otel-collector.md) for a ready-to-use configuration.
 
 ## Configuration

--- a/bundles/org.openhab.io.opentelemetry/doc/lgtm-stack.md
+++ b/bundles/org.openhab.io.opentelemetry/doc/lgtm-stack.md
@@ -1,13 +1,15 @@
 # OpenTelemetry Service – LGTM Stack Example
 
-To receive, process, and view OpenTelemetry data, the open-source LGTM Stack from Grafana Labs can be used.
+To receive, process, and view all three OpenTelemetry signals, the open-source LGTM Stack from Grafana Labs can be used.
 It consists of [Loki](https://grafana.com/oss/loki/) for log storage, [Grafana](https://grafana.com/oss/grafana/) for visualization, [Tempo](https://grafana.com/oss/tempo/) for traces, and [Mimir](https://grafana.com/oss/mimir/) for metrics.
 
-For our use case of receiving and viewing logs, Loki and Grafana are enough.
-However, the [grafana/otel-lgtm](https://github.com/grafana/docker-otel-lgtm) container image makes it easy to set up a complete LGTM Stack, so you can use that instead of setting up the individual components yourself.
-We won't cover setting up the LGTM Stack in this documentation, you should be able to figure this out with their documentation and the internet.
+The [grafana/otel-lgtm](https://github.com/grafana/docker-otel-lgtm) container image bundles all components and an embedded OTel Collector, making it easy to get started without configuring each component separately.
 
-Configure openHAB with the URL of your LGTM Stack, e.g., `http://localhost:4318`, and turn on _Export Logs_ to send OpenTelemetry data.
+Configure openHAB with the URL of your LGTM Stack, e.g., `http://localhost:4318`, to send logs, metrics, and traces.
+
+:::note
+Leave `metricsAggregationTemporality` at its default value of `CUMULATIVE` when using this stack.
+:::
 
 ## Grafana Dashboard
 

--- a/bundles/org.openhab.io.opentelemetry/doc/lgtm-stack.md
+++ b/bundles/org.openhab.io.opentelemetry/doc/lgtm-stack.md
@@ -7,7 +7,7 @@ The [grafana/otel-lgtm](https://github.com/grafana/docker-otel-lgtm) container i
 
 Configure openHAB with the URL of your LGTM Stack, e.g., `http://localhost:4318`, to send logs, metrics, and traces.
 
-:::note
+:::tip Note
 Leave `metricsAggregationTemporality` at its default value of `CUMULATIVE` when using this stack.
 :::
 

--- a/bundles/org.openhab.io.opentelemetry/doc/otel-collector.md
+++ b/bundles/org.openhab.io.opentelemetry/doc/otel-collector.md
@@ -1,12 +1,76 @@
-# OpenTelemetry Service – OTel Collector Example
+# OpenTelemetry Service – OTel Collector Setup
 
-To receive and view OpenTelemetry logs, the vendor-agnostic [OTel Collector](https://opentelemetry.io/docs/collector/) can be used.
+The [OpenTelemetry Collector](https://opentelemetry.io/docs/collector/) is a standalone process that receives telemetry from openHAB, transforms it, and forwards it to one or more backends.
+Running a collector in front of your backend is optional but recommended when you want to:
 
-Below is a minimal Docker setup to collect openHAB logs and print them to the console.
+- Keep backend credentials out of openHAB's configuration
+- Fan out to multiple backends without reconfiguring openHAB
+- Apply transformations such as delta conversion for metrics
+- Add retry, buffering, or filtering at the collection layer
 
-## OTel Collector Configuration
+With a collector running, set openHAB's `otlpURL` to the collector's HTTP endpoint (e.g. `http://localhost:4318`) and leave `otlpHeaders` empty.
+The collector owns all routing, authentication, and backend-specific tuning.
 
-Create a `otel-collector-config.yaml` file with the following content:
+:::note
+The Collector is an independent process — it is not part of openHAB and is not installed by the OpenTelemetry add-on.
+You run it alongside openHAB, for example via Docker.
+:::
+
+## Collector Configuration
+
+The Collector is configured with a YAML file that defines receivers, processors, and exporters for each signal pipeline.
+
+### Forwarding to an OTLP Backend
+
+The following configuration receives all three signals from openHAB and forwards them to any OTLP-compatible backend.
+Backend credentials are supplied via environment variables so they stay out of the config file.
+
+Create an `otelcol-config.yaml`:
+
+```yaml
+receivers:
+  otlp:
+    protocols:
+      http:
+        endpoint: 0.0.0.0:4318    # openHAB sends here
+
+processors:
+  batch:
+  cumulativetodelta:
+    # Converts cumulative metrics to delta encoding.
+    # Include in the metrics pipeline only if your backend requires delta metrics.
+    # Remove it (and the reference below) when sending to Prometheus-compatible backends.
+
+exporters:
+  otlphttp:
+    endpoint: ${env:OTLP_BACKEND_ENDPOINT}    # e.g. https://otlp.example.com
+    headers:
+      Authorization: ${env:OTLP_AUTH_HEADER}  # e.g. Bearer mytoken
+
+service:
+  pipelines:
+    logs:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [otlphttp]
+    metrics:
+      receivers: [otlp]
+      processors: [cumulativetodelta, batch]   # remove cumulativetodelta if not needed
+      exporters: [otlphttp]
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [otlphttp]
+```
+
+:::note
+`cumulativetodelta` is provided by the [OpenTelemetry Collector Contrib](https://github.com/open-telemetry/opentelemetry-collector-contrib) distribution.
+Use the `otel/opentelemetry-collector-contrib` Docker image (see below) rather than the base `otel/opentelemetry-collector` image.
+:::
+
+### Console Output (for debugging)
+
+To print all received telemetry to the console without forwarding anywhere, use this minimal configuration:
 
 ```yaml
 receivers:
@@ -28,42 +92,66 @@ service:
       receivers: [otlp]
       processors: [batch]
       exporters: [debug]
+    metrics:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [debug]
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [debug]
 ```
 
-## Docker Compose Definition
+## Running with Docker
 
-Create a `docker-compose.yaml` file with the following content:
+### Docker Compose
+
+Create a `docker-compose.yaml` alongside your `otelcol-config.yaml`:
 
 ```yaml
 services:
   otel-collector:
-    image: otel/opentelemetry-collector:latest
+    image: otel/opentelemetry-collector-contrib:latest
     container_name: otel-collector
-    command: ["--config=/etc/otel-collector-config.yaml"]
+    command: ["--config=/etc/otelcol/config.yaml"]
     volumes:
-      - ./otel-collector-config.yaml:/etc/otel-collector-config.yaml
+      - ./otelcol-config.yaml:/etc/otelcol/config.yaml
     ports:
-      - "4318:4318" # OTLP HTTP receiver
+      - "4318:4318"   # OTLP HTTP receiver — openHAB sends here
+    environment:
+      - OTLP_BACKEND_ENDPOINT=${OTLP_BACKEND_ENDPOINT}
+      - OTLP_AUTH_HEADER=${OTLP_AUTH_HEADER}
 ```
 
-## Running the Example
+Set the environment variables in a `.env` file next to the `docker-compose.yaml`:
 
-### Start the Collector
+```ini
+OTLP_BACKEND_ENDPOINT=https://otlp.example.com
+OTLP_AUTH_HEADER=Bearer mytoken
+```
 
-Start the container:
+Start the collector:
 
 ```bash
 docker compose up -d
 ```
 
-### Configure openHAB
-
-Configure openHAB with the URL of your OpenTelemetry Collector, e.g., `http://localhost:4318`, and turn on _Export Logs_.
-
-### View the Logs
-
-You can then view the logs in real-time:
+View live output:
 
 ```bash
 docker compose logs -f
 ```
+
+## Configuring openHAB
+
+Once the collector is running, configure the OpenTelemetry add-on to point at it:
+
+```ini
+# $OPENHAB_CONF/services/org.openhab.opentelemetry.cfg
+otlpURL=http://localhost:4318
+
+# otlpHeaders is not needed — the collector holds backend credentials
+# metricsAggregationTemporality stays at CUMULATIVE — the collector converts if needed
+```
+
+The collector handles the rest.

--- a/bundles/org.openhab.io.opentelemetry/doc/otel-collector.md
+++ b/bundles/org.openhab.io.opentelemetry/doc/otel-collector.md
@@ -11,7 +11,7 @@ Running a collector in front of your backend is optional but recommended when yo
 With a collector running, set openHAB's `otlpURL` to the collector's HTTP endpoint (e.g. `http://localhost:4318`) and leave `otlpHeaders` empty.
 The collector owns all routing, authentication, and backend-specific tuning.
 
-:::note
+:::tip Note
 The Collector is an independent process — it is not part of openHAB and is not installed by the OpenTelemetry add-on.
 You run it alongside openHAB, for example via Docker.
 :::
@@ -22,7 +22,7 @@ The Collector is configured with a YAML file that defines receivers, processors,
 
 ### Forwarding to an OTLP Backend
 
-The following configuration receives all three signals from openHAB and forwards them to any OTLP-compatible backend.
+The following configuration receives logs, metrics & traces from openHAB and forwards them to any OTLP-compatible backend.
 Backend credentials are supplied via environment variables so they stay out of the config file.
 
 Create an `otelcol-config.yaml`:
@@ -63,7 +63,7 @@ service:
       exporters: [otlphttp]
 ```
 
-:::note
+:::tip Note
 `cumulativetodelta` is provided by the [OpenTelemetry Collector Contrib](https://github.com/open-telemetry/opentelemetry-collector-contrib) distribution.
 Use the `otel/opentelemetry-collector-contrib` Docker image (see below) rather than the base `otel/opentelemetry-collector` image.
 :::
@@ -106,7 +106,7 @@ service:
 
 ### Docker Compose
 
-Create a `docker-compose.yaml` alongside your `otelcol-config.yaml`:
+Create a `compose.yaml` alongside your `otelcol-config.yaml`:
 
 ```yaml
 services:
@@ -117,13 +117,13 @@ services:
     volumes:
       - ./otelcol-config.yaml:/etc/otelcol/config.yaml
     ports:
-      - "4318:4318"   # OTLP HTTP receiver — openHAB sends here
+      - "4318:4318" # OTLP HTTP receiver — openHAB sends here
     environment:
       - OTLP_BACKEND_ENDPOINT=${OTLP_BACKEND_ENDPOINT}
       - OTLP_AUTH_HEADER=${OTLP_AUTH_HEADER}
 ```
 
-Set the environment variables in a `.env` file next to the `docker-compose.yaml`:
+Set the environment variables in a `.env` file next to the `compose.yaml`:
 
 ```ini
 OTLP_BACKEND_ENDPOINT=https://otlp.example.com
@@ -147,7 +147,7 @@ docker compose logs -f
 Once the collector is running, configure the OpenTelemetry add-on to point at it:
 
 ```ini
-# $OPENHAB_CONF/services/org.openhab.opentelemetry.cfg
+# $OPENHAB_CONF/services/opentelemetry.cfg
 otlpURL=http://localhost:4318
 
 # otlpHeaders is not needed — the collector holds backend credentials

--- a/bundles/org.openhab.io.opentelemetry/pom.xml
+++ b/bundles/org.openhab.io.opentelemetry/pom.xml
@@ -16,8 +16,12 @@
 
   <properties>
     <opentelemetry.version>1.63.0</opentelemetry.version>
-    <bnd.exportpackage>!io.opentelemetry.*</bnd.exportpackage>
-    <bnd.importpackage>io.grpc*;resolution:=optional,io.opentelemetry.api.incubator*;resolution:=optional,io.opentelemetry.sdk.autoconfigure*;resolution:=optional,org.jspecify.annotations*;resolution:=optional,*</bnd.importpackage>
+    <micrometer.version>1.16.3</micrometer.version>
+    <!-- Export proto packages so micrometer-registry-otlp (a separate bundle) can wire to them;
+         embed protobuf-java privately so the exported proto classes can load their runtime deps.
+         All other io.opentelemetry.* and io.micrometer.* packages stay private (not exported). -->
+    <bnd.exportpackage>io.opentelemetry.proto.*;-noimport:=true,!io.opentelemetry.*,!io.micrometer.*,!com.google.protobuf.*</bnd.exportpackage>
+    <bnd.importpackage>io.grpc*;resolution:=optional,io.opentelemetry.api.incubator*;resolution:=optional,io.opentelemetry.sdk.autoconfigure*;resolution:=optional,org.jspecify.annotations*;resolution:=optional,io.micrometer.core.lang*;resolution:=optional,*</bnd.importpackage>
   </properties>
 
   <dependencies>
@@ -90,6 +94,40 @@
       <groupId>io.opentelemetry</groupId>
       <artifactId>opentelemetry-exporter-otlp-common</artifactId>
       <version>${opentelemetry.version}</version>
+    </dependency>
+
+    <!-- Micrometer OTLP registry for metrics export -->
+    <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-registry-otlp</artifactId>
+      <version>${micrometer.version}</version>
+    </dependency>
+    <!-- OTel proto classes required by micrometer-registry-otlp; embedded and exported so
+         micrometer-registry-otlp (a separate OSGi bundle) can wire its proto import to us -->
+    <dependency>
+      <groupId>io.opentelemetry.proto</groupId>
+      <artifactId>opentelemetry-proto</artifactId>
+      <version>1.8.0-alpha</version>
+    </dependency>
+    <!-- protobuf runtime embedded privately: required by the embedded opentelemetry-proto classes -->
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+      <version>4.32.0</version>
+    </dependency>
+    <!-- micrometer-core is provided by openhab.core.io.monitor -->
+    <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-core</artifactId>
+      <version>${micrometer.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <!-- openHAB core monitor bundle for MeterRegistryProvider -->
+    <dependency>
+      <groupId>org.openhab.core.bundles</groupId>
+      <artifactId>org.openhab.core.io.monitor</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
     </dependency>
 
     <!-- OSGi Logging Service -->

--- a/bundles/org.openhab.io.opentelemetry/pom.xml
+++ b/bundles/org.openhab.io.opentelemetry/pom.xml
@@ -102,18 +102,19 @@
       <artifactId>micrometer-registry-otlp</artifactId>
       <version>${micrometer.version}</version>
     </dependency>
-    <!-- OTel proto classes required by micrometer-registry-otlp; embedded and exported so
-         micrometer-registry-otlp (a separate OSGi bundle) can wire its proto import to us -->
+    <!-- OTel proto classes required by the embedded micrometer-registry-otlp.
+         Every release of this artifact carries the -alpha suffix, it does not mark a pre-release.
+         Keep the version in sync with the one micrometer-registry-otlp compiles against. -->
     <dependency>
       <groupId>io.opentelemetry.proto</groupId>
       <artifactId>opentelemetry-proto</artifactId>
-      <version>1.8.0-alpha</version>
+      <version>1.10.0-alpha</version>
     </dependency>
     <!-- protobuf runtime embedded privately: required by the embedded opentelemetry-proto classes -->
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
-      <version>4.32.0</version>
+      <version>4.34.0</version>
     </dependency>
     <!-- micrometer-core is provided by openhab.core.io.monitor -->
     <dependency>

--- a/bundles/org.openhab.io.opentelemetry/pom.xml
+++ b/bundles/org.openhab.io.opentelemetry/pom.xml
@@ -16,7 +16,7 @@
 
   <properties>
     <opentelemetry.version>1.63.0</opentelemetry.version>
-    <micrometer.version>1.16.3</micrometer.version>
+    <micrometer.version>1.17.0</micrometer.version>
     <!-- Export proto packages so micrometer-registry-otlp (a separate bundle) can wire to them;
          embed protobuf-java privately so the exported proto classes can load their runtime deps.
          All other io.opentelemetry.* and io.micrometer.* packages stay private (not exported). -->

--- a/bundles/org.openhab.io.opentelemetry/src/main/java/org/openhab/io/opentelemetry/internal/OpenTelemetryConfiguration.java
+++ b/bundles/org.openhab.io.opentelemetry/src/main/java/org/openhab/io/opentelemetry/internal/OpenTelemetryConfiguration.java
@@ -21,30 +21,75 @@ import org.eclipse.jdt.annotation.Nullable;
  * The {@link OpenTelemetryConfiguration} class holds the configuration for the OpenTelemetry service.
  *
  * @author Florian Hotze - Initial contribution
+ * @author Florian Lettner - Add metrics and traces configuration
  */
 @NonNullByDefault
 public class OpenTelemetryConfiguration {
     public String otlpURL = "http://localhost:4318";
-    public @Nullable String otlpHeaders;
+    public @Nullable String otlpHeaders = null;
 
     public boolean logsEnabled = false;
     public String logsEndpoint = "/v1/logs";
 
+    public boolean metricsEnabled = false;
+    public String metricsEndpoint = "/v1/metrics";
+    public String metricsInterval = "PT60S";
+    public String metricsAggregationTemporality = "CUMULATIVE";
+
+    public boolean tracesEnabled = false;
+    public String tracesEndpoint = "/v1/traces";
+    public double tracesSamplingRatio = 1.0;
+
     /**
      * Get the resolved URL for the OTLP log endpoint.
-     * 
+     *
      * @return the resolved URL for the OTLP log endpoint.
      * @throws IllegalArgumentException if the URL is invalid
      */
     public String getLogsURL() throws IllegalArgumentException {
-        return URI.create(otlpURL).resolve(logsEndpoint).toString();
+        return joinURL(otlpURL, logsEndpoint);
+    }
+
+    /**
+     * Get the resolved URL for the OTLP metrics endpoint.
+     *
+     * @return the resolved URL for the OTLP metrics endpoint.
+     * @throws IllegalArgumentException if the URL is invalid
+     */
+    public String getMetricsURL() throws IllegalArgumentException {
+        return joinURL(otlpURL, metricsEndpoint);
+    }
+
+    /**
+     * Get the resolved URL for the OTLP traces endpoint.
+     *
+     * @return the resolved URL for the OTLP traces endpoint.
+     * @throws IllegalArgumentException if the URL is invalid
+     */
+    public String getTracesURL() throws IllegalArgumentException {
+        return joinURL(otlpURL, tracesEndpoint);
+    }
+
+    /**
+     * Joins a base URL and an endpoint path, normalising trailing/leading slashes.
+     * URI.resolve() cannot be used here: a path-absolute endpoint (starting with /)
+     * would discard the base path (e.g. /api/v2/otlp), producing wrong URLs for
+     * vendor endpoints that are not at the root.
+     */
+    private String joinURL(String base, String path) throws IllegalArgumentException {
+        String b = base.endsWith("/") ? base.substring(0, base.length() - 1) : base;
+        String p = path.startsWith("/") ? path : "/" + path;
+        return URI.create(b + p).toString();
     }
 
     @Override
     public String toString() {
-        String headers = otlpHeaders;
         return "OpenTelemetryConfiguration{" + "otlpURL='" + otlpURL + '\'' + ", otlpHeaders="
-                + (headers == null ? "null" : "*".repeat(headers.length())) + ", logsEnabled=" + logsEnabled
-                + ", logsEndpoint='" + logsEndpoint + '\'' + '}';
+                + (otlpHeaders == null ? "null" : "***") + ", logsEnabled=" + logsEnabled
+                + ", logsEndpoint='" + logsEndpoint + '\'' + ", metricsEnabled=" + metricsEnabled
+                + ", metricsEndpoint='" + metricsEndpoint + '\'' + ", metricsInterval='" + metricsInterval + '\''
+                + ", metricsAggregationTemporality='" + metricsAggregationTemporality + '\'' + ", tracesEnabled="
+                + tracesEnabled + ", tracesEndpoint='" + tracesEndpoint + '\'' + ", tracesSamplingRatio="
+                + tracesSamplingRatio + '}';
     }
 }

--- a/bundles/org.openhab.io.opentelemetry/src/main/java/org/openhab/io/opentelemetry/internal/OpenTelemetryConfiguration.java
+++ b/bundles/org.openhab.io.opentelemetry/src/main/java/org/openhab/io/opentelemetry/internal/OpenTelemetryConfiguration.java
@@ -85,11 +85,10 @@ public class OpenTelemetryConfiguration {
     @Override
     public String toString() {
         return "OpenTelemetryConfiguration{" + "otlpURL='" + otlpURL + '\'' + ", otlpHeaders="
-                + (otlpHeaders == null ? "null" : "***") + ", logsEnabled=" + logsEnabled
-                + ", logsEndpoint='" + logsEndpoint + '\'' + ", metricsEnabled=" + metricsEnabled
-                + ", metricsEndpoint='" + metricsEndpoint + '\'' + ", metricsInterval='" + metricsInterval + '\''
-                + ", metricsAggregationTemporality='" + metricsAggregationTemporality + '\'' + ", tracesEnabled="
-                + tracesEnabled + ", tracesEndpoint='" + tracesEndpoint + '\'' + ", tracesSamplingRatio="
-                + tracesSamplingRatio + '}';
+                + (otlpHeaders == null ? "null" : "***") + ", logsEnabled=" + logsEnabled + ", logsEndpoint='"
+                + logsEndpoint + '\'' + ", metricsEnabled=" + metricsEnabled + ", metricsEndpoint='" + metricsEndpoint
+                + '\'' + ", metricsInterval='" + metricsInterval + '\'' + ", metricsAggregationTemporality='"
+                + metricsAggregationTemporality + '\'' + ", tracesEnabled=" + tracesEnabled + ", tracesEndpoint='"
+                + tracesEndpoint + '\'' + ", tracesSamplingRatio=" + tracesSamplingRatio + '}';
     }
 }

--- a/bundles/org.openhab.io.opentelemetry/src/main/java/org/openhab/io/opentelemetry/internal/OpenTelemetryEventListener.java
+++ b/bundles/org.openhab.io.opentelemetry/src/main/java/org/openhab/io/opentelemetry/internal/OpenTelemetryEventListener.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.io.opentelemetry.internal;
+
+import java.util.Set;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.core.events.Event;
+import org.openhab.core.events.EventFilter;
+import org.openhab.core.events.EventSubscriber;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.Context;
+
+/**
+ * Subscribes to the entire openHAB event bus and emits a flat OTLP span per event.
+ *
+ * <p>
+ * Spans are flat by design: openHAB's event bus is fire-and-forget (async dispatch on a
+ * dedicated handler thread), so there is no propagated call context to attach to. {@link Context#root()}
+ * is used as the parent so spans are always root spans even if a stale context is active on
+ * the handler thread. Volume can be controlled via {@code tracesSamplingRatio} in the config.
+ *
+ * <p>
+ * The handler is intentionally non-blocking: span construction and hand-off to the
+ * {@code BatchSpanProcessor} are O(1) operations; all I/O happens asynchronously.
+ *
+ * <p>
+ * Registered and unregistered dynamically by {@link OpenTelemetryService} via the OSGi service
+ * registry — not a {@code @Component}.
+ *
+ * @author Florian Lettner - Initial contribution
+ */
+@NonNullByDefault
+public class OpenTelemetryEventListener implements EventSubscriber {
+    private final Logger logger = LoggerFactory.getLogger(OpenTelemetryEventListener.class);
+
+    private final Tracer tracer;
+
+    public OpenTelemetryEventListener(Tracer tracer) {
+        this.tracer = tracer;
+    }
+
+    @Override
+    public Set<String> getSubscribedEventTypes() {
+        return Set.of(EventSubscriber.ALL_EVENT_TYPES);
+    }
+
+    @Override
+    public @Nullable EventFilter getEventFilter() {
+        return null;
+    }
+
+    @Override
+    public void receive(Event event) {
+        try {
+            Span span = tracer.spanBuilder(event.getType()) //
+                    .setParent(Context.root()) // explicitly flat — not a child of any active span
+                    .setSpanKind(SpanKind.INTERNAL) //
+                    .startSpan();
+            try {
+                span.setAttribute("event.type", event.getType());
+                span.setAttribute("event.topic", event.getTopic());
+                String source = event.getSource();
+                if (source != null && !source.isBlank()) {
+                    span.setAttribute("event.source", source);
+                }
+            } finally {
+                span.end();
+            }
+        } catch (RuntimeException e) {
+            logger.trace("Failed to emit span for event {}: {}", event.getType(), e.getMessage());
+        }
+    }
+}

--- a/bundles/org.openhab.io.opentelemetry/src/main/java/org/openhab/io/opentelemetry/internal/OpenTelemetryEventListener.java
+++ b/bundles/org.openhab.io.opentelemetry/src/main/java/org/openhab/io/opentelemetry/internal/OpenTelemetryEventListener.java
@@ -28,21 +28,9 @@ import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.context.Context;
 
 /**
- * Subscribes to the entire openHAB event bus and emits a flat OTLP span per event.
- *
- * <p>
- * Spans are flat by design: openHAB's event bus is fire-and-forget (async dispatch on a
- * dedicated handler thread), so there is no propagated call context to attach to. {@link Context#root()}
- * is used as the parent so spans are always root spans even if a stale context is active on
- * the handler thread. Volume can be controlled via {@code tracesSamplingRatio} in the config.
- *
- * <p>
- * The handler is intentionally non-blocking: span construction and hand-off to the
- * {@code BatchSpanProcessor} are O(1) operations; all I/O happens asynchronously.
- *
- * <p>
- * Registered and unregistered dynamically by {@link OpenTelemetryService} via the OSGi service
- * registry — not a {@code @Component}.
+ * The {@link OpenTelemetryEventListener} class subscribes to the entire openHAB event bus and
+ * emits a flat root span per event, since the event bus is fire-and-forget and has no call
+ * context to attach to.
  *
  * @author Florian Lettner - Initial contribution
  */

--- a/bundles/org.openhab.io.opentelemetry/src/main/java/org/openhab/io/opentelemetry/internal/OpenTelemetryLogListener.java
+++ b/bundles/org.openhab.io.opentelemetry/src/main/java/org/openhab/io/opentelemetry/internal/OpenTelemetryLogListener.java
@@ -32,6 +32,7 @@ import io.opentelemetry.api.logs.Severity;
  * and forwards logs to OpenTelemetry.
  *
  * @author Florian Hotze - Initial contribution
+ * @author Florian Lettner - Add own-logger suppression
  */
 @NonNullByDefault
 public class OpenTelemetryLogListener implements LogListener {
@@ -43,10 +44,11 @@ public class OpenTelemetryLogListener implements LogListener {
 
     @Override
     public void logged(@NonNullByDefault({}) LogEntry logEntry) {
+        // Suppress our own bundle and OTel exporter logs to break the export-failure feedback loop
+        // (e.g. a 403 from the OTLP endpoint would be re-ingested and re-exported indefinitely).
         String loggerName = logEntry.getLoggerName();
-
-        // Prevent logging loop
-        if (loggerName.startsWith("io.opentelemetry.")) {
+        if (loggerName != null && (loggerName.startsWith("org.openhab.io.opentelemetry")
+                || loggerName.startsWith("io.opentelemetry.exporter"))) {
             return;
         }
 
@@ -59,7 +61,7 @@ public class OpenTelemetryLogListener implements LogListener {
                 .setBody(logEntry.getMessage());
 
         AttributesBuilder attributesBuilder = Attributes.builder() //
-                .put("log.logger.name", loggerName) //
+                .put("log.logger.name", loggerName != null ? loggerName : "") //
                 .put("thread.name", logEntry.getThreadInfo());
 
         @Nullable

--- a/bundles/org.openhab.io.opentelemetry/src/main/java/org/openhab/io/opentelemetry/internal/OpenTelemetryLogListener.java
+++ b/bundles/org.openhab.io.opentelemetry/src/main/java/org/openhab/io/opentelemetry/internal/OpenTelemetryLogListener.java
@@ -21,6 +21,7 @@ import org.eclipse.jdt.annotation.Nullable;
 import org.osgi.service.log.LogEntry;
 import org.osgi.service.log.LogLevel;
 import org.osgi.service.log.LogListener;
+import org.slf4j.LoggerFactory;
 
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.AttributesBuilder;
@@ -36,6 +37,7 @@ import io.opentelemetry.api.logs.Severity;
  */
 @NonNullByDefault
 public class OpenTelemetryLogListener implements LogListener {
+    private final org.slf4j.Logger logger = LoggerFactory.getLogger(OpenTelemetryLogListener.class);
     private final Logger otelLogger;
 
     public OpenTelemetryLogListener(Logger otelLogger) {
@@ -44,51 +46,52 @@ public class OpenTelemetryLogListener implements LogListener {
 
     @Override
     public void logged(@NonNullByDefault({}) LogEntry logEntry) {
-        // Suppress our own bundle and all OTel SDK/exporter logs to break the export-failure
-        // feedback loop. SDK batch processors (e.g. BatchLogRecordProcessor) log under
-        // io.opentelemetry.sdk.*, not just io.opentelemetry.exporter.*, so the full namespace
-        // must be suppressed (e.g. a 403 from the OTLP endpoint would otherwise be re-ingested
-        // and re-exported indefinitely).
+        // Suppress our own bundle and the OTel SDK to break the export-failure feedback loop
+        // (e.g. a 403 from the OTLP endpoint would otherwise be re-ingested and re-exported).
         String loggerName = logEntry.getLoggerName();
         if (loggerName != null && (loggerName.startsWith("org.openhab.io.opentelemetry")
                 || loggerName.startsWith("io.opentelemetry."))) {
             return;
         }
 
-        Severity severity = mapSeverity(logEntry.getLogLevel());
+        try {
+            Severity severity = mapSeverity(logEntry.getLogLevel());
 
-        var logRecordBuilder = otelLogger.logRecordBuilder().setTimestamp(Instant.ofEpochMilli(logEntry.getTime())) //
-                .setObservedTimestamp(Instant.now()) //
-                .setSeverity(severity) //
-                .setSeverityText(severity.name()) //
-                .setBody(logEntry.getMessage());
+            var logRecordBuilder = otelLogger.logRecordBuilder().setTimestamp(Instant.ofEpochMilli(logEntry.getTime())) //
+                    .setObservedTimestamp(Instant.now()) //
+                    .setSeverity(severity) //
+                    .setSeverityText(severity.name()) //
+                    .setBody(logEntry.getMessage());
 
-        AttributesBuilder attributesBuilder = Attributes.builder() //
-                .put("log.logger.name", loggerName != null ? loggerName : "") //
-                .put("thread.name", logEntry.getThreadInfo());
+            AttributesBuilder attributesBuilder = Attributes.builder() //
+                    .put("log.logger.name", loggerName != null ? loggerName : "") //
+                    .put("thread.name", logEntry.getThreadInfo());
 
-        @Nullable
-        Throwable exception = logEntry.getException();
-        if (exception != null) {
-            StringWriter sw = new StringWriter();
-            try (PrintWriter pw = new PrintWriter(sw)) {
-                exception.printStackTrace(pw);
+            @Nullable
+            Throwable exception = logEntry.getException();
+            if (exception != null) {
+                StringWriter sw = new StringWriter();
+                try (PrintWriter pw = new PrintWriter(sw)) {
+                    exception.printStackTrace(pw);
+                }
+                String stackTrace = sw.toString();
+
+                String exceptionMessage = exception.getMessage();
+                if (exceptionMessage == null) {
+                    exceptionMessage = exception.getClass().getName();
+                }
+
+                attributesBuilder //
+                        .put("exception.type", exception.getClass().getName()) //
+                        .put("exception.message", exceptionMessage) //
+                        .put("exception.stacktrace", stackTrace);
             }
-            String stackTrace = sw.toString();
 
-            String exceptionMessage = exception.getMessage();
-            if (exceptionMessage == null) {
-                exceptionMessage = exception.getClass().getName();
-            }
-
-            attributesBuilder //
-                    .put("exception.type", exception.getClass().getName()) //
-                    .put("exception.message", exceptionMessage) //
-                    .put("exception.stacktrace", stackTrace);
+            logRecordBuilder.setAllAttributes(attributesBuilder.build());
+            logRecordBuilder.emit();
+        } catch (RuntimeException e) {
+            logger.trace("Failed to forward log entry to OpenTelemetry: {}", e.getMessage());
         }
-
-        logRecordBuilder.setAllAttributes(attributesBuilder.build());
-        logRecordBuilder.emit();
     }
 
     private Severity mapSeverity(LogLevel logLevel) {

--- a/bundles/org.openhab.io.opentelemetry/src/main/java/org/openhab/io/opentelemetry/internal/OpenTelemetryLogListener.java
+++ b/bundles/org.openhab.io.opentelemetry/src/main/java/org/openhab/io/opentelemetry/internal/OpenTelemetryLogListener.java
@@ -44,11 +44,14 @@ public class OpenTelemetryLogListener implements LogListener {
 
     @Override
     public void logged(@NonNullByDefault({}) LogEntry logEntry) {
-        // Suppress our own bundle and OTel exporter logs to break the export-failure feedback loop
-        // (e.g. a 403 from the OTLP endpoint would be re-ingested and re-exported indefinitely).
+        // Suppress our own bundle and all OTel SDK/exporter logs to break the export-failure
+        // feedback loop. SDK batch processors (e.g. BatchLogRecordProcessor) log under
+        // io.opentelemetry.sdk.*, not just io.opentelemetry.exporter.*, so the full namespace
+        // must be suppressed (e.g. a 403 from the OTLP endpoint would otherwise be re-ingested
+        // and re-exported indefinitely).
         String loggerName = logEntry.getLoggerName();
         if (loggerName != null && (loggerName.startsWith("org.openhab.io.opentelemetry")
-                || loggerName.startsWith("io.opentelemetry.exporter"))) {
+                || loggerName.startsWith("io.opentelemetry."))) {
             return;
         }
 

--- a/bundles/org.openhab.io.opentelemetry/src/main/java/org/openhab/io/opentelemetry/internal/OpenTelemetryLogListener.java
+++ b/bundles/org.openhab.io.opentelemetry/src/main/java/org/openhab/io/opentelemetry/internal/OpenTelemetryLogListener.java
@@ -46,11 +46,11 @@ public class OpenTelemetryLogListener implements LogListener {
 
     @Override
     public void logged(@NonNullByDefault({}) LogEntry logEntry) {
-        // Suppress our own bundle and the OTel SDK to break the export-failure feedback loop
+        // Suppress our own bundle, the OTel SDK and Micrometer to break the export-failure feedback loop
         // (e.g. a 403 from the OTLP endpoint would otherwise be re-ingested and re-exported).
         String loggerName = logEntry.getLoggerName();
-        if (loggerName != null && (loggerName.startsWith("org.openhab.io.opentelemetry")
-                || loggerName.startsWith("io.opentelemetry."))) {
+        if (loggerName.startsWith("org.openhab.io.opentelemetry") || loggerName.startsWith("io.opentelemetry.")
+                || loggerName.startsWith("io.micrometer.")) {
             return;
         }
 
@@ -64,7 +64,7 @@ public class OpenTelemetryLogListener implements LogListener {
                     .setBody(logEntry.getMessage());
 
             AttributesBuilder attributesBuilder = Attributes.builder() //
-                    .put("log.logger.name", loggerName != null ? loggerName : "") //
+                    .put("log.logger.name", loggerName) //
                     .put("thread.name", logEntry.getThreadInfo());
 
             @Nullable

--- a/bundles/org.openhab.io.opentelemetry/src/main/java/org/openhab/io/opentelemetry/internal/OpenTelemetryService.java
+++ b/bundles/org.openhab.io.opentelemetry/src/main/java/org/openhab/io/opentelemetry/internal/OpenTelemetryService.java
@@ -12,11 +12,16 @@
  */
 package org.openhab.io.opentelemetry.internal;
 
+import java.lang.management.ManagementFactory;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import java.time.Duration;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
@@ -24,6 +29,10 @@ import org.openhab.core.OpenHAB;
 import org.openhab.core.config.core.ConfigUtil;
 import org.openhab.core.config.core.ConfigurableService;
 import org.openhab.core.config.core.Configuration;
+import org.openhab.core.events.EventSubscriber;
+import org.openhab.core.io.monitor.MeterRegistryProvider;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceRegistration;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Deactivate;
@@ -33,19 +42,35 @@ import org.osgi.service.log.LogReaderService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import io.micrometer.core.instrument.Clock;
+import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
+import io.micrometer.core.instrument.config.MeterFilter;
+import io.micrometer.registry.otlp.AggregationTemporality;
+import io.micrometer.registry.otlp.OtlpConfig;
+import io.micrometer.registry.otlp.OtlpMeterRegistry;
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.exporter.otlp.http.logs.OtlpHttpLogRecordExporter;
 import io.opentelemetry.exporter.otlp.http.logs.OtlpHttpLogRecordExporterBuilder;
+import io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporter;
+import io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporterBuilder;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.OpenTelemetrySdkBuilder;
 import io.opentelemetry.sdk.logs.SdkLoggerProvider;
 import io.opentelemetry.sdk.logs.SdkLoggerProviderBuilder;
 import io.opentelemetry.sdk.logs.export.BatchLogRecordProcessor;
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.resources.ResourceBuilder;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
+import io.opentelemetry.sdk.trace.samplers.Sampler;
 
 /**
- * The {@link OpenTelemetryService} class manages the OpenTelemetry SDK and forwards logs to an OTLP endpoint.
+ * The {@link OpenTelemetryService} class manages the OpenTelemetry SDK and exports logs, metrics
+ * and traces via OTLP.
  *
  * @author Florian Hotze - Initial contribution
+ * @author Florian Lettner - Add OTLP metrics and traces
  */
 @Component(configurationPid = "org.openhab.opentelemetry", immediate = true, service = OpenTelemetryService.class)
 @ConfigurableService(category = "io", label = "OpenTelemetry Service", description_uri = "io:opentelemetry")
@@ -53,9 +78,22 @@ import io.opentelemetry.sdk.resources.ResourceBuilder;
 public class OpenTelemetryService {
     private final Logger logger = LoggerFactory.getLogger(OpenTelemetryService.class);
 
+    /** Stable within the JVM lifetime; does not change across {@code modified()} reconfigurations. */
+    static final String SERVICE_INSTANCE_ID = UUID.randomUUID().toString();
+
+    private @Nullable BundleContext bundleContext;
+
+    // Logs + traces pipeline (OTel SDK)
     private @Nullable OpenTelemetrySdk openTelemetrySdk;
     private @Nullable OpenTelemetryLogListener logListener;
+    private @Nullable ServiceRegistration<EventSubscriber> eventListenerRegistration;
+
+    // References
     private @Nullable LogReaderService logReaderService;
+    private @Nullable MeterRegistryProvider meterRegistryProvider;
+
+    // Metrics pipeline (Micrometer OTLP registry)
+    private @Nullable OtlpMeterRegistry otlpMeterRegistry;
 
     @Reference
     protected void setLogReaderService(LogReaderService logReaderService) {
@@ -66,8 +104,18 @@ public class OpenTelemetryService {
         this.logReaderService = null;
     }
 
+    @Reference
+    protected void setMeterRegistryProvider(MeterRegistryProvider meterRegistryProvider) {
+        this.meterRegistryProvider = meterRegistryProvider;
+    }
+
+    protected void unsetMeterRegistryProvider(MeterRegistryProvider meterRegistryProvider) {
+        this.meterRegistryProvider = null;
+    }
+
     @Activate
-    protected void activate(Map<String, Object> config) {
+    protected void activate(BundleContext bundleContext, Map<String, Object> config) {
+        this.bundleContext = bundleContext;
         updateConfig(config);
     }
 
@@ -78,7 +126,8 @@ public class OpenTelemetryService {
 
     @Deactivate
     protected void deactivate() {
-        shutdownSdk();
+        shutdownAll();
+        this.bundleContext = null;
     }
 
     private void updateConfig(Map<String, Object> configMap) {
@@ -86,48 +135,68 @@ public class OpenTelemetryService {
                 .as(OpenTelemetryConfiguration.class);
         logger.debug("Updating OpenTelemetry configuration: {}", config);
 
-        shutdownSdk();
+        shutdownAll();
 
         if (config.otlpURL.isBlank()) {
             logger.debug("OpenTelemetry is disabled: No URL configured.");
             return;
         }
 
-        initializeSdk(config);
-    }
-
-    private Resource getOtlpResource() {
-        String hostname = null;
-        try {
-            hostname = InetAddress.getLocalHost().getHostName();
-        } catch (UnknownHostException e) {
-            // ignore
+        if (config.otlpURL.startsWith("http://")) {
+            logger.warn(
+                    "OpenTelemetry OTLP endpoint '{}' uses cleartext HTTP. Use HTTPS in production to protect credentials in transit.",
+                    config.otlpURL);
         }
 
-        ResourceBuilder resourceBuilder = Resource.getDefault().toBuilder() //
-                // Application Identity
-                .put("service.name", "openHAB") //
-                .put("service.namespace", "org.openhab") //
-                .put("service.version", OpenHAB.getVersion());
-        // Host/Infrastructure Metadata
+        initializeSdk(config);
+        initializeMetrics(config);
+    }
+
+    // -------------------------------------------------------------------------
+    // Shared resource / attribute helpers
+    // -------------------------------------------------------------------------
+
+    /** Builds service attributes used by both the OTel SDK resource and micrometer OtlpConfig. */
+    private Map<String, String> buildServiceAttributes() {
+        Map<String, String> attrs = new LinkedHashMap<>();
+        attrs.put("service.name", "openHAB");
+        attrs.put("service.namespace", "org.openhab");
+        attrs.put("service.version", OpenHAB.getVersion());
+        attrs.put("service.instance.id", SERVICE_INSTANCE_ID);
+        try {
+            attrs.put("host.name", InetAddress.getLocalHost().getHostName());
+        } catch (UnknownHostException e) {
+            // hostname not resolvable — omit
+        }
         String osName = System.getProperty("os.name");
         if (osName != null) {
-            resourceBuilder.put("os.name", osName);
+            attrs.put("os.name", osName);
         }
         String osVersion = System.getProperty("os.version");
         if (osVersion != null) {
-            resourceBuilder.put("os.version", osVersion);
+            attrs.put("os.version", osVersion);
         }
-        if (hostname != null) {
-            resourceBuilder.put("host.name", hostname);
-        }
+        return attrs;
+    }
 
-        return resourceBuilder.build();
+    private Resource getOtlpResource() {
+        ResourceBuilder builder = Resource.getDefault().toBuilder();
+        buildServiceAttributes().forEach(builder::put);
+        return builder.build();
     }
 
     Map<String, String> parseOtlpHeaders(@Nullable String rawHeaders) {
         if (rawHeaders == null || rawHeaders.isBlank()) {
             return Collections.emptyMap();
+        }
+
+        // Reject control characters to prevent HTTP header injection attacks
+        for (int i = 0; i < rawHeaders.length(); i++) {
+            char c = rawHeaders.charAt(i);
+            if (c == '\n' || c == '\r' || c == '\0') {
+                throw new IllegalArgumentException(
+                        "otlpHeaders must not contain newline, carriage-return, or null characters");
+            }
         }
 
         Map<String, String> headers = new HashMap<>();
@@ -145,6 +214,10 @@ public class OpenTelemetryService {
 
         return headers;
     }
+
+    // -------------------------------------------------------------------------
+    // Logs + traces pipeline (OTel SDK)
+    // -------------------------------------------------------------------------
 
     private @Nullable SdkLoggerProviderBuilder createOtlpLoggerProvider(OpenTelemetryConfiguration config) {
         if (!config.logsEnabled) {
@@ -164,7 +237,13 @@ public class OpenTelemetryService {
             return null;
         }
 
-        Map<String, String> headers = parseOtlpHeaders(config.otlpHeaders);
+        Map<String, String> headers;
+        try {
+            headers = parseOtlpHeaders(config.otlpHeaders);
+        } catch (IllegalArgumentException e) {
+            logger.warn("Invalid OTLP headers: {}", e.getMessage());
+            return null;
+        }
         if (!headers.isEmpty()) {
             for (Map.Entry<String, String> header : headers.entrySet()) {
                 logExporterBuilder.addHeader(header.getKey(), header.getValue());
@@ -175,6 +254,54 @@ public class OpenTelemetryService {
                 .addLogRecordProcessor(BatchLogRecordProcessor.builder(logExporterBuilder.build()).build());
     }
 
+    private @Nullable SdkTracerProvider createSdkTracerProvider(OpenTelemetryConfiguration config, Resource resource) {
+        if (!config.tracesEnabled) {
+            return null;
+        }
+        if (config.tracesEndpoint.isBlank()) {
+            logger.warn("OpenTelemetry traces is enabled, but no endpoint is configured.");
+            return null;
+        }
+
+        String tracesUrl;
+        try {
+            tracesUrl = config.getTracesURL();
+        } catch (IllegalArgumentException e) {
+            logger.warn("Invalid OTLP traces endpoint: {}", e.getMessage());
+            return null;
+        }
+
+        OtlpHttpSpanExporterBuilder spanExporterBuilder = OtlpHttpSpanExporter.builder().setEndpoint(tracesUrl);
+        Map<String, String> headers;
+        try {
+            headers = parseOtlpHeaders(config.otlpHeaders);
+        } catch (IllegalArgumentException e) {
+            logger.warn("Invalid OTLP headers: {}", e.getMessage());
+            return null;
+        }
+        if (!headers.isEmpty()) {
+            for (Map.Entry<String, String> header : headers.entrySet()) {
+                spanExporterBuilder.addHeader(header.getKey(), header.getValue());
+            }
+        }
+
+        double raw = config.tracesSamplingRatio;
+        double ratio = Double.isNaN(raw) ? 1.0 : Math.max(0.0, Math.min(1.0, raw));
+        Sampler sampler = Sampler.parentBased(Sampler.traceIdRatioBased(ratio));
+
+        return SdkTracerProvider.builder() //
+                .setSampler(sampler) //
+                .addSpanProcessor(BatchSpanProcessor.builder(spanExporterBuilder.build()).build()) //
+                .setResource(resource) //
+                .build();
+    }
+
+    /** Returns true when the OTel Java agent is running (detected via JVM arguments). */
+    static boolean isAgentPresent() {
+        return ManagementFactory.getRuntimeMXBean().getInputArguments().stream()
+                .anyMatch(arg -> arg.contains("opentelemetry-javaagent"));
+    }
+
     private synchronized void initializeSdk(OpenTelemetryConfiguration config) {
         if (openTelemetrySdk != null) {
             logger.debug("OpenTelemetry SDK already initialized.");
@@ -183,6 +310,7 @@ public class OpenTelemetryService {
 
         Resource resource = getOtlpResource();
 
+        // Build logger provider (nullable if logs disabled)
         SdkLoggerProviderBuilder loggerProviderBuilder = createOtlpLoggerProvider(config);
         SdkLoggerProvider loggerProvider = null;
         if (loggerProviderBuilder != null) {
@@ -190,26 +318,88 @@ public class OpenTelemetryService {
             loggerProvider = loggerProviderBuilder.build();
         }
 
-        if (loggerProvider == null) {
+        // Build tracer provider (nullable if traces disabled or agent present)
+        SdkTracerProvider tracerProvider = null;
+        Tracer tracer = null;
+        if (config.tracesEnabled) {
+            if (isAgentPresent()) {
+                logger.info(
+                        "OTel Java agent detected — event-bus spans will join the agent's pipeline (read-only GlobalOpenTelemetry).");
+                tracer = GlobalOpenTelemetry.get().getTracer("org.openhab.io.opentelemetry");
+            } else {
+                tracerProvider = createSdkTracerProvider(config, resource);
+            }
+        }
+
+        if (loggerProvider == null && tracerProvider == null) {
+            // No SDK providers to configure; if a tracer came from the agent, wire it directly
+            if (tracer != null) {
+                registerEventListener(tracer);
+            }
             return;
         }
 
-        OpenTelemetrySdk sdk = OpenTelemetrySdk.builder().setLoggerProvider(loggerProvider).build();
+        OpenTelemetrySdkBuilder sdkBuilder = OpenTelemetrySdk.builder();
+        if (loggerProvider != null) {
+            sdkBuilder.setLoggerProvider(loggerProvider);
+        }
+        if (tracerProvider != null) {
+            sdkBuilder.setTracerProvider(tracerProvider);
+        }
+
+        OpenTelemetrySdk sdk = sdkBuilder.build();
         this.openTelemetrySdk = sdk;
 
-        LogReaderService lrs = this.logReaderService;
-        if (config.logsEnabled && lrs != null) {
+        // Register log listener
+        if (loggerProvider != null) {
             io.opentelemetry.api.logs.Logger otelLogger = sdk.getLogsBridge().get("org.openhab.io.opentelemetry");
             OpenTelemetryLogListener listener = new OpenTelemetryLogListener(otelLogger);
             this.logListener = listener;
-            lrs.addLogListener(listener);
-            logger.debug("OpenTelemetry LogListener registered.");
+            LogReaderService lrs = this.logReaderService;
+            if (lrs != null) {
+                lrs.addLogListener(listener);
+                logger.debug("OpenTelemetry LogListener registered.");
+            }
         }
 
-        logger.info("OpenTelemetry service started.");
+        // Register event listener for traces
+        if (config.tracesEnabled) {
+            if (tracer == null && tracerProvider != null) {
+                tracer = sdk.getTracer("org.openhab.io.opentelemetry");
+            }
+            if (tracer != null) {
+                registerEventListener(tracer);
+            }
+        }
+
+        logger.info("OpenTelemetry SDK started (logs={}, traces={}).", config.logsEnabled, config.tracesEnabled);
+    }
+
+    private void registerEventListener(Tracer tracer) {
+        BundleContext bc = this.bundleContext;
+        if (bc == null) {
+            logger.warn("BundleContext not available — event-bus listener not registered.");
+            return;
+        }
+        OpenTelemetryEventListener listener = new OpenTelemetryEventListener(tracer);
+        this.eventListenerRegistration = bc.registerService(EventSubscriber.class, listener, null);
+        logger.debug("OpenTelemetry EventSubscriber registered.");
     }
 
     private synchronized void shutdownSdk() {
+        // Unregister event listener first so no new spans are emitted after shutdown
+        ServiceRegistration<EventSubscriber> reg = this.eventListenerRegistration;
+        if (reg != null) {
+            try {
+                reg.unregister();
+            } catch (IllegalStateException e) {
+                // already unregistered — ignore
+            }
+            this.eventListenerRegistration = null;
+            logger.debug("OpenTelemetry EventSubscriber unregistered.");
+        }
+
+        // Unregister log listener
         LogReaderService lrs = this.logReaderService;
         OpenTelemetryLogListener listener = this.logListener;
         if (lrs != null && listener != null) {
@@ -218,11 +408,149 @@ public class OpenTelemetryService {
         }
         this.logListener = null;
 
+        // Flush in-flight batches (bounded), then shut down
         OpenTelemetrySdk sdk = this.openTelemetrySdk;
         if (sdk != null) {
+            sdk.getSdkTracerProvider().forceFlush().join(3, TimeUnit.SECONDS);
+            sdk.getSdkLoggerProvider().forceFlush().join(3, TimeUnit.SECONDS);
             sdk.close();
             this.openTelemetrySdk = null;
-            logger.info("OpenTelemetry service shut down.");
+            logger.info("OpenTelemetry SDK shut down.");
         }
+    }
+
+    // -------------------------------------------------------------------------
+    // Metrics pipeline (Micrometer OTLP registry)
+    // -------------------------------------------------------------------------
+
+    /**
+     * MeterFilter prefixes: only openHAB's own meters and standard JVM/process metrics
+     * are exported to avoid leaking unrelated add-on meters or host-monitoring data.
+     */
+    static final String[] ALLOWED_METER_PREFIXES = { "openhab.", "jvm.", "process.", "system.", "executor.", "logback.",
+            "http." };
+
+    static boolean isAllowedMeterName(String name) {
+        for (String prefix : ALLOWED_METER_PREFIXES) {
+            if (name.startsWith(prefix)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @SuppressWarnings("null") // implementing unannotated Micrometer OtlpConfig interface
+    private synchronized void initializeMetrics(OpenTelemetryConfiguration config) {
+        if (otlpMeterRegistry != null) {
+            logger.debug("OpenTelemetry metrics already initialized.");
+            return;
+        }
+        if (!config.metricsEnabled) {
+            logger.debug("OpenTelemetry metrics is disabled.");
+            return;
+        }
+
+        String metricsUrl;
+        try {
+            metricsUrl = config.getMetricsURL();
+        } catch (IllegalArgumentException e) {
+            logger.warn("Invalid OTLP metrics endpoint: {}", e.getMessage());
+            return;
+        }
+
+        Duration step;
+        try {
+            step = Duration.parse(config.metricsInterval);
+        } catch (Exception e) {
+            logger.warn("Invalid metrics interval '{}', using default PT60S: {}", config.metricsInterval,
+                    e.getMessage());
+            step = Duration.ofSeconds(60);
+        }
+        if (step.isZero() || step.isNegative()) {
+            logger.warn("metricsInterval '{}' must be positive, using default PT60S", config.metricsInterval);
+            step = Duration.ofSeconds(60);
+        }
+
+        Map<String, String> attrs = buildServiceAttributes();
+        Map<String, String> headers;
+        try {
+            headers = parseOtlpHeaders(config.otlpHeaders);
+        } catch (IllegalArgumentException e) {
+            logger.warn("Invalid OTLP headers: {}", e.getMessage());
+            return;
+        }
+        final String finalUrl = metricsUrl;
+        final Duration finalStep = step;
+
+        OtlpConfig otlpConfig = new OtlpConfig() {
+            @Override
+            public @Nullable String get(@Nullable String key) {
+                return null;
+            }
+
+            @Override
+            public String url() {
+                return finalUrl;
+            }
+
+            @Override
+            public Duration step() {
+                return finalStep;
+            }
+
+            @Override
+            @NonNullByDefault({})
+            public Map<String, String> headers() {
+                return headers;
+            }
+
+            @Override
+            public AggregationTemporality aggregationTemporality() {
+                return "DELTA".equals(config.metricsAggregationTemporality) ? AggregationTemporality.DELTA
+                        : AggregationTemporality.CUMULATIVE;
+            }
+
+            @Override
+            @NonNullByDefault({})
+            public Map<String, String> resourceAttributes() {
+                return attrs;
+            }
+        };
+
+        OtlpMeterRegistry registry = new OtlpMeterRegistry(otlpConfig, Clock.SYSTEM);
+        registry.config().meterFilter(MeterFilter.denyUnless(id -> isAllowedMeterName(id.getName())));
+
+        MeterRegistryProvider provider = this.meterRegistryProvider;
+        if (provider != null) {
+            CompositeMeterRegistry composite = provider.getOHMeterRegistry();
+            composite.add(registry);
+            this.otlpMeterRegistry = registry;
+            logger.info("OpenTelemetry metrics pipeline started (pushing to {}).", finalUrl);
+        } else {
+            registry.close();
+            logger.warn("MeterRegistryProvider not available — metrics pipeline not started.");
+        }
+    }
+
+    private synchronized void shutdownMetrics() {
+        OtlpMeterRegistry registry = this.otlpMeterRegistry;
+        if (registry != null) {
+            MeterRegistryProvider provider = this.meterRegistryProvider;
+            if (provider != null) {
+                provider.getOHMeterRegistry().remove(registry);
+            }
+            registry.close();
+            this.otlpMeterRegistry = null;
+            logger.info("OpenTelemetry metrics pipeline shut down.");
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Combined teardown
+    // -------------------------------------------------------------------------
+
+    private void shutdownAll() {
+        shutdownMetrics();
+        shutdownSdk();
     }
 }

--- a/bundles/org.openhab.io.opentelemetry/src/main/java/org/openhab/io/opentelemetry/internal/OpenTelemetryService.java
+++ b/bundles/org.openhab.io.opentelemetry/src/main/java/org/openhab/io/opentelemetry/internal/OpenTelemetryService.java
@@ -432,7 +432,8 @@ public class OpenTelemetryService {
 
     /**
      * Tag attached by openHAB core's DefaultMetricsRegistration to every core meter binder.
-     * The constant lives in a non-exported core package, so the literal is duplicated here.
+     * The constant lives in a non-exported core package, so the literal is duplicated here until
+     * core exposes it from org.openhab.core.io.monitor.
      */
     static final String CORE_METRIC_TAG_KEY = "openhab_core_metric";
     static final String CORE_METRIC_TAG_VALUE = "true";

--- a/bundles/org.openhab.io.opentelemetry/src/main/java/org/openhab/io/opentelemetry/internal/OpenTelemetryService.java
+++ b/bundles/org.openhab.io.opentelemetry/src/main/java/org/openhab/io/opentelemetry/internal/OpenTelemetryService.java
@@ -142,7 +142,8 @@ public class OpenTelemetryService {
             return;
         }
 
-        if (config.otlpURL.startsWith("http://")) {
+        boolean anyPipelineEnabled = config.logsEnabled || config.metricsEnabled || config.tracesEnabled;
+        if (anyPipelineEnabled && config.otlpURL.startsWith("http://")) {
             logger.warn(
                     "OpenTelemetry OTLP endpoint '{}' uses cleartext HTTP. Use HTTPS in production to protect credentials in transit.",
                     config.otlpURL);
@@ -285,8 +286,7 @@ public class OpenTelemetryService {
             }
         }
 
-        double raw = config.tracesSamplingRatio;
-        double ratio = Double.isNaN(raw) ? 1.0 : Math.max(0.0, Math.min(1.0, raw));
+        double ratio = clampSamplingRatio(config.tracesSamplingRatio);
         Sampler sampler = Sampler.parentBased(Sampler.traceIdRatioBased(ratio));
 
         return SdkTracerProvider.builder() //
@@ -294,6 +294,11 @@ public class OpenTelemetryService {
                 .addSpanProcessor(BatchSpanProcessor.builder(spanExporterBuilder.build()).build()) //
                 .setResource(resource) //
                 .build();
+    }
+
+    /** Clamps the sampling ratio to [0.0, 1.0]; NaN falls back to 1.0 (sample all). */
+    static double clampSamplingRatio(double raw) {
+        return Double.isNaN(raw) ? 1.0 : Math.max(0.0, Math.min(1.0, raw));
     }
 
     /** Returns true when the OTel Java agent is running (detected via JVM arguments). */

--- a/bundles/org.openhab.io.opentelemetry/src/main/java/org/openhab/io/opentelemetry/internal/OpenTelemetryService.java
+++ b/bundles/org.openhab.io.opentelemetry/src/main/java/org/openhab/io/opentelemetry/internal/OpenTelemetryService.java
@@ -43,6 +43,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.micrometer.core.instrument.Clock;
+import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 import io.micrometer.core.instrument.config.MeterFilter;
 import io.micrometer.registry.otlp.AggregationTemporality;
@@ -255,7 +256,8 @@ public class OpenTelemetryService {
                 .addLogRecordProcessor(BatchLogRecordProcessor.builder(logExporterBuilder.build()).build());
     }
 
-    private @Nullable SdkTracerProvider createSdkTracerProvider(OpenTelemetryConfiguration config, Resource resource) {
+    @Nullable
+    SdkTracerProvider createSdkTracerProvider(OpenTelemetryConfiguration config, Resource resource) {
         if (!config.tracesEnabled) {
             return null;
         }
@@ -264,15 +266,13 @@ public class OpenTelemetryService {
             return null;
         }
 
-        String tracesUrl;
+        OtlpHttpSpanExporterBuilder spanExporterBuilder;
         try {
-            tracesUrl = config.getTracesURL();
+            spanExporterBuilder = OtlpHttpSpanExporter.builder().setEndpoint(config.getTracesURL());
         } catch (IllegalArgumentException e) {
             logger.warn("Invalid OTLP traces endpoint: {}", e.getMessage());
             return null;
         }
-
-        OtlpHttpSpanExporterBuilder spanExporterBuilder = OtlpHttpSpanExporter.builder().setEndpoint(tracesUrl);
         Map<String, String> headers;
         try {
             headers = parseOtlpHeaders(config.otlpHeaders);
@@ -429,19 +429,14 @@ public class OpenTelemetryService {
     // -------------------------------------------------------------------------
 
     /**
-     * MeterFilter prefixes: only openHAB's own meters and standard JVM/process metrics
-     * are exported to avoid leaking unrelated add-on meters or host-monitoring data.
+     * Tag attached by openHAB core's DefaultMetricsRegistration to every core meter binder.
+     * The constant lives in a non-exported core package, so the literal is duplicated here.
      */
-    static final String[] ALLOWED_METER_PREFIXES = { "openhab.", "jvm.", "process.", "system.", "executor.", "logback.",
-            "http." };
+    static final String CORE_METRIC_TAG_KEY = "openhab_core_metric";
+    static final String CORE_METRIC_TAG_VALUE = "true";
 
-    static boolean isAllowedMeterName(String name) {
-        for (String prefix : ALLOWED_METER_PREFIXES) {
-            if (name.startsWith(prefix)) {
-                return true;
-            }
-        }
-        return false;
+    static boolean isCoreMeter(Meter.Id id) {
+        return CORE_METRIC_TAG_VALUE.equals(id.getTag(CORE_METRIC_TAG_KEY));
     }
 
     @SuppressWarnings("null") // implementing unannotated Micrometer OtlpConfig interface
@@ -523,7 +518,7 @@ public class OpenTelemetryService {
         };
 
         OtlpMeterRegistry registry = new OtlpMeterRegistry(otlpConfig, Clock.SYSTEM);
-        registry.config().meterFilter(MeterFilter.denyUnless(id -> isAllowedMeterName(id.getName())));
+        registry.config().meterFilter(MeterFilter.denyUnless(OpenTelemetryService::isCoreMeter));
 
         MeterRegistryProvider provider = this.meterRegistryProvider;
         if (provider != null) {

--- a/bundles/org.openhab.io.opentelemetry/src/main/java/org/openhab/io/opentelemetry/internal/OpenTelemetryService.java
+++ b/bundles/org.openhab.io.opentelemetry/src/main/java/org/openhab/io/opentelemetry/internal/OpenTelemetryService.java
@@ -20,6 +20,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
@@ -30,6 +31,7 @@ import org.openhab.core.config.core.ConfigUtil;
 import org.openhab.core.config.core.ConfigurableService;
 import org.openhab.core.config.core.Configuration;
 import org.openhab.core.events.EventSubscriber;
+import org.openhab.core.id.InstanceUUID;
 import org.openhab.core.io.monitor.MeterRegistryProvider;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceRegistration;
@@ -79,8 +81,12 @@ import io.opentelemetry.sdk.trace.samplers.Sampler;
 public class OpenTelemetryService {
     private final Logger logger = LoggerFactory.getLogger(OpenTelemetryService.class);
 
-    /** Stable within the JVM lifetime; does not change across {@code modified()} reconfigurations. */
-    static final String SERVICE_INSTANCE_ID = UUID.randomUUID().toString();
+    /**
+     * openHAB's persistent per-installation UUID, stored under {@code $OPENHAB_USERDATA}. Falls
+     * back to a fresh UUID if the core UUID file cannot be read or created.
+     */
+    static final String SERVICE_INSTANCE_ID = Objects.requireNonNullElseGet(InstanceUUID.get(),
+            () -> UUID.randomUUID().toString());
 
     private @Nullable BundleContext bundleContext;
 
@@ -89,12 +95,12 @@ public class OpenTelemetryService {
     private @Nullable OpenTelemetryLogListener logListener;
     private @Nullable ServiceRegistration<EventSubscriber> eventListenerRegistration;
 
+    // Metrics pipeline (Micrometer OTLP registry)
+    private @Nullable OtlpMeterRegistry otlpMeterRegistry;
+
     // References
     private @Nullable LogReaderService logReaderService;
     private @Nullable MeterRegistryProvider meterRegistryProvider;
-
-    // Metrics pipeline (Micrometer OTLP registry)
-    private @Nullable OtlpMeterRegistry otlpMeterRegistry;
 
     @Reference
     protected void setLogReaderService(LogReaderService logReaderService) {
@@ -145,13 +151,21 @@ public class OpenTelemetryService {
 
         boolean anyPipelineEnabled = config.logsEnabled || config.metricsEnabled || config.tracesEnabled;
         if (anyPipelineEnabled && config.otlpURL.startsWith("http://")) {
-            logger.warn(
+            logger.info(
                     "OpenTelemetry OTLP endpoint '{}' uses cleartext HTTP. Use HTTPS in production to protect credentials in transit.",
                     config.otlpURL);
         }
 
-        initializeSdk(config);
-        initializeMetrics(config);
+        Map<String, String> headers;
+        try {
+            headers = parseOtlpHeaders(config.otlpHeaders);
+        } catch (IllegalArgumentException e) {
+            logger.warn("Invalid OTLP headers: {}", e.getMessage());
+            return;
+        }
+
+        initializeSdk(config, headers);
+        initializeMetrics(config, headers);
     }
 
     // -------------------------------------------------------------------------
@@ -221,7 +235,8 @@ public class OpenTelemetryService {
     // Logs + traces pipeline (OTel SDK)
     // -------------------------------------------------------------------------
 
-    private @Nullable SdkLoggerProviderBuilder createOtlpLoggerProvider(OpenTelemetryConfiguration config) {
+    private @Nullable SdkLoggerProviderBuilder createOtlpLoggerProvider(OpenTelemetryConfiguration config,
+            Map<String, String> headers) {
         if (!config.logsEnabled) {
             logger.debug("OpenTelemetry logging is disabled.");
             return null;
@@ -239,17 +254,8 @@ public class OpenTelemetryService {
             return null;
         }
 
-        Map<String, String> headers;
-        try {
-            headers = parseOtlpHeaders(config.otlpHeaders);
-        } catch (IllegalArgumentException e) {
-            logger.warn("Invalid OTLP headers: {}", e.getMessage());
-            return null;
-        }
-        if (!headers.isEmpty()) {
-            for (Map.Entry<String, String> header : headers.entrySet()) {
-                logExporterBuilder.addHeader(header.getKey(), header.getValue());
-            }
+        for (Map.Entry<String, String> header : headers.entrySet()) {
+            logExporterBuilder.addHeader(header.getKey(), header.getValue());
         }
 
         return SdkLoggerProvider.builder() //
@@ -257,7 +263,8 @@ public class OpenTelemetryService {
     }
 
     @Nullable
-    SdkTracerProvider createSdkTracerProvider(OpenTelemetryConfiguration config, Resource resource) {
+    SdkTracerProvider createSdkTracerProvider(OpenTelemetryConfiguration config, Resource resource,
+            Map<String, String> headers) {
         if (!config.tracesEnabled) {
             return null;
         }
@@ -273,17 +280,8 @@ public class OpenTelemetryService {
             logger.warn("Invalid OTLP traces endpoint: {}", e.getMessage());
             return null;
         }
-        Map<String, String> headers;
-        try {
-            headers = parseOtlpHeaders(config.otlpHeaders);
-        } catch (IllegalArgumentException e) {
-            logger.warn("Invalid OTLP headers: {}", e.getMessage());
-            return null;
-        }
-        if (!headers.isEmpty()) {
-            for (Map.Entry<String, String> header : headers.entrySet()) {
-                spanExporterBuilder.addHeader(header.getKey(), header.getValue());
-            }
+        for (Map.Entry<String, String> header : headers.entrySet()) {
+            spanExporterBuilder.addHeader(header.getKey(), header.getValue());
         }
 
         double ratio = clampSamplingRatio(config.tracesSamplingRatio);
@@ -307,7 +305,7 @@ public class OpenTelemetryService {
                 .anyMatch(arg -> arg.contains("opentelemetry-javaagent"));
     }
 
-    private synchronized void initializeSdk(OpenTelemetryConfiguration config) {
+    private synchronized void initializeSdk(OpenTelemetryConfiguration config, Map<String, String> headers) {
         if (openTelemetrySdk != null) {
             logger.debug("OpenTelemetry SDK already initialized.");
             return;
@@ -316,7 +314,7 @@ public class OpenTelemetryService {
         Resource resource = getOtlpResource();
 
         // Build logger provider (nullable if logs disabled)
-        SdkLoggerProviderBuilder loggerProviderBuilder = createOtlpLoggerProvider(config);
+        SdkLoggerProviderBuilder loggerProviderBuilder = createOtlpLoggerProvider(config, headers);
         SdkLoggerProvider loggerProvider = null;
         if (loggerProviderBuilder != null) {
             loggerProviderBuilder.setResource(resource);
@@ -332,7 +330,7 @@ public class OpenTelemetryService {
                         "OTel Java agent detected — event-bus spans will join the agent's pipeline (read-only GlobalOpenTelemetry).");
                 tracer = GlobalOpenTelemetry.get().getTracer("org.openhab.io.opentelemetry");
             } else {
-                tracerProvider = createSdkTracerProvider(config, resource);
+                tracerProvider = createSdkTracerProvider(config, resource, headers);
             }
         }
 
@@ -381,6 +379,10 @@ public class OpenTelemetryService {
     }
 
     private void registerEventListener(Tracer tracer) {
+        if (this.eventListenerRegistration != null) {
+            logger.debug("OpenTelemetry EventSubscriber already registered.");
+            return;
+        }
         BundleContext bc = this.bundleContext;
         if (bc == null) {
             logger.warn("BundleContext not available — event-bus listener not registered.");
@@ -440,7 +442,7 @@ public class OpenTelemetryService {
     }
 
     @SuppressWarnings("null") // implementing unannotated Micrometer OtlpConfig interface
-    private synchronized void initializeMetrics(OpenTelemetryConfiguration config) {
+    private synchronized void initializeMetrics(OpenTelemetryConfiguration config, Map<String, String> headers) {
         if (otlpMeterRegistry != null) {
             logger.debug("OpenTelemetry metrics already initialized.");
             return;
@@ -472,13 +474,6 @@ public class OpenTelemetryService {
         }
 
         Map<String, String> attrs = buildServiceAttributes();
-        Map<String, String> headers;
-        try {
-            headers = parseOtlpHeaders(config.otlpHeaders);
-        } catch (IllegalArgumentException e) {
-            logger.warn("Invalid OTLP headers: {}", e.getMessage());
-            return;
-        }
         final String finalUrl = metricsUrl;
         final Duration finalStep = step;
 

--- a/bundles/org.openhab.io.opentelemetry/src/main/java/org/openhab/io/opentelemetry/internal/OpenTelemetryService.java
+++ b/bundles/org.openhab.io.opentelemetry/src/main/java/org/openhab/io/opentelemetry/internal/OpenTelemetryService.java
@@ -12,7 +12,6 @@
  */
 package org.openhab.io.opentelemetry.internal;
 
-import java.lang.management.ManagementFactory;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.time.Duration;
@@ -299,10 +298,9 @@ public class OpenTelemetryService {
         return Double.isNaN(raw) ? 1.0 : Math.max(0.0, Math.min(1.0, raw));
     }
 
-    /** Returns true when the OTel Java agent is running (detected via JVM arguments). */
-    static boolean isAgentPresent() {
-        return ManagementFactory.getRuntimeMXBean().getInputArguments().stream()
-                .anyMatch(arg -> arg.contains("opentelemetry-javaagent"));
+    /** Returns true when a global OpenTelemetry is already installed, e.g. by the OTel Java agent. */
+    static boolean isGlobalOpenTelemetrySet() {
+        return GlobalOpenTelemetry.isSet();
     }
 
     private synchronized void initializeSdk(OpenTelemetryConfiguration config, Map<String, String> headers) {
@@ -325,9 +323,9 @@ public class OpenTelemetryService {
         SdkTracerProvider tracerProvider = null;
         Tracer tracer = null;
         if (config.tracesEnabled) {
-            if (isAgentPresent()) {
+            if (isGlobalOpenTelemetrySet()) {
                 logger.info(
-                        "OTel Java agent detected — event-bus spans will join the agent's pipeline (read-only GlobalOpenTelemetry).");
+                        "Global OpenTelemetry already installed — event-bus spans will join its pipeline (read-only GlobalOpenTelemetry).");
                 tracer = GlobalOpenTelemetry.get().getTracer("org.openhab.io.opentelemetry");
             } else {
                 tracerProvider = createSdkTracerProvider(config, resource, headers);

--- a/bundles/org.openhab.io.opentelemetry/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.io.opentelemetry/src/main/resources/OH-INF/addon/addon.xml
@@ -5,7 +5,7 @@
 
 	<type>misc</type>
 	<name>OpenTelemetry Service</name>
-	<description>Forwards openHAB logs to an OpenTelemetry collector.</description>
+	<description>Forwards openHAB logs, metrics and traces to an OpenTelemetry collector.</description>
 	<connection>local</connection>
 
 	<service-id>org.openhab.opentelemetry</service-id>

--- a/bundles/org.openhab.io.opentelemetry/src/main/resources/OH-INF/config/config.xml
+++ b/bundles/org.openhab.io.opentelemetry/src/main/resources/OH-INF/config/config.xml
@@ -9,10 +9,22 @@
 		<parameter-group name="logs">
 			<label>OpenTelemetry Logging</label>
 		</parameter-group>
+		<parameter-group name="metrics">
+			<label>OpenTelemetry Metrics</label>
+		</parameter-group>
+		<parameter-group name="traces">
+			<label>OpenTelemetry Traces</label>
+		</parameter-group>
 
 		<parameter name="otlpURL" type="text">
-			<label>OpenTelemetry Collector URL</label>
-			<description>The URL of the OpenTelemetry Collector instance (using HTTP transport)</description>
+			<label>OTLP Endpoint URL</label>
+			<description>
+				<![CDATA[
+				OTLP endpoint to push telemetry to. Set to a local <a href="https://opentelemetry.io/docs/collector/">OTel Collector</a>
+				(e.g. <code>http://localhost:4318</code>) or directly to a backend ingest URL.
+				Using a collector keeps backend credentials out of openHAB and allows routing to multiple backends.
+				]]>
+			</description>
 			<default>http://localhost:4318</default>
 			<context>network-address</context>
 		</parameter>
@@ -20,7 +32,8 @@
 			<label>OTLP Headers</label>
 			<description>
 				<![CDATA[
-				Optional headers for authentication (e.g., <code>Authorization=Bearer token</code>)
+				Comma-separated authentication headers, e.g. <code>Authorization=Bearer token</code>.
+				Only required for direct-to-backend deployments. Leave empty when using a collector.
 				]]>
 			</description>
 			<context>password</context>
@@ -35,6 +48,68 @@
 			<label>Log Endpoint</label>
 			<description>The endpoint to send logs to.</description>
 			<default>/v1/logs</default>
+		</parameter>
+
+		<parameter name="metricsEnabled" type="boolean" groupName="metrics">
+			<label>Export Metrics</label>
+			<description>Enable exporting openHAB metrics to OpenTelemetry.</description>
+			<default>false</default>
+		</parameter>
+		<parameter name="metricsEndpoint" type="text" groupName="metrics">
+			<label>Metrics Endpoint</label>
+			<description>The endpoint to send metrics to.</description>
+			<default>/v1/metrics</default>
+		</parameter>
+		<parameter name="metricsInterval" type="text" groupName="metrics">
+			<label>Metrics Export Interval</label>
+			<description>
+				<![CDATA[
+				How often metrics are pushed (ISO 8601 duration, e.g. <code>PT60S</code> for 60 seconds).
+				]]>
+			</description>
+			<default>PT60S</default>
+		</parameter>
+		<parameter name="metricsAggregationTemporality" type="text" groupName="metrics">
+			<label>Aggregation Temporality</label>
+			<description>
+				<![CDATA[
+				<code>CUMULATIVE</code>: running totals since process start; works with most backends and OTel Collector pipelines.<br/>
+				<code>DELTA</code>: change since last report; required by some backends when receiving OTLP directly. Consult your backend's documentation.
+				]]>
+			</description>
+			<default>CUMULATIVE</default>
+			<options>
+				<option value="CUMULATIVE">Cumulative</option>
+				<option value="DELTA">Delta</option>
+			</options>
+		</parameter>
+
+		<parameter name="tracesEnabled" type="boolean" groupName="traces">
+			<label>Export Traces</label>
+			<description>
+				<![CDATA[
+				Enable exporting openHAB event-bus spans to OpenTelemetry. These are flat, single-span traces
+				(item/thing/rule events), not distributed call trees — openHAB's event bus has no request context
+				to attach a parent to. For real distributed HTTP traces, run the OTel Java agent alongside this
+				bundle (see README).
+				]]>
+			</description>
+			<default>false</default>
+		</parameter>
+		<parameter name="tracesEndpoint" type="text" groupName="traces">
+			<label>Traces Endpoint</label>
+			<description>The endpoint to send traces to.</description>
+			<default>/v1/traces</default>
+		</parameter>
+		<parameter name="tracesSamplingRatio" type="decimal" groupName="traces" min="0" max="1" step="0.01">
+			<label>Traces Sampling Ratio</label>
+			<description>
+				<![CDATA[
+				Fraction of event-bus spans to export (0.0 = none, 1.0 = all).
+				Lower values reduce volume on busy instances.
+				]]>
+			</description>
+			<default>1</default>
 		</parameter>
 	</config-description>
 

--- a/bundles/org.openhab.io.opentelemetry/src/main/resources/OH-INF/i18n/io-opentelemetry.properties
+++ b/bundles/org.openhab.io.opentelemetry/src/main/resources/OH-INF/i18n/io-opentelemetry.properties
@@ -1,16 +1,32 @@
 # add-on
 
 addon.opentelemetry.name = OpenTelemetry Service
-addon.opentelemetry.description = Forwards openHAB logs to an OpenTelemetry collector.
+addon.opentelemetry.description = Forwards openHAB logs, metrics and traces to an OpenTelemetry collector.
 
 # add-on config
 
 io.config.opentelemetry.group.logs.label = OpenTelemetry Logging
+io.config.opentelemetry.group.metrics.label = OpenTelemetry Metrics
+io.config.opentelemetry.group.traces.label = OpenTelemetry Traces
 io.config.opentelemetry.logsEnabled.label = Export Logs
 io.config.opentelemetry.logsEnabled.description = Enable exporting openHAB logs to OpenTelemetry.
 io.config.opentelemetry.logsEndpoint.label = Log Endpoint
 io.config.opentelemetry.logsEndpoint.description = The endpoint to send logs to.
+io.config.opentelemetry.metricsEnabled.label = Export Metrics
+io.config.opentelemetry.metricsEnabled.description = Enable exporting openHAB metrics to OpenTelemetry.
+io.config.opentelemetry.metricsEndpoint.label = Metrics Endpoint
+io.config.opentelemetry.metricsEndpoint.description = The endpoint to send metrics to.
+io.config.opentelemetry.metricsInterval.label = Metrics Export Interval
+io.config.opentelemetry.metricsInterval.description = How often metrics are pushed (ISO 8601 duration, e.g. PT60S for 60 seconds).
+io.config.opentelemetry.metricsAggregationTemporality.label = Aggregation Temporality
+io.config.opentelemetry.metricsAggregationTemporality.description = CUMULATIVE: running totals since process start; works with most backends and OTel Collector pipelines. DELTA: change since last report; required by some backends when receiving OTLP directly.
+io.config.opentelemetry.tracesEnabled.label = Export Traces
+io.config.opentelemetry.tracesEnabled.description = Enable exporting openHAB event-bus spans to OpenTelemetry. These are flat, single-span traces (item/thing/rule events), not distributed call trees — openHAB's event bus has no request context to attach a parent to. For real distributed HTTP traces, run the OTel Java agent alongside this bundle (see README).
+io.config.opentelemetry.tracesEndpoint.label = Traces Endpoint
+io.config.opentelemetry.tracesEndpoint.description = The endpoint to send traces to.
+io.config.opentelemetry.tracesSamplingRatio.label = Traces Sampling Ratio
+io.config.opentelemetry.tracesSamplingRatio.description = Fraction of event-bus spans to export (0.0 = none, 1.0 = all). Lower values reduce volume on busy instances.
 io.config.opentelemetry.otlpHeaders.label = OTLP Headers
-io.config.opentelemetry.otlpHeaders.description = Optional headers for authentication (e.g., <code>Authorization=Bearer token</code>)
-io.config.opentelemetry.otlpURL.label = OpenTelemetry Collector URL
-io.config.opentelemetry.otlpURL.description = The URL of the OpenTelemetry Collector instance (using HTTP transport)
+io.config.opentelemetry.otlpHeaders.description = Comma-separated authentication headers, e.g. Authorization=Bearer token. Only required for direct-to-backend deployments; leave empty when using a collector.
+io.config.opentelemetry.otlpURL.label = OTLP Endpoint URL
+io.config.opentelemetry.otlpURL.description = OTLP endpoint to push telemetry to. Set to a local OTel Collector (e.g. http://localhost:4318) or directly to a backend ingest URL. Using a collector keeps credentials out of openHAB.

--- a/bundles/org.openhab.io.opentelemetry/src/test/java/org/openhab/io/opentelemetry/internal/OpenTelemetryEventListenerTest.java
+++ b/bundles/org.openhab.io.opentelemetry/src/test/java/org/openhab/io/opentelemetry/internal/OpenTelemetryEventListenerTest.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.io.opentelemetry.internal;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.openhab.core.events.Event;
+import org.openhab.core.events.EventSubscriber;
+
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanBuilder;
+import io.opentelemetry.api.trace.Tracer;
+
+/**
+ * Tests for {@link OpenTelemetryEventListener}.
+ *
+ * @author Florian Lettner - Initial contribution
+ */
+@NonNullByDefault
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class OpenTelemetryEventListenerTest {
+
+    @Mock(answer = Answers.RETURNS_SELF)
+    private @NonNullByDefault({}) SpanBuilder spanBuilder;
+
+    @Mock
+    private @NonNullByDefault({}) Span span;
+
+    @Mock
+    private @NonNullByDefault({}) Tracer tracer;
+
+    @Mock
+    private @NonNullByDefault({}) Event event;
+
+    private @NonNullByDefault({}) OpenTelemetryEventListener listener;
+
+    @BeforeEach
+    public void setUp() {
+        when(tracer.spanBuilder(anyString())).thenReturn(spanBuilder);
+        when(spanBuilder.startSpan()).thenReturn(span);
+        listener = new OpenTelemetryEventListener(tracer);
+    }
+
+    @Test
+    public void testSubscribesToAllEventTypes() {
+        assertTrue(listener.getSubscribedEventTypes().contains(EventSubscriber.ALL_EVENT_TYPES),
+                "Listener must subscribe to ALL_EVENT_TYPES to capture the full event bus");
+    }
+
+    @Test
+    public void testNoEventFilter() {
+        assertNull(listener.getEventFilter(), "EventFilter must be null to receive all events without topic filtering");
+    }
+
+    @Test
+    public void testReceiveCreatesSpanNamedAfterEventType() {
+        when(event.getType()).thenReturn("ItemStateChangedEvent");
+        when(event.getTopic()).thenReturn("openhab/items/MyItem/statechanged");
+        when(event.getSource()).thenReturn("test-source");
+
+        listener.receive(event);
+
+        verify(tracer).spanBuilder("ItemStateChangedEvent");
+    }
+
+    @Test
+    public void testReceiveSetsEventAttributes() {
+        when(event.getType()).thenReturn("ThingStatusInfoChangedEvent");
+        when(event.getTopic()).thenReturn("openhab/things/hue:light:1/status");
+        when(event.getSource()).thenReturn("hue-binding");
+
+        listener.receive(event);
+
+        // attributes are set on the span after startSpan(), not on the builder
+        verify(span).setAttribute("event.type", "ThingStatusInfoChangedEvent");
+        verify(span).setAttribute("event.topic", "openhab/things/hue:light:1/status");
+        verify(span).setAttribute("event.source", "hue-binding");
+    }
+
+    @Test
+    public void testReceiveEndsSpan() {
+        when(event.getType()).thenReturn("RuleStatusInfoEvent");
+        when(event.getTopic()).thenReturn("openhab/rules/myRule/status");
+        when(event.getSource()).thenReturn("rules-engine");
+
+        listener.receive(event);
+
+        verify(span).end();
+    }
+
+    @Test
+    public void testReceiveUsesRootContext() {
+        when(event.getType()).thenReturn("ItemStateChangedEvent");
+        when(event.getTopic()).thenReturn("openhab/items/MyItem/statechanged");
+        when(event.getSource()).thenReturn("test");
+
+        listener.receive(event);
+
+        // setParent(Context.root()) is called — verified via RETURNS_SELF chain
+        verify(spanBuilder).setParent(any());
+    }
+
+    @Test
+    public void testReceiveOmitsEventSourceWhenNull() {
+        when(event.getType()).thenReturn("ThingStatusInfoChangedEvent");
+        when(event.getTopic()).thenReturn("openhab/things/hue:light:1/status");
+        when(event.getSource()).thenReturn(null);
+
+        listener.receive(event);
+
+        verify(span, never()).setAttribute(eq("event.source"), any(String.class));
+    }
+
+    @Test
+    public void testReceiveOmitsEventSourceWhenBlank() {
+        when(event.getType()).thenReturn("InboxUpdatedEvent");
+        when(event.getTopic()).thenReturn("openhab/inbox/hue:light:1/added");
+        when(event.getSource()).thenReturn("");
+
+        listener.receive(event);
+
+        verify(span, never()).setAttribute(eq("event.source"), any(String.class));
+    }
+
+    @Test
+    public void testReceiveHandlesRuntimeExceptionGracefully() {
+        when(event.getType()).thenReturn("ItemStateChangedEvent");
+        when(tracer.spanBuilder(anyString())).thenThrow(new RuntimeException("tracer broken"));
+
+        // must not throw — errors in telemetry must not break openHAB event dispatch
+        assertDoesNotThrow(() -> listener.receive(event));
+    }
+}

--- a/bundles/org.openhab.io.opentelemetry/src/test/java/org/openhab/io/opentelemetry/internal/OpenTelemetryLogListenerTest.java
+++ b/bundles/org.openhab.io.opentelemetry/src/test/java/org/openhab/io/opentelemetry/internal/OpenTelemetryLogListenerTest.java
@@ -41,6 +41,7 @@ import io.opentelemetry.api.logs.Severity;
  * The {@link OpenTelemetryLogListenerTest} class contains tests for logging mapping logic.
  *
  * @author Florian Hotze - Initial contribution
+ * @author Florian Lettner - Add unit tests
  */
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
@@ -50,6 +51,37 @@ public class OpenTelemetryLogListenerTest {
 
     private @Mock @NonNullByDefault({}) Logger otelLogger;
     private @Mock(answer = Answers.RETURNS_SELF) @NonNullByDefault({}) LogRecordBuilder logRecordBuilder;
+
+    @Test
+    public void testOwnLoggerSuppression() {
+        OpenTelemetryLogListener listener = new OpenTelemetryLogListener(otelLogger);
+
+        // Our bundle logger — must be suppressed
+        LogEntry bundleEntry = mock(LogEntry.class);
+        when(bundleEntry.getLogLevel()).thenReturn(LogLevel.WARN);
+        when(bundleEntry.getLoggerName()).thenReturn("org.openhab.io.opentelemetry.internal.OpenTelemetryService");
+        listener.logged(bundleEntry);
+
+        // OTel exporter logger — must also be suppressed
+        LogEntry exporterEntry = mock(LogEntry.class);
+        when(exporterEntry.getLogLevel()).thenReturn(LogLevel.WARN);
+        when(exporterEntry.getLoggerName()).thenReturn("io.opentelemetry.exporter.internal.otlp.OtlpHttpExporter");
+        listener.logged(exporterEntry);
+
+        verify(otelLogger, never()).logRecordBuilder();
+
+        // Unrelated logger — must pass through
+        when(otelLogger.logRecordBuilder()).thenReturn(logRecordBuilder);
+        LogEntry otherEntry = mock(LogEntry.class);
+        when(otherEntry.getLogLevel()).thenReturn(LogLevel.INFO);
+        when(otherEntry.getTime()).thenReturn(0L);
+        when(otherEntry.getMessage()).thenReturn("test");
+        when(otherEntry.getLoggerName()).thenReturn("org.openhab.core.something");
+        when(otherEntry.getThreadInfo()).thenReturn("main");
+        when(otherEntry.getException()).thenReturn(null);
+        listener.logged(otherEntry);
+        verify(otelLogger, times(1)).logRecordBuilder();
+    }
 
     @Test
     public void testLoggedBasic() {

--- a/bundles/org.openhab.io.opentelemetry/src/test/java/org/openhab/io/opentelemetry/internal/OpenTelemetryLogListenerTest.java
+++ b/bundles/org.openhab.io.opentelemetry/src/test/java/org/openhab/io/opentelemetry/internal/OpenTelemetryLogListenerTest.java
@@ -62,12 +62,6 @@ public class OpenTelemetryLogListenerTest {
         when(bundleEntry.getLoggerName()).thenReturn("org.openhab.io.opentelemetry.internal.OpenTelemetryService");
         listener.logged(bundleEntry);
 
-        // OTel exporter logger — must also be suppressed
-        LogEntry exporterEntry = mock(LogEntry.class);
-        when(exporterEntry.getLogLevel()).thenReturn(LogLevel.WARN);
-        when(exporterEntry.getLoggerName()).thenReturn("io.opentelemetry.exporter.internal.otlp.OtlpHttpExporter");
-        listener.logged(exporterEntry);
-
         verify(otelLogger, never()).logRecordBuilder();
 
         // Unrelated logger — must pass through
@@ -189,7 +183,7 @@ public class OpenTelemetryLogListenerTest {
     }
 
     @Test
-    public void testOpenTelemetryInternalLoggingIgnored() {
+    public void testOpenTelemetryExporterLoggingIgnored() {
         OpenTelemetryLogListener listener = new OpenTelemetryLogListener(otelLogger);
 
         LogEntry logEntry = mock(LogEntry.class);
@@ -219,5 +213,17 @@ public class OpenTelemetryLogListenerTest {
         listener.logged(logEntry);
 
         verifyNoInteractions(otelLogger);
+    }
+
+    @Test
+    public void testRuntimeExceptionDuringLoggingIsSwallowed() {
+        when(otelLogger.logRecordBuilder()).thenThrow(new RuntimeException("boom"));
+        OpenTelemetryLogListener listener = new OpenTelemetryLogListener(otelLogger);
+
+        LogEntry logEntry = mock(LogEntry.class);
+        when(logEntry.getLogLevel()).thenReturn(LogLevel.INFO);
+        when(logEntry.getLoggerName()).thenReturn("org.openhab.test");
+
+        assertDoesNotThrow(() -> listener.logged(logEntry));
     }
 }

--- a/bundles/org.openhab.io.opentelemetry/src/test/java/org/openhab/io/opentelemetry/internal/OpenTelemetryLogListenerTest.java
+++ b/bundles/org.openhab.io.opentelemetry/src/test/java/org/openhab/io/opentelemetry/internal/OpenTelemetryLogListenerTest.java
@@ -203,4 +203,21 @@ public class OpenTelemetryLogListenerTest {
         // Verify that the listener returns early and does not call any methods on the OTel Logger
         verifyNoInteractions(otelLogger);
     }
+
+    @Test
+    public void testOpenTelemetrySdkLoggingIgnored() {
+        // SDK batch processors (e.g. BatchLogRecordProcessor) log under io.opentelemetry.sdk.*
+        // and must be suppressed to prevent re-ingesting export-failure log lines
+        OpenTelemetryLogListener listener = new OpenTelemetryLogListener(otelLogger);
+
+        LogEntry logEntry = mock(LogEntry.class);
+        when(logEntry.getLoggerName()).thenReturn("io.opentelemetry.sdk.logs.export.BatchLogRecordProcessor");
+        when(logEntry.getLogLevel()).thenReturn(LogLevel.WARN);
+        when(logEntry.getMessage()).thenReturn("Timeout when waiting for signals to be sent to the exporter");
+        when(logEntry.getTime()).thenReturn(System.currentTimeMillis());
+
+        listener.logged(logEntry);
+
+        verifyNoInteractions(otelLogger);
+    }
 }

--- a/bundles/org.openhab.io.opentelemetry/src/test/java/org/openhab/io/opentelemetry/internal/OpenTelemetryLogListenerTest.java
+++ b/bundles/org.openhab.io.opentelemetry/src/test/java/org/openhab/io/opentelemetry/internal/OpenTelemetryLogListenerTest.java
@@ -216,6 +216,23 @@ public class OpenTelemetryLogListenerTest {
     }
 
     @Test
+    public void testMicrometerLoggingIgnored() {
+        // The Micrometer OTLP registry logs metrics export failures under io.micrometer.*
+        // and must be suppressed for the same reason as the OTel SDK loggers
+        OpenTelemetryLogListener listener = new OpenTelemetryLogListener(otelLogger);
+
+        LogEntry logEntry = mock(LogEntry.class);
+        when(logEntry.getLoggerName()).thenReturn("io.micrometer.registry.otlp.OtlpMeterRegistry");
+        when(logEntry.getLogLevel()).thenReturn(LogLevel.WARN);
+        when(logEntry.getMessage()).thenReturn("Failed to publish metrics to OTLP receiver");
+        when(logEntry.getTime()).thenReturn(System.currentTimeMillis());
+
+        listener.logged(logEntry);
+
+        verifyNoInteractions(otelLogger);
+    }
+
+    @Test
     public void testRuntimeExceptionDuringLoggingIsSwallowed() {
         when(otelLogger.logRecordBuilder()).thenThrow(new RuntimeException("boom"));
         OpenTelemetryLogListener listener = new OpenTelemetryLogListener(otelLogger);

--- a/bundles/org.openhab.io.opentelemetry/src/test/java/org/openhab/io/opentelemetry/internal/OpenTelemetryServiceTest.java
+++ b/bundles/org.openhab.io.opentelemetry/src/test/java/org/openhab/io/opentelemetry/internal/OpenTelemetryServiceTest.java
@@ -20,10 +20,11 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.junit.jupiter.api.Test;
 
 /**
- * The {@link OpenTelemetryServiceTest} class contains tests for header parsing
- * and URL resolution.
+ * The {@link OpenTelemetryServiceTest} class contains tests for header parsing,
+ * URL resolution, meter filtering, and service attribute consistency.
  *
  * @author Florian Hotze - Initial contribution
+ * @author Florian Lettner - Add unit tests
  */
 @NonNullByDefault
 public class OpenTelemetryServiceTest {
@@ -70,6 +71,16 @@ public class OpenTelemetryServiceTest {
     }
 
     @Test
+    public void testParseOtlpHeadersRejectsInjectionChars() {
+        OpenTelemetryService service = new OpenTelemetryService();
+
+        assertThrows(IllegalArgumentException.class,
+                () -> service.parseOtlpHeaders("Authorization=Bearer token\nX-Injected=true"));
+        assertThrows(IllegalArgumentException.class, () -> service.parseOtlpHeaders("key\rvalue"));
+        assertThrows(IllegalArgumentException.class, () -> service.parseOtlpHeaders("key\0value"));
+    }
+
+    @Test
     public void testGetLogsURL() {
         OpenTelemetryConfiguration config = new OpenTelemetryConfiguration();
 
@@ -96,8 +107,134 @@ public class OpenTelemetryServiceTest {
         config.logsEndpoint = "/custom/logs/path";
         assertEquals("http://127.0.0.1:5555/custom/logs/path", config.getLogsURL());
 
+        // Vendor endpoint with base path — URI.resolve() regression: path-absolute endpoint
+        // must not discard the base path (e.g. /api/v2/otlp)
+        config.otlpURL = "https://example.dynatracelabs.com/api/v2/otlp";
+        config.logsEndpoint = "/v1/logs";
+        assertEquals("https://example.dynatracelabs.com/api/v2/otlp/v1/logs", config.getLogsURL());
+
         // Invalid URI structure throws IllegalArgumentException
         config.otlpURL = "invalid-uri-scheme:\\";
         assertThrows(IllegalArgumentException.class, config::getLogsURL);
+    }
+
+    @Test
+    public void testGetMetricsURL() {
+        OpenTelemetryConfiguration config = new OpenTelemetryConfiguration();
+
+        // Default configuration
+        assertEquals("http://localhost:4318/v1/metrics", config.getMetricsURL());
+
+        // Custom base URL
+        config.otlpURL = "http://otelcol.example.com:4318";
+        config.metricsEndpoint = "/v1/metrics";
+        assertEquals("http://otelcol.example.com:4318/v1/metrics", config.getMetricsURL());
+
+        // Custom endpoint path
+        config.otlpURL = "http://127.0.0.1:5555";
+        config.metricsEndpoint = "/custom/metrics";
+        assertEquals("http://127.0.0.1:5555/custom/metrics", config.getMetricsURL());
+
+        // Vendor endpoint with base path — URI.resolve() regression
+        config.otlpURL = "https://example.dynatracelabs.com/api/v2/otlp";
+        config.metricsEndpoint = "/v1/metrics";
+        assertEquals("https://example.dynatracelabs.com/api/v2/otlp/v1/metrics", config.getMetricsURL());
+
+        // Invalid URI throws
+        config.otlpURL = "invalid-uri-scheme:\\";
+        assertThrows(IllegalArgumentException.class, () -> config.getMetricsURL());
+    }
+
+    @Test
+    public void testGetTracesURL() {
+        OpenTelemetryConfiguration config = new OpenTelemetryConfiguration();
+
+        // Default configuration
+        assertEquals("http://localhost:4318/v1/traces", config.getTracesURL());
+
+        // Custom base URL
+        config.otlpURL = "http://otelcol.example.com:4318";
+        config.tracesEndpoint = "/v1/traces";
+        assertEquals("http://otelcol.example.com:4318/v1/traces", config.getTracesURL());
+
+        // Vendor endpoint with base path — URI.resolve() regression
+        config.otlpURL = "https://example.dynatracelabs.com/api/v2/otlp";
+        config.tracesEndpoint = "/v1/traces";
+        assertEquals("https://example.dynatracelabs.com/api/v2/otlp/v1/traces", config.getTracesURL());
+
+        // Invalid URI throws
+        config.otlpURL = "invalid-uri-scheme:\\";
+        assertThrows(IllegalArgumentException.class, () -> config.getTracesURL());
+    }
+
+    @Test
+    public void testMeterNameFilterAcceptsOpenHabPrefixes() {
+        // openHAB-specific meters
+        assertTrue(OpenTelemetryService.isAllowedMeterName("openhab.thing.count"));
+        assertTrue(OpenTelemetryService.isAllowedMeterName("openhab.item.state.changed"));
+        assertTrue(OpenTelemetryService.isAllowedMeterName("openhab.rule.execution.time"));
+
+        // Standard JVM and process metrics (openHAB process telemetry)
+        assertTrue(OpenTelemetryService.isAllowedMeterName("jvm.memory.used"));
+        assertTrue(OpenTelemetryService.isAllowedMeterName("jvm.gc.pause"));
+        assertTrue(OpenTelemetryService.isAllowedMeterName("process.cpu.usage"));
+        assertTrue(OpenTelemetryService.isAllowedMeterName("system.cpu.usage"));
+        assertTrue(OpenTelemetryService.isAllowedMeterName("executor.pool.size"));
+        assertTrue(OpenTelemetryService.isAllowedMeterName("logback.events"));
+        assertTrue(OpenTelemetryService.isAllowedMeterName("http.server.requests"));
+    }
+
+    @Test
+    public void testMeterNameFilterDeniesNonOpenHabMeters() {
+        assertFalse(OpenTelemetryService.isAllowedMeterName("kafka.consumer.records"));
+        assertFalse(OpenTelemetryService.isAllowedMeterName("db.pool.active"));
+        assertFalse(OpenTelemetryService.isAllowedMeterName("host.disk.usage"));
+        assertFalse(OpenTelemetryService.isAllowedMeterName("custom.addon.metric"));
+        assertFalse(OpenTelemetryService.isAllowedMeterName(""));
+    }
+
+    @Test
+    public void testServiceInstanceIdIsStable() {
+        // Same static ID across multiple accesses
+        String id1 = OpenTelemetryService.SERVICE_INSTANCE_ID;
+        String id2 = OpenTelemetryService.SERVICE_INSTANCE_ID;
+        assertEquals(id1, id2);
+        assertFalse(id1.isBlank());
+    }
+
+    @Test
+    public void testConfigurationToStringMasksHeaders() {
+        OpenTelemetryConfiguration config = new OpenTelemetryConfiguration();
+        config.otlpHeaders = "Authorization=Bearer secret-token";
+        String str = config.toString();
+        assertFalse(str.contains("secret-token"), "Secret header value must not appear in toString()");
+        assertFalse(str.contains("Bearer"), "Secret header value must not appear in toString()");
+        assertFalse(str.contains("Authorization"), "Secret header key must not appear in toString()");
+        assertTrue(str.contains("otlpHeaders="), "toString() should still mention the field");
+    }
+
+    @Test
+    public void testTracesSamplingRatioClampHandlesNaN() {
+        // NaN bypasses Math.min/max — must not silently drop all spans
+        double nan = Double.NaN;
+        double result = Double.isNaN(nan) ? 1.0 : Math.max(0.0, Math.min(1.0, nan));
+        assertEquals(1.0, result, 0.0001, "NaN sampling ratio must fall back to 1.0 (sample all)");
+
+        // Negative and above-1 should be clamped
+        assertEquals(0.0, Math.max(0.0, Math.min(1.0, -0.5)), 0.0001);
+        assertEquals(1.0, Math.max(0.0, Math.min(1.0, 1.5)), 0.0001);
+    }
+
+    @Test
+    public void testDefaultConfigValues() {
+        OpenTelemetryConfiguration config = new OpenTelemetryConfiguration();
+        assertFalse(config.logsEnabled);
+        assertFalse(config.metricsEnabled);
+        assertFalse(config.tracesEnabled);
+        assertEquals("/v1/logs", config.logsEndpoint);
+        assertEquals("/v1/metrics", config.metricsEndpoint);
+        assertEquals("/v1/traces", config.tracesEndpoint);
+        assertEquals("CUMULATIVE", config.metricsAggregationTemporality);
+        assertEquals(1.0, config.tracesSamplingRatio, 0.0001);
     }
 }

--- a/bundles/org.openhab.io.opentelemetry/src/test/java/org/openhab/io/opentelemetry/internal/OpenTelemetryServiceTest.java
+++ b/bundles/org.openhab.io.opentelemetry/src/test/java/org/openhab/io/opentelemetry/internal/OpenTelemetryServiceTest.java
@@ -23,6 +23,8 @@ import org.openhab.core.id.InstanceUUID;
 
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.Tags;
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.sdk.resources.Resource;
 
 /**
@@ -220,6 +222,17 @@ public class OpenTelemetryServiceTest {
         assertEquals(0.0, OpenTelemetryService.clampSamplingRatio(-0.5), 0.0001);
         assertEquals(1.0, OpenTelemetryService.clampSamplingRatio(1.5), 0.0001);
         assertEquals(0.5, OpenTelemetryService.clampSamplingRatio(0.5), 0.0001);
+    }
+
+    @Test
+    public void testIsGlobalOpenTelemetrySetReflectsGlobalState() {
+        assertFalse(OpenTelemetryService.isGlobalOpenTelemetrySet());
+        GlobalOpenTelemetry.set(OpenTelemetry.noop());
+        try {
+            assertTrue(OpenTelemetryService.isGlobalOpenTelemetrySet());
+        } finally {
+            GlobalOpenTelemetry.resetForTest();
+        }
     }
 
     @Test

--- a/bundles/org.openhab.io.opentelemetry/src/test/java/org/openhab/io/opentelemetry/internal/OpenTelemetryServiceTest.java
+++ b/bundles/org.openhab.io.opentelemetry/src/test/java/org/openhab/io/opentelemetry/internal/OpenTelemetryServiceTest.java
@@ -19,6 +19,10 @@ import java.util.Map;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.junit.jupiter.api.Test;
 
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.Tags;
+import io.opentelemetry.sdk.resources.Resource;
+
 /**
  * The {@link OpenTelemetryServiceTest} class contains tests for header parsing,
  * URL resolution, meter filtering, and service attribute consistency.
@@ -167,30 +171,27 @@ public class OpenTelemetryServiceTest {
         assertThrows(IllegalArgumentException.class, () -> config.getTracesURL());
     }
 
-    @Test
-    public void testMeterNameFilterAcceptsOpenHabPrefixes() {
-        // openHAB-specific meters
-        assertTrue(OpenTelemetryService.isAllowedMeterName("openhab.thing.count"));
-        assertTrue(OpenTelemetryService.isAllowedMeterName("openhab.item.state.changed"));
-        assertTrue(OpenTelemetryService.isAllowedMeterName("openhab.rule.execution.time"));
-
-        // Standard JVM and process metrics (openHAB process telemetry)
-        assertTrue(OpenTelemetryService.isAllowedMeterName("jvm.memory.used"));
-        assertTrue(OpenTelemetryService.isAllowedMeterName("jvm.gc.pause"));
-        assertTrue(OpenTelemetryService.isAllowedMeterName("process.cpu.usage"));
-        assertTrue(OpenTelemetryService.isAllowedMeterName("system.cpu.usage"));
-        assertTrue(OpenTelemetryService.isAllowedMeterName("executor.pool.size"));
-        assertTrue(OpenTelemetryService.isAllowedMeterName("logback.events"));
-        assertTrue(OpenTelemetryService.isAllowedMeterName("http.server.requests"));
+    private static Meter.Id meterId(String name, Tags tags) {
+        return new Meter.Id(name, tags, null, null, Meter.Type.GAUGE);
     }
 
     @Test
-    public void testMeterNameFilterDeniesNonOpenHabMeters() {
-        assertFalse(OpenTelemetryService.isAllowedMeterName("kafka.consumer.records"));
-        assertFalse(OpenTelemetryService.isAllowedMeterName("db.pool.active"));
-        assertFalse(OpenTelemetryService.isAllowedMeterName("host.disk.usage"));
-        assertFalse(OpenTelemetryService.isAllowedMeterName("custom.addon.metric"));
-        assertFalse(OpenTelemetryService.isAllowedMeterName(""));
+    public void testCoreMetricTagFilterAcceptsTaggedMeters() {
+        Tags coreTag = Tags.of(OpenTelemetryService.CORE_METRIC_TAG_KEY, OpenTelemetryService.CORE_METRIC_TAG_VALUE);
+        assertTrue(OpenTelemetryService.isCoreMeter(meterId("openhab.thing.count", coreTag)));
+        assertTrue(OpenTelemetryService.isCoreMeter(meterId("jvm.memory.used", coreTag)));
+        assertTrue(OpenTelemetryService.isCoreMeter(meterId("process.cpu.usage", coreTag)));
+        assertTrue(OpenTelemetryService.isCoreMeter(meterId("system.cpu.usage", coreTag)));
+        assertTrue(OpenTelemetryService.isCoreMeter(meterId("executor.pool.size", coreTag)));
+    }
+
+    @Test
+    public void testCoreMetricTagFilterDeniesMetersByNameAlone() {
+        // A third-party meter using an openHAB-style prefix must still be denied if untagged
+        assertFalse(OpenTelemetryService.isCoreMeter(meterId("executor.pool.size", Tags.empty())));
+        assertFalse(OpenTelemetryService.isCoreMeter(meterId("jvm.memory.used", Tags.empty())));
+        assertFalse(OpenTelemetryService.isCoreMeter(meterId("kafka.consumer.records", Tags.empty())));
+        assertFalse(OpenTelemetryService.isCoreMeter(meterId("", Tags.empty())));
     }
 
     @Test
@@ -220,6 +221,17 @@ public class OpenTelemetryServiceTest {
         assertEquals(0.0, OpenTelemetryService.clampSamplingRatio(-0.5), 0.0001);
         assertEquals(1.0, OpenTelemetryService.clampSamplingRatio(1.5), 0.0001);
         assertEquals(0.5, OpenTelemetryService.clampSamplingRatio(0.5), 0.0001);
+    }
+
+    @Test
+    public void testInvalidTracesSchemeReturnsNull() {
+        // setEndpoint() in OtlpHttpSpanExporter rejects non-http(s) schemes;
+        // the method must return null rather than propagating an IllegalArgumentException
+        OpenTelemetryConfiguration config = new OpenTelemetryConfiguration();
+        config.tracesEnabled = true;
+        config.otlpURL = "ftp://host";
+        config.tracesEndpoint = "/v1/traces";
+        assertNull(new OpenTelemetryService().createSdkTracerProvider(config, Resource.empty()));
     }
 
     @Test

--- a/bundles/org.openhab.io.opentelemetry/src/test/java/org/openhab/io/opentelemetry/internal/OpenTelemetryServiceTest.java
+++ b/bundles/org.openhab.io.opentelemetry/src/test/java/org/openhab/io/opentelemetry/internal/OpenTelemetryServiceTest.java
@@ -14,10 +14,12 @@ package org.openhab.io.opentelemetry.internal;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.util.Collections;
 import java.util.Map;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.junit.jupiter.api.Test;
+import org.openhab.core.id.InstanceUUID;
 
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.Tags;
@@ -195,12 +197,9 @@ public class OpenTelemetryServiceTest {
     }
 
     @Test
-    public void testServiceInstanceIdIsStable() {
-        // Same static ID across multiple accesses
-        String id1 = OpenTelemetryService.SERVICE_INSTANCE_ID;
-        String id2 = OpenTelemetryService.SERVICE_INSTANCE_ID;
-        assertEquals(id1, id2);
-        assertFalse(id1.isBlank());
+    public void testServiceInstanceIdUsesOpenHabInstanceUuid() {
+        // Must delegate to core's persistent InstanceUUID, not a locally generated value
+        assertEquals(InstanceUUID.get(), OpenTelemetryService.SERVICE_INSTANCE_ID);
     }
 
     @Test
@@ -231,7 +230,8 @@ public class OpenTelemetryServiceTest {
         config.tracesEnabled = true;
         config.otlpURL = "ftp://host";
         config.tracesEndpoint = "/v1/traces";
-        assertNull(new OpenTelemetryService().createSdkTracerProvider(config, Resource.empty()));
+        assertNull(
+                new OpenTelemetryService().createSdkTracerProvider(config, Resource.empty(), Collections.emptyMap()));
     }
 
     @Test

--- a/bundles/org.openhab.io.opentelemetry/src/test/java/org/openhab/io/opentelemetry/internal/OpenTelemetryServiceTest.java
+++ b/bundles/org.openhab.io.opentelemetry/src/test/java/org/openhab/io/opentelemetry/internal/OpenTelemetryServiceTest.java
@@ -215,14 +215,11 @@ public class OpenTelemetryServiceTest {
 
     @Test
     public void testTracesSamplingRatioClampHandlesNaN() {
-        // NaN bypasses Math.min/max — must not silently drop all spans
-        double nan = Double.NaN;
-        double result = Double.isNaN(nan) ? 1.0 : Math.max(0.0, Math.min(1.0, nan));
-        assertEquals(1.0, result, 0.0001, "NaN sampling ratio must fall back to 1.0 (sample all)");
-
-        // Negative and above-1 should be clamped
-        assertEquals(0.0, Math.max(0.0, Math.min(1.0, -0.5)), 0.0001);
-        assertEquals(1.0, Math.max(0.0, Math.min(1.0, 1.5)), 0.0001);
+        assertEquals(1.0, OpenTelemetryService.clampSamplingRatio(Double.NaN), 0.0001,
+                "NaN sampling ratio must fall back to 1.0 (sample all)");
+        assertEquals(0.0, OpenTelemetryService.clampSamplingRatio(-0.5), 0.0001);
+        assertEquals(1.0, OpenTelemetryService.clampSamplingRatio(1.5), 0.0001);
+        assertEquals(0.5, OpenTelemetryService.clampSamplingRatio(0.5), 0.0001);
     }
 
     @Test


### PR DESCRIPTION
# Description

This is a follow-up to #21127 (initial logs-only contribution), extending the OpenTelemetry service with a full three-signal OTLP/HTTP pipeline - logs (already in #21127), **metrics**, and **traces**.

## Metrics

A Micrometer `OtlpMeterRegistry` (Micrometer 1.16.3) is attached to openHAB's `CompositeMeterRegistry` via `MeterRegistryProvider`. A `MeterFilter` scopes export to openHAB-own meters (`openhab.*`, `jvm.*`, `executor.*`, `process.*`, `system.*`, `logback.*`, `http.*`) to avoid leaking unrelated add-on metrics.

Configuration: `metricsEnabled`, `metricsEndpoint`, `metricsInterval` (ISO-8601 duration), and `metricsAggregationTemporality` (`CUMULATIVE` / `DELTA` - required for some backends such as Dynatrace).

## Traces (event-bus spans)

A `SdkTracerProvider` with `BatchSpanProcessor` and `OtlpHttpSpanExporter` is wired to an `OpenTelemetryEventListener` that subscribes to `ALL_EVENT_TYPES` on the openHAB event bus. Each event produces a flat root span (`event.type`, `event.topic`, `event.source` attributes). Spans are root-level by design - the event bus is fire-and-forget with no propagated call context.

When an OTel Java agent is detected at JVM startup the bundle reuses `GlobalOpenTelemetry` instead of starting a competing SDK instance.

Configuration: `tracesEnabled`, `tracesEndpoint`, `tracesSamplingRatio` (0.0-1.0, clamped, NaN-safe).

## Lifecycle hardening

- Bounded `forceFlush` (3 s) before `sdk.close()` on deactivate/reconfigure
- Header injection guard in `parseOtlpHeaders()` - rejects `\n`, `\r`, `\0`
- Own-bundle and OTel-exporter log entries suppressed in `OpenTelemetryLogListener` to prevent export-failure feedback loops
- Cleartext `http://` warning on startup
- Non-positive `metricsInterval` clamped to default (PT60S); NaN `tracesSamplingRatio` falls back to 1.0

## OSGi dependency notes

`micrometer-registry-otlp` imports `io.opentelemetry.proto.*`. We embed `opentelemetry-proto:1.8.0-alpha` and `protobuf-java:4.32.0` privately, and export `io.opentelemetry.proto.*` with `-noimport:=true` so the micrometer bundle can wire to them. All other OTel SDK classes stay private. The resulting JAR is self-contained.

## Shared resource / signal correlation

All three signals share a single `otlpURL` / `otlpHeaders` and a common OTel `Resource` (`service.name=openHAB`, `service.namespace`, `service.version`, stable `service.instance.id`, `host.name`, `os.*`) so logs, metrics, and traces correlate to a single service entity in the observability backend.

## Tests

31 unit tests added covering: header parsing and injection guard, URL joining (including vendor base-path regression), meter-name filter, log severity mapping, own-logger suppression, event attribute mapping, null/blank `event.source` omission, sampling-ratio clamping, and secret masking in `toString()`.

# Testing

Gate build: **BUILD SUCCESS - 31/31 tests, 0 failures**.

The three signals have been verified end-to-end against a Dynatrace OTLP ingest with both an OTel Collector and direct-to-backend configurations.