### PR TITLE
[androiddebugbridge] Tolerate transient ADB stream rejects in standby

### DIFF
--- a/bundles/org.openhab.binding.androiddebugbridge/src/main/java/org/openhab/binding/androiddebugbridge/internal/AndroidDebugBridgeDevice.java
+++ b/bundles/org.openhab.binding.androiddebugbridge/src/main/java/org/openhab/binding/androiddebugbridge/internal/AndroidDebugBridgeDevice.java
@@ -33,6 +33,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -752,6 +753,7 @@ public class AndroidDebugBridgeDevice {
         if (adb == null) {
             throw new AndroidDebugBridgeDeviceException("Device not connected");
         }
+        AtomicReference<@Nullable Exception> streamError = new AtomicReference<>();
         try {
             commandLock.lock();
             var commandFuture = scheduler.submit(() -> {
@@ -764,13 +766,23 @@ public class AndroidDebugBridgeDevice {
                     } while (!stream.isClosed());
                 } catch (IllegalStateException | IOException e) {
                     if (!"Stream closed".equals(e.getMessage())) {
-                        throw e;
+                        // Capture rather than throw: letting it escape the scheduled task makes openHAB's
+                        // WrappedScheduledExecutorService log a noisy "Scheduled runnable ended with an
+                        // exception" stacktrace for an expected condition (a standby adbd rejecting the
+                        // shell stream). It is re-surfaced as a typed exception on the calling thread below.
+                        streamError.set(e);
                     }
                 }
                 return byteArrayOutputStream.toString(StandardCharsets.US_ASCII);
             });
             this.commandFuture = commandFuture;
-            return commandFuture.get(commandTimeout, TimeUnit.SECONDS);
+            String result = commandFuture.get(commandTimeout, TimeUnit.SECONDS);
+            Exception error = streamError.get();
+            if (error != null) {
+                throw new AndroidDebugBridgeDeviceException(
+                        "Error opening adb shell stream " + ip + ":" + port + ": " + error.getMessage());
+            }
+            return result;
         } finally {
             var commandFuture = this.commandFuture;
             if (commandFuture != null) {

--- a/bundles/org.openhab.binding.androiddebugbridge/src/main/java/org/openhab/binding/androiddebugbridge/internal/AndroidDebugBridgeHandler.java
+++ b/bundles/org.openhab.binding.androiddebugbridge/src/main/java/org/openhab/binding/androiddebugbridge/internal/AndroidDebugBridgeHandler.java
@@ -66,6 +66,10 @@ public class AndroidDebugBridgeHandler extends BaseThingHandler {
     private static final String SHUTDOWN_REBOOT = "REBOOT";
     private static final Gson GSON = new Gson();
     private static final Pattern RECORD_NAME_PATTERN = Pattern.compile("^[A-Za-z0-9_]*$");
+    // Consecutive failed connection-check cycles tolerated before marking the thing OFFLINE. Absorbs
+    // transient ADB stream rejections from devices whose adbd half-freezes in standby (they reject a
+    // shell stream instead of timing out), which would otherwise flap the thing ONLINE/OFFLINE each cycle.
+    private static final int OFFLINE_AFTER_FAILURES = 3;
     private final Logger logger = LoggerFactory.getLogger(AndroidDebugBridgeHandler.class);
 
     private final AndroidDebugBridgeDynamicCommandDescriptionProvider commandDescriptionProvider;
@@ -76,6 +80,7 @@ public class AndroidDebugBridgeHandler extends BaseThingHandler {
     private AndroidDebugBridgeMediaStatePackageConfig @Nullable [] packageConfigs = null;
     private boolean deviceAwake = false;
     private int consecutiveTimeouts = 0;
+    private int connectionFailures = 0;
 
     public AndroidDebugBridgeHandler(Thing thing,
             AndroidDebugBridgeDynamicCommandDescriptionProvider commandDescriptionProvider) {
@@ -381,8 +386,8 @@ public class AndroidDebugBridgeHandler extends BaseThingHandler {
                     // refresh properties only on state changes
                     refreshProperties();
                 }
-                updateStatus(ThingStatus.ONLINE);
                 refreshStatus();
+                reportOnline();
             } else {
                 try {
                     adbConnection.connect();
@@ -390,20 +395,41 @@ public class AndroidDebugBridgeHandler extends BaseThingHandler {
                     logger.debug("Error connecting to device; [{}]: {}", e.getClass().getCanonicalName(),
                             e.getMessage());
                     adbConnection.disconnect();
-                    updateStatus(ThingStatus.OFFLINE);
+                    reportOffline(ThingStatusDetail.COMMUNICATION_ERROR, e.getMessage());
                     return;
                 }
                 if (adbConnection.isConnected()) {
-                    updateStatus(ThingStatus.ONLINE);
                     refreshProperties();
                     refreshStatus();
+                    reportOnline();
                 }
             }
         } catch (InterruptedException ignored) {
         } catch (AndroidDebugBridgeDeviceException | AndroidDebugBridgeDeviceReadException | ExecutionException e) {
             logger.debug("Connection checker error: {}", e.getMessage());
             adbConnection.disconnect();
-            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, e.getMessage());
+            reportOffline(ThingStatusDetail.COMMUNICATION_ERROR, e.getMessage());
+        }
+    }
+
+    /** Mark the thing ONLINE and reset the transient-failure counter after a fully successful cycle. */
+    private void reportOnline() {
+        connectionFailures = 0;
+        updateStatus(ThingStatus.ONLINE);
+    }
+
+    /**
+     * Mark the thing OFFLINE only once {@link #OFFLINE_AFTER_FAILURES} consecutive check cycles have
+     * failed. A single transient ADB stream rejection (common on devices whose adbd half-freezes in
+     * standby and rejects the shell stream rather than timing out) is ridden through with the previous
+     * status retained, instead of flapping the thing ONLINE/OFFLINE every cycle.
+     */
+    private void reportOffline(ThingStatusDetail statusDetail, @Nullable String description) {
+        if (++connectionFailures >= OFFLINE_AFTER_FAILURES) {
+            updateStatus(ThingStatus.OFFLINE, statusDetail, description);
+        } else {
+            logger.debug("{} - transient ADB failure {}/{}, keeping status {}", config.ip, connectionFailures,
+                    OFFLINE_AFTER_FAILURES, getThing().getStatus());
         }
     }
 
@@ -466,35 +492,35 @@ public class AndroidDebugBridgeHandler extends BaseThingHandler {
         } catch (AndroidDebugBridgeDeviceReadException e) {
             logger.warn("Unable to refresh media volume: {}", e.getMessage());
         } catch (TimeoutException e) {
-            logger.warn("Unable to refresh media volume: Timeout");
+            logger.debug("Unable to refresh media volume: Timeout");
         }
         try {
             handleCommandInternal(new ChannelUID(this.thing.getUID(), MEDIA_CONTROL_CHANNEL), RefreshType.REFRESH);
         } catch (AndroidDebugBridgeDeviceReadException e) {
             logger.warn("Unable to refresh play status: {}", e.getMessage());
         } catch (TimeoutException e) {
-            logger.warn("Unable to refresh play status: Timeout");
+            logger.debug("Unable to refresh play status: Timeout");
         }
         try {
             handleCommandInternal(new ChannelUID(this.thing.getUID(), CURRENT_PACKAGE_CHANNEL), RefreshType.REFRESH);
         } catch (AndroidDebugBridgeDeviceReadException e) {
             logger.warn("Unable to refresh current package: {}", e.getMessage());
         } catch (TimeoutException e) {
-            logger.warn("Unable to refresh current package: Timeout");
+            logger.debug("Unable to refresh current package: Timeout");
         }
         try {
             handleCommandInternal(new ChannelUID(this.thing.getUID(), WAKE_LOCK_CHANNEL), RefreshType.REFRESH);
         } catch (AndroidDebugBridgeDeviceReadException e) {
             logger.warn("Unable to refresh wake lock: {}", e.getMessage());
         } catch (TimeoutException e) {
-            logger.warn("Unable to refresh wake lock: Timeout");
+            logger.debug("Unable to refresh wake lock: Timeout");
         }
         try {
             handleCommandInternal(new ChannelUID(this.thing.getUID(), SCREEN_STATE_CHANNEL), RefreshType.REFRESH);
         } catch (AndroidDebugBridgeDeviceReadException e) {
             logger.warn("Unable to refresh screen state: {}", e.getMessage());
         } catch (TimeoutException e) {
-            logger.warn("Unable to refresh screen state: Timeout");
+            logger.debug("Unable to refresh screen state: Timeout");
         }
     }
 


### PR DESCRIPTION
## Problem

Some Android TV devices half-freeze their `adbd` in standby: the TCP connection and ADB auth still succeed, but opening a shell stream is rejected with `java.net.ConnectException: Stream open actively rejected by remote peer`. On such a device (seen on a Vestel panel) the thing flaps ONLINE↔OFFLINE on every poll while it sleeps, and each rejection also logs a `Scheduled runnable ended with an exception` stack trace.

`checkConnection()` already tolerates `TimeoutException` via `maxADBTimeouts`, but a single connection/stream error goes straight to `COMMUNICATION_ERROR` → OFFLINE, then reconnects on the next cycle → the flap.

## Changes

- **Grace before OFFLINE** — `checkConnection()` now marks the thing OFFLINE only after `OFFLINE_AFTER_FAILURES` (3) consecutive failed cycles. A single transient rejection is ridden through with the previous status retained, and ONLINE is reported only after a fully successful refresh. A genuinely unreachable device still goes OFFLINE after the grace window.
- **No executor stack-trace spam** — `runAdbShell()` no longer lets the stream-open exception escape the scheduled task (which triggered `WrappedScheduledExecutorService`'s "Scheduled runnable ended with an exception"). It captures the error and re-throws it on the calling thread, which already handles it.
- Lowered the five `Unable to refresh <channel>: Timeout` refresh warnings to `debug`, since those timeouts are expected while a device sleeps.

Robust devices are unaffected — they never fail consecutively. Verified live on the affected panel: rejections are now absorbed (`transient ADB failure 1/3, keeping status ONLINE`), zero ONLINE/OFFLINE flaps, and no executor stack traces.
