### PR TITLE
[remehaheating] Fix token refresh failing after ~1 hour

### DIFF
--- a/bundles/org.openhab.binding.remehaheating/src/main/java/org/openhab/binding/remehaheating/internal/RemehaHeatingHandler.java
+++ b/bundles/org.openhab.binding.remehaheating/src/main/java/org/openhab/binding/remehaheating/internal/RemehaHeatingHandler.java
@@ -42,10 +42,10 @@ import com.google.gson.JsonObject;
 
 /**
  * The {@link RemehaHeatingHandler} handles communication with Remeha Home heating systems.
- * 
+ *
  * This handler manages the connection to the Remeha API, authenticates using OAuth2 PKCE flow,
  * and provides access to heating system data including temperatures, water pressure, and DHW controls.
- * 
+ *
  * Supported features:
  * - Room and outdoor temperature monitoring
  * - Target temperature control
@@ -63,6 +63,8 @@ public class RemehaHeatingHandler extends BaseThingHandler {
     private final HttpClient httpClient;
     private @Nullable RemehaApiClient apiClient;
     private @Nullable ScheduledFuture<?> refreshJob;
+    private @Nullable String cachedClimateZoneId;
+    private @Nullable String cachedHotWaterZoneId;
 
     public RemehaHeatingHandler(Thing thing, HttpClient httpClient) {
         super(thing);
@@ -71,11 +73,11 @@ public class RemehaHeatingHandler extends BaseThingHandler {
 
     /**
      * Handles commands sent to the binding channels.
-     * 
+     *
      * Supported commands:
      * - RefreshType: Updates all channel states from API
-     * - DecimalType on targetTemperature: Sets new target room temperature
-     * - StringType on dhwMode: Changes DHW mode (anti-frost/schedule/continuous-comfort)
+     * - QuantityType/DecimalType on target-temperature: Sets new target room temperature
+     * - StringType on dhw-mode: Changes DHW mode (anti-frost/schedule/continuous-comfort)
      */
     @Override
     public void handleCommand(ChannelUID channelUID, Command command) {
@@ -143,12 +145,14 @@ public class RemehaHeatingHandler extends BaseThingHandler {
 
     /**
      * Cleans up resources when the handler is disposed.
-     * Stops the refresh job.
+     * Stops the refresh job and the HTTP client.
      */
     @Override
     public void dispose() {
         stopRefreshJob();
         apiClient = null;
+        cachedClimateZoneId = null;
+        cachedHotWaterZoneId = null;
         try {
             if (httpClient.isStarted()) {
                 httpClient.stop();
@@ -161,7 +165,7 @@ public class RemehaHeatingHandler extends BaseThingHandler {
 
     /**
      * Starts the periodic data refresh job.
-     * 
+     *
      * @param intervalSeconds Refresh interval in seconds
      */
     private void startRefreshJob(int intervalSeconds) {
@@ -181,13 +185,9 @@ public class RemehaHeatingHandler extends BaseThingHandler {
 
     /**
      * Fetches latest data from Remeha API and updates all channel states.
-     * 
-     * Updates the following channels:
-     * - Room and outdoor temperatures
-     * - Target temperature
-     * - DHW temperature, target, mode, and status
-     * - Water pressure and pressure OK status
-     * - System error status
+     *
+     * If the dashboard request fails, the handler attempts re-authentication before
+     * setting the thing status to OFFLINE.
      */
     private void updateData() {
         RemehaApiClient client = apiClient;
@@ -204,48 +204,7 @@ public class RemehaHeatingHandler extends BaseThingHandler {
             }
 
             updateStatus(ThingStatus.ONLINE);
-
-            JsonArray appliances = dashboard.getAsJsonArray("appliances");
-            if (appliances != null && appliances.size() > 0) {
-                JsonObject appliance = appliances.get(0).getAsJsonObject();
-
-                // Update channels with proper units
-                double pressure = appliance.get("waterPressure").getAsDouble();
-                logger.debug("Updating water pressure: {} bar", pressure);
-                updateState(CHANNEL_WATER_PRESSURE, new QuantityType<>(pressure, Units.BAR));
-                updateState(CHANNEL_STATUS, new StringType(appliance.get("errorStatus").getAsString()));
-                updateState(CHANNEL_WATER_PRESSURE_OK, OnOffType.from(appliance.get("waterPressureOK").getAsBoolean()));
-
-                JsonObject outdoorInfo = appliance.getAsJsonObject("outdoorTemperatureInformation");
-                if (outdoorInfo != null) {
-                    double temp = outdoorInfo.get("internetOutdoorTemperature").getAsDouble();
-                    updateState(CHANNEL_OUTDOOR_TEMPERATURE, new QuantityType<>(temp, SIUnits.CELSIUS));
-                }
-
-                // Climate zones
-                JsonArray climateZones = appliance.getAsJsonArray("climateZones");
-                if (climateZones != null && climateZones.size() > 0) {
-                    JsonObject zone = climateZones.get(0).getAsJsonObject();
-                    double roomTemp = zone.get("roomTemperature").getAsDouble();
-                    double targetTemp = zone.get("setPoint").getAsDouble();
-                    updateState(CHANNEL_ROOM_TEMPERATURE, new QuantityType<>(roomTemp, SIUnits.CELSIUS));
-                    updateState(CHANNEL_TARGET_TEMPERATURE, new QuantityType<>(targetTemp, SIUnits.CELSIUS));
-                }
-
-                // Hot water zones
-                JsonArray hotWaterZones = appliance.getAsJsonArray("hotWaterZones");
-                if (hotWaterZones != null && hotWaterZones.size() > 0) {
-                    JsonObject zone = hotWaterZones.get(0).getAsJsonObject();
-                    double dhwTemp = zone.get("dhwTemperature").getAsDouble();
-                    double dhwTarget = zone.get("targetSetpoint").getAsDouble();
-                    String dhwMode = zone.get("dhwZoneMode").getAsString();
-                    String dhwStatus = zone.get("dhwStatus").getAsString();
-                    updateState(CHANNEL_DHW_TEMPERATURE, new QuantityType<>(dhwTemp, SIUnits.CELSIUS));
-                    updateState(CHANNEL_DHW_TARGET, new QuantityType<>(dhwTarget, SIUnits.CELSIUS));
-                    updateState(CHANNEL_DHW_MODE, new StringType(dhwMode));
-                    updateState(CHANNEL_DHW_STATUS, new StringType(dhwStatus));
-                }
-            }
+            updateChannelsFromDashboard(dashboard);
         } catch (IllegalStateException | NullPointerException e) {
             logger.debug("Error updating data", e);
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
@@ -254,96 +213,121 @@ public class RemehaHeatingHandler extends BaseThingHandler {
     }
 
     /**
+     * Updates all channel states from the dashboard JSON data and caches zone IDs.
+     *
+     * @param dashboard the dashboard JSON response
+     */
+    private void updateChannelsFromDashboard(JsonObject dashboard) {
+        JsonArray appliances = dashboard.getAsJsonArray("appliances");
+        if (appliances == null || appliances.isEmpty()) {
+            return;
+        }
+
+        JsonObject appliance = appliances.get(0).getAsJsonObject();
+
+        double pressure = appliance.get("waterPressure").getAsDouble();
+        updateState(CHANNEL_WATER_PRESSURE, new QuantityType<>(pressure, Units.BAR));
+        updateState(CHANNEL_STATUS, new StringType(appliance.get("errorStatus").getAsString()));
+        updateState(CHANNEL_WATER_PRESSURE_OK, OnOffType.from(appliance.get("waterPressureOK").getAsBoolean()));
+
+        JsonObject outdoorInfo = appliance.getAsJsonObject("outdoorTemperatureInformation");
+        if (outdoorInfo != null && outdoorInfo.has("internetOutdoorTemperature")) {
+            double temp = outdoorInfo.get("internetOutdoorTemperature").getAsDouble();
+            updateState(CHANNEL_OUTDOOR_TEMPERATURE, new QuantityType<>(temp, SIUnits.CELSIUS));
+        }
+
+        // Climate zones
+        JsonArray climateZones = appliance.getAsJsonArray("climateZones");
+        if (climateZones != null && !climateZones.isEmpty()) {
+            JsonObject zone = climateZones.get(0).getAsJsonObject();
+            double roomTemp = zone.get("roomTemperature").getAsDouble();
+            double targetTemp = zone.get("setPoint").getAsDouble();
+            updateState(CHANNEL_ROOM_TEMPERATURE, new QuantityType<>(roomTemp, SIUnits.CELSIUS));
+            updateState(CHANNEL_TARGET_TEMPERATURE, new QuantityType<>(targetTemp, SIUnits.CELSIUS));
+
+            // Cache climate zone ID
+            if (zone.has("climateZoneId")) {
+                cachedClimateZoneId = zone.get("climateZoneId").getAsString();
+            }
+        }
+
+        // Hot water zones
+        JsonArray hotWaterZones = appliance.getAsJsonArray("hotWaterZones");
+        if (hotWaterZones != null && !hotWaterZones.isEmpty()) {
+            JsonObject zone = hotWaterZones.get(0).getAsJsonObject();
+            double dhwTemp = zone.get("dhwTemperature").getAsDouble();
+            double dhwTarget = zone.get("targetSetpoint").getAsDouble();
+            String dhwMode = zone.get("dhwZoneMode").getAsString();
+            String dhwStatus = zone.get("dhwStatus").getAsString();
+            updateState(CHANNEL_DHW_TEMPERATURE, new QuantityType<>(dhwTemp, SIUnits.CELSIUS));
+            updateState(CHANNEL_DHW_TARGET, new QuantityType<>(dhwTarget, SIUnits.CELSIUS));
+            updateState(CHANNEL_DHW_MODE, new StringType(dhwMode));
+            updateState(CHANNEL_DHW_STATUS, new StringType(dhwStatus));
+
+            // Cache hot water zone ID
+            if (zone.has("hotWaterZoneId")) {
+                cachedHotWaterZoneId = zone.get("hotWaterZoneId").getAsString();
+            }
+        }
+    }
+
+    /**
      * Sets the target room temperature via API.
-     * 
+     *
      * @param temperature Target temperature in Celsius
      */
     private void setTargetTemperature(double temperature) {
         RemehaApiClient client = apiClient;
-        if (client != null) {
-            String climateZoneId = getClimateZoneId();
-            if (climateZoneId != null) {
-                if (!client.setTemperature(climateZoneId, temperature)) {
-                    logger.debug("Failed to set target temperature");
-                }
+        if (client == null) {
+            return;
+        }
+
+        String climateZoneId = cachedClimateZoneId;
+        if (climateZoneId == null) {
+            logger.debug("Climate zone ID not cached, fetching from dashboard");
+            JsonObject dashboard = client.getDashboard();
+            if (dashboard != null) {
+                updateChannelsFromDashboard(dashboard);
+                climateZoneId = cachedClimateZoneId;
             }
+        }
+        if (climateZoneId == null) {
+            logger.debug("Climate zone ID not available, cannot set temperature");
+            return;
+        }
+
+        if (!client.setTemperature(climateZoneId, temperature)) {
+            logger.debug("Failed to set target temperature to {}", temperature);
         }
     }
 
     /**
      * Sets the DHW (Domestic Hot Water) mode via API.
-     * 
+     *
      * @param mode DHW mode: "anti-frost", "schedule", or "continuous-comfort"
      */
     private void setDhwMode(String mode) {
         RemehaApiClient client = apiClient;
-        if (client != null) {
-            String hotWaterZoneId = getHotWaterZoneId();
-            if (hotWaterZoneId != null) {
-                if (!client.setDhwMode(hotWaterZoneId, mode)) {
-                    logger.debug("Failed to set DHW mode");
-                }
-            }
-        }
-    }
-
-    /**
-     * Retrieves the climate zone ID from the dashboard data.
-     * Used for temperature control API calls.
-     * 
-     * @return Climate zone ID or null if not available
-     */
-    private @Nullable String getClimateZoneId() {
-        RemehaApiClient client = apiClient;
         if (client == null) {
-            return null;
+            return;
         }
 
-        try {
+        String hotWaterZoneId = cachedHotWaterZoneId;
+        if (hotWaterZoneId == null) {
+            logger.debug("Hot water zone ID not cached, fetching from dashboard");
             JsonObject dashboard = client.getDashboard();
             if (dashboard != null) {
-                JsonArray appliances = dashboard.getAsJsonArray("appliances");
-                if (appliances != null && appliances.size() > 0) {
-                    JsonObject appliance = appliances.get(0).getAsJsonObject();
-                    JsonArray climateZones = appliance.getAsJsonArray("climateZones");
-                    if (climateZones != null && climateZones.size() > 0) {
-                        return climateZones.get(0).getAsJsonObject().get("climateZoneId").getAsString();
-                    }
-                }
+                updateChannelsFromDashboard(dashboard);
+                hotWaterZoneId = cachedHotWaterZoneId;
             }
-        } catch (IllegalStateException | NullPointerException e) {
-            logger.debug("Error getting climate zone ID: {}", e.getMessage());
         }
-        return null;
-    }
-
-    /**
-     * Retrieves the hot water zone ID from the dashboard data.
-     * Used for DHW control API calls.
-     * 
-     * @return Hot water zone ID or null if not available
-     */
-    private @Nullable String getHotWaterZoneId() {
-        RemehaApiClient client = apiClient;
-        if (client == null) {
-            return null;
+        if (hotWaterZoneId == null) {
+            logger.debug("Hot water zone ID not available, cannot set DHW mode");
+            return;
         }
 
-        try {
-            JsonObject dashboard = client.getDashboard();
-            if (dashboard != null) {
-                JsonArray appliances = dashboard.getAsJsonArray("appliances");
-                if (appliances != null && appliances.size() > 0) {
-                    JsonObject appliance = appliances.get(0).getAsJsonObject();
-                    JsonArray hotWaterZones = appliance.getAsJsonArray("hotWaterZones");
-                    if (hotWaterZones != null && hotWaterZones.size() > 0) {
-                        return hotWaterZones.get(0).getAsJsonObject().get("hotWaterZoneId").getAsString();
-                    }
-                }
-            }
-        } catch (IllegalStateException | NullPointerException e) {
-            logger.debug("Error getting hot water zone ID: {}", e.getMessage());
+        if (!client.setDhwMode(hotWaterZoneId, mode)) {
+            logger.debug("Failed to set DHW mode to {}", mode);
         }
-        return null;
     }
 }

--- a/bundles/org.openhab.binding.remehaheating/src/main/java/org/openhab/binding/remehaheating/internal/RemehaHeatingHandlerFactory.java
+++ b/bundles/org.openhab.binding.remehaheating/src/main/java/org/openhab/binding/remehaheating/internal/RemehaHeatingHandlerFactory.java
@@ -19,6 +19,7 @@ import java.util.Set;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.WWWAuthenticationProtocolHandler;
 import org.openhab.core.io.net.http.HttpClientFactory;
 import org.openhab.core.thing.Thing;
 import org.openhab.core.thing.ThingTypeUID;
@@ -31,11 +32,11 @@ import org.osgi.service.component.annotations.Reference;
 
 /**
  * The {@link RemehaHeatingHandlerFactory} is responsible for creating things and thing handlers.
- * 
+ *
  * This factory creates handlers for supported Remeha heating system things.
  * It implements the OSGi component pattern and is automatically registered
  * as a ThingHandlerFactory service.
- * 
+ *
  * Currently supports:
  * - Remeha boiler things (THING_TYPE_BOILER)
  *
@@ -55,7 +56,7 @@ public class RemehaHeatingHandlerFactory extends BaseThingHandlerFactory {
 
     /**
      * Checks if this factory supports the given thing type.
-     * 
+     *
      * @param thingTypeUID The thing type UID to check
      * @return true if the thing type is supported, false otherwise
      */
@@ -66,7 +67,11 @@ public class RemehaHeatingHandlerFactory extends BaseThingHandlerFactory {
 
     /**
      * Creates a thing handler for the given thing.
-     * 
+     *
+     * A dedicated HttpClient is created per thing instance because the Remeha OAuth2 flow
+     * requires custom buffer sizes (16384 bytes) to handle large Azure B2C responses.
+     * The HttpClient lifecycle is managed by the handler's dispose method.
+     *
      * @param thing The thing for which to create a handler
      * @return A new handler instance or null if the thing type is not supported
      */
@@ -80,7 +85,18 @@ public class RemehaHeatingHandlerFactory extends BaseThingHandlerFactory {
             httpClient.setResponseBufferSize(16384);
             try {
                 httpClient.start();
+                // The Remeha API returns HTTP 401 without a WWW-Authenticate header, which violates
+                // RFC 7235. Jetty's WWWAuthenticationProtocolHandler throws an exception in this case.
+                // Removing it allows the 401 response to be handled normally by the API client.
+                if (httpClient.getProtocolHandlers() != null) {
+                    httpClient.getProtocolHandlers().remove(WWWAuthenticationProtocolHandler.NAME);
+                }
             } catch (Exception e) {
+                try {
+                    httpClient.stop();
+                } catch (Exception stopEx) {
+                    // ignore cleanup failure
+                }
                 throw new IllegalStateException("Failed to start HTTP client", e);
             }
             return new RemehaHeatingHandler(thing, httpClient);

--- a/bundles/org.openhab.binding.remehaheating/src/main/java/org/openhab/binding/remehaheating/internal/api/RemehaApiClient.java
+++ b/bundles/org.openhab.binding.remehaheating/src/main/java/org/openhab/binding/remehaheating/internal/api/RemehaApiClient.java
@@ -12,6 +12,7 @@
  */
 package org.openhab.binding.remehaheating.internal.api;
 
+import java.net.CookieStore;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
@@ -58,19 +59,28 @@ public class RemehaApiClient {
     private final HttpClient httpClient;
     private final Gson gson = new Gson();
     private @Nullable String accessToken;
+    private @Nullable String refreshToken;
+    private @Nullable String email;
+    private @Nullable String password;
     private String codeVerifier = "";
+    private long lastAuthFailureTime;
     private static final SecureRandom SECURE_RANDOM = new SecureRandom();
     private static final String API_BASE_URL = "https://api.bdrthermea.net/Mobile/api";
     private static final String SUBSCRIPTION_KEY = "df605c5470d846fc91e848b1cc653ddf";
+    private static final String CLIENT_ID = "6ce007c6-0628-419e-88f4-bee2e6418eec";
+    private static final String REDIRECT_URI = "com.b2c.remehaapp://login-callback";
+    private static final String TOKEN_ENDPOINT = "https://remehalogin.bdrthermea.net/bdrb2cprod.onmicrosoft.com/oauth2/v2.0/token?p=B2C_1A_RPSignUpSignInNewRoomV3.1";
     private static final long REQUEST_TIMEOUT_MS = 30000;
+    private static final long AUTH_RETRY_BACKOFF_MS = 300000; // 5 minutes
     private static final Pattern CSRF_PATTERN = Pattern.compile("x-ms-cpim-csrf=([^;]+)");
 
     /**
      * Creates a new RemehaApiClient with the provided HttpClient.
      *
      * Note: This client requires custom buffer sizes (16384 bytes) to handle large OAuth2 responses
-     * from Azure B2C authentication. The HttpClient should be created via HttpClientFactory.createHttpClient()
-     * with buffer sizes configured in the factory, not using the common HTTP client.
+     * from Azure B2C authentication. The HttpClient should be created via
+     * {@code HttpClientFactory.createHttpClient("remehaheating")} with buffer sizes configured
+     * in the handler factory, not using the common HTTP client.
      *
      * @param httpClient HttpClient instance with appropriate buffer sizes configured
      */
@@ -87,13 +97,24 @@ public class RemehaApiClient {
      * 3. Extracts CSRF token from response cookies
      * 4. Submits user credentials
      * 5. Retrieves authorization code from redirect
-     * 6. Exchanges authorization code for access token
+     * 6. Exchanges authorization code for access token and refresh token
+     *
+     * Credentials are stored internally to enable automatic re-authentication when the token expires.
      *
      * @param email Remeha Home account email
      * @param password Remeha Home account password
      * @return true if authentication successful, false otherwise
      */
     public boolean authenticate(String email, String password) {
+        this.email = email;
+        this.password = password;
+
+        // Clear cookies from any previous session to ensure a clean authentication flow
+        CookieStore cookieStore = httpClient.getCookieStore();
+        if (cookieStore != null) {
+            cookieStore.removeAll();
+        }
+
         try {
             codeVerifier = generateRandomString();
             String codeChallenge = generateCodeChallenge(codeVerifier);
@@ -134,6 +155,55 @@ public class RemehaApiClient {
     }
 
     /**
+     * Checks if the client is currently authenticated with a valid token.
+     *
+     * @return true if an access token is available
+     */
+    public boolean isAuthenticated() {
+        return accessToken != null;
+    }
+
+    /**
+     * Attempts to re-authenticate using stored credentials or refresh token.
+     *
+     * First tries to use the refresh token (faster, no full login flow needed).
+     * Falls back to full re-authentication with stored credentials if refresh fails.
+     *
+     * @return true if re-authentication successful, false otherwise
+     */
+    public boolean reAuthenticate() {
+        long now = System.currentTimeMillis();
+        if (now - lastAuthFailureTime < AUTH_RETRY_BACKOFF_MS) {
+            logger.debug("Skipping re-authentication, last failure was less than 5 minutes ago");
+            return false;
+        }
+
+        String currentRefreshToken = refreshToken;
+        if (currentRefreshToken != null) {
+            logger.debug("Attempting token refresh");
+            if (refreshAccessToken(currentRefreshToken)) {
+                return true;
+            }
+            logger.debug("Token refresh failed, attempting full re-authentication");
+        }
+
+        String storedEmail = email;
+        String storedPassword = password;
+        if (storedEmail != null && storedPassword != null) {
+            logger.debug("Attempting full re-authentication");
+            boolean success = authenticate(storedEmail, storedPassword);
+            if (!success) {
+                lastAuthFailureTime = System.currentTimeMillis();
+            }
+            return success;
+        }
+
+        logger.debug("No credentials available for re-authentication");
+        lastAuthFailureTime = System.currentTimeMillis();
+        return false;
+    }
+
+    /**
      * Retrieves the dashboard data containing all heating system information.
      *
      * The dashboard includes:
@@ -142,20 +212,29 @@ public class RemehaApiClient {
      * - Hot water zones (DHW temperature, mode, status)
      * - Outdoor temperature information
      *
+     * If no access token is available or the token has expired (HTTP 401), this method
+     * automatically attempts re-authentication and retries the request once.
+     *
      * @return Dashboard JSON object or null if request fails
      */
     public @Nullable JsonObject getDashboard() {
         if (accessToken == null) {
-            return null;
+            logger.debug("No access token available, attempting re-authentication");
+            if (!reAuthenticate()) {
+                return null;
+            }
         }
         try {
             ContentResponse response = httpClient.newRequest(API_BASE_URL + "/homes/dashboard").method(HttpMethod.GET)
                     .timeout(REQUEST_TIMEOUT_MS, TimeUnit.MILLISECONDS).header("Authorization", "Bearer " + accessToken)
                     .header("Ocp-Apim-Subscription-Key", SUBSCRIPTION_KEY).send();
             if (response.getStatus() == 401) {
-                logger.debug("Received 401 Unauthorized, token expired");
+                logger.debug("Received 401 Unauthorized, attempting re-authentication");
                 accessToken = null;
-                return null;
+                if (!reAuthenticate()) {
+                    return null;
+                }
+                return getDashboardInternal();
             }
             return gson.fromJson(response.getContentAsString(), JsonObject.class);
         } catch (InterruptedException e) {
@@ -163,7 +242,7 @@ public class RemehaApiClient {
             logger.debug("Dashboard request interrupted", e);
             return null;
         } catch (Exception e) {
-            logger.debug("Failed to get dashboard", e);
+            logger.warn("Failed to get dashboard: {} - {}", e.getClass().getSimpleName(), e.getMessage());
             return null;
         }
     }
@@ -177,7 +256,7 @@ public class RemehaApiClient {
      */
     public boolean setTemperature(String climateZoneId, double temperature) {
         return apiRequest("/climate-zones/" + climateZoneId + "/modes/manual",
-                "{\"roomTemperatureSetPoint\":" + temperature + "}");
+                "{\"roomTemperatureSetPoint\":\"" + temperature + "\"}");
     }
 
     /**
@@ -189,6 +268,87 @@ public class RemehaApiClient {
      */
     public boolean setDhwMode(String hotWaterZoneId, String mode) {
         return apiRequest("/hot-water-zones/" + hotWaterZoneId + "/modes/" + mode, null);
+    }
+
+    /**
+     * Internal dashboard request without 401 retry logic (to prevent recursion).
+     */
+    private @Nullable JsonObject getDashboardInternal() {
+        if (accessToken == null) {
+            return null;
+        }
+        try {
+            ContentResponse response = httpClient.newRequest(API_BASE_URL + "/homes/dashboard").method(HttpMethod.GET)
+                    .timeout(REQUEST_TIMEOUT_MS, TimeUnit.MILLISECONDS).header("Authorization", "Bearer " + accessToken)
+                    .header("Ocp-Apim-Subscription-Key", SUBSCRIPTION_KEY).send();
+            if (response.getStatus() == 200) {
+                return gson.fromJson(response.getContentAsString(), JsonObject.class);
+            }
+            logger.debug("Dashboard retry failed with status: {}", response.getStatus());
+            return null;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            logger.debug("Dashboard retry interrupted", e);
+            return null;
+        } catch (Exception e) {
+            logger.debug("Dashboard retry failed", e);
+            return null;
+        }
+    }
+
+    /**
+     * Refreshes the access token using the refresh token.
+     *
+     * @param currentRefreshToken the refresh token to use
+     * @return true if token refresh successful, false otherwise
+     */
+    private boolean refreshAccessToken(String currentRefreshToken) {
+        try {
+            String formData = "grant_type=refresh_token" + "&refresh_token="
+                    + URLEncoder.encode(currentRefreshToken, StandardCharsets.UTF_8) + "&client_id=" + CLIENT_ID
+                    + "&scope="
+                    + URLEncoder.encode(
+                            "openid https://bdrb2cprod.onmicrosoft.com/iotdevice/user_impersonation offline_access",
+                            StandardCharsets.UTF_8);
+
+            Request request = httpClient.newRequest(TOKEN_ENDPOINT).method(HttpMethod.POST)
+                    .timeout(REQUEST_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+                    .header("Content-Type", "application/x-www-form-urlencoded")
+                    .content(new StringContentProvider(formData));
+
+            ContentResponse response = request.send();
+            if (response.getStatus() == 200) {
+                return parseTokenResponse(response.getContentAsString());
+            }
+            logger.debug("Token refresh failed with status: {}", response.getStatus());
+            refreshToken = null;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            logger.debug("Token refresh interrupted", e);
+        } catch (Exception e) {
+            logger.debug("Token refresh failed: {}", e.getMessage());
+        }
+        return false;
+    }
+
+    /**
+     * Parses the token response JSON and stores access and refresh tokens.
+     *
+     * @param responseBody the JSON response body
+     * @return true if tokens were extracted successfully
+     */
+    private boolean parseTokenResponse(String responseBody) {
+        JsonObject tokenResponse = gson.fromJson(responseBody, JsonObject.class);
+        if (tokenResponse != null && tokenResponse.has("access_token")) {
+            accessToken = tokenResponse.get("access_token").getAsString();
+            if (tokenResponse.has("refresh_token")) {
+                refreshToken = tokenResponse.get("refresh_token").getAsString();
+            }
+            logger.debug("Successfully obtained access token");
+            return true;
+        }
+        logger.debug("Token response missing access_token field");
+        return false;
     }
 
     private String generateCodeChallenge(String verifier) throws Exception {
@@ -205,8 +365,8 @@ public class RemehaApiClient {
 
     private String buildAuthUrl(String codeChallenge, String state) {
         return "https://remehalogin.bdrthermea.net/bdrb2cprod.onmicrosoft.com/oauth2/v2.0/authorize"
-                + "?response_type=code" + "&client_id=6ce007c6-0628-419e-88f4-bee2e6418eec" + "&redirect_uri="
-                + URLEncoder.encode("com.b2c.remehaapp://login-callback", StandardCharsets.UTF_8) + "&scope="
+                + "?response_type=code" + "&client_id=" + CLIENT_ID + "&redirect_uri="
+                + URLEncoder.encode(REDIRECT_URI, StandardCharsets.UTF_8) + "&scope="
                 + URLEncoder.encode(
                         "openid https://bdrb2cprod.onmicrosoft.com/iotdevice/user_impersonation offline_access",
                         StandardCharsets.UTF_8)
@@ -284,19 +444,21 @@ public class RemehaApiClient {
 
             if (response.getStatus() == 302) {
                 String location = response.getHeaders().get("Location");
-                logger.debug("Redirect location: {}", location);
+                logger.debug("Redirect location received");
                 if (location != null) {
                     Pattern pattern = Pattern.compile("code=([^&]+)");
                     Matcher matcher = pattern.matcher(location);
                     if (matcher.find()) {
-                        String authCode = matcher.group(1);
-                        logger.debug("Authorization code successfully extracted.");
-                        return authCode;
+                        logger.debug("Authorization code successfully extracted");
+                        return matcher.group(1);
                     }
                 }
             } else {
                 logger.debug("Expected 302 redirect, got {}", response.getStatus());
             }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            logger.debug("Authorization code request interrupted", e);
         } catch (Exception e) {
             logger.debug("Failed to get authorization code: {}", e.getMessage());
         }
@@ -305,35 +467,26 @@ public class RemehaApiClient {
 
     private boolean exchangeCodeForToken(String authCode) {
         try {
-            String url = "https://remehalogin.bdrthermea.net/bdrb2cprod.onmicrosoft.com/oauth2/v2.0/token?p=B2C_1A_RPSignUpSignInNewRoomV3.1";
-            String formData = "grant_type=authorization_code&code=" + authCode + "&redirect_uri="
-                    + URLEncoder.encode("com.b2c.remehaapp://login-callback", StandardCharsets.UTF_8)
-                    + "&code_verifier=" + codeVerifier + "&client_id=6ce007c6-0628-419e-88f4-bee2e6418eec";
+            String formData = "grant_type=authorization_code&code="
+                    + URLEncoder.encode(authCode, StandardCharsets.UTF_8) + "&redirect_uri="
+                    + URLEncoder.encode(REDIRECT_URI, StandardCharsets.UTF_8) + "&code_verifier=" + codeVerifier
+                    + "&client_id=" + CLIENT_ID;
 
-            Request request = httpClient.newRequest(url).method(HttpMethod.POST)
+            Request request = httpClient.newRequest(TOKEN_ENDPOINT).method(HttpMethod.POST)
                     .timeout(REQUEST_TIMEOUT_MS, TimeUnit.MILLISECONDS)
                     .header("Content-Type", "application/x-www-form-urlencoded")
                     .content(new StringContentProvider(formData));
 
             ContentResponse response = request.send();
             if (response.getStatus() == 200) {
-                String json = response.getContentAsString();
-                JsonObject tokenResponse = gson.fromJson(json, JsonObject.class);
-                if (tokenResponse != null && tokenResponse.has("access_token")) {
-                    accessToken = tokenResponse.get("access_token").getAsString();
-                    logger.debug("Successfully obtained access token");
-                    return true;
-                } else {
-                    logger.debug("Token response missing access_token field");
-                }
-            } else {
-                logger.debug("Token exchange failed with status: {}", response.getStatus());
+                return parseTokenResponse(response.getContentAsString());
             }
+            logger.debug("Token exchange failed with status: {}", response.getStatus());
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             logger.debug("Token exchange interrupted", e);
         } catch (java.util.concurrent.TimeoutException e) {
-            logger.debug("Token exchange timed out after {}ms", REQUEST_TIMEOUT_MS, e);
+            logger.debug("Token exchange timed out after {}ms", REQUEST_TIMEOUT_MS);
         } catch (Exception e) {
             logger.debug("Failed to exchange code for token: {}", e.getMessage());
         }
@@ -342,7 +495,10 @@ public class RemehaApiClient {
 
     private boolean apiRequest(String path, @Nullable String jsonData) {
         if (accessToken == null) {
-            return false;
+            logger.debug("No access token for API request, attempting re-authentication");
+            if (!reAuthenticate()) {
+                return false;
+            }
         }
         try {
             Request request = httpClient.newRequest(API_BASE_URL + path).method(HttpMethod.POST)
@@ -353,13 +509,45 @@ public class RemehaApiClient {
             }
             int status = request.send().getStatus();
             if (status == 401) {
-                logger.debug("Received 401 Unauthorized, token expired");
+                logger.debug("API request received 401, attempting re-authentication");
                 accessToken = null;
-                return false;
+                if (!reAuthenticate()) {
+                    return false;
+                }
+                return apiRequestInternal(path, jsonData);
             }
             return status == 200;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            logger.debug("API request interrupted for {}", path);
+            return false;
         } catch (Exception e) {
             logger.debug("API request failed for {}: {}", path, e.getMessage());
+            return false;
+        }
+    }
+
+    /**
+     * Internal API request without 401 retry logic (to prevent recursion).
+     */
+    private boolean apiRequestInternal(String path, @Nullable String jsonData) {
+        if (accessToken == null) {
+            return false;
+        }
+        try {
+            Request request = httpClient.newRequest(API_BASE_URL + path).method(HttpMethod.POST)
+                    .timeout(REQUEST_TIMEOUT_MS, TimeUnit.MILLISECONDS).header("Authorization", "Bearer " + accessToken)
+                    .header("Ocp-Apim-Subscription-Key", SUBSCRIPTION_KEY).header("Content-Type", "application/json");
+            if (jsonData != null) {
+                request.content(new StringContentProvider(jsonData));
+            }
+            return request.send().getStatus() == 200;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            logger.debug("API request retry interrupted for {}", path);
+            return false;
+        } catch (Exception e) {
+            logger.debug("API request retry failed for {}: {}", path, e.getMessage());
             return false;
         }
     }

--- a/bundles/org.openhab.binding.remehaheating/src/main/resources/OH-INF/i18n/remehaheating.properties
+++ b/bundles/org.openhab.binding.remehaheating/src/main/resources/OH-INF/i18n/remehaheating.properties
@@ -46,8 +46,8 @@ channel-type.remehaheating.water-pressure.description = System water pressure
 # thing status descriptions
 
 offline.conf-error-no-credentials = Email and password are required
-offline.conf-error-invalid-config = Configuration error
-offline.comm-error-authentication-failed = Authentication failed
-offline.comm-error-authentication-error = Authentication error
+offline.conf-error-invalid-config = Invalid configuration parameters
+offline.comm-error-authentication-failed = Authentication with Remeha API failed
+offline.comm-error-authentication-error = Unexpected error during authentication
 offline.comm-error-data-fetch-failed = Failed to retrieve data from API
-offline.comm-error-data-update-failed = Data update failed
+offline.comm-error-data-update-failed = Error processing data from API


### PR DESCRIPTION
**Classification: Bugfix**

The binding goes permanently OFFLINE after ~1 hour when the access token expires. Two root causes were identified and fixed:

Jetty protocol violation: The Remeha API returns HTTP 401 without a WWW-Authenticate header, violating RFC 7235. Jetty's WWWAuthenticationProtocolHandler throws an HttpResponseException instead of returning the 401 response, preventing the binding from detecting the expired token.

No re-authentication logic: Once the token expired, the binding had no mechanism to refresh or re-acquire it.

Changes
Remove Jetty WWWAuthenticationProtocolHandler to allow normal 401 handling
Add automatic re-authentication with refresh token on 401 responses
Store credentials for full re-authentication fallback when refresh fails
Add scope parameter to refresh token request (required by Azure B2C)
Clear cookies before re-authentication to avoid stale session issues
Add backoff mechanism (5 min) to prevent excessive re-auth attempts
Cache climate zone and hot water zone IDs to avoid redundant API calls
Send temperature setpoint as string value (matching official app behavior)
Add i18n keys for thing status messages
Testing
Tested on openHAB 5.2.0 with Remeha Calenta Ace boiler. Token refresh confirmed working automatically after expiry (~1 hour). Thing stays ONLINE continuously.