### PR TITLE
[vizio] Send input CNAME on current_input change

### DIFF
--- a/bundles/org.openhab.binding.vizio/src/main/java/org/openhab/binding/vizio/internal/handler/VizioHandler.java
+++ b/bundles/org.openhab.binding.vizio/src/main/java/org/openhab/binding/vizio/internal/handler/VizioHandler.java
@@ -16,8 +16,10 @@ import static org.openhab.binding.vizio.internal.VizioBindingConstants.*;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Random;
 import java.util.concurrent.ScheduledFuture;
@@ -93,6 +95,10 @@ public class VizioHandler extends BaseThingHandler {
     private Long currentVolumeHash = 0L;
     private String currentApp = EMPTY;
     private String currentInput = EMPTY;
+    // Maps each input's display name (the Source channel command/option value) to the device CNAME.
+    // Newer Vizio firmware only accepts the CNAME in a current_input MODIFY; older firmware accepts
+    // either. Rebuilt on every refreshVizioMetadata().
+    private Map<String, String> inputCnameByName = new HashMap<>();
     private boolean currentMute = false;
     private int currentVolume = -1;
     private boolean powerOn = false;
@@ -347,9 +353,12 @@ public class VizioHandler extends BaseThingHandler {
                 InputList inputList = communicator.getSourceInputList();
 
                 List<StateOption> sourceListOptions = new ArrayList<>();
+                Map<String, String> cnameByName = new HashMap<>();
                 inputList.getItems().forEach(source -> {
                     sourceListOptions.add(new StateOption(source.getName(), source.getValue().getName()));
+                    cnameByName.put(source.getName(), source.getCname());
                 });
+                inputCnameByName = cnameByName;
 
                 stateDescriptionProvider.setStateOptions(new ChannelUID(getThing().getUID(), SOURCE),
                         sourceListOptions);
@@ -465,8 +474,13 @@ public class VizioHandler extends BaseThingHandler {
                                     currentInputHash = polledInput.getItems().get(0).getHashval();
                                 }
                             }
-                            communicator
-                                    .changeInput(String.format(MODIFY_STRING_SETTING_JSON, command, currentInputHash));
+                            // Newer Vizio firmware requires the input CNAME ("hdmi1"); the display name
+                            // ("HDMI-1") is rejected with RESULT: FAILURE. Older firmware accepts either, so
+                            // the CNAME is safe for both. Fall back to the raw command if the input list has
+                            // not been fetched yet.
+                            String sourceCname = inputCnameByName.getOrDefault(command.toString(), command.toString());
+                            communicator.changeInput(
+                                    String.format(MODIFY_STRING_SETTING_JSON, sourceCname, currentInputHash));
                             currentInputHash = 0L;
                         } catch (VizioException e) {
                             logger.warn("Unable to set current source on the Vizio TV, source: {}, Exception: {}",

--- a/bundles/org.openhab.binding.vizio/src/main/java/org/openhab/binding/vizio/internal/handler/VizioHandler.java
+++ b/bundles/org.openhab.binding.vizio/src/main/java/org/openhab/binding/vizio/internal/handler/VizioHandler.java
@@ -95,9 +95,6 @@ public class VizioHandler extends BaseThingHandler {
     private Long currentVolumeHash = 0L;
     private String currentApp = EMPTY;
     private String currentInput = EMPTY;
-    // Maps each input's display name (the Source channel command/option value) to the device CNAME.
-    // Newer Vizio firmware only accepts the CNAME in a current_input MODIFY; older firmware accepts
-    // either. Rebuilt on every refreshVizioMetadata().
     private Map<String, String> inputCnameByName = new HashMap<>();
     private boolean currentMute = false;
     private int currentVolume = -1;
@@ -477,12 +474,10 @@ public class VizioHandler extends BaseThingHandler {
                             // Newer Vizio firmware requires the input CNAME ("hdmi1"); the display name
                             // ("HDMI-1") is rejected with RESULT: FAILURE. Older firmware accepts either, so
                             // the CNAME is safe for both. Fall back to the raw command if the input list has
-                            // not been fetched yet, or if the mapped CNAME is missing/blank.
-                            String mappedCname = inputCnameByName.get(command.toString());
-                            String sourceCname = (mappedCname != null && !mappedCname.isBlank()) ? mappedCname
-                                    : command.toString();
-                            communicator.changeInput(
-                                    String.format(MODIFY_STRING_SETTING_JSON, sourceCname, currentInputHash));
+                            // not been fetched yet, or the CNAME is missing.
+                            String sourceCname = inputCnameByName.get(command.toString());
+                            communicator.changeInput(String.format(MODIFY_STRING_SETTING_JSON,
+                                    sourceCname != null ? sourceCname : command, currentInputHash));
                             currentInputHash = 0L;
                         } catch (VizioException e) {
                             logger.warn("Unable to set current source on the Vizio TV, source: {}, Exception: {}",

--- a/bundles/org.openhab.binding.vizio/src/main/java/org/openhab/binding/vizio/internal/handler/VizioHandler.java
+++ b/bundles/org.openhab.binding.vizio/src/main/java/org/openhab/binding/vizio/internal/handler/VizioHandler.java
@@ -477,8 +477,10 @@ public class VizioHandler extends BaseThingHandler {
                             // Newer Vizio firmware requires the input CNAME ("hdmi1"); the display name
                             // ("HDMI-1") is rejected with RESULT: FAILURE. Older firmware accepts either, so
                             // the CNAME is safe for both. Fall back to the raw command if the input list has
-                            // not been fetched yet.
-                            String sourceCname = inputCnameByName.getOrDefault(command.toString(), command.toString());
+                            // not been fetched yet, or if the mapped CNAME is missing/blank.
+                            String mappedCname = inputCnameByName.get(command.toString());
+                            String sourceCname = (mappedCname != null && !mappedCname.isBlank()) ? mappedCname
+                                    : command.toString();
                             communicator.changeInput(
                                     String.format(MODIFY_STRING_SETTING_JSON, sourceCname, currentInputHash));
                             currentInputHash = 0L;


### PR DESCRIPTION
## Summary

Fixes #21237.

On newer (account-era) Vizio firmware, commanding the **Source** channel had no effect — the TV never switched inputs, while the item optimistically updated via core autoUpdate, so it looked like it worked.

Root cause: the binding sends the input **display name** (e.g. `HDMI-1`) in the `current_input` MODIFY. Newer firmware (e.g. VQM55C) rejects the display name with `RESULT: FAILURE` and only accepts the input **CNAME** (`hdmi1`). Older firmware accepts either.

## Change

Translate the Source command to the input's CNAME before sending it to the device. The channel's option/state values are left as the display names, so existing rules that read e.g. `SOURCE == "HDMI-1"` keep working — only the value sent to the device changes. Falls back to the raw command if the input list has not been fetched yet.

This mirrors the maintained reference library [`vizaio`](https://github.com/raman325/vizaio) (successor to `pyvizio`), which sends the CNAME unconditionally for all Vizio generations and documents it as "the only stable identifier."

## Verification

Built locally with `mvn clean install` (JDK 21): compile, Spotless, static analysis (Checkstyle/PMD/SpotBugs), and karaf feature verification all pass.

Tested with **real input switches** (each confirmed by an independent `current_input` readback) on two generations:

| Unit | Model | Firmware | CNAME (`hdmi2`) | display name (`HDMI-2`) |
| --- | --- | --- | --- | --- |
| New | VQM55C-1004 | 86.804.21.3-1 | SUCCESS — input moves | FAILURE — no move |
| Old | P55-C1 | 11.0.120.1-1 | SUCCESS — input moves | SUCCESS — input moves |

The CNAME moves the input on both generations; the display name works only on older firmware — so the change fixes newer TVs without regressing older ones.

---

*This change was prepared with AI assistance (Claude). It was compiled/verified locally and tested on real hardware (VQM55C-1004 and P55-C1) as described above.*
