### PR TITLE
[unifi] Fall back to the private WebSocket for Protect camera detections

### DIFF
--- a/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/protect/api/priv/dto/system/Event.java
+++ b/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/protect/api/priv/dto/system/Event.java
@@ -34,9 +34,6 @@ public class Event extends UniFiProtectModel {
     public Integer score;
     @SerializedName(value = "heatmap", alternate = { "heatmapId" })
     public String heatmapId;
-    // The event payload names the camera "camera"; nothing in it is called "cameraId", so without
-    // this mapping the field stays null and every consumer of it -- the thumbnail/heatmap update
-    // and the private-WS camera event routing -- silently does nothing.
     @SerializedName(value = "camera", alternate = { "cameraId" })
     public String cameraId;
     public List<SmartDetectObjectType> smartDetectTypes;

--- a/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/protect/api/priv/dto/system/Event.java
+++ b/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/protect/api/priv/dto/system/Event.java
@@ -32,16 +32,16 @@ public class Event extends UniFiProtectModel {
     public Instant start;
     public Instant end;
     public Integer score;
-    @SerializedName(value = "heatmapId", alternate = { "heatmap" })
+    @SerializedName(value = "heatmap", alternate = { "heatmapId" })
     public String heatmapId;
-    // The event payload names the camera "camera" (with "device" repeating it); nothing in it is
-    // called "cameraId", so without this mapping the field stays null and every consumer of it --
-    // the thumbnail/heatmap update and the private-WS camera event routing -- silently does nothing.
-    @SerializedName(value = "camera", alternate = { "cameraId", "device" })
+    // The event payload names the camera "camera"; nothing in it is called "cameraId", so without
+    // this mapping the field stays null and every consumer of it -- the thumbnail/heatmap update
+    // and the private-WS camera event routing -- silently does nothing.
+    @SerializedName(value = "camera", alternate = { "cameraId" })
     public String cameraId;
     public List<SmartDetectObjectType> smartDetectTypes;
     public List<String> smartDetectEventIds;
-    @SerializedName(value = "thumbnailId", alternate = { "thumbnail" })
+    @SerializedName(value = "thumbnail", alternate = { "thumbnailId" })
     public String thumbnailId;
     public String userId;
     public Instant timestamp;

--- a/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/protect/api/priv/dto/system/Event.java
+++ b/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/protect/api/priv/dto/system/Event.java
@@ -19,6 +19,8 @@ import org.openhab.binding.unifi.internal.protect.api.priv.dto.base.UniFiProtect
 import org.openhab.binding.unifi.internal.protect.api.priv.dto.types.EventType;
 import org.openhab.binding.unifi.internal.protect.api.priv.dto.types.SmartDetectObjectType;
 
+import com.google.gson.annotations.SerializedName;
+
 /**
  * Event model for UniFi Protect
  *
@@ -30,10 +32,16 @@ public class Event extends UniFiProtectModel {
     public Instant start;
     public Instant end;
     public Integer score;
+    @SerializedName(value = "heatmapId", alternate = { "heatmap" })
     public String heatmapId;
+    // The event payload names the camera "camera" (with "device" repeating it); nothing in it is
+    // called "cameraId", so without this mapping the field stays null and every consumer of it --
+    // the thumbnail/heatmap update and the private-WS camera event routing -- silently does nothing.
+    @SerializedName(value = "camera", alternate = { "cameraId", "device" })
     public String cameraId;
     public List<SmartDetectObjectType> smartDetectTypes;
     public List<String> smartDetectEventIds;
+    @SerializedName(value = "thumbnailId", alternate = { "thumbnail" })
     public String thumbnailId;
     public String userId;
     public Instant timestamp;

--- a/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/protect/api/priv/dto/types/EventType.java
+++ b/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/protect/api/priv/dto/types/EventType.java
@@ -32,6 +32,9 @@ public enum EventType {
     @SerializedName("smartDetectLine")
     SMART_DETECT_LINE,
 
+    @SerializedName("smartDetectLoiterZone")
+    SMART_DETECT_LOITER_ZONE,
+
     @SerializedName("smartAudioDetect")
     SMART_AUDIO_DETECT,
 

--- a/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/protect/handler/UnifiProtectCameraHandler.java
+++ b/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/protect/handler/UnifiProtectCameraHandler.java
@@ -1160,6 +1160,7 @@ public class UnifiProtectCameraHandler extends UnifiProtectAbstractDeviceHandler
                 break;
             case SMART_DETECT:
             case SMART_DETECT_LINE:
+            case SMART_DETECT_LOITER_ZONE:
             case SMART_AUDIO_DETECT:
                 thumbnailChannel = CHANNEL_SMART_DETECT_THUMBNAIL;
                 break;

--- a/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/protect/handler/UnifiProtectNVRHandler.java
+++ b/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/protect/handler/UnifiProtectNVRHandler.java
@@ -23,6 +23,9 @@ import java.util.Objects;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
@@ -143,6 +146,11 @@ public class UnifiProtectNVRHandler extends BaseBridgeHandler {
     // Stamped where an event arrives, on the WebSocket thread, so a snapshot that was superseded
     // before its dispatch task got to run can be recognised and skipped.
     private final AtomicLong eventSequence = new AtomicLong();
+    // Private EVENT frames are dispatched on one thread so an event's ADD is always processed
+    // before the UPDATEs that follow it. The shared pool gives no such guarantee, and an UPDATE
+    // overtaking its ADD would deliver a *_UPDATE trigger before the matching *_START.
+    private final ExecutorService privateEventExecutor = Executors
+            .newSingleThreadExecutor(r -> new Thread(r, "OH-binding-unifi-protect-events"));
     // Highest sequence already delivered per event id. PendingUpdate is discarded on delivery, so
     // without this a task delayed past the delivery of a newer one would find no pending state,
     // start a fresh one, and be taken for the newest snapshot.
@@ -319,7 +327,8 @@ public class UnifiProtectNVRHandler extends BaseBridgeHandler {
                 if (update.modelType == ModelType.EVENT) {
                     update.data = trackPrivateEventPayload(update.action, update.id, update.data);
                 }
-                scheduler.execute(() -> {
+                Executor dispatcher = update.modelType == ModelType.EVENT ? privateEventExecutor : scheduler;
+                dispatcher.execute(() -> {
                     logger.trace("Private API WebSocket update: action={}, model={}", update.action, update.modelType);
                     routePrivateApiUpdate(update, sequence);
                 });
@@ -391,6 +400,7 @@ public class UnifiProtectNVRHandler extends BaseBridgeHandler {
         shuttingDown = true;
         stopTasks();
         stopApiClient();
+        privateEventExecutor.shutdownNow();
         super.dispose();
     }
 

--- a/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/protect/handler/UnifiProtectNVRHandler.java
+++ b/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/protect/handler/UnifiProtectNVRHandler.java
@@ -580,6 +580,7 @@ public class UnifiProtectNVRHandler extends BaseBridgeHandler {
         for (int attempt = 1; attempt <= WS_CONNECT_MAX_RETRIES; attempt++) {
             try {
                 apiClient.getPublicClient().subscribeEvents(add -> {
+                    logger.debug("Public events WS event add, id={}, type={}", add.item.id, add.item.type);
                     routePublicApiEvent(add.item, WSEventType.ADD);
                 }, update -> {
                     handleUpdateEvent(update.item);
@@ -669,10 +670,14 @@ public class UnifiProtectNVRHandler extends BaseBridgeHandler {
         if (event.device == null) {
             return;
         }
-        // The same detection can arrive on the public integration WS and, as a fallback,
-        // on the private updates WS; dispatch each event once per ADD/UPDATE phase.
+        // The same detection ADD can arrive on both the public integration WS and, as a
+        // fallback, on the private updates WS, so de-dup ADD to fire each detection once.
+        // UPDATEs are intentionally repeated over an event's lifetime (and coalesced by
+        // handleUpdateEvent's debounce), so they are not de-duped here -- otherwise the
+        // repeated sensor/ring UPDATEs, which only ever use the public WS, would be dropped
+        // for the whole dedup TTL after their first delivery.
         String dedupId = event.id;
-        if (dedupId != null && !markEventDispatched(dedupId + ":" + eventType)) {
+        if (eventType == WSEventType.ADD && dedupId != null && !markEventDispatched(dedupId)) {
             return;
         }
         String deviceId = event.device;
@@ -864,14 +869,24 @@ public class UnifiProtectNVRHandler extends BaseBridgeHandler {
                 case EVENT:
                     Event event = gson.fromJson(update.data, Event.class);
                     if (event != null) {
+                        logger.debug("Private updates WS event {}, id={}, type={}", update.action, update.id,
+                                event.type);
                         // Fallback dispatch: smart-detect / motion events also arrive on the private
                         // updates WS. Route them to the camera channels so detections keep working even
                         // when the public integration events WS connects but silently delivers nothing.
                         BaseEvent pubEvent = toPublicCameraEvent(event);
                         if (pubEvent != null) {
                             pubEvent.id = update.id;
-                            routePublicApiEvent(pubEvent,
-                                    "add".equals(update.action) ? WSEventType.ADD : WSEventType.UPDATE);
+                            // Mirror the public events WS: an "add" dispatches immediately; an
+                            // "update" goes through the same debounce as public updates, so a
+                            // private update coalesces with (and never beats) the settled public
+                            // one. Any other action -- notably "remove" for a deleted event --
+                            // must not fire a detection.
+                            if ("add".equals(update.action)) {
+                                routePublicApiEvent(pubEvent, WSEventType.ADD);
+                            } else if ("update".equals(update.action)) {
+                                handleUpdateEvent(pubEvent);
+                            }
                         }
                         // Thumbnail/heatmap IDs arrive on event UPDATE messages (not add), as the NVR
                         // generates them asynchronously after the event starts.

--- a/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/protect/handler/UnifiProtectNVRHandler.java
+++ b/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/protect/handler/UnifiProtectNVRHandler.java
@@ -289,6 +289,14 @@ public class UnifiProtectNVRHandler extends BaseBridgeHandler {
             connectDeviceWebSocket(apiClient);
             logger.debug("Enabling Private API WebSocket for real-time updates");
             apiClient.getPrivateClient().enableWebSocket(update -> {
+                // Fold incremental EVENT deltas into the last full payload here, on the WebSocket
+                // thread, where frames still arrive in the order the NVR sent them. The dispatch
+                // below runs on the shared multi-threaded handler pool, which does not preserve
+                // that order: an UPDATE could otherwise overtake the ADD it depends on, and two
+                // UPDATEs could merge from the same snapshot and lose one of the two changes.
+                if (update.modelType == ModelType.EVENT) {
+                    update.data = trackPrivateEventPayload(update.action, update.id, update.data);
+                }
                 scheduler.execute(() -> {
                     logger.trace("Private API WebSocket update: action={}, model={}", update.action, update.modelType);
                     routePrivateApiUpdate(update);
@@ -766,16 +774,20 @@ public class UnifiProtectNVRHandler extends BaseBridgeHandler {
         if (!"update".equals(action)) {
             return data;
         }
-        TimestampedPayload cached = privateEventPayloads.get(id);
-        if (cached == null) {
+        // Read, merge and store as one atomic step. Callers are expected to be ordered (the
+        // WebSocket thread), but doing this under compute() means overlapping calls still cannot
+        // merge from the same snapshot and drop one of the two changes.
+        TimestampedPayload result = privateEventPayloads.computeIfPresent(id, (key, cached) -> {
+            JsonObject merged = cached.payload().deepCopy();
+            data.entrySet().forEach(e -> merged.add(e.getKey(), e.getValue()));
+            return new TimestampedPayload(merged, now);
+        });
+        if (result == null) {
             // No add seen for this id; the delta is all there is. It still reaches the
             // thumbnail/heatmap path below when it happens to carry those fields.
             return data;
         }
-        JsonObject merged = cached.payload.deepCopy();
-        data.entrySet().forEach(e -> merged.add(e.getKey(), e.getValue()));
-        privateEventPayloads.put(id, new TimestampedPayload(merged.deepCopy(), now));
-        return merged;
+        return result.payload().deepCopy();
     }
 
     /**
@@ -924,11 +936,9 @@ public class UnifiProtectNVRHandler extends BaseBridgeHandler {
                     }
                     break;
                 case EVENT:
-                    // /ws/updates sends UPDATEs as incremental deltas, so an update carrying only
-                    // e.g. "end" has no type or camera and cannot be converted on its own. Merge it
-                    // into the last full payload seen for this event id first.
-                    JsonObject eventPayload = trackPrivateEventPayload(update.action, update.id, update.data);
-                    Event event = eventPayload == null ? null : gson.fromJson(eventPayload, Event.class);
+                    // update.data has already been merged with the last full payload for this event
+                    // id, on the WebSocket thread -- see where the update handler is registered.
+                    Event event = update.data == null ? null : gson.fromJson(update.data, Event.class);
                     if (event != null) {
                         logger.debug("Private updates WS event {}, id={}, type={}", update.action, update.id,
                                 event.type);

--- a/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/protect/handler/UnifiProtectNVRHandler.java
+++ b/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/protect/handler/UnifiProtectNVRHandler.java
@@ -149,8 +149,7 @@ public class UnifiProtectNVRHandler extends BaseBridgeHandler {
     // Private EVENT frames are dispatched on one thread so an event's ADD is always processed
     // before the UPDATEs that follow it. The shared pool gives no such guarantee, and an UPDATE
     // overtaking its ADD would deliver a *_UPDATE trigger before the matching *_START.
-    private final ExecutorService privateEventExecutor = Executors
-            .newSingleThreadExecutor(r -> new Thread(r, "OH-binding-unifi-protect-events"));
+    private volatile @Nullable ExecutorService privateEventExecutor;
     // Highest sequence already delivered per event id. PendingUpdate is discarded on delivery, so
     // without this a task delayed past the delivery of a newer one would find no pending state,
     // start a fresh one, and be taken for the newest snapshot.
@@ -220,6 +219,10 @@ public class UnifiProtectNVRHandler extends BaseBridgeHandler {
     public void initialize() {
         logger.debug("Initializing NVR");
         shuttingDown = false;
+        // Recreated per initialize: the same handler instance is reused across a dispose/initialize
+        // cycle, e.g. on a configuration update, and a once-only executor would stay shut down and
+        // silently reject every private EVENT frame from then on.
+        privateEventExecutor = Executors.newSingleThreadExecutor(r -> new Thread(r, "OH-unifi-protect-events"));
         ensureStaticChannels();
 
         UniFiControllerBridgeHandler parentHandler = getParentHandler();
@@ -327,7 +330,9 @@ public class UnifiProtectNVRHandler extends BaseBridgeHandler {
                 if (update.modelType == ModelType.EVENT) {
                     update.data = trackPrivateEventPayload(update.action, update.id, update.data);
                 }
-                Executor dispatcher = update.modelType == ModelType.EVENT ? privateEventExecutor : scheduler;
+                ExecutorService eventExecutor = privateEventExecutor;
+                Executor dispatcher = update.modelType == ModelType.EVENT && eventExecutor != null
+                        && !eventExecutor.isShutdown() ? eventExecutor : scheduler;
                 dispatcher.execute(() -> {
                     logger.trace("Private API WebSocket update: action={}, model={}", update.action, update.modelType);
                     routePrivateApiUpdate(update, sequence);
@@ -400,7 +405,11 @@ public class UnifiProtectNVRHandler extends BaseBridgeHandler {
         shuttingDown = true;
         stopTasks();
         stopApiClient();
-        privateEventExecutor.shutdownNow();
+        ExecutorService eventExecutor = privateEventExecutor;
+        if (eventExecutor != null) {
+            eventExecutor.shutdownNow();
+            privateEventExecutor = null;
+        }
         super.dispose();
     }
 

--- a/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/protect/handler/UnifiProtectNVRHandler.java
+++ b/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/protect/handler/UnifiProtectNVRHandler.java
@@ -211,7 +211,6 @@ public class UnifiProtectNVRHandler extends BaseBridgeHandler {
     public void initialize() {
         logger.debug("Initializing NVR");
         shuttingDown = false;
-        // Recreated per initialize: the handler instance is reused across dispose/initialize.
         privateEventExecutor = Executors.newSingleThreadExecutor(r -> new Thread(r, "OH-unifi-protect-events"));
         ensureStaticChannels();
 
@@ -829,8 +828,6 @@ public class UnifiProtectNVRHandler extends BaseBridgeHandler {
             return new TimestampedPayload(merged, now);
         });
         if (result == null) {
-            // No add seen for this id; the delta is all there is. It still reaches the
-            // thumbnail/heatmap path below when it happens to carry those fields.
             return data;
         }
         return result.payload().deepCopy();
@@ -993,25 +990,16 @@ public class UnifiProtectNVRHandler extends BaseBridgeHandler {
                     if (event != null) {
                         logger.debug("Private updates WS event {}, id={}, type={}", update.action, update.id,
                                 event.type);
-                        // Fallback dispatch: smart-detect / motion events also arrive on the private
-                        // updates WS. Route them to the camera channels so detections keep working even
-                        // when the public integration events WS connects but silently delivers nothing.
                         BaseEvent pubEvent = toPublicCameraEvent(event);
                         if (pubEvent != null) {
                             pubEvent.id = update.id;
-                            // Mirror the public events WS: an "add" dispatches immediately; an
-                            // "update" goes through the same debounce as public updates, so a
-                            // private update coalesces with (and never beats) the settled public
-                            // one. Any other action -- notably "remove" for a deleted event --
-                            // must not fire a detection.
+                            // "remove" must not fire a detection.
                             if ("add".equals(update.action)) {
                                 routePublicApiEvent(pubEvent, WSEventType.ADD);
                             } else if ("update".equals(update.action)) {
                                 handleUpdateEvent(pubEvent, sequence);
                             }
                         }
-                        // Thumbnail/heatmap IDs arrive on event UPDATE messages (not add), as the NVR
-                        // generates them asynchronously after the event starts.
                         // Merging makes the ids sticky, so only act on an id not already fetched.
                         if ("update".equals(update.action) && event.cameraId != null
                                 && isNewEventMedia(update.id, event.thumbnailId, event.heatmapId)) {

--- a/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/protect/handler/UnifiProtectNVRHandler.java
+++ b/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/protect/handler/UnifiProtectNVRHandler.java
@@ -87,6 +87,7 @@ import org.slf4j.LoggerFactory;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.JsonObject;
 
 /**
  * Bridge handler for the UniFi Protect NVR.
@@ -124,6 +125,12 @@ public class UnifiProtectNVRHandler extends BaseBridgeHandler {
     // de-duplicated; UPDATEs for an already seen event are expected to pass through.
     private final Map<String, Long> dispatchedEventKeys = new ConcurrentHashMap<>();
     private static final long EVENT_DEDUP_TTL_MS = 120_000;
+    // Last full payload per private event id, so incremental UPDATE deltas can be merged into it.
+    private final Map<String, TimestampedPayload> privateEventPayloads = new ConcurrentHashMap<>();
+    private static final long EVENT_PAYLOAD_TTL_MS = 600_000;
+
+    private record TimestampedPayload(JsonObject payload, long timestamp) {
+    }
 
     private static final class PendingUpdate {
         @Nullable
@@ -730,6 +737,48 @@ public class UnifiProtectNVRHandler extends BaseBridgeHandler {
     }
 
     /**
+     * Keep the last full payload per event id and merge incremental UPDATE frames into it.
+     *
+     * Protect's private updates WebSocket sends an "add" with the complete event and subsequent
+     * "update" frames containing only the changed fields. Converting such a delta on its own fails,
+     * because the mapping needs the type and camera that only the "add" carried, which would drop
+     * the *_UPDATE dispatch and stop the contact latch from being refreshed.
+     *
+     * @return the full payload to work with, or {@code null} if there is nothing usable (an update
+     *         for an event whose add was never seen, e.g. one that started before openHAB did)
+     */
+    @Nullable
+    JsonObject trackPrivateEventPayload(@Nullable String action, @Nullable String id, @Nullable JsonObject data) {
+        if (id == null || data == null) {
+            return data;
+        }
+        long now = System.currentTimeMillis();
+        privateEventPayloads.values().removeIf(p -> now - p.timestamp > EVENT_PAYLOAD_TTL_MS);
+
+        if ("remove".equals(action)) {
+            privateEventPayloads.remove(id);
+            return data;
+        }
+        if ("add".equals(action)) {
+            privateEventPayloads.put(id, new TimestampedPayload(data.deepCopy(), now));
+            return data;
+        }
+        if (!"update".equals(action)) {
+            return data;
+        }
+        TimestampedPayload cached = privateEventPayloads.get(id);
+        if (cached == null) {
+            // No add seen for this id; the delta is all there is. It still reaches the
+            // thumbnail/heatmap path below when it happens to carry those fields.
+            return data;
+        }
+        JsonObject merged = cached.payload.deepCopy();
+        data.entrySet().forEach(e -> merged.add(e.getKey(), e.getValue()));
+        privateEventPayloads.put(id, new TimestampedPayload(merged.deepCopy(), now));
+        return merged;
+    }
+
+    /**
      * Convert a private-API {@link Event} into the matching public camera event so the
      * standard {@link #routePublicApiEvent} dispatch (channels + contacts) can be reused.
      * Returns {@code null} for events that are not camera motion / smart-detect zone, line or
@@ -875,7 +924,11 @@ public class UnifiProtectNVRHandler extends BaseBridgeHandler {
                     }
                     break;
                 case EVENT:
-                    Event event = gson.fromJson(update.data, Event.class);
+                    // /ws/updates sends UPDATEs as incremental deltas, so an update carrying only
+                    // e.g. "end" has no type or camera and cannot be converted on its own. Merge it
+                    // into the last full payload seen for this event id first.
+                    JsonObject eventPayload = trackPrivateEventPayload(update.action, update.id, update.data);
+                    Event event = eventPayload == null ? null : gson.fromJson(eventPayload, Event.class);
                     if (event != null) {
                         logger.debug("Private updates WS event {}, id={}, type={}", update.action, update.id,
                                 event.type);

--- a/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/protect/handler/UnifiProtectNVRHandler.java
+++ b/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/protect/handler/UnifiProtectNVRHandler.java
@@ -25,6 +25,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
@@ -132,7 +133,12 @@ public class UnifiProtectNVRHandler extends BaseBridgeHandler {
     private record TimestampedPayload(JsonObject payload, long timestamp) {
     }
 
+    // Stamped where an event arrives, on the WebSocket thread, so a snapshot that was superseded
+    // before its dispatch task got to run can be recognised and skipped.
+    private final AtomicLong eventSequence = new AtomicLong();
+
     private static final class PendingUpdate {
+        long lastSequence = Long.MIN_VALUE;
         @Nullable
         BaseEvent lastEvent;
         @Nullable
@@ -294,12 +300,13 @@ public class UnifiProtectNVRHandler extends BaseBridgeHandler {
                 // below runs on the shared multi-threaded handler pool, which does not preserve
                 // that order: an UPDATE could otherwise overtake the ADD it depends on, and two
                 // UPDATEs could merge from the same snapshot and lose one of the two changes.
+                long sequence = eventSequence.incrementAndGet();
                 if (update.modelType == ModelType.EVENT) {
                     update.data = trackPrivateEventPayload(update.action, update.id, update.data);
                 }
                 scheduler.execute(() -> {
                     logger.trace("Private API WebSocket update: action={}, model={}", update.action, update.modelType);
-                    routePrivateApiUpdate(update);
+                    routePrivateApiUpdate(update, sequence);
                 });
             }).whenComplete((result, ex) -> {
                 if (ex != null) {
@@ -752,8 +759,10 @@ public class UnifiProtectNVRHandler extends BaseBridgeHandler {
      * because the mapping needs the type and camera that only the "add" carried, which would drop
      * the *_UPDATE dispatch and stop the contact latch from being refreshed.
      *
-     * @return the full payload to work with, or {@code null} if there is nothing usable (an update
-     *         for an event whose add was never seen, e.g. one that started before openHAB did)
+     * @return the full payload to work with. An update for an event whose add was never seen -- one
+     *         that started before openHAB did, say -- yields the delta unchanged, which still feeds
+     *         the thumbnail/heatmap path when it carries those fields. Only a {@code null} input
+     *         gives {@code null} back.
      */
     @Nullable
     JsonObject trackPrivateEventPayload(@Nullable String action, @Nullable String id, @Nullable JsonObject data) {
@@ -855,7 +864,7 @@ public class UnifiProtectNVRHandler extends BaseBridgeHandler {
         return out;
     }
 
-    private void routePrivateApiUpdate(WebSocketUpdate update) {
+    private void routePrivateApiUpdate(WebSocketUpdate update, long sequence) {
         if (update.data == null) {
             return;
         }
@@ -961,7 +970,7 @@ public class UnifiProtectNVRHandler extends BaseBridgeHandler {
                             if ("add".equals(update.action)) {
                                 routePublicApiEvent(pubEvent, WSEventType.ADD);
                             } else if ("update".equals(update.action)) {
-                                handleUpdateEvent(pubEvent);
+                                handleUpdateEvent(pubEvent, sequence);
                             }
                         }
                         // Thumbnail/heatmap IDs arrive on event UPDATE messages (not add), as the NVR
@@ -1037,13 +1046,28 @@ public class UnifiProtectNVRHandler extends BaseBridgeHandler {
         pendingEventUpdates.clear();
     }
 
-    private synchronized void handleUpdateEvent(@Nullable BaseEvent event) {
+    private void handleUpdateEvent(@Nullable BaseEvent event) {
+        handleUpdateEvent(event, eventSequence.incrementAndGet());
+    }
+
+    /**
+     * @param sequence arrival order of this snapshot, taken on the WebSocket thread. Dispatch tasks
+     *            are submitted independently to the shared multi-threaded scheduler, so without it
+     *            a task carrying an older snapshot could run last and overwrite a newer one.
+     */
+    private synchronized void handleUpdateEvent(@Nullable BaseEvent event, long sequence) {
         if (event == null || event.id == null) {
             return;
         }
         final String eventId = event.id;
         PendingUpdate state = Objects
                 .requireNonNull(pendingEventUpdates.computeIfAbsent(eventId, k -> new PendingUpdate()));
+        if (sequence < state.lastSequence) {
+            logger.trace("Skipping event {} snapshot {}, a newer one ({}) already arrived", eventId, sequence,
+                    state.lastSequence);
+            return;
+        }
+        state.lastSequence = sequence;
         // Schedule max wait once per burst (only if not already scheduled)
         if (state.maxFuture == null) {
             final PendingUpdate stateFinalForMax = state;

--- a/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/protect/handler/UnifiProtectNVRHandler.java
+++ b/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/protect/handler/UnifiProtectNVRHandler.java
@@ -133,6 +133,13 @@ public class UnifiProtectNVRHandler extends BaseBridgeHandler {
     private record TimestampedPayload(JsonObject payload, long timestamp) {
     }
 
+    // Thumbnail/heatmap ids already fetched per event id, so a merged payload that keeps carrying
+    // them does not re-fetch the same image on every later frame.
+    private final Map<String, TimestampedMedia> fetchedEventMedia = new ConcurrentHashMap<>();
+
+    private record TimestampedMedia(String ids, long timestamp) {
+    }
+
     // Stamped where an event arrives, on the WebSocket thread, so a snapshot that was superseded
     // before its dispatch task got to run can be recognised and skipped.
     private final AtomicLong eventSequence = new AtomicLong();
@@ -752,6 +759,25 @@ public class UnifiProtectNVRHandler extends BaseBridgeHandler {
     }
 
     /**
+     * Whether this frame carries a thumbnail or heatmap id not already fetched for this event.
+     *
+     * The NVR generates those asynchronously and announces each once, but the merged payload keeps
+     * them from then on, so the id has to be compared against what was last seen rather than merely
+     * being present. Returns false when neither id is set.
+     */
+    private boolean isNewEventMedia(@Nullable String eventId, @Nullable String thumbnailId,
+            @Nullable String heatmapId) {
+        if (eventId == null || (thumbnailId == null && heatmapId == null)) {
+            return false;
+        }
+        String seen = thumbnailId + "|" + heatmapId;
+        long now = System.currentTimeMillis();
+        fetchedEventMedia.values().removeIf(p -> now - p.timestamp() > EVENT_PAYLOAD_TTL_MS);
+        TimestampedMedia previous = fetchedEventMedia.put(eventId, new TimestampedMedia(seen, now));
+        return previous == null || !seen.equals(previous.ids());
+    }
+
+    /**
      * Keep the last full payload per event id and merge incremental UPDATE frames into it.
      *
      * Protect's private updates WebSocket sends an "add" with the complete event and subsequent
@@ -760,9 +786,9 @@ public class UnifiProtectNVRHandler extends BaseBridgeHandler {
      * the *_UPDATE dispatch and stop the contact latch from being refreshed.
      *
      * @return the full payload to work with. An update for an event whose add was never seen -- one
-     *         that started before openHAB did, say -- yields the delta unchanged, which still feeds
-     *         the thumbnail/heatmap path when it carries those fields. Only a {@code null} input
-     *         gives {@code null} back.
+     *         that started before openHAB did, say -- yields the delta unchanged; it cannot be
+     *         converted into a camera event without the type and camera the add carried, so it is
+     *         effectively dropped. Only a {@code null} input gives {@code null} back.
      */
     @Nullable
     JsonObject trackPrivateEventPayload(@Nullable String action, @Nullable String id, @Nullable JsonObject data) {
@@ -975,8 +1001,11 @@ public class UnifiProtectNVRHandler extends BaseBridgeHandler {
                         }
                         // Thumbnail/heatmap IDs arrive on event UPDATE messages (not add), as the NVR
                         // generates them asynchronously after the event starts.
+                        // Merging keeps thumbnailId/heatmapId in the payload once they appear, so
+                        // every later frame of the same event would otherwise re-fetch the identical
+                        // image. Only act when this frame actually brought a new id.
                         if ("update".equals(update.action) && event.cameraId != null
-                                && (event.thumbnailId != null || event.heatmapId != null)) {
+                                && isNewEventMedia(update.id, event.thumbnailId, event.heatmapId)) {
                             UnifiProtectCameraHandler camHandler = findChildHandler(event.cameraId,
                                     UnifiProtectCameraHandler.class);
                             if (camHandler != null) {

--- a/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/protect/handler/UnifiProtectNVRHandler.java
+++ b/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/protect/handler/UnifiProtectNVRHandler.java
@@ -119,7 +119,7 @@ public class UnifiProtectNVRHandler extends BaseBridgeHandler {
 
     private int reconnectAttempt = 0;
     private int throttledReconnectAttempt = 0;
-    private final Map<String, PendingUpdate> pendingEventUpdates = new ConcurrentHashMap<>();
+    final Map<String, PendingUpdate> pendingEventUpdates = new ConcurrentHashMap<>();
     private final Map<String, ScheduledFuture<?>> childRefreshRetryTasks = new ConcurrentHashMap<>();
     // De-dup events that can arrive on BOTH the public integration WS and the private
     // updates WS fallback path — dispatch each event id exactly once. Only ADDs are
@@ -143,8 +143,16 @@ public class UnifiProtectNVRHandler extends BaseBridgeHandler {
     // Stamped where an event arrives, on the WebSocket thread, so a snapshot that was superseded
     // before its dispatch task got to run can be recognised and skipped.
     private final AtomicLong eventSequence = new AtomicLong();
+    // Highest sequence already delivered per event id. PendingUpdate is discarded on delivery, so
+    // without this a task delayed past the delivery of a newer one would find no pending state,
+    // start a fresh one, and be taken for the newest snapshot.
+    private final Map<String, TimestampedSequence> deliveredEventSequences = new ConcurrentHashMap<>();
+    private static final long EVENT_SEQUENCE_TTL_MS = 600_000;
 
-    private static final class PendingUpdate {
+    private record TimestampedSequence(long sequence, long timestamp) {
+    }
+
+    static final class PendingUpdate {
         long lastSequence = Long.MIN_VALUE;
         @Nullable
         BaseEvent lastEvent;
@@ -1084,11 +1092,20 @@ public class UnifiProtectNVRHandler extends BaseBridgeHandler {
      *            are submitted independently to the shared multi-threaded scheduler, so without it
      *            a task carrying an older snapshot could run last and overwrite a newer one.
      */
-    private synchronized void handleUpdateEvent(@Nullable BaseEvent event, long sequence) {
+    synchronized void handleUpdateEvent(@Nullable BaseEvent event, long sequence) {
         if (event == null || event.id == null) {
             return;
         }
         final String eventId = event.id;
+        // Compare against what was already delivered as well: PendingUpdate is discarded on
+        // delivery, so a task delayed past it would otherwise start a fresh state and be taken for
+        // the newest snapshot even though a later one has already gone out.
+        TimestampedSequence delivered = deliveredEventSequences.get(eventId);
+        if (delivered != null && sequence <= delivered.sequence()) {
+            logger.trace("Skipping event {} snapshot {}, {} was already delivered", eventId, sequence,
+                    delivered.sequence());
+            return;
+        }
         PendingUpdate state = Objects
                 .requireNonNull(pendingEventUpdates.computeIfAbsent(eventId, k -> new PendingUpdate()));
         if (sequence < state.lastSequence) {
@@ -1117,11 +1134,18 @@ public class UnifiProtectNVRHandler extends BaseBridgeHandler {
                 WS_UPDATE_DEBOUNCE_MS, TimeUnit.MILLISECONDS);
     }
 
-    private synchronized void deliverDebouncedUpdate(String eventId, PendingUpdate state) {
+    synchronized void deliverDebouncedUpdate(String eventId, PendingUpdate state) {
         // Guard against races if another task already delivered and cleared state
         PendingUpdate current = pendingEventUpdates.get(eventId);
         if (!state.equals(current)) {
             return;
+        }
+        // Remember how far this event got before the pending state is dropped, so a straggler
+        // carrying an older snapshot cannot be mistaken for a new burst.
+        long now = System.currentTimeMillis();
+        deliveredEventSequences.values().removeIf(s -> now - s.timestamp() > EVENT_SEQUENCE_TTL_MS);
+        if (state.lastSequence != Long.MIN_VALUE) {
+            deliveredEventSequences.put(eventId, new TimestampedSequence(state.lastSequence, now));
         }
         // Cancel all update timers
         ScheduledFuture<?> f1 = state.debounceFuture;

--- a/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/protect/handler/UnifiProtectNVRHandler.java
+++ b/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/protect/handler/UnifiProtectNVRHandler.java
@@ -124,9 +124,7 @@ public class UnifiProtectNVRHandler extends BaseBridgeHandler {
     private int throttledReconnectAttempt = 0;
     final Map<String, PendingUpdate> pendingEventUpdates = new ConcurrentHashMap<>();
     private final Map<String, ScheduledFuture<?>> childRefreshRetryTasks = new ConcurrentHashMap<>();
-    // De-dup events that can arrive on BOTH the public integration WS and the private
-    // updates WS fallback path — dispatch each event id exactly once. Only ADDs are
-    // de-duplicated; UPDATEs for an already seen event are expected to pass through.
+    // Events can arrive on both WebSockets. Only ADDs are de-duplicated; UPDATEs pass through.
     private final Map<String, Long> dispatchedEventKeys = new ConcurrentHashMap<>();
     private static final long EVENT_DEDUP_TTL_MS = 120_000;
     // Last full payload per private event id, so incremental UPDATE deltas can be merged into it.
@@ -136,23 +134,17 @@ public class UnifiProtectNVRHandler extends BaseBridgeHandler {
     private record TimestampedPayload(JsonObject payload, long timestamp) {
     }
 
-    // Thumbnail/heatmap ids already fetched per event id, so a merged payload that keeps carrying
-    // them does not re-fetch the same image on every later frame.
+    // Already-fetched ids, so a merged payload carrying them does not re-fetch the same image.
     private final Map<String, TimestampedMedia> fetchedEventMedia = new ConcurrentHashMap<>();
 
     private record TimestampedMedia(String ids, long timestamp) {
     }
 
-    // Stamped where an event arrives, on the WebSocket thread, so a snapshot that was superseded
-    // before its dispatch task got to run can be recognised and skipped.
+    // Stamped on the WebSocket thread, so a superseded snapshot can be skipped on dispatch.
     private final AtomicLong eventSequence = new AtomicLong();
-    // Private EVENT frames are dispatched on one thread so an event's ADD is always processed
-    // before the UPDATEs that follow it. The shared pool gives no such guarantee, and an UPDATE
-    // overtaking its ADD would deliver a *_UPDATE trigger before the matching *_START.
+    // Single thread so an event's ADD is always processed before the UPDATEs that follow it.
     private volatile @Nullable ExecutorService privateEventExecutor;
-    // Highest sequence already delivered per event id. PendingUpdate is discarded on delivery, so
-    // without this a task delayed past the delivery of a newer one would find no pending state,
-    // start a fresh one, and be taken for the newest snapshot.
+    // Survives PendingUpdate, which is discarded on delivery, so a straggler cannot look new.
     private final Map<String, TimestampedSequence> deliveredEventSequences = new ConcurrentHashMap<>();
     private static final long EVENT_SEQUENCE_TTL_MS = 600_000;
 
@@ -219,9 +211,7 @@ public class UnifiProtectNVRHandler extends BaseBridgeHandler {
     public void initialize() {
         logger.debug("Initializing NVR");
         shuttingDown = false;
-        // Recreated per initialize: the same handler instance is reused across a dispose/initialize
-        // cycle, e.g. on a configuration update, and a once-only executor would stay shut down and
-        // silently reject every private EVENT frame from then on.
+        // Recreated per initialize: the handler instance is reused across dispose/initialize.
         privateEventExecutor = Executors.newSingleThreadExecutor(r -> new Thread(r, "OH-unifi-protect-events"));
         ensureStaticChannels();
 
@@ -321,11 +311,7 @@ public class UnifiProtectNVRHandler extends BaseBridgeHandler {
             connectDeviceWebSocket(apiClient);
             logger.debug("Enabling Private API WebSocket for real-time updates");
             apiClient.getPrivateClient().enableWebSocket(update -> {
-                // Fold incremental EVENT deltas into the last full payload here, on the WebSocket
-                // thread, where frames still arrive in the order the NVR sent them. The dispatch
-                // below runs on the shared multi-threaded handler pool, which does not preserve
-                // that order: an UPDATE could otherwise overtake the ADD it depends on, and two
-                // UPDATEs could merge from the same snapshot and lose one of the two changes.
+                // Merged here, on the WebSocket thread, where frames are still in NVR order.
                 long sequence = eventSequence.incrementAndGet();
                 if (update.modelType == ModelType.EVENT) {
                     update.data = trackPrivateEventPayload(update.action, update.id, update.data);
@@ -836,9 +822,7 @@ public class UnifiProtectNVRHandler extends BaseBridgeHandler {
         if (!"update".equals(action)) {
             return data;
         }
-        // Read, merge and store as one atomic step. Callers are expected to be ordered (the
-        // WebSocket thread), but doing this under compute() means overlapping calls still cannot
-        // merge from the same snapshot and drop one of the two changes.
+        // One atomic step, so overlapping calls cannot merge from the same snapshot.
         TimestampedPayload result = privateEventPayloads.computeIfPresent(id, (key, cached) -> {
             JsonObject merged = cached.payload().deepCopy();
             data.entrySet().forEach(e -> merged.add(e.getKey(), e.getValue()));
@@ -1028,9 +1012,7 @@ public class UnifiProtectNVRHandler extends BaseBridgeHandler {
                         }
                         // Thumbnail/heatmap IDs arrive on event UPDATE messages (not add), as the NVR
                         // generates them asynchronously after the event starts.
-                        // Merging keeps thumbnailId/heatmapId in the payload once they appear, so
-                        // every later frame of the same event would otherwise re-fetch the identical
-                        // image. Only act when this frame actually brought a new id.
+                        // Merging makes the ids sticky, so only act on an id not already fetched.
                         if ("update".equals(update.action) && event.cameraId != null
                                 && isNewEventMedia(update.id, event.thumbnailId, event.heatmapId)) {
                             UnifiProtectCameraHandler camHandler = findChildHandler(event.cameraId,
@@ -1116,9 +1098,7 @@ public class UnifiProtectNVRHandler extends BaseBridgeHandler {
             return;
         }
         final String eventId = event.id;
-        // Compare against what was already delivered as well: PendingUpdate is discarded on
-        // delivery, so a task delayed past it would otherwise start a fresh state and be taken for
-        // the newest snapshot even though a later one has already gone out.
+        // PendingUpdate is gone after delivery, so check the delivered mark too.
         TimestampedSequence delivered = deliveredEventSequences.get(eventId);
         if (delivered != null && sequence <= delivered.sequence()) {
             logger.trace("Skipping event {} snapshot {}, {} was already delivered", eventId, sequence,
@@ -1159,8 +1139,7 @@ public class UnifiProtectNVRHandler extends BaseBridgeHandler {
         if (!state.equals(current)) {
             return;
         }
-        // Remember how far this event got before the pending state is dropped, so a straggler
-        // carrying an older snapshot cannot be mistaken for a new burst.
+        // Remember how far this event got before the pending state is dropped.
         long now = System.currentTimeMillis();
         deliveredEventSequences.values().removeIf(s -> now - s.timestamp() > EVENT_SEQUENCE_TTL_MS);
         if (state.lastSequence != Long.MIN_VALUE) {

--- a/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/protect/handler/UnifiProtectNVRHandler.java
+++ b/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/protect/handler/UnifiProtectNVRHandler.java
@@ -713,12 +713,9 @@ public class UnifiProtectNVRHandler extends BaseBridgeHandler {
         if (event.device == null) {
             return;
         }
-        // The same detection ADD can arrive on both the public integration WS and, as a
-        // fallback, on the private updates WS, so de-dup ADD to fire each detection once.
-        // UPDATEs are intentionally repeated over an event's lifetime (and coalesced by
-        // handleUpdateEvent's debounce), so they are not de-duped here -- otherwise the
-        // repeated sensor/ring UPDATEs, which only ever use the public WS, would be dropped
-        // for the whole dedup TTL after their first delivery.
+        // ADD can arrive on both the public integration WS and fallback private updates WS,
+        // so de-dupe it. UPDATEs repeat over an event's lifetime and are debounced by
+        // handleUpdateEvent; de-duping them would drop public-WS sensor/ring updates for the dedup TTL.
         String dedupId = event.id;
         if (eventType == WSEventType.ADD && dedupId != null && !markEventDispatched(dedupId)) {
             return;

--- a/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/protect/handler/UnifiProtectNVRHandler.java
+++ b/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/protect/handler/UnifiProtectNVRHandler.java
@@ -55,6 +55,7 @@ import org.openhab.binding.unifi.internal.protect.api.pub.dto.ObjectType;
 import org.openhab.binding.unifi.internal.protect.api.pub.dto.events.BaseEvent;
 import org.openhab.binding.unifi.internal.protect.api.pub.dto.events.CameraMotionEvent;
 import org.openhab.binding.unifi.internal.protect.api.pub.dto.events.CameraSmartDetectLineEvent;
+import org.openhab.binding.unifi.internal.protect.api.pub.dto.events.CameraSmartDetectLoiterEvent;
 import org.openhab.binding.unifi.internal.protect.api.pub.dto.events.CameraSmartDetectZoneEvent;
 import org.openhab.binding.unifi.internal.protect.api.pub.dto.events.EventType;
 import org.openhab.binding.unifi.internal.protect.api.pub.dto.gson.DeviceTypeAdapterFactory;
@@ -119,7 +120,8 @@ public class UnifiProtectNVRHandler extends BaseBridgeHandler {
     private final Map<String, PendingUpdate> pendingEventUpdates = new ConcurrentHashMap<>();
     private final Map<String, ScheduledFuture<?>> childRefreshRetryTasks = new ConcurrentHashMap<>();
     // De-dup events that can arrive on BOTH the public integration WS and the private
-    // updates WS fallback path — dispatch each (eventId, ADD|UPDATE) exactly once.
+    // updates WS fallback path — dispatch each event id exactly once. Only ADDs are
+    // de-duplicated; UPDATEs for an already seen event are expected to pass through.
     private final Map<String, Long> dispatchedEventKeys = new ConcurrentHashMap<>();
     private static final long EVENT_DEDUP_TTL_MS = 120_000;
 
@@ -730,10 +732,10 @@ public class UnifiProtectNVRHandler extends BaseBridgeHandler {
     /**
      * Convert a private-API {@link Event} into the matching public camera event so the
      * standard {@link #routePublicApiEvent} dispatch (channels + contacts) can be reused.
-     * Returns {@code null} for events that are not camera motion / smart-detect zone / line
-     * (audio and ring stay on the public integration path only).
+     * Returns {@code null} for events that are not camera motion / smart-detect zone, line or
+     * loiter zone (audio and ring stay on the public integration path only).
      */
-    private @Nullable BaseEvent toPublicCameraEvent(Event event) {
+    static @Nullable BaseEvent toPublicCameraEvent(Event event) {
         var type = event.type;
         String cameraId = event.cameraId;
         if (type == null || cameraId == null) {
@@ -757,6 +759,12 @@ public class UnifiProtectNVRHandler extends BaseBridgeHandler {
                 pub = line;
                 pub.type = EventType.SMART_DETECT_LINE;
                 break;
+            case SMART_DETECT_LOITER_ZONE:
+                CameraSmartDetectLoiterEvent loiter = new CameraSmartDetectLoiterEvent();
+                loiter.smartDetectTypes = toObjectTypes(event.smartDetectTypes);
+                pub = loiter;
+                pub.type = EventType.SMART_DETECT_LOITER_ZONE;
+                break;
             default:
                 return null;
         }
@@ -766,7 +774,7 @@ public class UnifiProtectNVRHandler extends BaseBridgeHandler {
         return pub;
     }
 
-    private List<ObjectType> toObjectTypes(@Nullable List<SmartDetectObjectType> types) {
+    private static List<ObjectType> toObjectTypes(@Nullable List<SmartDetectObjectType> types) {
         List<ObjectType> out = new ArrayList<>();
         if (types == null) {
             return out;

--- a/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/protect/handler/UnifiProtectNVRHandler.java
+++ b/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/protect/handler/UnifiProtectNVRHandler.java
@@ -841,6 +841,11 @@ public class UnifiProtectNVRHandler extends BaseBridgeHandler {
             return out;
         }
         for (SmartDetectObjectType type : types) {
+            if (type == null) {
+                // Gson yields null for a value this enum does not know, so a smart-detect type
+                // added by a later Protect release would otherwise take the whole event down here.
+                continue;
+            }
             try {
                 out.add(ObjectType.valueOf(type.name()));
             } catch (IllegalArgumentException ignored) {

--- a/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/protect/handler/UnifiProtectNVRHandler.java
+++ b/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/protect/handler/UnifiProtectNVRHandler.java
@@ -47,10 +47,15 @@ import org.openhab.binding.unifi.internal.protect.api.priv.dto.system.Bootstrap;
 import org.openhab.binding.unifi.internal.protect.api.priv.dto.system.Event;
 import org.openhab.binding.unifi.internal.protect.api.priv.dto.system.Nvr;
 import org.openhab.binding.unifi.internal.protect.api.priv.dto.types.ModelType;
+import org.openhab.binding.unifi.internal.protect.api.priv.dto.types.SmartDetectObjectType;
 import org.openhab.binding.unifi.internal.protect.api.priv.exception.AuthenticationException;
 import org.openhab.binding.unifi.internal.protect.api.priv.exception.ThrottledException;
 import org.openhab.binding.unifi.internal.protect.api.pub.dto.DeviceState;
+import org.openhab.binding.unifi.internal.protect.api.pub.dto.ObjectType;
 import org.openhab.binding.unifi.internal.protect.api.pub.dto.events.BaseEvent;
+import org.openhab.binding.unifi.internal.protect.api.pub.dto.events.CameraMotionEvent;
+import org.openhab.binding.unifi.internal.protect.api.pub.dto.events.CameraSmartDetectLineEvent;
+import org.openhab.binding.unifi.internal.protect.api.pub.dto.events.CameraSmartDetectZoneEvent;
 import org.openhab.binding.unifi.internal.protect.api.pub.dto.events.EventType;
 import org.openhab.binding.unifi.internal.protect.api.pub.dto.gson.DeviceTypeAdapterFactory;
 import org.openhab.binding.unifi.internal.protect.api.pub.dto.gson.EventTypeAdapterFactory;
@@ -113,6 +118,10 @@ public class UnifiProtectNVRHandler extends BaseBridgeHandler {
     private int throttledReconnectAttempt = 0;
     private final Map<String, PendingUpdate> pendingEventUpdates = new ConcurrentHashMap<>();
     private final Map<String, ScheduledFuture<?>> childRefreshRetryTasks = new ConcurrentHashMap<>();
+    // De-dup events that can arrive on BOTH the public integration WS and the private
+    // updates WS fallback path — dispatch each (eventId, ADD|UPDATE) exactly once.
+    private final Map<String, Long> dispatchedEventKeys = new ConcurrentHashMap<>();
+    private static final long EVENT_DEDUP_TTL_MS = 120_000;
 
     private static final class PendingUpdate {
         @Nullable
@@ -660,6 +669,12 @@ public class UnifiProtectNVRHandler extends BaseBridgeHandler {
         if (event.device == null) {
             return;
         }
+        // The same detection can arrive on the public integration WS and, as a fallback,
+        // on the private updates WS; dispatch each event once per ADD/UPDATE phase.
+        String dedupId = event.id;
+        if (dedupId != null && !markEventDispatched(dedupId + ":" + eventType)) {
+            return;
+        }
         String deviceId = event.device;
         EventType et = event.type;
         switch (et) {
@@ -699,6 +714,66 @@ public class UnifiProtectNVRHandler extends BaseBridgeHandler {
             default:
                 break;
         }
+    }
+
+    private boolean markEventDispatched(String key) {
+        long now = System.currentTimeMillis();
+        dispatchedEventKeys.values().removeIf(ts -> now - ts > EVENT_DEDUP_TTL_MS);
+        return dispatchedEventKeys.putIfAbsent(key, now) == null;
+    }
+
+    /**
+     * Convert a private-API {@link Event} into the matching public camera event so the
+     * standard {@link #routePublicApiEvent} dispatch (channels + contacts) can be reused.
+     * Returns {@code null} for events that are not camera motion / smart-detect zone / line
+     * (audio and ring stay on the public integration path only).
+     */
+    private @Nullable BaseEvent toPublicCameraEvent(Event event) {
+        var type = event.type;
+        String cameraId = event.cameraId;
+        if (type == null || cameraId == null) {
+            return null;
+        }
+        BaseEvent pub;
+        switch (type) {
+            case MOTION:
+                pub = new CameraMotionEvent();
+                pub.type = EventType.CAMERA_MOTION;
+                break;
+            case SMART_DETECT:
+                CameraSmartDetectZoneEvent zone = new CameraSmartDetectZoneEvent();
+                zone.smartDetectTypes = toObjectTypes(event.smartDetectTypes);
+                pub = zone;
+                pub.type = EventType.SMART_DETECT_ZONE;
+                break;
+            case SMART_DETECT_LINE:
+                CameraSmartDetectLineEvent line = new CameraSmartDetectLineEvent();
+                line.smartDetectTypes = toObjectTypes(event.smartDetectTypes);
+                pub = line;
+                pub.type = EventType.SMART_DETECT_LINE;
+                break;
+            default:
+                return null;
+        }
+        pub.device = cameraId;
+        pub.start = event.start != null ? event.start.toEpochMilli() : null;
+        pub.end = event.end != null ? event.end.toEpochMilli() : null;
+        return pub;
+    }
+
+    private List<ObjectType> toObjectTypes(@Nullable List<SmartDetectObjectType> types) {
+        List<ObjectType> out = new ArrayList<>();
+        if (types == null) {
+            return out;
+        }
+        for (SmartDetectObjectType type : types) {
+            try {
+                out.add(ObjectType.valueOf(type.name()));
+            } catch (IllegalArgumentException ignored) {
+                // an audio object type in a smart-detect list — not a camera object type
+            }
+        }
+        return out;
     }
 
     private void routePrivateApiUpdate(WebSocketUpdate update) {
@@ -787,11 +862,20 @@ public class UnifiProtectNVRHandler extends BaseBridgeHandler {
                     }
                     break;
                 case EVENT:
-                    // Thumbnail/heatmap IDs arrive on event UPDATE messages (not add), as the NVR
-                    // generates them asynchronously after the event starts.
-                    if ("update".equals(update.action)) {
-                        Event event = gson.fromJson(update.data, Event.class);
-                        if (event != null && event.cameraId != null
+                    Event event = gson.fromJson(update.data, Event.class);
+                    if (event != null) {
+                        // Fallback dispatch: smart-detect / motion events also arrive on the private
+                        // updates WS. Route them to the camera channels so detections keep working even
+                        // when the public integration events WS connects but silently delivers nothing.
+                        BaseEvent pubEvent = toPublicCameraEvent(event);
+                        if (pubEvent != null) {
+                            pubEvent.id = update.id;
+                            routePublicApiEvent(pubEvent,
+                                    "add".equals(update.action) ? WSEventType.ADD : WSEventType.UPDATE);
+                        }
+                        // Thumbnail/heatmap IDs arrive on event UPDATE messages (not add), as the NVR
+                        // generates them asynchronously after the event starts.
+                        if ("update".equals(update.action) && event.cameraId != null
                                 && (event.thumbnailId != null || event.heatmapId != null)) {
                             UnifiProtectCameraHandler camHandler = findChildHandler(event.cameraId,
                                     UnifiProtectCameraHandler.class);

--- a/bundles/org.openhab.binding.unifi/src/test/java/org/openhab/binding/unifi/internal/protect/dto/EventDeserializationTest.java
+++ b/bundles/org.openhab.binding.unifi/src/test/java/org/openhab/binding/unifi/internal/protect/dto/EventDeserializationTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.unifi.internal.protect.dto;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.jupiter.api.Test;
+import org.openhab.binding.unifi.internal.protect.api.priv.dto.gson.JsonUtil;
+import org.openhab.binding.unifi.internal.protect.api.priv.dto.system.Event;
+import org.openhab.binding.unifi.internal.protect.api.priv.dto.types.EventType;
+import org.openhab.binding.unifi.internal.protect.api.priv.dto.types.SmartDetectObjectType;
+
+/**
+ * Tests deserialization of the event payload delivered on the private updates WebSocket.
+ *
+ * @author Stamate Viorel - Initial contribution
+ */
+@NonNullByDefault
+public class EventDeserializationTest {
+
+    // Verbatim smartDetectZone frame from a UniFi Protect private updates WebSocket.
+    private static final String SMART_DETECT_ZONE_EVENT = """
+            {"camera":"62e3a86301824803e700041d","createdAt":"2026-07-25T13:21:22.506090292Z",\
+            "device":"62e3a86301824803e700041d","id":"4b61ed79-7789-4ac1-8cce-927ded49c44e",\
+            "locked":false,"score":88,"smartDetectTypes":["face","person"],"start":1784985677286,\
+            "type":"smartDetectZone","updatedAt":"2026-07-25T13:21:22.506090961Z"}\
+            """;
+
+    @Test
+    public void smartDetectZoneEventResolvesTheCamera() {
+        Event event = JsonUtil.getGson().fromJson(SMART_DETECT_ZONE_EVENT, Event.class);
+
+        assertNotNull(event);
+        assertEquals(EventType.SMART_DETECT, event.type);
+        // The payload spells this "camera"; a mapping is required or every consumer of cameraId
+        // (thumbnail/heatmap updates, camera event routing) silently drops the event.
+        assertEquals("62e3a86301824803e700041d", event.cameraId);
+        assertEquals("4b61ed79-7789-4ac1-8cce-927ded49c44e", event.id);
+        assertNotNull(event.smartDetectTypes);
+        assertTrue(event.smartDetectTypes.contains(SmartDetectObjectType.PERSON));
+    }
+
+    @Test
+    public void thumbnailAndHeatmapAreResolved() {
+        Event event = JsonUtil.getGson().fromJson("""
+                {"camera":"62e3a86301824803e700041d","id":"e1","type":"motion",\
+                "thumbnail":"e-thumb-1","heatmap":"e-heat-1"}\
+                """, Event.class);
+
+        assertNotNull(event);
+        assertEquals("e-thumb-1", event.thumbnailId);
+        assertEquals("e-heat-1", event.heatmapId);
+    }
+
+    @Test
+    public void legacyFieldNamesStillDeserialize() {
+        Event event = JsonUtil.getGson().fromJson("""
+                {"cameraId":"cam-legacy","id":"e2","type":"smartDetectLine",\
+                "thumbnailId":"t-legacy","heatmapId":"h-legacy"}\
+                """, Event.class);
+
+        assertNotNull(event);
+        assertEquals("cam-legacy", event.cameraId);
+        assertEquals("t-legacy", event.thumbnailId);
+        assertEquals("h-legacy", event.heatmapId);
+    }
+}

--- a/bundles/org.openhab.binding.unifi/src/test/java/org/openhab/binding/unifi/internal/protect/dto/EventDeserializationTest.java
+++ b/bundles/org.openhab.binding.unifi/src/test/java/org/openhab/binding/unifi/internal/protect/dto/EventDeserializationTest.java
@@ -43,7 +43,6 @@ public class EventDeserializationTest {
 
         assertNotNull(event);
         assertEquals(EventType.SMART_DETECT, event.type);
-        // The payload spells this "camera"; a mapping is required or every consumer of cameraId
         // (thumbnail/heatmap updates, camera event routing) silently drops the event.
         assertEquals("62e3a86301824803e700041d", event.cameraId);
         assertEquals("4b61ed79-7789-4ac1-8cce-927ded49c44e", event.id);

--- a/bundles/org.openhab.binding.unifi/src/test/java/org/openhab/binding/unifi/internal/protect/handler/EventSequenceOrderingTest.java
+++ b/bundles/org.openhab.binding.unifi/src/test/java/org/openhab/binding/unifi/internal/protect/handler/EventSequenceOrderingTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.unifi.internal.protect.handler;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openhab.binding.unifi.internal.protect.api.pub.dto.events.BaseEvent;
+import org.openhab.binding.unifi.internal.protect.api.pub.dto.events.CameraMotionEvent;
+import org.openhab.binding.unifi.internal.protect.api.pub.dto.events.EventType;
+import org.openhab.core.thing.Bridge;
+import org.openhab.core.thing.type.ThingTypeRegistry;
+
+/**
+ * Event snapshots are stamped in WebSocket order but dispatched through a multi-threaded pool, so a
+ * task can run after a newer one. These tests pin that an older snapshot never wins -- including
+ * across a delivery, which discards the pending state the guard would otherwise live in.
+ *
+ * @author Stamate Viorel - Initial contribution
+ */
+@NonNullByDefault
+public class EventSequenceOrderingTest {
+
+    private static final String EVENT_ID = "4b61ed79-7789-4ac1-8cce-927ded49c44e";
+
+    private @NonNullByDefault({}) UnifiProtectNVRHandler handler;
+
+    private static BaseEvent event(long end) {
+        BaseEvent e = new CameraMotionEvent();
+        e.type = EventType.CAMERA_MOTION;
+        e.id = EVENT_ID;
+        e.device = "62e3a86301824803e700041d";
+        e.end = end;
+        return e;
+    }
+
+    @BeforeEach
+    public void setUp() {
+        handler = new UnifiProtectNVRHandler(mock(Bridge.class), mock(ThingTypeRegistry.class));
+    }
+
+    private long pendingSequence() {
+        UnifiProtectNVRHandler.PendingUpdate state = handler.pendingEventUpdates.get(EVENT_ID);
+        return state == null ? Long.MIN_VALUE : state.lastSequence;
+    }
+
+    @Test
+    public void olderSnapshotIsIgnoredWithinABurst() {
+        handler.handleUpdateEvent(event(200), 11);
+        handler.handleUpdateEvent(event(100), 10);
+
+        assertEquals(11, pendingSequence(), "sequence 10 must not overwrite the newer 11");
+        BaseEvent kept = handler.pendingEventUpdates.get(EVENT_ID).lastEvent;
+        assertNotNull(kept);
+        assertEquals(200L, kept.end);
+    }
+
+    @Test
+    public void olderSnapshotIsIgnoredAfterTheNewerOneWasDelivered() {
+        // 11 arrives and its burst is delivered, which discards the pending state.
+        handler.handleUpdateEvent(event(200), 11);
+        UnifiProtectNVRHandler.PendingUpdate delivered = handler.pendingEventUpdates.get(EVENT_ID);
+        assertNotNull(delivered);
+        handler.deliverDebouncedUpdate(EVENT_ID, delivered);
+
+        // 10 was stuck in the scheduler all along and only now gets to run.
+        handler.handleUpdateEvent(event(100), 10);
+
+        assertNull(handler.pendingEventUpdates.get(EVENT_ID),
+                "a snapshot older than the delivered one must not start a new burst");
+    }
+
+    @Test
+    public void aGenuinelyNewerSnapshotAfterDeliveryIsStillAccepted() {
+        handler.handleUpdateEvent(event(200), 11);
+        UnifiProtectNVRHandler.PendingUpdate delivered = handler.pendingEventUpdates.get(EVENT_ID);
+        assertNotNull(delivered);
+        handler.deliverDebouncedUpdate(EVENT_ID, delivered);
+
+        handler.handleUpdateEvent(event(300), 12);
+
+        assertEquals(12, pendingSequence(), "the guard must not block later updates of the same event");
+    }
+}

--- a/bundles/org.openhab.binding.unifi/src/test/java/org/openhab/binding/unifi/internal/protect/handler/PrivateEventConversionTest.java
+++ b/bundles/org.openhab.binding.unifi/src/test/java/org/openhab/binding/unifi/internal/protect/handler/PrivateEventConversionTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.unifi.internal.protect.handler;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.jupiter.api.Test;
+import org.openhab.binding.unifi.internal.protect.api.priv.dto.gson.JsonUtil;
+import org.openhab.binding.unifi.internal.protect.api.priv.dto.system.Event;
+import org.openhab.binding.unifi.internal.protect.api.pub.dto.ObjectType;
+import org.openhab.binding.unifi.internal.protect.api.pub.dto.events.BaseEvent;
+import org.openhab.binding.unifi.internal.protect.api.pub.dto.events.CameraMotionEvent;
+import org.openhab.binding.unifi.internal.protect.api.pub.dto.events.CameraSmartDetectLineEvent;
+import org.openhab.binding.unifi.internal.protect.api.pub.dto.events.CameraSmartDetectLoiterEvent;
+import org.openhab.binding.unifi.internal.protect.api.pub.dto.events.CameraSmartDetectZoneEvent;
+import org.openhab.binding.unifi.internal.protect.api.pub.dto.events.EventType;
+
+/**
+ * Tests the conversion of private updates-WebSocket events into the public camera events the
+ * regular dispatch reuses. The bugs found while building the fallback were in this routing rather
+ * than in deserialization, so each supported type is covered plus the types that must be ignored.
+ *
+ * @author Stamate Viorel - Initial contribution
+ */
+@NonNullByDefault
+public class PrivateEventConversionTest {
+
+    private static final String CAMERA_ID = "62e3a86301824803e700041d";
+
+    private static Event event(String type, String extra) {
+        return JsonUtil.fromJson("""
+                {"camera":"%s","device":"%s","id":"evt-1","start":1784985677286,"type":"%s"%s}\
+                """.formatted(CAMERA_ID, CAMERA_ID, type, extra), Event.class);
+    }
+
+    @Test
+    public void motionConvertsToPublicMotionEvent() {
+        BaseEvent pub = UnifiProtectNVRHandler.toPublicCameraEvent(event("motion", ""));
+
+        assertNotNull(pub);
+        assertInstanceOf(CameraMotionEvent.class, pub);
+        assertEquals(EventType.CAMERA_MOTION, pub.type);
+        assertEquals(CAMERA_ID, pub.device);
+        assertEquals(1784985677286L, pub.start);
+    }
+
+    @Test
+    public void smartDetectZoneKeepsItsObjectTypes() {
+        BaseEvent pub = UnifiProtectNVRHandler
+                .toPublicCameraEvent(event("smartDetectZone", ",\"smartDetectTypes\":[\"person\",\"face\"]"));
+
+        assertNotNull(pub);
+        assertInstanceOf(CameraSmartDetectZoneEvent.class, pub);
+        assertEquals(EventType.SMART_DETECT_ZONE, pub.type);
+        assertEquals(List.of(ObjectType.PERSON, ObjectType.FACE), ((CameraSmartDetectZoneEvent) pub).smartDetectTypes);
+    }
+
+    @Test
+    public void smartDetectLineConvertsToLineEvent() {
+        BaseEvent pub = UnifiProtectNVRHandler
+                .toPublicCameraEvent(event("smartDetectLine", ",\"smartDetectTypes\":[\"vehicle\"]"));
+
+        assertNotNull(pub);
+        assertInstanceOf(CameraSmartDetectLineEvent.class, pub);
+        assertEquals(EventType.SMART_DETECT_LINE, pub.type);
+    }
+
+    @Test
+    public void smartDetectLoiterZoneConvertsToLoiterEvent() {
+        BaseEvent pub = UnifiProtectNVRHandler
+                .toPublicCameraEvent(event("smartDetectLoiterZone", ",\"smartDetectTypes\":[\"person\"]"));
+
+        assertNotNull(pub);
+        assertInstanceOf(CameraSmartDetectLoiterEvent.class, pub);
+        assertEquals(EventType.SMART_DETECT_LOITER_ZONE, pub.type);
+        assertEquals(List.of(ObjectType.PERSON), ((CameraSmartDetectLoiterEvent) pub).smartDetectTypes);
+    }
+
+    @Test
+    public void typesHandledOnlyByThePublicPathAreIgnored() {
+        // Audio and ring have no private fallback on purpose, so they must not be converted.
+        assertNull(UnifiProtectNVRHandler.toPublicCameraEvent(event("smartAudioDetect", "")));
+        assertNull(UnifiProtectNVRHandler.toPublicCameraEvent(event("ring", "")));
+    }
+
+    @Test
+    public void unknownAndCameralessEventsAreIgnored() {
+        assertNull(UnifiProtectNVRHandler.toPublicCameraEvent(event("disconnect", "")));
+
+        Event noCamera = JsonUtil.fromJson("""
+                {"id":"evt-2","type":"motion","start":1784985677286}\
+                """, Event.class);
+        assertNull(UnifiProtectNVRHandler.toPublicCameraEvent(noCamera));
+    }
+}

--- a/bundles/org.openhab.binding.unifi/src/test/java/org/openhab/binding/unifi/internal/protect/handler/PrivateEventPayloadMergeTest.java
+++ b/bundles/org.openhab.binding.unifi/src/test/java/org/openhab/binding/unifi/internal/protect/handler/PrivateEventPayloadMergeTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.unifi.internal.protect.handler;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openhab.binding.unifi.internal.protect.api.priv.dto.gson.JsonUtil;
+import org.openhab.binding.unifi.internal.protect.api.priv.dto.system.Event;
+import org.openhab.binding.unifi.internal.protect.api.pub.dto.events.BaseEvent;
+import org.openhab.binding.unifi.internal.protect.api.pub.dto.events.EventType;
+import org.openhab.core.thing.Bridge;
+import org.openhab.core.thing.type.ThingTypeRegistry;
+
+import com.google.gson.JsonObject;
+
+/**
+ * Tests that incremental UPDATE frames from the private updates WebSocket are merged into the last
+ * full payload for that event. Protect sends the complete event only on "add"; later "update"
+ * frames carry just the changed fields, which cannot be converted on their own.
+ *
+ * @author Stamate Viorel - Initial contribution
+ */
+@NonNullByDefault
+public class PrivateEventPayloadMergeTest {
+
+    private static final String EVENT_ID = "4b61ed79-7789-4ac1-8cce-927ded49c44e";
+    private static final String CAMERA_ID = "62e3a86301824803e700041d";
+
+    // Verbatim shape of a smartDetectZone "add" from the private updates WebSocket.
+    private static final String FULL_ADD = """
+            {"camera":"%s","device":"%s","id":"%s","score":88,\
+            "smartDetectTypes":["person"],"start":1784985677286,"type":"smartDetectZone"}\
+            """.formatted(CAMERA_ID, CAMERA_ID, EVENT_ID);
+
+    // A real "update" delta: only the fields that changed.
+    private static final String PARTIAL_UPDATE = """
+            {"end":1784985699000,"score":93}\
+            """;
+
+    private @NonNullByDefault({}) UnifiProtectNVRHandler handler;
+
+    private static JsonObject json(String s) {
+        return JsonUtil.fromJson(s, JsonObject.class);
+    }
+
+    @BeforeEach
+    public void setUp() {
+        handler = new UnifiProtectNVRHandler(mock(Bridge.class), mock(ThingTypeRegistry.class));
+    }
+
+    @Test
+    public void partialUpdateIsMergedIntoTheAddPayload() {
+        handler.trackPrivateEventPayload("add", EVENT_ID, json(FULL_ADD));
+
+        @Nullable
+        JsonObject merged = handler.trackPrivateEventPayload("update", EVENT_ID, json(PARTIAL_UPDATE));
+
+        assertNotNull(merged);
+        // Fields carried only by the add survive.
+        assertEquals("smartDetectZone", merged.get("type").getAsString());
+        assertEquals(CAMERA_ID, merged.get("camera").getAsString());
+        assertEquals(1784985677286L, merged.get("start").getAsLong());
+        // Fields from the delta are applied, overwriting where they overlap.
+        assertEquals(1784985699000L, merged.get("end").getAsLong());
+        assertEquals(93, merged.get("score").getAsInt());
+    }
+
+    @Test
+    public void mergedPartialUpdateStillConvertsToAPublicEvent() {
+        handler.trackPrivateEventPayload("add", EVENT_ID, json(FULL_ADD));
+        JsonObject merged = handler.trackPrivateEventPayload("update", EVENT_ID, json(PARTIAL_UPDATE));
+
+        assertNotNull(merged);
+        Event event = JsonUtil.fromJson(merged.toString(), Event.class);
+        BaseEvent pub = UnifiProtectNVRHandler.toPublicCameraEvent(event);
+
+        // Without the merge this is null, because the delta has no type or camera, and the
+        // *_UPDATE dispatch plus the contact latch refresh would be lost.
+        assertNotNull(pub);
+        assertEquals(EventType.SMART_DETECT_ZONE, pub.type);
+        assertEquals(CAMERA_ID, pub.device);
+        assertEquals(1784985699000L, pub.end);
+    }
+
+    @Test
+    public void repeatedUpdatesKeepAccumulating() {
+        handler.trackPrivateEventPayload("add", EVENT_ID, json(FULL_ADD));
+        handler.trackPrivateEventPayload("update", EVENT_ID, json("{\"score\":90}"));
+        JsonObject second = handler.trackPrivateEventPayload("update", EVENT_ID, json(PARTIAL_UPDATE));
+
+        assertNotNull(second);
+        assertEquals("smartDetectZone", second.get("type").getAsString());
+        assertEquals(93, second.get("score").getAsInt());
+        assertEquals(1784985699000L, second.get("end").getAsLong());
+    }
+
+    @Test
+    public void updateWithoutAKnownAddIsPassedThroughUnchanged() {
+        JsonObject out = handler.trackPrivateEventPayload("update", "never-added", json(PARTIAL_UPDATE));
+
+        assertNotNull(out);
+        assertFalse(out.has("type"));
+        assertEquals(1784985699000L, out.get("end").getAsLong());
+    }
+
+    @Test
+    public void removeDropsTheCachedPayload() {
+        handler.trackPrivateEventPayload("add", EVENT_ID, json(FULL_ADD));
+        handler.trackPrivateEventPayload("remove", EVENT_ID, json("{}"));
+
+        JsonObject afterRemove = handler.trackPrivateEventPayload("update", EVENT_ID, json(PARTIAL_UPDATE));
+
+        assertNotNull(afterRemove);
+        assertFalse(afterRemove.has("type"), "a removed event must not keep merging into its old payload");
+    }
+}

--- a/bundles/org.openhab.binding.unifi/src/test/java/org/openhab/binding/unifi/internal/protect/handler/PrivateEventPayloadMergeTest.java
+++ b/bundles/org.openhab.binding.unifi/src/test/java/org/openhab/binding/unifi/internal/protect/handler/PrivateEventPayloadMergeTest.java
@@ -15,6 +15,14 @@ package org.openhab.binding.unifi.internal.protect.handler;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.junit.jupiter.api.BeforeEach;
@@ -116,6 +124,42 @@ public class PrivateEventPayloadMergeTest {
         assertNotNull(out);
         assertFalse(out.has("type"));
         assertEquals(1784985699000L, out.get("end").getAsLong());
+    }
+
+    @Test
+    public void concurrentUpdatesDoNotLoseEachOthersChanges() throws Exception {
+        handler.trackPrivateEventPayload("add", EVENT_ID, json(FULL_ADD));
+
+        // Each thread contributes its own distinct field. If the read/merge/write were not atomic,
+        // threads merging from the same snapshot would overwrite one another and fields would go
+        // missing -- which is what would silently undo the incremental-update handling.
+        int threads = 16;
+        ExecutorService pool = Executors.newFixedThreadPool(threads);
+        CountDownLatch start = new CountDownLatch(1);
+        try {
+            List<Future<?>> futures = new ArrayList<>();
+            for (int i = 0; i < threads; i++) {
+                int n = i;
+                futures.add(pool.submit(() -> {
+                    start.await();
+                    handler.trackPrivateEventPayload("update", EVENT_ID, json("{\"f" + n + "\":" + n + "}"));
+                    return null;
+                }));
+            }
+            start.countDown();
+            for (Future<?> f : futures) {
+                f.get(10, TimeUnit.SECONDS);
+            }
+        } finally {
+            pool.shutdownNow();
+        }
+
+        JsonObject finalPayload = handler.trackPrivateEventPayload("update", EVENT_ID, json("{}"));
+        assertNotNull(finalPayload);
+        assertEquals("smartDetectZone", finalPayload.get("type").getAsString());
+        for (int i = 0; i < threads; i++) {
+            assertTrue(finalPayload.has("f" + i), "field f" + i + " was lost by a concurrent merge");
+        }
     }
 
     @Test


### PR DESCRIPTION
## Problem

The UniFi Protect **integration events** WebSocket (`/proxy/protect/integration/v1/subscribe/events`) can connect and authenticate but then deliver **no events at all** — a Protect-side condition, not a disconnect. When that happens, every camera **motion** and **smart-detect** channel/trigger goes quiet while the bridge still reports ONLINE, so nothing downstream fires and it looks like the cameras simply stopped detecting.

## Change

The **private updates** WebSocket (already used for device/state deltas) still carries these detections. In `routePrivateApiUpdate`'s `EVENT` branch, `MOTION` / `SMART_DETECT` / `SMART_DETECT_LINE` / `SMART_DETECT_LOITER_ZONE` events are converted to the matching public camera event (`toPublicCameraEvent`) and dispatched through the existing `routePublicApiEvent` path — so the same channels + contacts fire regardless of which WebSocket delivered the event. A short-TTL (120 s) dedup on the event id fires each detection exactly once when both WebSockets deliver it; only ADDs are de-duplicated, UPDATEs for an event already seen are expected to pass through. Audio and ring events stay on the public integration path only.

`/ws/updates` sends the complete event only on `add` — later `update` frames carry just the changed fields. Those deltas are merged into the last full payload for that event id before conversion, on the WebSocket thread so the frames stay in the order the NVR sent them.

## Testing

Unit tests cover the private → public conversion for each supported type, the ADD-only dedup, `remove` handling, and an ADD followed by a partial UPDATE carrying only `end`, plus concurrent merges.

The end-to-end case — integration WS connected but mute — has not been reproduced since the field-name fix that made this fallback actually work (the payload uses `camera`, not `cameraId`), so the detection counts quoted in an earlier version of this description came from a period when the fallback was still a no-op and do not describe the current implementation.

Loiter-zone events could not be exercised here either: no camera on my NVR has a loiter zone that triggers in normal use. The wire name matches the public API — the private REST API on my NVR returns `motion`, `smartDetectZone`, `smartDetectLine`, `smartAudioDetect` and `ring` with exactly the same strings as the public enum, and `uilibs/uiprotect` carries `smartDetectLoiterZone` in the same `EventType` its WebSocket handler reads.

Complements #21186 (which reconnects a WebSocket that dies silently); this covers the different failure — the WebSocket is alive but mute.
