### PR TITLE
[solaredge] Fix PrivateApi

### DIFF
--- a/bundles/org.openhab.binding.solaredge/README.md
+++ b/bundles/org.openhab.binding.solaredge/README.md
@@ -58,6 +58,10 @@ Setting less than 10 minutes is only allowed when using the private API. (Defaul
 Interval (minutes) in which aggregate data values are retrieved from SolarEdge.
 Setting less than 60 minutes is only allowed when using the private API. (Default: 60)
 
+- **batteryCriticalLevel** (optional)<br>
+Only for use with private API.
+Battery charge level below which the battery is considered critical. (Default: 10)
+
 ## Channels
 
 Available channels depend on the specific setup, e.g., if a meter and/or a battery is present.

--- a/bundles/org.openhab.binding.solaredge/src/main/java/org/openhab/binding/solaredge/internal/SolarEdgeBindingConstants.java
+++ b/bundles/org.openhab.binding.solaredge/src/main/java/org/openhab/binding/solaredge/internal/SolarEdgeBindingConstants.java
@@ -19,7 +19,8 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.core.thing.ThingTypeUID;
 
 /**
- * The {@link SolarEdgeBindingConstants} class defines common constants, which are
+ * The {@link SolarEdgeBindingConstants} class defines common constants, which
+ * are
  * used across the whole binding.
  *
  * @author Alexander Friese - Initial contribution
@@ -62,10 +63,11 @@ public class SolarEdgeBindingConstants {
 
     // PRIVATE API CONSTANTS
     // URLs
-    public static final String PRIVATE_DATA_API_URL = "https://monitoring.solaredge.com/solaredge-apigw/api/site/";
-    public static final String PRIVATE_DATA_API_URL_AGGREGATE_DATA_DAY_WEEK_SUFFIX = "/powerDashboardChart";
-    public static final String PRIVATE_DATA_API_URL_AGGREGATE_DATA_MONTH_YEAR_SUFFIX = "/energyDashboardChart";
-    public static final String PRIVATE_DATA_API_URL_LIVE_DATA_SUFFIX = "/currentPowerFlow.json";
+    public static final String PRIVATE_DATA_API_URL = "https://monitoring.solaredge.com/services/dashboard/power-flow/v2/sites/";
+    public static final String PRIVATE_DATA_API_URL_AGGREGATE = "https://monitoring.solaredge.com/services/dashboard/energy/sites/";
+    public static final String PRIVATE_DATA_API_URL_AGGREGATE_DATA_DAY_WEEK_SUFFIX = "?chart-time-unit=days&measurement-types=production&measurement-types=yield&measurement-types=average-power-factor&measurement-types=performance-ratio&measurement-types=site-availability&measurement-types=consumption&measurement-types=production-distribution-with-storage&measurement-types=consumption-distribution-with-storage&measurement-types=import&measurement-types=export&isCniViewer=true";
+    public static final String PRIVATE_DATA_API_URL_AGGREGATE_DATA_MONTH_YEAR_SUFFIX = "?chart-time-unit=months&measurement-types=production&measurement-types=yield&measurement-types=average-power-factor&measurement-types=performance-ratio&measurement-types=site-availability&measurement-types=consumption&measurement-types=production-distribution-with-storage&measurement-types=consumption-distribution-with-storage&measurement-types=import&measurement-types=export&isCniViewer=true";
+    public static final String PRIVATE_DATA_API_URL_LIVE_DATA_SUFFIX = "?components=grid&components=consumption&components=dc-storage";
 
     // field names
     public static final String PRIVATE_API_TOKEN_COOKIE_NAME = "SPRING_SECURITY_REMEMBER_ME_COOKIE";
@@ -75,7 +77,7 @@ public class SolarEdgeBindingConstants {
 
     //
     //
-    // PRIVATE API CONSTANTS
+    // PUBLIC API CONSTANTS
     // URLs
     public static final String PUBLIC_DATA_API_URL = "https://monitoringapi.solaredge.com/site/";
     public static final String PUBLIC_DATA_API_URL_AGGREGATE_DATA_SUFFIX = "/energyDetails";

--- a/bundles/org.openhab.binding.solaredge/src/main/java/org/openhab/binding/solaredge/internal/SolarEdgeBindingConstants.java
+++ b/bundles/org.openhab.binding.solaredge/src/main/java/org/openhab/binding/solaredge/internal/SolarEdgeBindingConstants.java
@@ -65,9 +65,11 @@ public class SolarEdgeBindingConstants {
     // URLs
     public static final String PRIVATE_DATA_API_URL = "https://monitoring.solaredge.com/services/dashboard/power-flow/v2/sites/";
     public static final String PRIVATE_DATA_API_URL_AGGREGATE = "https://monitoring.solaredge.com/services/dashboard/energy/sites/";
-    public static final String PRIVATE_DATA_API_URL_AGGREGATE_DATA_DAY_WEEK_SUFFIX = "?chart-time-unit=days&measurement-types=production&measurement-types=yield&measurement-types=average-power-factor&measurement-types=performance-ratio&measurement-types=site-availability&measurement-types=consumption&measurement-types=production-distribution-with-storage&measurement-types=consumption-distribution-with-storage&measurement-types=import&measurement-types=export&isCniViewer=true";
-    public static final String PRIVATE_DATA_API_URL_AGGREGATE_DATA_MONTH_YEAR_SUFFIX = "?chart-time-unit=months&measurement-types=production&measurement-types=yield&measurement-types=average-power-factor&measurement-types=performance-ratio&measurement-types=site-availability&measurement-types=consumption&measurement-types=production-distribution-with-storage&measurement-types=consumption-distribution-with-storage&measurement-types=import&measurement-types=export&isCniViewer=true";
+    public static final String PRIVATE_DATA_API_URL_AGGREGATE_DATA_DAY_WEEK_MONTH_SUFFIX = "?chart-time-unit=days&measurement-types=production&measurement-types=yield&measurement-types=average-power-factor&measurement-types=performance-ratio&measurement-types=site-availability&measurement-types=consumption&measurement-types=production-distribution-with-storage&measurement-types=consumption-distribution-with-storage&measurement-types=import&measurement-types=export&isCniViewer=true";
+    public static final String PRIVATE_DATA_API_URL_AGGREGATE_DATA_YEAR_SUFFIX = "?chart-time-unit=months&measurement-types=production&measurement-types=yield&measurement-types=average-power-factor&measurement-types=performance-ratio&measurement-types=site-availability&measurement-types=consumption&measurement-types=production-distribution-with-storage&measurement-types=consumption-distribution-with-storage&measurement-types=import&measurement-types=export&isCniViewer=true";
     public static final String PRIVATE_DATA_API_URL_LIVE_DATA_SUFFIX = "?components=grid&components=consumption&components=dc-storage";
+    public static final String PRIVATE_DATA_API_PARAM_START_DATE = "&start-date=";
+    public static final String PRIVATE_DATA_API_PARAM_END_DATE = "&end-date=";
 
     // field names
     public static final String PRIVATE_API_TOKEN_COOKIE_NAME = "SPRING_SECURITY_REMEMBER_ME_COOKIE";

--- a/bundles/org.openhab.binding.solaredge/src/main/java/org/openhab/binding/solaredge/internal/command/AggregateDataUpdatePrivateApi.java
+++ b/bundles/org.openhab.binding.solaredge/src/main/java/org/openhab/binding/solaredge/internal/command/AggregateDataUpdatePrivateApi.java
@@ -15,6 +15,7 @@ package org.openhab.binding.solaredge.internal.command;
 import static org.openhab.binding.solaredge.internal.SolarEdgeBindingConstants.*;
 
 import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
@@ -66,18 +67,35 @@ public class AggregateDataUpdatePrivateApi extends AbstractCommand implements So
         this.transformer = new AggregateDataResponseTransformerPrivateApi(handler);
         this.period = period;
         switch (period) {
-            case DAY:
-                this.urlSuffix = PRIVATE_DATA_API_URL_AGGREGATE_DATA_DAY_WEEK_SUFFIX;
+            case DAY: {
+                String today = LocalDate.now().toString();
+                this.urlSuffix = PRIVATE_DATA_API_URL_AGGREGATE_DATA_DAY_WEEK_SUFFIX + "&start-date=" + today
+                        + "&end-date=" + today;
                 break;
-            case WEEK:
-                this.urlSuffix = PRIVATE_DATA_API_URL_AGGREGATE_DATA_DAY_WEEK_SUFFIX;
+            }
+            case WEEK: {
+                String startDate = LocalDate.now().minusDays(6).toString();
+                String endDate = LocalDate.now().toString();
+                this.urlSuffix = PRIVATE_DATA_API_URL_AGGREGATE_DATA_DAY_WEEK_SUFFIX + "&start-date=" + startDate
+                        + "&end-date=" + endDate;
                 break;
-            case MONTH:
-                this.urlSuffix = PRIVATE_DATA_API_URL_AGGREGATE_DATA_MONTH_YEAR_SUFFIX;
+            }
+            case MONTH: {
+                LocalDate today = LocalDate.now();
+                String startDate = today.withDayOfMonth(1).toString();
+                String endDate = today.toString();
+                this.urlSuffix = PRIVATE_DATA_API_URL_AGGREGATE_DATA_DAY_WEEK_SUFFIX + "&start-date=" + startDate
+                        + "&end-date=" + endDate;
                 break;
-            case YEAR:
-                this.urlSuffix = PRIVATE_DATA_API_URL_AGGREGATE_DATA_MONTH_YEAR_SUFFIX;
+            }
+            case YEAR: {
+                LocalDate today = LocalDate.now();
+                String startDate = today.minusYears(1).plusDays(1).toString();
+                String endDate = today.toString();
+                this.urlSuffix = PRIVATE_DATA_API_URL_AGGREGATE_DATA_MONTH_YEAR_SUFFIX + "&start-date=" + startDate
+                        + "&end-date=" + endDate;
                 break;
+            }
             default:
                 this.urlSuffix = "";
         }
@@ -94,12 +112,13 @@ public class AggregateDataUpdatePrivateApi extends AbstractCommand implements So
 
     @Override
     protected String getURL() {
-        return PRIVATE_DATA_API_URL + config.getSolarId() + urlSuffix;
+        return PRIVATE_DATA_API_URL_AGGREGATE + config.getSolarId() + urlSuffix;
     }
 
     @Override
     public void onComplete(@Nullable Result result) {
-        logger.debug("onComplete()");
+        logger.debug("[AggregateDataUpdatePrivateApi] onComplete()");
+        logger.trace("URL: {}", getURL());
 
         if (!HttpStatus.Code.OK.equals(getCommunicationStatus().getHttpCode())) {
             if (retries++ < MAX_RETRIES) {

--- a/bundles/org.openhab.binding.solaredge/src/main/java/org/openhab/binding/solaredge/internal/command/AggregateDataUpdatePrivateApi.java
+++ b/bundles/org.openhab.binding.solaredge/src/main/java/org/openhab/binding/solaredge/internal/command/AggregateDataUpdatePrivateApi.java
@@ -69,31 +69,31 @@ public class AggregateDataUpdatePrivateApi extends AbstractCommand implements So
         switch (period) {
             case DAY: {
                 String today = LocalDate.now().toString();
-                this.urlSuffix = PRIVATE_DATA_API_URL_AGGREGATE_DATA_DAY_WEEK_SUFFIX + "&start-date=" + today
-                        + "&end-date=" + today;
+                this.urlSuffix = PRIVATE_DATA_API_URL_AGGREGATE_DATA_DAY_WEEK_MONTH_SUFFIX
+                        + PRIVATE_DATA_API_PARAM_START_DATE + today + PRIVATE_DATA_API_PARAM_END_DATE + today;
                 break;
             }
             case WEEK: {
                 String startDate = LocalDate.now().minusDays(6).toString();
                 String endDate = LocalDate.now().toString();
-                this.urlSuffix = PRIVATE_DATA_API_URL_AGGREGATE_DATA_DAY_WEEK_SUFFIX + "&start-date=" + startDate
-                        + "&end-date=" + endDate;
+                this.urlSuffix = PRIVATE_DATA_API_URL_AGGREGATE_DATA_DAY_WEEK_MONTH_SUFFIX
+                        + PRIVATE_DATA_API_PARAM_START_DATE + startDate + PRIVATE_DATA_API_PARAM_END_DATE + endDate;
                 break;
             }
             case MONTH: {
                 LocalDate today = LocalDate.now();
                 String startDate = today.withDayOfMonth(1).toString();
                 String endDate = today.toString();
-                this.urlSuffix = PRIVATE_DATA_API_URL_AGGREGATE_DATA_DAY_WEEK_SUFFIX + "&start-date=" + startDate
-                        + "&end-date=" + endDate;
+                this.urlSuffix = PRIVATE_DATA_API_URL_AGGREGATE_DATA_DAY_WEEK_MONTH_SUFFIX
+                        + PRIVATE_DATA_API_PARAM_START_DATE + startDate + PRIVATE_DATA_API_PARAM_END_DATE + endDate;
                 break;
             }
             case YEAR: {
                 LocalDate today = LocalDate.now();
                 String startDate = today.minusYears(1).plusDays(1).toString();
                 String endDate = today.toString();
-                this.urlSuffix = PRIVATE_DATA_API_URL_AGGREGATE_DATA_MONTH_YEAR_SUFFIX + "&start-date=" + startDate
-                        + "&end-date=" + endDate;
+                this.urlSuffix = PRIVATE_DATA_API_URL_AGGREGATE_DATA_YEAR_SUFFIX + PRIVATE_DATA_API_PARAM_START_DATE
+                        + startDate + PRIVATE_DATA_API_PARAM_END_DATE + endDate;
                 break;
             }
             default:

--- a/bundles/org.openhab.binding.solaredge/src/main/java/org/openhab/binding/solaredge/internal/command/AggregateDataUpdatePublicApi.java
+++ b/bundles/org.openhab.binding.solaredge/src/main/java/org/openhab/binding/solaredge/internal/command/AggregateDataUpdatePublicApi.java
@@ -91,7 +91,8 @@ public class AggregateDataUpdatePublicApi extends AbstractCommand implements Sol
 
     @Override
     public void onComplete(@Nullable Result result) {
-        logger.debug("onComplete()");
+        logger.debug("[AggregateDataUpdatePublicApi] onComplete()");
+        logger.trace("URL: {}", getURL());
 
         if (!HttpStatus.Code.OK.equals(getCommunicationStatus().getHttpCode())) {
             if (retries++ < MAX_RETRIES) {

--- a/bundles/org.openhab.binding.solaredge/src/main/java/org/openhab/binding/solaredge/internal/command/LiveDataUpdateMeterless.java
+++ b/bundles/org.openhab.binding.solaredge/src/main/java/org/openhab/binding/solaredge/internal/command/LiveDataUpdateMeterless.java
@@ -25,7 +25,7 @@ import org.eclipse.jetty.http.HttpStatus;
 import org.openhab.binding.solaredge.internal.connector.StatusUpdateListener;
 import org.openhab.binding.solaredge.internal.handler.SolarEdgeHandler;
 import org.openhab.binding.solaredge.internal.model.LiveDataResponseMeterless;
-import org.openhab.binding.solaredge.internal.model.LiveDataResponseTransformer;
+import org.openhab.binding.solaredge.internal.model.LiveDataResponseTransformerPublicApi;
 
 /**
  * command that retrieves status values for live data channels via public API
@@ -36,13 +36,13 @@ import org.openhab.binding.solaredge.internal.model.LiveDataResponseTransformer;
 public class LiveDataUpdateMeterless extends AbstractCommand implements SolarEdgeCommand {
 
     private final SolarEdgeHandler handler;
-    private final LiveDataResponseTransformer transformer;
+    private final LiveDataResponseTransformerPublicApi transformer;
     private int retries = 0;
 
     public LiveDataUpdateMeterless(SolarEdgeHandler handler, StatusUpdateListener listener) {
         super(handler.getConfiguration(), listener);
         this.handler = handler;
-        this.transformer = new LiveDataResponseTransformer(handler);
+        this.transformer = new LiveDataResponseTransformerPublicApi(handler);
     }
 
     @Override
@@ -60,7 +60,8 @@ public class LiveDataUpdateMeterless extends AbstractCommand implements SolarEdg
 
     @Override
     public void onComplete(@Nullable Result result) {
-        logger.debug("onComplete()");
+        logger.debug("[LiveDataUpdateMeterless] onComplete()");
+        logger.trace("URL: {}", getURL());
 
         if (!HttpStatus.Code.OK.equals(getCommunicationStatus().getHttpCode())) {
             if (retries++ < MAX_RETRIES) {

--- a/bundles/org.openhab.binding.solaredge/src/main/java/org/openhab/binding/solaredge/internal/command/LiveDataUpdatePrivateApi.java
+++ b/bundles/org.openhab.binding.solaredge/src/main/java/org/openhab/binding/solaredge/internal/command/LiveDataUpdatePrivateApi.java
@@ -24,8 +24,8 @@ import org.eclipse.jetty.http.HttpMethod;
 import org.eclipse.jetty.http.HttpStatus;
 import org.openhab.binding.solaredge.internal.connector.StatusUpdateListener;
 import org.openhab.binding.solaredge.internal.handler.SolarEdgeHandler;
-import org.openhab.binding.solaredge.internal.model.LiveDataResponse;
-import org.openhab.binding.solaredge.internal.model.LiveDataResponseTransformer;
+import org.openhab.binding.solaredge.internal.model.LiveDataResponsePrivateApi;
+import org.openhab.binding.solaredge.internal.model.LiveDataResponseTransformerPrivateApi;
 
 /**
  * command that retrieves status values for live data channels via private API
@@ -36,13 +36,13 @@ import org.openhab.binding.solaredge.internal.model.LiveDataResponseTransformer;
 public class LiveDataUpdatePrivateApi extends AbstractCommand implements SolarEdgeCommand {
 
     private final SolarEdgeHandler handler;
-    private final LiveDataResponseTransformer transformer;
+    private final LiveDataResponseTransformerPrivateApi transformer;
     private int retries = 0;
 
     public LiveDataUpdatePrivateApi(SolarEdgeHandler handler, StatusUpdateListener listener) {
         super(handler.getConfiguration(), listener);
         this.handler = handler;
-        this.transformer = new LiveDataResponseTransformer(handler);
+        this.transformer = new LiveDataResponseTransformerPrivateApi(handler);
     }
 
     @Override
@@ -60,7 +60,8 @@ public class LiveDataUpdatePrivateApi extends AbstractCommand implements SolarEd
 
     @Override
     public void onComplete(@Nullable Result result) {
-        logger.debug("onComplete()");
+        logger.debug("[LiveDataUpdatePrivateApi] onComplete()");
+        logger.trace("URL: {}", getURL());
 
         if (!HttpStatus.Code.OK.equals(getCommunicationStatus().getHttpCode())) {
             if (retries++ < MAX_RETRIES) {
@@ -71,7 +72,7 @@ public class LiveDataUpdatePrivateApi extends AbstractCommand implements SolarEd
             String json = getContentAsString(StandardCharsets.UTF_8);
             if (json != null) {
                 logger.debug("JSON String: {}", json);
-                LiveDataResponse jsonObject = fromJson(json, LiveDataResponse.class);
+                LiveDataResponsePrivateApi jsonObject = fromJson(json, LiveDataResponsePrivateApi.class);
                 if (jsonObject != null) {
                     handler.updateChannelStatus(transformer.transform(jsonObject));
                 }

--- a/bundles/org.openhab.binding.solaredge/src/main/java/org/openhab/binding/solaredge/internal/command/LiveDataUpdatePrivateApi.java
+++ b/bundles/org.openhab.binding.solaredge/src/main/java/org/openhab/binding/solaredge/internal/command/LiveDataUpdatePrivateApi.java
@@ -42,7 +42,7 @@ public class LiveDataUpdatePrivateApi extends AbstractCommand implements SolarEd
     public LiveDataUpdatePrivateApi(SolarEdgeHandler handler, StatusUpdateListener listener) {
         super(handler.getConfiguration(), listener);
         this.handler = handler;
-        this.transformer = new LiveDataResponseTransformerPrivateApi(handler);
+        this.transformer = new LiveDataResponseTransformerPrivateApi(handler, config);
     }
 
     @Override

--- a/bundles/org.openhab.binding.solaredge/src/main/java/org/openhab/binding/solaredge/internal/command/LiveDataUpdatePublicApi.java
+++ b/bundles/org.openhab.binding.solaredge/src/main/java/org/openhab/binding/solaredge/internal/command/LiveDataUpdatePublicApi.java
@@ -24,8 +24,8 @@ import org.eclipse.jetty.http.HttpMethod;
 import org.eclipse.jetty.http.HttpStatus;
 import org.openhab.binding.solaredge.internal.connector.StatusUpdateListener;
 import org.openhab.binding.solaredge.internal.handler.SolarEdgeHandler;
-import org.openhab.binding.solaredge.internal.model.LiveDataResponse;
-import org.openhab.binding.solaredge.internal.model.LiveDataResponseTransformer;
+import org.openhab.binding.solaredge.internal.model.LiveDataResponsePublicApi;
+import org.openhab.binding.solaredge.internal.model.LiveDataResponseTransformerPublicApi;
 
 /**
  * command that retrieves status values for live data channels via public API
@@ -36,13 +36,13 @@ import org.openhab.binding.solaredge.internal.model.LiveDataResponseTransformer;
 public class LiveDataUpdatePublicApi extends AbstractCommand implements SolarEdgeCommand {
 
     private final SolarEdgeHandler handler;
-    private final LiveDataResponseTransformer transformer;
+    private final LiveDataResponseTransformerPublicApi transformer;
     private int retries = 0;
 
     public LiveDataUpdatePublicApi(SolarEdgeHandler handler, StatusUpdateListener listener) {
         super(handler.getConfiguration(), listener);
         this.handler = handler;
-        this.transformer = new LiveDataResponseTransformer(handler);
+        this.transformer = new LiveDataResponseTransformerPublicApi(handler);
     }
 
     @Override
@@ -60,7 +60,9 @@ public class LiveDataUpdatePublicApi extends AbstractCommand implements SolarEdg
 
     @Override
     public void onComplete(@Nullable Result result) {
-        logger.debug("onComplete()");
+        logger.debug("[LiveDataUpdatePublicApi] onComplete()");
+        logger.trace("URL: {}", getURL());
+
         if (!HttpStatus.Code.OK.equals(getCommunicationStatus().getHttpCode())) {
             if (retries++ < MAX_RETRIES) {
                 handler.getWebInterface().enqueueCommand(this);
@@ -70,7 +72,7 @@ public class LiveDataUpdatePublicApi extends AbstractCommand implements SolarEdg
             String json = getContentAsString(StandardCharsets.UTF_8);
             if (json != null) {
                 logger.debug("JSON String: {}", json);
-                LiveDataResponse jsonObject = fromJson(json, LiveDataResponse.class);
+                LiveDataResponsePublicApi jsonObject = fromJson(json, LiveDataResponsePublicApi.class);
                 if (jsonObject != null) {
                     handler.updateChannelStatus(transformer.transform(jsonObject));
                 }

--- a/bundles/org.openhab.binding.solaredge/src/main/java/org/openhab/binding/solaredge/internal/config/SolarEdgeConfiguration.java
+++ b/bundles/org.openhab.binding.solaredge/src/main/java/org/openhab/binding/solaredge/internal/config/SolarEdgeConfiguration.java
@@ -32,6 +32,7 @@ public class SolarEdgeConfiguration {
     private Integer syncTimeout = 120;
     private Integer liveDataPollingInterval = 10;
     private Integer aggregateDataPollingInterval = 60;
+    private Integer batteryCriticalLevel = 10;
 
     public String getTokenOrApiKey() {
         return tokenOrApiKey;
@@ -81,6 +82,14 @@ public class SolarEdgeConfiguration {
         this.aggregateDataPollingInterval = aggregateDataPollingInterval;
     }
 
+    public Integer getBatteryCriticalLevel() {
+        return batteryCriticalLevel;
+    }
+
+    public void setBatteryCriticalLevel(Integer batteryCriticalLevel) {
+        this.batteryCriticalLevel = batteryCriticalLevel;
+    }
+
     public boolean isMeterInstalled() {
         return meterInstalled;
     }
@@ -102,7 +111,7 @@ public class SolarEdgeConfiguration {
         return getClass().getSimpleName() + "{ tokenOrApiKey=" + getTokenOrApiKey() + ", solarId=" + getSolarId()
                 + ", meterInstalled=" + isMeterInstalled() + ", usePrivateApi=" + isUsePrivateApi()
                 + ", live data pollingInterval=" + getLiveDataPollingInterval() + ", aggregate data pollingInterval="
-                + getAggregateDataPollingInterval() + ", asyncTimeout=" + getAsyncTimeout() + ", syncTimeout="
-                + getSyncTimeout() + "}";
+                + getAggregateDataPollingInterval() + ", batteryCriticalLevel=" + getBatteryCriticalLevel()
+                + ", asyncTimeout=" + getAsyncTimeout() + ", syncTimeout=" + getSyncTimeout() + "}";
     }
 }

--- a/bundles/org.openhab.binding.solaredge/src/main/java/org/openhab/binding/solaredge/internal/model/AbstractDataResponseTransformer.java
+++ b/bundles/org.openhab.binding.solaredge/src/main/java/org/openhab/binding/solaredge/internal/model/AbstractDataResponseTransformer.java
@@ -23,8 +23,6 @@ import javax.measure.quantity.Power;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
-import org.openhab.binding.solaredge.internal.model.AggregateDataResponsePrivateApi.Value;
-import org.openhab.binding.solaredge.internal.model.AggregateDataResponsePrivateApi.ValueAndPercent;
 import org.openhab.binding.solaredge.internal.model.AggregateDataResponsePublicApi.MeterTelemetry;
 import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.library.types.QuantityType;
@@ -154,18 +152,6 @@ abstract class AbstractDataResponseTransformer {
     }
 
     /**
-     * converts the value to {@code QuantityType<Energy>} and puts it into the targetMap. If no value or unit is
-     * provided, UnDefType.UNDEF will be used
-     *
-     * @param targetMap result will be put into this map
-     * @param channel channel to assign the value
-     * @param value the value to convert
-     */
-    protected final void putEnergyType(Map<Channel, State> targetMap, @Nullable Channel channel, Value value) {
-        putEnergyType(targetMap, channel, value.value, value.unit);
-    }
-
-    /**
      * converts the meter value to {@code QuantityType<Energy>} and puts it into the targetMap. If multiple meter value
      * are provided a sum will be calculated. If no
      * unit can be determined UnDefType.UNDEF will be used
@@ -242,18 +228,6 @@ abstract class AbstractDataResponseTransformer {
     protected final void putPercentType(Map<Channel, State> targetMap, @Nullable Channel channel,
             @Nullable Double value) {
         putPercentType(targetMap, channel, value, 1);
-    }
-
-    /**
-     * put value as PercentType into targetMap.
-     *
-     * @param targetMap result will be put into this map
-     * @param channel channel to assign the value
-     * @param value the value to convert
-     */
-    protected final void putPercentType(Map<Channel, State> targetMap, @Nullable Channel channel,
-            ValueAndPercent value) {
-        putPercentType(targetMap, channel, value.percentage, 100);
     }
 
     /**

--- a/bundles/org.openhab.binding.solaredge/src/main/java/org/openhab/binding/solaredge/internal/model/AggregateDataResponsePrivateApi.java
+++ b/bundles/org.openhab.binding.solaredge/src/main/java/org/openhab/binding/solaredge/internal/model/AggregateDataResponsePrivateApi.java
@@ -12,45 +12,112 @@
  */
 package org.openhab.binding.solaredge.internal.model;
 
+import java.util.List;
+
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 
 import com.google.gson.annotations.SerializedName;
 
 /**
- * this abstract class is used as base for the specific aggregate response classes
+ * this class represents the energy response of the private SolarEdge API
  *
  * @author Alexander Friese - initial contribution
  */
 @NonNullByDefault
 public class AggregateDataResponsePrivateApi {
 
-    public static class Value {
-        public @Nullable Double value;
-        public @Nullable String unit;
+    public static class ProductionDistribution {
+        public @Nullable Double productionToHome;
+        public @Nullable Double productionToHomePercentage;
+        public @Nullable Double productionUnknown;
+        public @Nullable Double productionUnknownPercentage;
+        public @Nullable Double productionToBattery;
+        public @Nullable Double productionToBatteryPercentage;
+        public @Nullable Double productionToGrid;
+        public @Nullable Double productionToGridPercentage;
     }
 
-    public static class ValueAndPercent extends Value {
-        public @Nullable Double percentage;
+    public static class ConsumptionDistribution {
+        public @Nullable Double consumptionFromBattery;
+        public @Nullable Double consumptionFromBatteryPercentage;
+        public @Nullable Double consumptionFromSolar;
+        public @Nullable Double consumptionFromSolarPercentage;
+        public @Nullable Double consumptionFromGrid;
+        public @Nullable Double consumptionFromGridPercentage;
     }
 
-    public static class UtilizationMeasures {
-        public @Nullable Value production;
-        public @Nullable Value consumption;
-        public @Nullable ValueAndPercent selfConsumptionForConsumption;
-        public @Nullable ValueAndPercent batterySelfConsumption;
+    public static class Summary {
+        public @Nullable Double production;
+        public @Nullable ProductionDistribution productionDistribution;
+        public @Nullable Double consumption;
+        public @Nullable ConsumptionDistribution consumptionDistribution;
+        public @Nullable Double performanceRatio;
+        public @Nullable Double averagePowerFactor;
+        public @Nullable Double selfConsumptionRatio;
+        public @Nullable Double selfSufficiencyRatio;
+        public @Nullable Integer siteAvailability;
+        public @Nullable Double export;
+        public @Nullable String lateProductionStartDate;
+        public @Nullable String lateProductionDistributionStartDate;
+        public @Nullable String lateConsumptionStartDate;
+        public @Nullable String lateConsumptionDistributionStartDate;
+        public @Nullable String latePerformanceRatioStartDate;
+        public @Nullable String lateYieldStartDate;
+        public @Nullable Double yield;
+
         @SerializedName("import")
-        public @Nullable ValueAndPercent imported;
-        public @Nullable ValueAndPercent export;
+        public @Nullable Double imported;
     }
 
-    private @Nullable UtilizationMeasures utilizationMeasures;
-
-    public final @Nullable UtilizationMeasures getUtilizationMeasures() {
-        return utilizationMeasures;
+    public static class MeasurementProductionDistribution {
+        public @Nullable Double productionToHome;
+        public @Nullable Double productionUnknown;
+        public @Nullable Double productionToBattery;
+        public @Nullable Double productionToGrid;
+        public @Nullable Boolean estimated;
     }
 
-    public final void setUtilizationMeasures(UtilizationMeasures utilizationMeasures) {
-        this.utilizationMeasures = utilizationMeasures;
+    public static class MeasurementConsumptionDistribution {
+        public @Nullable Double consumptionFromBattery;
+        public @Nullable Double consumptionFromSolar;
+        public @Nullable Double consumptionFromGrid;
+        public @Nullable Boolean estimated;
+    }
+
+    public static class Measurement {
+        public @Nullable String measurementTime;
+        public @Nullable Double production;
+        public @Nullable MeasurementProductionDistribution productionDistribution;
+        public @Nullable Double consumption;
+        public @Nullable MeasurementConsumptionDistribution consumptionDistribution;
+        public @Nullable String weatherDescription;
+        public @Nullable Double export;
+
+        @SerializedName("import")
+        public @Nullable Double imported;
+    }
+
+    public static class Chart {
+        public @Nullable List<Measurement> measurements;
+    }
+
+    private @Nullable Summary summary;
+    private @Nullable Chart chart;
+
+    public final @Nullable Summary getSummary() {
+        return summary;
+    }
+
+    public final void setSummary(Summary summary) {
+        this.summary = summary;
+    }
+
+    public final @Nullable Chart getChart() {
+        return chart;
+    }
+
+    public final void setChart(Chart chart) {
+        this.chart = chart;
     }
 }

--- a/bundles/org.openhab.binding.solaredge/src/main/java/org/openhab/binding/solaredge/internal/model/AggregateDataResponseTransformerPrivateApi.java
+++ b/bundles/org.openhab.binding.solaredge/src/main/java/org/openhab/binding/solaredge/internal/model/AggregateDataResponseTransformerPrivateApi.java
@@ -19,14 +19,13 @@ import java.util.Map;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.binding.solaredge.internal.handler.ChannelProvider;
-import org.openhab.binding.solaredge.internal.model.AggregateDataResponsePrivateApi.UtilizationMeasures;
-import org.openhab.binding.solaredge.internal.model.AggregateDataResponsePrivateApi.Value;
-import org.openhab.binding.solaredge.internal.model.AggregateDataResponsePrivateApi.ValueAndPercent;
+import org.openhab.binding.solaredge.internal.model.AggregateDataResponsePrivateApi.ConsumptionDistribution;
+import org.openhab.binding.solaredge.internal.model.AggregateDataResponsePrivateApi.Summary;
 import org.openhab.core.thing.Channel;
 import org.openhab.core.types.State;
 
 /**
- * transforms the http response into the openhab datamodel (instances of State)
+ * transforms the energy dashboard response into the openHAB datamodel (instances of State)
  *
  * @author Alexander Friese - initial contribution
  */
@@ -40,45 +39,34 @@ public class AggregateDataResponseTransformerPrivateApi extends AbstractDataResp
 
     public Map<Channel, State> transform(AggregateDataResponsePrivateApi response, AggregatePeriod period) {
         Map<Channel, State> result = new HashMap<>(20);
-        UtilizationMeasures utilizationMeasures = response.getUtilizationMeasures();
+        Summary summary = response.getSummary();
 
         String group = convertPeriodToGroup(period);
 
-        if (utilizationMeasures != null) {
-            Value production = utilizationMeasures.production;
-            if (production != null) {
-                putEnergyType(result, channelProvider.getChannel(group, CHANNEL_ID_PRODUCTION), production);
-            }
+        if (summary != null) {
+            putEnergyType(result, channelProvider.getChannel(group, CHANNEL_ID_PRODUCTION), summary.production,
+                    UNIT_WH);
 
-            Value consumption = utilizationMeasures.consumption;
-            if (consumption != null) {
-                putEnergyType(result, channelProvider.getChannel(group, CHANNEL_ID_CONSUMPTION), consumption);
-            }
+            putEnergyType(result, channelProvider.getChannel(group, CHANNEL_ID_CONSUMPTION), summary.consumption,
+                    UNIT_WH);
 
-            ValueAndPercent selfConsumptionForConsumption = utilizationMeasures.selfConsumptionForConsumption;
-            if (selfConsumptionForConsumption != null) {
+            putEnergyType(result, channelProvider.getChannel(group, CHANNEL_ID_IMPORT), summary.imported, UNIT_WH);
+
+            putEnergyType(result, channelProvider.getChannel(group, CHANNEL_ID_EXPORT), summary.export, UNIT_WH);
+
+            ConsumptionDistribution consumptionDistribution = summary.consumptionDistribution;
+            if (consumptionDistribution != null) {
                 putEnergyType(result, channelProvider.getChannel(group, CHANNEL_ID_SELF_CONSUMPTION_FOR_CONSUMPTION),
-                        selfConsumptionForConsumption);
+                        consumptionDistribution.consumptionFromSolar, UNIT_WH);
+
                 putPercentType(result, channelProvider.getChannel(group, CHANNEL_ID_SELF_CONSUMPTION_COVERAGE),
-                        selfConsumptionForConsumption);
-            }
+                        consumptionDistribution.consumptionFromSolarPercentage);
 
-            Value batterySelfConsumption = utilizationMeasures.batterySelfConsumption;
-            if (batterySelfConsumption != null) {
                 putEnergyType(result, channelProvider.getChannel(group, CHANNEL_ID_BATTERY_SELF_CONSUMPTION),
-                        batterySelfConsumption);
-            }
-
-            Value imported = utilizationMeasures.imported;
-            if (imported != null) {
-                putEnergyType(result, channelProvider.getChannel(group, CHANNEL_ID_IMPORT), imported);
-            }
-
-            Value export = utilizationMeasures.export;
-            if (export != null) {
-                putEnergyType(result, channelProvider.getChannel(group, CHANNEL_ID_EXPORT), export);
+                        consumptionDistribution.consumptionFromBattery, UNIT_WH);
             }
         }
+
         return result;
     }
 }

--- a/bundles/org.openhab.binding.solaredge/src/main/java/org/openhab/binding/solaredge/internal/model/LiveDataResponsePrivateApi.java
+++ b/bundles/org.openhab.binding.solaredge/src/main/java/org/openhab/binding/solaredge/internal/model/LiveDataResponsePrivateApi.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.solaredge.internal.model;
+
+import java.util.List;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
+/**
+ * this class is used to map the live data json response via private API
+ *
+ * @author Georg Kunz - initial contribution
+ */
+@NonNullByDefault
+public class LiveDataResponsePrivateApi {
+
+    public static class Grid {
+        public @Nullable Boolean isActive;
+        public @Nullable Double currentPower;
+        public @Nullable String status;
+    }
+
+    public static class Consumption {
+        public @Nullable Boolean isActive;
+        public @Nullable Double currentPower;
+        public @Nullable Boolean isConsuming;
+    }
+
+    public static class SolarProduction {
+        public @Nullable Boolean isActive;
+        public @Nullable Double currentPower;
+        public @Nullable Boolean isProducing;
+    }
+
+    public static class DcStorage {
+        public @Nullable Boolean isActive;
+        public @Nullable Double currentPower;
+        public @Nullable Double chargeLevel;
+        public @Nullable Double blockCount;
+        public @Nullable String status;
+        public @Nullable String storagePlan;
+    }
+
+    public static class EnergyProducers {
+        public @Nullable List<String> producers;
+    }
+
+    public @Nullable Grid grid;
+    public @Nullable Consumption consumption;
+    public @Nullable SolarProduction solarProduction;
+    public @Nullable DcStorage dcStorage;
+
+    public @Nullable String lastUpdateTime;
+    public @Nullable Boolean isRealTime;
+    public @Nullable Boolean isCommunicating;
+    public @Nullable Integer updateRefreshRate;
+}

--- a/bundles/org.openhab.binding.solaredge/src/main/java/org/openhab/binding/solaredge/internal/model/LiveDataResponsePublicApi.java
+++ b/bundles/org.openhab.binding.solaredge/src/main/java/org/openhab/binding/solaredge/internal/model/LiveDataResponsePublicApi.java
@@ -20,12 +20,12 @@ import org.eclipse.jdt.annotation.Nullable;
 import com.google.gson.annotations.SerializedName;
 
 /**
- * this class is used to map the live data json response
+ * this class is used to map the live data json response via public API
  *
  * @author Alexander Friese - initial contribution
  */
 @NonNullByDefault
-public class LiveDataResponse {
+public class LiveDataResponsePublicApi {
     public static final String GRID = "GRID";
     public static final String LOAD = "LOAD";
     public static final String PV = "PV";

--- a/bundles/org.openhab.binding.solaredge/src/main/java/org/openhab/binding/solaredge/internal/model/LiveDataResponseTransformerPrivateApi.java
+++ b/bundles/org.openhab.binding.solaredge/src/main/java/org/openhab/binding/solaredge/internal/model/LiveDataResponseTransformerPrivateApi.java
@@ -43,7 +43,8 @@ import org.openhab.core.types.State;
  * transforms the private API http response into the openhab datamodel
  * (instances of State)
  *
- * @author Georg Kunz Initial - contribution
+ * @author Georg Kunz - Initial contribution
+ * @author Ronny Grun - Add battery handling
  */
 @NonNullByDefault
 public class LiveDataResponseTransformerPrivateApi extends AbstractDataResponseTransformer {
@@ -63,7 +64,7 @@ public class LiveDataResponseTransformerPrivateApi extends AbstractDataResponseT
             putPowerType(result, channelProvider.getChannel(CHANNEL_GROUP_LIVE, CHANNEL_ID_PRODUCTION),
                     solarProduction.currentPower, "kW");
             putStringType(result, channelProvider.getChannel(CHANNEL_GROUP_LIVE, CHANNEL_ID_PV_STATUS),
-                    solarProduction.isActive ? "active" : "idle");
+                    Boolean.TRUE.equals(solarProduction.isActive) ? "active" : "idle");
         }
 
         Consumption consumption = response.consumption;
@@ -71,17 +72,7 @@ public class LiveDataResponseTransformerPrivateApi extends AbstractDataResponseT
             putPowerType(result, channelProvider.getChannel(CHANNEL_GROUP_LIVE, CHANNEL_ID_CONSUMPTION),
                     consumption.currentPower, "kW");
             putStringType(result, channelProvider.getChannel(CHANNEL_GROUP_LIVE, CHANNEL_ID_LOAD_STATUS),
-                    consumption.isActive ? "active" : "idle");
-        }
-
-        DcStorage dcStorage = response.dcStorage;
-        if (dcStorage != null) {
-            putStringType(result, channelProvider.getChannel(CHANNEL_GROUP_LIVE, CHANNEL_ID_BATTERY_STATUS),
-                    dcStorage.isActive ? "active" : "idle");
-            putStringType(result, channelProvider.getChannel(CHANNEL_GROUP_LIVE, CHANNEL_ID_BATTERY_CRITICAL),
-                    dcStorage.status);
-            putPercentType(result, channelProvider.getChannel(CHANNEL_GROUP_LIVE, CHANNEL_ID_BATTERY_LEVEL),
-                    dcStorage.chargeLevel);
+                    Boolean.TRUE.equals(consumption.isActive) ? "active" : "idle");
         }
 
         // init fields with zero
@@ -94,14 +85,42 @@ public class LiveDataResponseTransformerPrivateApi extends AbstractDataResponseT
         putPowerType(result, channelProvider.getChannel(CHANNEL_GROUP_LIVE, CHANNEL_ID_BATTERY_CHARGE_DISCHARGE),
                 ZERO_POWER, "kW");
 
+        DcStorage dcStorage = response.dcStorage;
+        if (dcStorage != null) {
+            putStringType(result, channelProvider.getChannel(CHANNEL_GROUP_LIVE, CHANNEL_ID_BATTERY_STATUS),
+                    dcStorage.status);
+            putPercentType(result, channelProvider.getChannel(CHANNEL_GROUP_LIVE, CHANNEL_ID_BATTERY_LEVEL),
+                    dcStorage.chargeLevel);
+
+            // battery_critical does not exist in new PrivateApi
+            putStringType(result, channelProvider.getChannel(CHANNEL_GROUP_LIVE, CHANNEL_ID_BATTERY_CRITICAL),
+                    Boolean.TRUE.equals(dcStorage.isActive) ? "active" : "idle");
+
+            Double currentPower = dcStorage.currentPower;
+            currentPower = currentPower != null ? currentPower : 0;
+            if ("charging".equalsIgnoreCase(dcStorage.status)) {
+                putPowerType(result, channelProvider.getChannel(CHANNEL_GROUP_LIVE, CHANNEL_ID_BATTERY_CHARGE),
+                        currentPower, "kW");
+                putPowerType(result,
+                        channelProvider.getChannel(CHANNEL_GROUP_LIVE, CHANNEL_ID_BATTERY_CHARGE_DISCHARGE),
+                        currentPower, "kW");
+            } else if ("discharging".equalsIgnoreCase(dcStorage.status)) {
+                putPowerType(result, channelProvider.getChannel(CHANNEL_GROUP_LIVE, CHANNEL_ID_BATTERY_DISCHARGE),
+                        currentPower, "kW");
+                putPowerType(result,
+                        channelProvider.getChannel(CHANNEL_GROUP_LIVE, CHANNEL_ID_BATTERY_CHARGE_DISCHARGE),
+                        -1 * currentPower, "kW");
+            }
+        }
+
         Grid grid = response.grid;
         if (grid != null) {
             putStringType(result, channelProvider.getChannel(CHANNEL_GROUP_LIVE, CHANNEL_ID_GRID_STATUS),
-                    grid.isActive ? "active" : "idle");
-            if (grid.status.equalsIgnoreCase("import")) {
+                    Boolean.TRUE.equals(grid.isActive) ? "active" : "idle");
+            if ("import".equalsIgnoreCase(grid.status)) {
                 putPowerType(result, channelProvider.getChannel(CHANNEL_GROUP_LIVE, CHANNEL_ID_IMPORT),
                         grid.currentPower, "kW");
-            } else if (grid.status.equalsIgnoreCase("import")) {
+            } else if ("export".equalsIgnoreCase(grid.status)) {
                 putPowerType(result, channelProvider.getChannel(CHANNEL_GROUP_LIVE, CHANNEL_ID_EXPORT),
                         grid.currentPower, "kW");
             }

--- a/bundles/org.openhab.binding.solaredge/src/main/java/org/openhab/binding/solaredge/internal/model/LiveDataResponseTransformerPrivateApi.java
+++ b/bundles/org.openhab.binding.solaredge/src/main/java/org/openhab/binding/solaredge/internal/model/LiveDataResponseTransformerPrivateApi.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.solaredge.internal.model;
+
+import static org.openhab.binding.solaredge.internal.SolarEdgeBindingConstants.CHANNEL_GROUP_LIVE;
+import static org.openhab.binding.solaredge.internal.SolarEdgeBindingConstants.CHANNEL_ID_BATTERY_CHARGE;
+import static org.openhab.binding.solaredge.internal.SolarEdgeBindingConstants.CHANNEL_ID_BATTERY_CHARGE_DISCHARGE;
+import static org.openhab.binding.solaredge.internal.SolarEdgeBindingConstants.CHANNEL_ID_BATTERY_CRITICAL;
+import static org.openhab.binding.solaredge.internal.SolarEdgeBindingConstants.CHANNEL_ID_BATTERY_DISCHARGE;
+import static org.openhab.binding.solaredge.internal.SolarEdgeBindingConstants.CHANNEL_ID_BATTERY_LEVEL;
+import static org.openhab.binding.solaredge.internal.SolarEdgeBindingConstants.CHANNEL_ID_BATTERY_STATUS;
+import static org.openhab.binding.solaredge.internal.SolarEdgeBindingConstants.CHANNEL_ID_CONSUMPTION;
+import static org.openhab.binding.solaredge.internal.SolarEdgeBindingConstants.CHANNEL_ID_EXPORT;
+import static org.openhab.binding.solaredge.internal.SolarEdgeBindingConstants.CHANNEL_ID_GRID_STATUS;
+import static org.openhab.binding.solaredge.internal.SolarEdgeBindingConstants.CHANNEL_ID_IMPORT;
+import static org.openhab.binding.solaredge.internal.SolarEdgeBindingConstants.CHANNEL_ID_LOAD_STATUS;
+import static org.openhab.binding.solaredge.internal.SolarEdgeBindingConstants.CHANNEL_ID_PRODUCTION;
+import static org.openhab.binding.solaredge.internal.SolarEdgeBindingConstants.CHANNEL_ID_PV_STATUS;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.binding.solaredge.internal.handler.ChannelProvider;
+import org.openhab.binding.solaredge.internal.model.LiveDataResponsePrivateApi.Consumption;
+import org.openhab.binding.solaredge.internal.model.LiveDataResponsePrivateApi.DcStorage;
+import org.openhab.binding.solaredge.internal.model.LiveDataResponsePrivateApi.Grid;
+import org.openhab.binding.solaredge.internal.model.LiveDataResponsePrivateApi.SolarProduction;
+import org.openhab.core.thing.Channel;
+import org.openhab.core.types.State;
+
+/**
+ * transforms the private API http response into the openhab datamodel
+ * (instances of State)
+ *
+ * @author Georg Kunz Initial - contribution
+ */
+@NonNullByDefault
+public class LiveDataResponseTransformerPrivateApi extends AbstractDataResponseTransformer {
+    private static final Double ZERO_POWER = 0.0;
+
+    private final ChannelProvider channelProvider;
+
+    public LiveDataResponseTransformerPrivateApi(ChannelProvider channelProvider) {
+        this.channelProvider = channelProvider;
+    }
+
+    public Map<Channel, State> transform(LiveDataResponsePrivateApi response) {
+        Map<Channel, State> result = new HashMap<>(20);
+
+        SolarProduction solarProduction = response.solarProduction;
+        if (solarProduction != null) {
+            putPowerType(result, channelProvider.getChannel(CHANNEL_GROUP_LIVE, CHANNEL_ID_PRODUCTION),
+                    solarProduction.currentPower, "kW");
+            putStringType(result, channelProvider.getChannel(CHANNEL_GROUP_LIVE, CHANNEL_ID_PV_STATUS),
+                    solarProduction.isActive ? "active" : "idle");
+        }
+
+        Consumption consumption = response.consumption;
+        if (consumption != null) {
+            putPowerType(result, channelProvider.getChannel(CHANNEL_GROUP_LIVE, CHANNEL_ID_CONSUMPTION),
+                    consumption.currentPower, "kW");
+            putStringType(result, channelProvider.getChannel(CHANNEL_GROUP_LIVE, CHANNEL_ID_LOAD_STATUS),
+                    consumption.isActive ? "active" : "idle");
+        }
+
+        DcStorage dcStorage = response.dcStorage;
+        if (dcStorage != null) {
+            putStringType(result, channelProvider.getChannel(CHANNEL_GROUP_LIVE, CHANNEL_ID_BATTERY_STATUS),
+                    dcStorage.isActive ? "active" : "idle");
+            putStringType(result, channelProvider.getChannel(CHANNEL_GROUP_LIVE, CHANNEL_ID_BATTERY_CRITICAL),
+                    dcStorage.status);
+            putPercentType(result, channelProvider.getChannel(CHANNEL_GROUP_LIVE, CHANNEL_ID_BATTERY_LEVEL),
+                    dcStorage.chargeLevel);
+        }
+
+        // init fields with zero
+        putPowerType(result, channelProvider.getChannel(CHANNEL_GROUP_LIVE, CHANNEL_ID_IMPORT), ZERO_POWER, "kW");
+        putPowerType(result, channelProvider.getChannel(CHANNEL_GROUP_LIVE, CHANNEL_ID_EXPORT), ZERO_POWER, "kW");
+        putPowerType(result, channelProvider.getChannel(CHANNEL_GROUP_LIVE, CHANNEL_ID_BATTERY_CHARGE), ZERO_POWER,
+                "kW");
+        putPowerType(result, channelProvider.getChannel(CHANNEL_GROUP_LIVE, CHANNEL_ID_BATTERY_DISCHARGE), ZERO_POWER,
+                "kW");
+        putPowerType(result, channelProvider.getChannel(CHANNEL_GROUP_LIVE, CHANNEL_ID_BATTERY_CHARGE_DISCHARGE),
+                ZERO_POWER, "kW");
+
+        Grid grid = response.grid;
+        if (grid != null) {
+            putStringType(result, channelProvider.getChannel(CHANNEL_GROUP_LIVE, CHANNEL_ID_GRID_STATUS),
+                    grid.isActive ? "active" : "idle");
+            if (grid.status.equalsIgnoreCase("import")) {
+                putPowerType(result, channelProvider.getChannel(CHANNEL_GROUP_LIVE, CHANNEL_ID_IMPORT),
+                        grid.currentPower, "kW");
+            } else if (grid.status.equalsIgnoreCase("import")) {
+                putPowerType(result, channelProvider.getChannel(CHANNEL_GROUP_LIVE, CHANNEL_ID_EXPORT),
+                        grid.currentPower, "kW");
+            }
+        }
+        return result;
+    }
+}

--- a/bundles/org.openhab.binding.solaredge/src/main/java/org/openhab/binding/solaredge/internal/model/LiveDataResponseTransformerPrivateApi.java
+++ b/bundles/org.openhab.binding.solaredge/src/main/java/org/openhab/binding/solaredge/internal/model/LiveDataResponseTransformerPrivateApi.java
@@ -64,7 +64,7 @@ public class LiveDataResponseTransformerPrivateApi extends AbstractDataResponseT
             putPowerType(result, channelProvider.getChannel(CHANNEL_GROUP_LIVE, CHANNEL_ID_PRODUCTION),
                     solarProduction.currentPower, "kW");
             putStringType(result, channelProvider.getChannel(CHANNEL_GROUP_LIVE, CHANNEL_ID_PV_STATUS),
-                    Boolean.TRUE.equals(solarProduction.isActive) ? "active" : "idle");
+                    Boolean.TRUE.equals(solarProduction.isActive) ? "Active" : "Idle");
         }
 
         Consumption consumption = response.consumption;
@@ -72,7 +72,7 @@ public class LiveDataResponseTransformerPrivateApi extends AbstractDataResponseT
             putPowerType(result, channelProvider.getChannel(CHANNEL_GROUP_LIVE, CHANNEL_ID_CONSUMPTION),
                     consumption.currentPower, "kW");
             putStringType(result, channelProvider.getChannel(CHANNEL_GROUP_LIVE, CHANNEL_ID_LOAD_STATUS),
-                    Boolean.TRUE.equals(consumption.isActive) ? "active" : "idle");
+                    Boolean.TRUE.equals(consumption.isActive) ? "Active" : "Idle");
         }
 
         // init fields with zero
@@ -94,7 +94,7 @@ public class LiveDataResponseTransformerPrivateApi extends AbstractDataResponseT
 
             // battery_critical does not exist in new PrivateApi
             putStringType(result, channelProvider.getChannel(CHANNEL_GROUP_LIVE, CHANNEL_ID_BATTERY_CRITICAL),
-                    Boolean.TRUE.equals(dcStorage.isActive) ? "active" : "idle");
+                    Boolean.TRUE.equals(dcStorage.isActive) ? "Active" : "Idle");
 
             Double currentPower = dcStorage.currentPower;
             currentPower = currentPower != null ? currentPower : 0;

--- a/bundles/org.openhab.binding.solaredge/src/main/java/org/openhab/binding/solaredge/internal/model/LiveDataResponseTransformerPrivateApi.java
+++ b/bundles/org.openhab.binding.solaredge/src/main/java/org/openhab/binding/solaredge/internal/model/LiveDataResponseTransformerPrivateApi.java
@@ -91,14 +91,14 @@ public class LiveDataResponseTransformerPrivateApi extends AbstractDataResponseT
         DcStorage dcStorage = response.dcStorage;
         if (dcStorage != null) {
             putStringType(result, channelProvider.getChannel(CHANNEL_GROUP_LIVE, CHANNEL_ID_BATTERY_STATUS),
-                    dcStorage.status);
+                    Boolean.TRUE.equals(dcStorage.isActive) ? "Active" : "Idle");
             Double chargeLevel = dcStorage.chargeLevel;
             putPercentType(result, channelProvider.getChannel(CHANNEL_GROUP_LIVE, CHANNEL_ID_BATTERY_LEVEL),
                     chargeLevel);
 
             // battery_critical does not exist in the private API, so derive it from the configured threshold
             putStringType(result, channelProvider.getChannel(CHANNEL_GROUP_LIVE, CHANNEL_ID_BATTERY_CRITICAL),
-                    chargeLevel != null && chargeLevel < config.getBatteryCriticalLevel() ? "true" : "false");
+                    chargeLevel == null ? null : chargeLevel < config.getBatteryCriticalLevel() ? "true" : "false");
 
             Double currentPower = dcStorage.currentPower;
             currentPower = currentPower != null ? currentPower : 0;
@@ -119,7 +119,8 @@ public class LiveDataResponseTransformerPrivateApi extends AbstractDataResponseT
 
         Grid grid = response.grid;
         if (grid != null) {
-            putStringType(result, channelProvider.getChannel(CHANNEL_GROUP_LIVE, CHANNEL_ID_GRID_STATUS), grid.status);
+            putStringType(result, channelProvider.getChannel(CHANNEL_GROUP_LIVE, CHANNEL_ID_GRID_STATUS),
+                    Boolean.TRUE.equals(grid.isActive) ? "Active" : "Idle");
             if ("import".equalsIgnoreCase(grid.status)) {
                 putPowerType(result, channelProvider.getChannel(CHANNEL_GROUP_LIVE, CHANNEL_ID_IMPORT),
                         grid.currentPower, "kW");

--- a/bundles/org.openhab.binding.solaredge/src/main/java/org/openhab/binding/solaredge/internal/model/LiveDataResponseTransformerPrivateApi.java
+++ b/bundles/org.openhab.binding.solaredge/src/main/java/org/openhab/binding/solaredge/internal/model/LiveDataResponseTransformerPrivateApi.java
@@ -115,8 +115,7 @@ public class LiveDataResponseTransformerPrivateApi extends AbstractDataResponseT
 
         Grid grid = response.grid;
         if (grid != null) {
-            putStringType(result, channelProvider.getChannel(CHANNEL_GROUP_LIVE, CHANNEL_ID_GRID_STATUS),
-                    Boolean.TRUE.equals(grid.isActive) ? "active" : "idle");
+            putStringType(result, channelProvider.getChannel(CHANNEL_GROUP_LIVE, CHANNEL_ID_GRID_STATUS), grid.status);
             if ("import".equalsIgnoreCase(grid.status)) {
                 putPowerType(result, channelProvider.getChannel(CHANNEL_GROUP_LIVE, CHANNEL_ID_IMPORT),
                         grid.currentPower, "kW");

--- a/bundles/org.openhab.binding.solaredge/src/main/java/org/openhab/binding/solaredge/internal/model/LiveDataResponseTransformerPrivateApi.java
+++ b/bundles/org.openhab.binding.solaredge/src/main/java/org/openhab/binding/solaredge/internal/model/LiveDataResponseTransformerPrivateApi.java
@@ -31,6 +31,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.binding.solaredge.internal.config.SolarEdgeConfiguration;
 import org.openhab.binding.solaredge.internal.handler.ChannelProvider;
 import org.openhab.binding.solaredge.internal.model.LiveDataResponsePrivateApi.Consumption;
 import org.openhab.binding.solaredge.internal.model.LiveDataResponsePrivateApi.DcStorage;
@@ -51,9 +52,11 @@ public class LiveDataResponseTransformerPrivateApi extends AbstractDataResponseT
     private static final Double ZERO_POWER = 0.0;
 
     private final ChannelProvider channelProvider;
+    private final SolarEdgeConfiguration config;
 
-    public LiveDataResponseTransformerPrivateApi(ChannelProvider channelProvider) {
+    public LiveDataResponseTransformerPrivateApi(ChannelProvider channelProvider, SolarEdgeConfiguration config) {
         this.channelProvider = channelProvider;
+        this.config = config;
     }
 
     public Map<Channel, State> transform(LiveDataResponsePrivateApi response) {
@@ -89,12 +92,13 @@ public class LiveDataResponseTransformerPrivateApi extends AbstractDataResponseT
         if (dcStorage != null) {
             putStringType(result, channelProvider.getChannel(CHANNEL_GROUP_LIVE, CHANNEL_ID_BATTERY_STATUS),
                     dcStorage.status);
+            Double chargeLevel = dcStorage.chargeLevel;
             putPercentType(result, channelProvider.getChannel(CHANNEL_GROUP_LIVE, CHANNEL_ID_BATTERY_LEVEL),
-                    dcStorage.chargeLevel);
+                    chargeLevel);
 
-            // battery_critical does not exist in new PrivateApi
+            // battery_critical does not exist in the private API, so derive it from the configured threshold
             putStringType(result, channelProvider.getChannel(CHANNEL_GROUP_LIVE, CHANNEL_ID_BATTERY_CRITICAL),
-                    Boolean.TRUE.equals(dcStorage.isActive) ? "Active" : "Idle");
+                    chargeLevel != null && chargeLevel < config.getBatteryCriticalLevel() ? "true" : "false");
 
             Double currentPower = dcStorage.currentPower;
             currentPower = currentPower != null ? currentPower : 0;

--- a/bundles/org.openhab.binding.solaredge/src/main/java/org/openhab/binding/solaredge/internal/model/LiveDataResponseTransformerPublicApi.java
+++ b/bundles/org.openhab.binding.solaredge/src/main/java/org/openhab/binding/solaredge/internal/model/LiveDataResponseTransformerPublicApi.java
@@ -20,13 +20,13 @@ import java.util.Map;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.binding.solaredge.internal.handler.ChannelProvider;
-import org.openhab.binding.solaredge.internal.model.LiveDataResponse.BatteryValue;
-import org.openhab.binding.solaredge.internal.model.LiveDataResponse.Connection;
-import org.openhab.binding.solaredge.internal.model.LiveDataResponse.SiteCurrentPowerFlow;
-import org.openhab.binding.solaredge.internal.model.LiveDataResponse.Value;
 import org.openhab.binding.solaredge.internal.model.LiveDataResponseMeterless.Energy;
 import org.openhab.binding.solaredge.internal.model.LiveDataResponseMeterless.Overview;
 import org.openhab.binding.solaredge.internal.model.LiveDataResponseMeterless.Power;
+import org.openhab.binding.solaredge.internal.model.LiveDataResponsePublicApi.BatteryValue;
+import org.openhab.binding.solaredge.internal.model.LiveDataResponsePublicApi.Connection;
+import org.openhab.binding.solaredge.internal.model.LiveDataResponsePublicApi.SiteCurrentPowerFlow;
+import org.openhab.binding.solaredge.internal.model.LiveDataResponsePublicApi.Value;
 import org.openhab.core.thing.Channel;
 import org.openhab.core.types.State;
 
@@ -36,12 +36,12 @@ import org.openhab.core.types.State;
  * @author Alexander Friese - initial contribution
  */
 @NonNullByDefault
-public class LiveDataResponseTransformer extends AbstractDataResponseTransformer {
+public class LiveDataResponseTransformerPublicApi extends AbstractDataResponseTransformer {
     private static final Double ZERO_POWER = 0.0;
 
     private final ChannelProvider channelProvider;
 
-    public LiveDataResponseTransformer(ChannelProvider channelProvider) {
+    public LiveDataResponseTransformerPublicApi(ChannelProvider channelProvider) {
         this.channelProvider = channelProvider;
     }
 
@@ -93,7 +93,7 @@ public class LiveDataResponseTransformer extends AbstractDataResponseTransformer
         return result;
     }
 
-    public Map<Channel, State> transform(LiveDataResponse response) {
+    public Map<Channel, State> transform(LiveDataResponsePublicApi response) {
         Map<Channel, State> result = new HashMap<>(20);
         SiteCurrentPowerFlow siteCurrentPowerFlow = response.getSiteCurrentPowerFlow();
 
@@ -149,10 +149,10 @@ public class LiveDataResponseTransformer extends AbstractDataResponseTransformer
                     String conFrom = con.from;
                     String conTo = con.to;
                     if (grid != null) {
-                        if (conFrom != null && conFrom.equalsIgnoreCase(LiveDataResponse.GRID)) {
+                        if (conFrom != null && conFrom.equalsIgnoreCase(LiveDataResponsePublicApi.GRID)) {
                             putPowerType(result, channelProvider.getChannel(CHANNEL_GROUP_LIVE, CHANNEL_ID_IMPORT),
                                     grid.currentPower, siteCurrentPowerFlow.unit);
-                        } else if (conTo != null && conTo.equalsIgnoreCase(LiveDataResponse.GRID)) {
+                        } else if (conTo != null && conTo.equalsIgnoreCase(LiveDataResponsePublicApi.GRID)) {
                             putPowerType(result, channelProvider.getChannel(CHANNEL_GROUP_LIVE, CHANNEL_ID_EXPORT),
                                     grid.currentPower, siteCurrentPowerFlow.unit);
                         }
@@ -161,14 +161,14 @@ public class LiveDataResponseTransformer extends AbstractDataResponseTransformer
                     if (storage != null) {
                         Double currentPower = storage.currentPower;
                         currentPower = currentPower != null ? currentPower : 0;
-                        if (conFrom != null && conFrom.equalsIgnoreCase(LiveDataResponse.STORAGE)) {
+                        if (conFrom != null && conFrom.equalsIgnoreCase(LiveDataResponsePublicApi.STORAGE)) {
                             putPowerType(result,
                                     channelProvider.getChannel(CHANNEL_GROUP_LIVE, CHANNEL_ID_BATTERY_DISCHARGE),
                                     currentPower, siteCurrentPowerFlow.unit);
                             putPowerType(result,
                                     channelProvider.getChannel(CHANNEL_GROUP_LIVE, CHANNEL_ID_BATTERY_CHARGE_DISCHARGE),
                                     -1 * currentPower, siteCurrentPowerFlow.unit);
-                        } else if (conTo != null && conTo.equalsIgnoreCase(LiveDataResponse.STORAGE)) {
+                        } else if (conTo != null && conTo.equalsIgnoreCase(LiveDataResponsePublicApi.STORAGE)) {
                             putPowerType(result,
                                     channelProvider.getChannel(CHANNEL_GROUP_LIVE, CHANNEL_ID_BATTERY_CHARGE),
                                     currentPower, siteCurrentPowerFlow.unit);

--- a/bundles/org.openhab.binding.solaredge/src/main/resources/OH-INF/config/config.xml
+++ b/bundles/org.openhab.binding.solaredge/src/main/resources/OH-INF/config/config.xml
@@ -16,6 +16,10 @@
 			<label>General</label>
 			<description>General settings.</description>
 		</parameter-group>
+		<parameter-group name="storage">
+			<label>Storage</label>
+			<description>Storage settings. (Private API)</description>
+		</parameter-group>
 
 		<parameter name="tokenOrApiKey" type="text" required="true" groupName="authentication">
 			<label>Token or API Key</label>
@@ -52,6 +56,12 @@
 			<description>Interval in which aggregate data is polled from SolarEdge (in minutes). If not using the private API
 				this must not be less than 60 minutes.</description>
 			<default>60</default>
+		</parameter>
+		<parameter name="batteryCriticalLevel" type="integer" required="false" min="0" max="100" unit="%"
+			groupName="storage">
+			<label>Critical Battery Level (Private API)</label>
+			<description>Battery charge level below which the battery is considered critical.</description>
+			<default>10</default>
 		</parameter>
 	</config-description>
 </config-description:config-descriptions>

--- a/bundles/org.openhab.binding.solaredge/src/main/resources/OH-INF/i18n/solaredge.properties
+++ b/bundles/org.openhab.binding.solaredge/src/main/resources/OH-INF/i18n/solaredge.properties
@@ -12,12 +12,16 @@ thing-type.solaredge.generic.description = Data retrieved from the SolarEdge web
 
 thing-type.config.solaredge.web.aggregateDataPollingInterval.label = Aggregate Data Polling Interval
 thing-type.config.solaredge.web.aggregateDataPollingInterval.description = Interval in which aggregate data is polled from SolarEdge (in minutes). If not using the private API this must not be less than 60 minutes.
+thing-type.config.solaredge.web.batteryCriticalLevel.label = Critical Battery Level (Private API)
+thing-type.config.solaredge.web.batteryCriticalLevel.description = Battery charge level below which the battery is considered critical.
 thing-type.config.solaredge.web.group.authentication.label = Authentication
 thing-type.config.solaredge.web.group.authentication.description = Authentication settings.
 thing-type.config.solaredge.web.group.connection.label = Connection
 thing-type.config.solaredge.web.group.connection.description = Connection settings.
 thing-type.config.solaredge.web.group.general.label = General
 thing-type.config.solaredge.web.group.general.description = General settings.
+thing-type.config.solaredge.web.group.storage.label = Storage
+thing-type.config.solaredge.web.group.storage.description = Storage settings. (Private API)
 thing-type.config.solaredge.web.liveDataPollingInterval.label = Live Data Polling Interval
 thing-type.config.solaredge.web.liveDataPollingInterval.description = Interval in which live data is polled from SolarEdge (in minutes). If not using the private API this should not be less than 10 minutes.
 thing-type.config.solaredge.web.meterInstalled.label = Meter Installed

--- a/bundles/org.openhab.binding.solaredge/src/main/resources/OH-INF/i18n/solaredge_de.properties
+++ b/bundles/org.openhab.binding.solaredge/src/main/resources/OH-INF/i18n/solaredge_de.properties
@@ -13,8 +13,6 @@ thing-type.config.solaredge.web.group.connection.label = Verbindung
 thing-type.config.solaredge.web.group.connection.description = Einstellungen für die Verbindung.
 thing-type.config.solaredge.web.group.general.label = Allgemeines
 thing-type.config.solaredge.web.group.general.description = Allgemeine Einstellungen.
-thing-type.config.solaredge.web.group.storage.label = Batterie
-thing-type.config.solaredge.web.group.storage.description = Batterie Einstellungen. (Private API)
 
 thing-type.config.solaredge.web.tokenOrApiKey.label = Token oder API-Key
 thing-type.config.solaredge.web.tokenOrApiKey.description = Spring Security Token (Browser Cookie bei Verwendung der Solaredge Webseite) bei Verwendung der Private API, API-Key bei Verwendung der Public API.
@@ -28,5 +26,3 @@ thing-type.config.solaredge.web.liveDataPollingInterval.label = Abfrageintervall
 thing-type.config.solaredge.web.liveDataPollingInterval.description = Intervall in welchem Abfragen für Live-Daten an SolarEdge geschickt werden.
 thing-type.config.solaredge.web.aggregateDataPollingInterval.label = Abfrageintervall Aggregatedaten
 thing-type.config.solaredge.web.aggregateDataPollingInterval.description = Intervall in welchem Abfragen für aggregierte Daten an SolarEdge geschickt werden.
-thing-type.config.solaredge.web.batteryCriticalLevel.label = Kritischer Batterieladestand (Private API)
-thing-type.config.solaredge.web.batteryCriticalLevel.description = Batterieladestand, unterhalb dessen die Batterie als kritisch eingestuft wird.

--- a/bundles/org.openhab.binding.solaredge/src/main/resources/OH-INF/i18n/solaredge_de.properties
+++ b/bundles/org.openhab.binding.solaredge/src/main/resources/OH-INF/i18n/solaredge_de.properties
@@ -13,6 +13,8 @@ thing-type.config.solaredge.web.group.connection.label = Verbindung
 thing-type.config.solaredge.web.group.connection.description = Einstellungen für die Verbindung.
 thing-type.config.solaredge.web.group.general.label = Allgemeines
 thing-type.config.solaredge.web.group.general.description = Allgemeine Einstellungen.
+thing-type.config.solaredge.web.group.storage.label = Batterie
+thing-type.config.solaredge.web.group.storage.description = Batterie Einstellungen. (Private API)
 
 thing-type.config.solaredge.web.tokenOrApiKey.label = Token oder API-Key
 thing-type.config.solaredge.web.tokenOrApiKey.description = Spring Security Token (Browser Cookie bei Verwendung der Solaredge Webseite) bei Verwendung der Private API, API-Key bei Verwendung der Public API.
@@ -26,3 +28,5 @@ thing-type.config.solaredge.web.liveDataPollingInterval.label = Abfrageintervall
 thing-type.config.solaredge.web.liveDataPollingInterval.description = Intervall in welchem Abfragen für Live-Daten an SolarEdge geschickt werden.
 thing-type.config.solaredge.web.aggregateDataPollingInterval.label = Abfrageintervall Aggregatedaten
 thing-type.config.solaredge.web.aggregateDataPollingInterval.description = Intervall in welchem Abfragen für aggregierte Daten an SolarEdge geschickt werden.
+thing-type.config.solaredge.web.batteryCriticalLevel.label = Kritischer Batterieladestand (Private API)
+thing-type.config.solaredge.web.batteryCriticalLevel.description = Batterieladestand, unterhalb dessen die Batterie als kritisch eingestuft wird.


### PR DESCRIPTION
# Summary

This PR updates the SolarEdge binding to support the current SolarEdge API behaviour and improves the handling of live and aggregate data.

The changes address Fixes #15867 and are based on findings from the [related openHAB Community discussion](https://community.openhab.org/t/solaredge-private-api-not-working-anymore/169848/).

# Notes

The aggregate date-range handling intentionally follows the SolarEdge API logic.

This work was developed in collaboration with @gkunz.