### PR TITLE
[androiddebugbridge] Retry a command once when standby rejects the shell stream

### DIFF
--- a/bundles/org.openhab.binding.androiddebugbridge/src/main/java/org/openhab/binding/androiddebugbridge/internal/AndroidDebugBridgeBindingConstants.java
+++ b/bundles/org.openhab.binding.androiddebugbridge/src/main/java/org/openhab/binding/androiddebugbridge/internal/AndroidDebugBridgeBindingConstants.java
@@ -50,6 +50,9 @@ public class AndroidDebugBridgeBindingConstants {
     public static final String SHUTDOWN_CHANNEL = "shutdown";
     public static final String RECORD_INPUT_CHANNEL = "record-input";
     public static final String RECORDED_INPUT_CHANNEL = "recorded-input";
+    // Wake-up key event, accepted by "input keyevent" either by name or by numeric code
+    public static final String KEY_EVENT_WAKEUP_NAME = "KEYCODE_WAKEUP";
+    public static final String KEY_EVENT_WAKEUP_CODE = "224";
     // List of all Parameters
     public static final String PARAMETER_IP = "ip";
     public static final String PARAMETER_PORT = "port";

--- a/bundles/org.openhab.binding.androiddebugbridge/src/main/java/org/openhab/binding/androiddebugbridge/internal/AndroidDebugBridgeDevice.java
+++ b/bundles/org.openhab.binding.androiddebugbridge/src/main/java/org/openhab/binding/androiddebugbridge/internal/AndroidDebugBridgeDevice.java
@@ -753,34 +753,54 @@ public class AndroidDebugBridgeDevice {
         if (adb == null) {
             throw new AndroidDebugBridgeDeviceException("Device not connected");
         }
-        AtomicReference<@Nullable Exception> streamError = new AtomicReference<>();
+        // Failures while opening the stream and failures while reading its output are tracked
+        // separately: only the former can mean the shell command never started. Folding both into
+        // one reference would let a failure that happened *after* the command already ran be
+        // reported as a stream rejection, and the caller may retry on that.
+        AtomicReference<@Nullable Exception> openError = new AtomicReference<>();
+        AtomicReference<@Nullable Exception> readError = new AtomicReference<>();
         try {
             commandLock.lock();
             var commandFuture = scheduler.submit(() -> {
                 var byteArrayOutputStream = new ByteArrayOutputStream();
                 String cmd = String.join(" ", args);
                 logger.debug("{} - shell:{}", ip, cmd);
-                try (AdbStream stream = adb.open("shell:" + cmd)) {
-                    do {
-                        byteArrayOutputStream.writeBytes(stream.read());
-                    } while (!stream.isClosed());
+                AdbStream stream;
+                try {
+                    stream = adb.open("shell:" + cmd);
                 } catch (IllegalStateException | IOException e) {
                     if (!"Stream closed".equals(e.getMessage())) {
                         // Capture rather than throw: letting it escape the scheduled task makes openHAB's
                         // WrappedScheduledExecutorService log a noisy "Scheduled runnable ended with an
                         // exception" stacktrace for an expected condition (a standby adbd rejecting the
                         // shell stream). It is re-surfaced as a typed exception on the calling thread below.
-                        streamError.set(e);
+                        openError.set(e);
+                    }
+                    return "";
+                }
+                try (stream) {
+                    do {
+                        byteArrayOutputStream.writeBytes(stream.read());
+                    } while (!stream.isClosed());
+                } catch (IllegalStateException | IOException e) {
+                    if (!"Stream closed".equals(e.getMessage())) {
+                        readError.set(e);
                     }
                 }
                 return byteArrayOutputStream.toString(StandardCharsets.US_ASCII);
             });
             this.commandFuture = commandFuture;
             String result = commandFuture.get(commandTimeout, TimeUnit.SECONDS);
-            Exception error = streamError.get();
-            if (error != null) {
+            Exception failedOpen = openError.get();
+            if (failedOpen != null) {
                 throw new AndroidDebugBridgeDeviceStreamRejectedException(
-                        "Error opening adb shell stream " + ip + ":" + port + ": " + error.getMessage());
+                        "Error opening adb shell stream " + ip + ":" + port + ": " + failedOpen.getMessage());
+            }
+            Exception failedRead = readError.get();
+            if (failedRead != null) {
+                // The stream was open, so the command reached the device: never retryable.
+                throw new AndroidDebugBridgeDeviceException(
+                        "Error reading adb shell stream " + ip + ":" + port + ": " + failedRead.getMessage());
             }
             return result;
         } finally {

--- a/bundles/org.openhab.binding.androiddebugbridge/src/main/java/org/openhab/binding/androiddebugbridge/internal/AndroidDebugBridgeDevice.java
+++ b/bundles/org.openhab.binding.androiddebugbridge/src/main/java/org/openhab/binding/androiddebugbridge/internal/AndroidDebugBridgeDevice.java
@@ -712,7 +712,24 @@ public class AndroidDebugBridgeDevice {
         return currentSocket != null && currentSocket.isConnected();
     }
 
+    /**
+     * Establish a connection, replacing any current one.
+     *
+     * Serialized with the shell commands and with {@link #reconnectForRetry()}: this starts by
+     * disconnecting, so two concurrent calls would otherwise tear down the connection the other one
+     * is still establishing. {@link #disconnect()} deliberately stays outside the lock, since
+     * aborting a running command is exactly what some of its callers need.
+     */
     public void connect() throws AndroidDebugBridgeDeviceException, InterruptedException {
+        commandLock.lock();
+        try {
+            connectInternal();
+        } finally {
+            commandLock.unlock();
+        }
+    }
+
+    private void connectInternal() throws AndroidDebugBridgeDeviceException, InterruptedException {
         this.disconnect();
         AdbConnection adbConnection;
         Socket sock;
@@ -855,20 +872,16 @@ public class AndroidDebugBridgeDevice {
     /**
      * Reconnect for a retry, without disturbing anything else that is running.
      *
-     * Taken under the command lock so no shell command can be in flight: a plain
-     * {@link #disconnect()} here would cancel whatever future another operation had just installed
-     * in {@code commandFuture}, making its {@code get()} throw {@link java.util.concurrent.CancellationException}
-     * in a caller that does not expect it. {@code disconnect()} keeps aborting running commands,
-     * which is what its other callers want.
+     * Kept as its own name because the reason differs from an ordinary reconnect: calling
+     * {@link #disconnect()} directly here would cancel whatever future another operation had just
+     * installed in {@code commandFuture}, making its {@code get()} throw
+     * {@link java.util.concurrent.CancellationException} in a caller that does not expect it.
+     * {@code disconnect()} keeps aborting running commands, which is what its other callers want.
      */
     public void reconnectForRetry() throws AndroidDebugBridgeDeviceException, InterruptedException {
-        commandLock.lock();
-        try {
-            disconnect();
-            connect();
-        } finally {
-            commandLock.unlock();
-        }
+        // connect() already disconnects first and takes the same lock, so this is simply a
+        // connect that cannot interleave with a shell command or with another connect.
+        connect();
     }
 
     public void disconnect() {

--- a/bundles/org.openhab.binding.androiddebugbridge/src/main/java/org/openhab/binding/androiddebugbridge/internal/AndroidDebugBridgeDevice.java
+++ b/bundles/org.openhab.binding.androiddebugbridge/src/main/java/org/openhab/binding/androiddebugbridge/internal/AndroidDebugBridgeDevice.java
@@ -779,7 +779,7 @@ public class AndroidDebugBridgeDevice {
             String result = commandFuture.get(commandTimeout, TimeUnit.SECONDS);
             Exception error = streamError.get();
             if (error != null) {
-                throw new AndroidDebugBridgeDeviceException(
+                throw new AndroidDebugBridgeDeviceStreamRejectedException(
                         "Error opening adb shell stream " + ip + ":" + port + ": " + error.getMessage());
             }
             return result;

--- a/bundles/org.openhab.binding.androiddebugbridge/src/main/java/org/openhab/binding/androiddebugbridge/internal/AndroidDebugBridgeDevice.java
+++ b/bundles/org.openhab.binding.androiddebugbridge/src/main/java/org/openhab/binding/androiddebugbridge/internal/AndroidDebugBridgeDevice.java
@@ -721,7 +721,10 @@ public class AndroidDebugBridgeDevice {
      * aborting a running command is exactly what some of its callers need.
      */
     public void connect() throws AndroidDebugBridgeDeviceException, InterruptedException {
-        commandLock.lock();
+        // Interruptible so cancellation actually aborts a pending attempt: dispose() interrupts the
+        // connection checker and then disconnects, and a plain lock() would let a checker that was
+        // waiting here acquire the lock afterwards and build a fresh connection post-disposal.
+        commandLock.lockInterruptibly();
         try {
             connectInternal();
         } finally {
@@ -772,7 +775,9 @@ public class AndroidDebugBridgeDevice {
         // reported as a stream rejection, and the caller may retry on that.
         AtomicReference<@Nullable Exception> openError = new AtomicReference<>();
         AtomicReference<@Nullable Exception> readError = new AtomicReference<>();
-        commandLock.lock();
+        // Interruptible for the same reason as connect(): a command waiting on the lock must not
+        // resume and run against the device after disposal interrupted it.
+        commandLock.lockInterruptibly();
         try {
             // Read the connection only once the lock is held. Capturing it earlier would let a
             // reconnect replace and close it while this call was still waiting for the lock, so the

--- a/bundles/org.openhab.binding.androiddebugbridge/src/main/java/org/openhab/binding/androiddebugbridge/internal/AndroidDebugBridgeDevice.java
+++ b/bundles/org.openhab.binding.androiddebugbridge/src/main/java/org/openhab/binding/androiddebugbridge/internal/AndroidDebugBridgeDevice.java
@@ -749,18 +749,21 @@ public class AndroidDebugBridgeDevice {
 
     private String runAdbShell(int commandTimeout, String... args)
             throws InterruptedException, AndroidDebugBridgeDeviceException, TimeoutException, ExecutionException {
-        var adb = connection;
-        if (adb == null) {
-            throw new AndroidDebugBridgeDeviceException("Device not connected");
-        }
         // Failures while opening the stream and failures while reading its output are tracked
         // separately: only the former can mean the shell command never started. Folding both into
         // one reference would let a failure that happened *after* the command already ran be
         // reported as a stream rejection, and the caller may retry on that.
         AtomicReference<@Nullable Exception> openError = new AtomicReference<>();
         AtomicReference<@Nullable Exception> readError = new AtomicReference<>();
+        commandLock.lock();
         try {
-            commandLock.lock();
+            // Read the connection only once the lock is held. Capturing it earlier would let a
+            // reconnect replace and close it while this call was still waiting for the lock, so the
+            // command would then run against a connection that is already closed.
+            var adb = connection;
+            if (adb == null) {
+                throw new AndroidDebugBridgeDeviceException("Device not connected");
+            }
             var commandFuture = scheduler.submit(() -> {
                 var byteArrayOutputStream = new ByteArrayOutputStream();
                 String cmd = String.join(" ", args);

--- a/bundles/org.openhab.binding.androiddebugbridge/src/main/java/org/openhab/binding/androiddebugbridge/internal/AndroidDebugBridgeDevice.java
+++ b/bundles/org.openhab.binding.androiddebugbridge/src/main/java/org/openhab/binding/androiddebugbridge/internal/AndroidDebugBridgeDevice.java
@@ -849,6 +849,25 @@ public class AndroidDebugBridgeDevice {
         return c;
     }
 
+    /**
+     * Reconnect for a retry, without disturbing anything else that is running.
+     *
+     * Taken under the command lock so no shell command can be in flight: a plain
+     * {@link #disconnect()} here would cancel whatever future another operation had just installed
+     * in {@code commandFuture}, making its {@code get()} throw {@link java.util.concurrent.CancellationException}
+     * in a caller that does not expect it. {@code disconnect()} keeps aborting running commands,
+     * which is what its other callers want.
+     */
+    public void reconnectForRetry() throws AndroidDebugBridgeDeviceException, InterruptedException {
+        commandLock.lock();
+        try {
+            disconnect();
+            connect();
+        } finally {
+            commandLock.unlock();
+        }
+    }
+
     public void disconnect() {
         var commandFuture = this.commandFuture;
         if (commandFuture != null && !commandFuture.isDone()) {

--- a/bundles/org.openhab.binding.androiddebugbridge/src/main/java/org/openhab/binding/androiddebugbridge/internal/AndroidDebugBridgeDevice.java
+++ b/bundles/org.openhab.binding.androiddebugbridge/src/main/java/org/openhab/binding/androiddebugbridge/internal/AndroidDebugBridgeDevice.java
@@ -713,17 +713,13 @@ public class AndroidDebugBridgeDevice {
     }
 
     /**
-     * Establish a connection, replacing any current one.
-     *
-     * Serialized with the shell commands and with {@link #reconnectForRetry()}: this starts by
-     * disconnecting, so two concurrent calls would otherwise tear down the connection the other one
-     * is still establishing. {@link #disconnect()} deliberately stays outside the lock, since
-     * aborting a running command is exactly what some of its callers need.
+     * Establish a connection, replacing any current one. Serialized with shell commands because it
+     * starts by disconnecting. {@link #disconnect()} stays outside the lock, since aborting a
+     * running command is what some of its callers need.
      */
     public void connect() throws AndroidDebugBridgeDeviceException, InterruptedException {
-        // Interruptible so cancellation actually aborts a pending attempt: dispose() interrupts the
-        // connection checker and then disconnects, and a plain lock() would let a checker that was
-        // waiting here acquire the lock afterwards and build a fresh connection post-disposal.
+        // Interruptible: dispose() interrupts the connection checker, and a plain lock() would let
+        // it acquire the lock afterwards and build a connection on a disposed handler.
         commandLock.lockInterruptibly();
         try {
             connectInternal();
@@ -769,19 +765,13 @@ public class AndroidDebugBridgeDevice {
 
     private String runAdbShell(int commandTimeout, String... args)
             throws InterruptedException, AndroidDebugBridgeDeviceException, TimeoutException, ExecutionException {
-        // Failures while opening the stream and failures while reading its output are tracked
-        // separately: only the former can mean the shell command never started. Folding both into
-        // one reference would let a failure that happened *after* the command already ran be
-        // reported as a stream rejection, and the caller may retry on that.
+        // Tracked separately: only a failed open can mean the command never started.
         AtomicReference<@Nullable Exception> openError = new AtomicReference<>();
         AtomicReference<@Nullable Exception> readError = new AtomicReference<>();
-        // Interruptible for the same reason as connect(): a command waiting on the lock must not
-        // resume and run against the device after disposal interrupted it.
+        // Interruptible for the same reason as connect().
         commandLock.lockInterruptibly();
         try {
-            // Read the connection only once the lock is held. Capturing it earlier would let a
-            // reconnect replace and close it while this call was still waiting for the lock, so the
-            // command would then run against a connection that is already closed.
+            // Read under the lock: a reconnect could otherwise close it while we waited.
             var adb = connection;
             if (adb == null) {
                 throw new AndroidDebugBridgeDeviceException("Device not connected");
@@ -795,10 +785,8 @@ public class AndroidDebugBridgeDevice {
                     stream = adb.open("shell:" + cmd);
                 } catch (IllegalStateException | IOException e) {
                     if (!"Stream closed".equals(e.getMessage())) {
-                        // Capture rather than throw: letting it escape the scheduled task makes openHAB's
-                        // WrappedScheduledExecutorService log a noisy "Scheduled runnable ended with an
-                        // exception" stacktrace for an expected condition (a standby adbd rejecting the
-                        // shell stream). It is re-surfaced as a typed exception on the calling thread below.
+                        // Captured rather than thrown: escaping the scheduled task would log a noisy
+                        // stacktrace for an expected condition. Re-thrown on the caller below.
                         openError.set(e);
                     }
                     return "";
@@ -875,17 +863,10 @@ public class AndroidDebugBridgeDevice {
     }
 
     /**
-     * Reconnect for a retry, without disturbing anything else that is running.
-     *
-     * Kept as its own name because the reason differs from an ordinary reconnect: calling
-     * {@link #disconnect()} directly here would cancel whatever future another operation had just
-     * installed in {@code commandFuture}, making its {@code get()} throw
-     * {@link java.util.concurrent.CancellationException} in a caller that does not expect it.
-     * {@code disconnect()} keeps aborting running commands, which is what its other callers want.
+     * Reconnect for a retry. Named separately from {@link #connect()} because calling
+     * {@link #disconnect()} here directly would cancel another operation's in-flight command.
      */
     public void reconnectForRetry() throws AndroidDebugBridgeDeviceException, InterruptedException {
-        // connect() already disconnects first and takes the same lock, so this is simply a
-        // connect that cannot interleave with a shell command or with another connect.
         connect();
     }
 

--- a/bundles/org.openhab.binding.androiddebugbridge/src/main/java/org/openhab/binding/androiddebugbridge/internal/AndroidDebugBridgeDeviceStreamRejectedException.java
+++ b/bundles/org.openhab.binding.androiddebugbridge/src/main/java/org/openhab/binding/androiddebugbridge/internal/AndroidDebugBridgeDeviceStreamRejectedException.java
@@ -15,9 +15,14 @@ package org.openhab.binding.androiddebugbridge.internal;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 
 /**
- * Thrown when the device refuses to open the adb shell stream, which a device in standby commonly
- * does. It is a distinct type because the shell command provably never ran, so the caller may
- * safely reconnect and retry it without risking a duplicate execution.
+ * Thrown when opening the adb shell stream fails, which a device in standby commonly causes.
+ *
+ * It is a distinct type so the caller can tell this apart from a failure that happened while
+ * reading an already-open stream, where the command certainly reached the device. It is however
+ * <em>not</em> proof that the command never ran: adblib writes the OPEN packet inside
+ * {@code AdbConnection.open()}, so an {@link java.io.IOException} raised while sending that packet
+ * leaves delivery ambiguous. Callers must therefore only repeat commands that stay correct when
+ * executed twice.
  *
  * @author Stamate Viorel - Initial contribution
  */

--- a/bundles/org.openhab.binding.androiddebugbridge/src/main/java/org/openhab/binding/androiddebugbridge/internal/AndroidDebugBridgeDeviceStreamRejectedException.java
+++ b/bundles/org.openhab.binding.androiddebugbridge/src/main/java/org/openhab/binding/androiddebugbridge/internal/AndroidDebugBridgeDeviceStreamRejectedException.java
@@ -15,14 +15,11 @@ package org.openhab.binding.androiddebugbridge.internal;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 
 /**
- * Thrown when opening the adb shell stream fails, which a device in standby commonly causes.
+ * Thrown when opening the adb shell stream fails, as a device in standby commonly causes.
  *
- * It is a distinct type so the caller can tell this apart from a failure that happened while
- * reading an already-open stream, where the command certainly reached the device. It is however
- * <em>not</em> proof that the command never ran: adblib writes the OPEN packet inside
- * {@code AdbConnection.open()}, so an {@link java.io.IOException} raised while sending that packet
- * leaves delivery ambiguous. Callers must therefore only repeat commands that stay correct when
- * executed twice.
+ * Distinct from a failure while reading an already-open stream, where the command certainly
+ * reached the device. It is not proof the command never ran though: adblib writes the OPEN packet
+ * inside {@code AdbConnection.open()}, so delivery is ambiguous if that write fails.
  *
  * @author Stamate Viorel - Initial contribution
  */

--- a/bundles/org.openhab.binding.androiddebugbridge/src/main/java/org/openhab/binding/androiddebugbridge/internal/AndroidDebugBridgeDeviceStreamRejectedException.java
+++ b/bundles/org.openhab.binding.androiddebugbridge/src/main/java/org/openhab/binding/androiddebugbridge/internal/AndroidDebugBridgeDeviceStreamRejectedException.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.androiddebugbridge.internal;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * Thrown when the device refuses to open the adb shell stream, which a device in standby commonly
+ * does. It is a distinct type because the shell command provably never ran, so the caller may
+ * safely reconnect and retry it without risking a duplicate execution.
+ *
+ * @author Stamate Viorel - Initial contribution
+ */
+@NonNullByDefault
+public class AndroidDebugBridgeDeviceStreamRejectedException extends AndroidDebugBridgeDeviceException {
+    private static final long serialVersionUID = 5471982041566281957L;
+
+    public AndroidDebugBridgeDeviceStreamRejectedException(String message) {
+        super(message);
+    }
+}

--- a/bundles/org.openhab.binding.androiddebugbridge/src/main/java/org/openhab/binding/androiddebugbridge/internal/AndroidDebugBridgeHandler.java
+++ b/bundles/org.openhab.binding.androiddebugbridge/src/main/java/org/openhab/binding/androiddebugbridge/internal/AndroidDebugBridgeHandler.java
@@ -101,13 +101,8 @@ public class AndroidDebugBridgeHandler extends BaseThingHandler {
             try {
                 handleCommandInternal(channelUID, command);
             } catch (AndroidDebugBridgeDeviceStreamRejectedException e) {
-                // Socket.isConnected() only records that a connection was once established; it stays
-                // true after the device stops serving the socket, so the check above cannot notice a
-                // device that went into standby and the shell stream open is refused instead. That
-                // drops the first command after standby, typically the very wake-up meant to end it.
-                //
-                // Opening the stream failing does not prove the device never got the request though,
-                // so only repeat commands that stay correct when they run twice.
+                // A failed stream open does not prove the device never got the request, so only
+                // repeat commands that stay correct when they run twice.
                 if (!isSafeToRepeat(channelUID.getId(), command)) {
                     throw e;
                 }
@@ -131,23 +126,16 @@ public class AndroidDebugBridgeHandler extends BaseThingHandler {
     }
 
     /**
-     * Channels whose handling of {@link RefreshType} is a read. Elsewhere REFRESH is not special
-     * cased and ends up as a value, so {@code text} would type "REFRESH" and {@code record-input}
-     * would act -- neither may be repeated.
+     * Channels that treat {@link RefreshType} as a read. Elsewhere REFRESH is not special cased and
+     * ends up as a value, so {@code text} would type "REFRESH".
      */
     private static final Set<String> REFRESH_READS_STATE = Set.of(CURRENT_PACKAGE_CHANNEL, WAKE_LOCK_CHANNEL,
             AWAKE_STATE_CHANNEL, SCREEN_STATE_CHANNEL, MEDIA_VOLUME_CHANNEL, MEDIA_CONTROL_CHANNEL,
             START_INTENT_CHANNEL);
 
     /**
-     * Tells whether running {@code command} a second time cannot change what the device ends up
-     * doing, which is what makes it safe to repeat after a rejected shell stream.
-     *
-     * Two cases qualify. A {@link RefreshType} on a channel that actually treats it as a read, and
-     * the wake-up key event, which is naturally idempotent since waking an already awake device
-     * does nothing -- that is also the case this recovery exists for. Everything else may act
-     * twice: {@code text} would type the input again, {@code tap} would tap again,
-     * {@code media-control} would toggle back, {@code shutdown} would reboot, and so on.
+     * Whether running {@code command} twice cannot change what the device ends up doing: a read, or
+     * the wake-up key event, which does nothing to an already awake device.
      */
     private static boolean isSafeToRepeat(String channelId, Command command) {
         if (command instanceof RefreshType) {

--- a/bundles/org.openhab.binding.androiddebugbridge/src/main/java/org/openhab/binding/androiddebugbridge/internal/AndroidDebugBridgeHandler.java
+++ b/bundles/org.openhab.binding.androiddebugbridge/src/main/java/org/openhab/binding/androiddebugbridge/internal/AndroidDebugBridgeHandler.java
@@ -102,10 +102,14 @@ public class AndroidDebugBridgeHandler extends BaseThingHandler {
             } catch (AndroidDebugBridgeDeviceStreamRejectedException e) {
                 // Socket.isConnected() only records that a connection was once established; it stays
                 // true after the device stops serving the socket, so the check above cannot notice a
-                // device that went into standby and the shell stream open is refused instead. The
-                // command provably never ran, so reconnect and run it once more rather than dropping
-                // it -- otherwise the first command after standby (typically the KEYCODE_WAKEUP meant
-                // to end it) is always lost.
+                // device that went into standby and the shell stream open is refused instead. That
+                // drops the first command after standby, typically the very wake-up meant to end it.
+                //
+                // Opening the stream failing does not prove the device never got the request though,
+                // so only repeat commands that stay correct when they run twice.
+                if (!isSafeToRepeat(channelUID.getId(), command)) {
+                    throw e;
+                }
                 logger.debug("{} - shell stream rejected, reconnecting and retrying command: {}", currentConfig.ip,
                         e.getMessage());
                 adbConnection.disconnect();
@@ -124,6 +128,28 @@ public class AndroidDebugBridgeHandler extends BaseThingHandler {
             logger.warn("{} - timeout error", currentConfig.ip);
             disconnectOnMaxADBTimeouts();
         }
+    }
+
+    /**
+     * Tells whether running {@code command} a second time cannot change what the device ends up
+     * doing, which is what makes it safe to repeat after a rejected shell stream.
+     *
+     * Only two cases qualify. A {@link RefreshType} merely reads state. And a wake-up key event is
+     * naturally idempotent, since waking an already awake device does nothing -- that is also the
+     * case this recovery exists for. Everything else may act twice: {@code text} would type the
+     * input again, {@code tap} would tap again, {@code media-control} would toggle back,
+     * {@code shutdown} would reboot, and so on.
+     */
+    private static boolean isSafeToRepeat(String channelId, Command command) {
+        if (command instanceof RefreshType) {
+            return true;
+        }
+        if (!KEY_EVENT_CHANNEL.equals(channelId)) {
+            return false;
+        }
+        // "input keyevent" takes either the symbolic name or the numeric code.
+        String keyEvent = command.toFullString().trim();
+        return KEY_EVENT_WAKEUP_NAME.equalsIgnoreCase(keyEvent) || KEY_EVENT_WAKEUP_CODE.equals(keyEvent);
     }
 
     private void handleCommandInternal(ChannelUID channelUID, Command command)

--- a/bundles/org.openhab.binding.androiddebugbridge/src/main/java/org/openhab/binding/androiddebugbridge/internal/AndroidDebugBridgeHandler.java
+++ b/bundles/org.openhab.binding.androiddebugbridge/src/main/java/org/openhab/binding/androiddebugbridge/internal/AndroidDebugBridgeHandler.java
@@ -17,6 +17,7 @@ import static org.openhab.binding.androiddebugbridge.internal.AndroidDebugBridge
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -112,8 +113,7 @@ public class AndroidDebugBridgeHandler extends BaseThingHandler {
                 }
                 logger.debug("{} - shell stream rejected, reconnecting and retrying command: {}", currentConfig.ip,
                         e.getMessage());
-                adbConnection.disconnect();
-                adbConnection.connect();
+                adbConnection.reconnectForRetry();
                 handleCommandInternal(channelUID, command);
             }
         } catch (InterruptedException ignored) {
@@ -131,18 +131,27 @@ public class AndroidDebugBridgeHandler extends BaseThingHandler {
     }
 
     /**
+     * Channels whose handling of {@link RefreshType} is a read. Elsewhere REFRESH is not special
+     * cased and ends up as a value, so {@code text} would type "REFRESH" and {@code record-input}
+     * would act -- neither may be repeated.
+     */
+    private static final Set<String> REFRESH_READS_STATE = Set.of(CURRENT_PACKAGE_CHANNEL, WAKE_LOCK_CHANNEL,
+            AWAKE_STATE_CHANNEL, SCREEN_STATE_CHANNEL, MEDIA_VOLUME_CHANNEL, MEDIA_CONTROL_CHANNEL,
+            START_INTENT_CHANNEL);
+
+    /**
      * Tells whether running {@code command} a second time cannot change what the device ends up
      * doing, which is what makes it safe to repeat after a rejected shell stream.
      *
-     * Only two cases qualify. A {@link RefreshType} merely reads state. And a wake-up key event is
-     * naturally idempotent, since waking an already awake device does nothing -- that is also the
-     * case this recovery exists for. Everything else may act twice: {@code text} would type the
-     * input again, {@code tap} would tap again, {@code media-control} would toggle back,
-     * {@code shutdown} would reboot, and so on.
+     * Two cases qualify. A {@link RefreshType} on a channel that actually treats it as a read, and
+     * the wake-up key event, which is naturally idempotent since waking an already awake device
+     * does nothing -- that is also the case this recovery exists for. Everything else may act
+     * twice: {@code text} would type the input again, {@code tap} would tap again,
+     * {@code media-control} would toggle back, {@code shutdown} would reboot, and so on.
      */
     private static boolean isSafeToRepeat(String channelId, Command command) {
         if (command instanceof RefreshType) {
-            return true;
+            return REFRESH_READS_STATE.contains(channelId);
         }
         if (!KEY_EVENT_CHANNEL.equals(channelId)) {
             return false;

--- a/bundles/org.openhab.binding.androiddebugbridge/src/main/java/org/openhab/binding/androiddebugbridge/internal/AndroidDebugBridgeHandler.java
+++ b/bundles/org.openhab.binding.androiddebugbridge/src/main/java/org/openhab/binding/androiddebugbridge/internal/AndroidDebugBridgeHandler.java
@@ -97,7 +97,21 @@ public class AndroidDebugBridgeHandler extends BaseThingHandler {
                 // try reconnect
                 adbConnection.connect();
             }
-            handleCommandInternal(channelUID, command);
+            try {
+                handleCommandInternal(channelUID, command);
+            } catch (AndroidDebugBridgeDeviceStreamRejectedException e) {
+                // Socket.isConnected() only records that a connection was once established; it stays
+                // true after the device stops serving the socket, so the check above cannot notice a
+                // device that went into standby and the shell stream open is refused instead. The
+                // command provably never ran, so reconnect and run it once more rather than dropping
+                // it -- otherwise the first command after standby (typically the KEYCODE_WAKEUP meant
+                // to end it) is always lost.
+                logger.debug("{} - shell stream rejected, reconnecting and retrying command: {}", currentConfig.ip,
+                        e.getMessage());
+                adbConnection.disconnect();
+                adbConnection.connect();
+                handleCommandInternal(channelUID, command);
+            }
         } catch (InterruptedException ignored) {
         } catch (AndroidDebugBridgeDeviceException | ExecutionException e) {
             if (!(e.getCause() instanceof InterruptedException)) {


### PR DESCRIPTION
## Problem

`Socket.isConnected()` only records that a connection was **once** established — it stays `true` after the peer stops serving the socket. A device in standby keeps the TCP connection up but refuses to open the adb shell stream, so the reconnect check at the top of `handleCommand` sees a "connected" socket, skips the reconnect, and the command fails on stream open:

```
Error opening adb shell stream 192.168.1.43:5555: Stream open actively rejected by remote peer
```

The command is then dropped. In practice that most often loses the `KEYCODE_WAKEUP` meant to end standby, so the device doesn't wake and the fix looks like "send it twice" — the first send is spent discovering the connection was stale, and only the second one, which reconnects, lands.

## Change

`runAdbShell` now separates the two failure phases. Only a failure while *opening* the stream raises the distinct `AndroidDebugBridgeDeviceStreamRejectedException`; a failure while reading an already-open stream stays an ordinary `AndroidDebugBridgeDeviceException`, because by then the command has certainly reached the device. `handleCommand` catches the first case, reconnects and runs the command once more.

A failed open is **not** proof that the device never saw the request: adblib writes the OPEN packet inside `AdbConnection.open()`, so an `IOException` raised while sending it leaves delivery ambiguous. The retry is therefore restricted to commands that stay correct if they run twice — a `REFRESH` on the channels that handle it as a read, and the wake-up key event this recovery exists for, which is idempotent since waking an already awake device does nothing. Text, taps, media control, package and intent commands and shutdown are never repeated.

The reconnect is serialized with the shell commands and with ordinary `connect()` calls through the existing command lock, and `runAdbShell` reads the connection only once that lock is held, so a reconnect cannot replace the connection a waiting call is about to use. `disconnect()` stays outside the lock, since aborting a running command is exactly what its other callers need.

## Testing

Verified on a Vestel Android TV that rejects the stream intermittently in standby: over repeated standby→wake cycles a single `KEYCODE_WAKEUP` now wakes it every time, and the retry is observably exercised when the reject occurs:

```
[DEBUG] AndroidDebugBridgeHandler - 192.168.1.43 - shell stream rejected, reconnecting and
  retrying command: Error opening adb shell stream 192.168.1.43:5555: Stream open actively
  rejected by remote peer
```

Follow-up to #21222, which made this reject catchable instead of escaping the scheduler; this makes it recoverable.
