### PR TITLE
[wled] Fix Race condition in Palettes and Effect initialization

### DIFF
--- a/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/WledState.java
+++ b/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/WledState.java
@@ -38,8 +38,8 @@ public class WledState {
     public PresetState[] presetState = new PresetState[1];
 
     public class JsonResponse {
-        public List<String> effects = new ArrayList<>();
-        public List<String> palettes = new ArrayList<>();
+        public @Nullable List<String> effects = new ArrayList<>();
+        public @Nullable List<String> palettes = new ArrayList<>();
     }
 
     public void unpackJsonObjects() {

--- a/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/api/WledApiV084.java
+++ b/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/api/WledApiV084.java
@@ -225,7 +225,7 @@ public class WledApiV084 implements WledApi {
             }
         } else {
             logger.debug(
-                    "Effects in JSON response are empty (either bridge isn't initialized properly (yet) or WLED firmware does not return them)");
+                    "Effects in JSON response are missing (either bridge isn't initialized properly (yet) or WLED firmware does not return them)");
         }
         return fxOptions;
     }
@@ -244,7 +244,7 @@ public class WledApiV084 implements WledApi {
             }
         } else {
             logger.debug(
-                    "Palettes in JSON response are empty (either bridge isn't initialized properly (yet) or WLED firmware does not return them)");
+                    "Palettes in JSON response are missing (either bridge isn't initialized properly (yet) or WLED firmware does not return them)");
         }
         return palleteOptions;
     }

--- a/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/api/WledApiV084.java
+++ b/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/api/WledApiV084.java
@@ -215,11 +215,17 @@ public class WledApiV084 implements WledApi {
     public List<StateOption> getUpdatedFxList() {
         List<StateOption> fxOptions = new ArrayList<>();
         int counter = 0;
-        for (String value : state.jsonResponse.effects) {
-            fxOptions.add(new StateOption(Integer.toString(counter++), value));
-        }
-        if (handler.config.sortEffects) {
-            fxOptions.sort(Comparator.comparing(o -> "0".equals(o.getValue()) ? "" : o.getLabel()));
+        List<String> responseEffects = state.jsonResponse.effects;
+        if (responseEffects != null) {
+            for (String value : responseEffects) {
+                fxOptions.add(new StateOption(Integer.toString(counter++), value));
+            }
+            if (handler.config.sortEffects) {
+                fxOptions.sort(Comparator.comparing(o -> "0".equals(o.getValue()) ? "" : o.getLabel()));
+            }
+        } else {
+            logger.debug(
+                    "Effects in JSON response are empty (either bridge isn't initialized properly (yet) or WLED firmware does not return them)");
         }
         return fxOptions;
     }
@@ -228,11 +234,17 @@ public class WledApiV084 implements WledApi {
     public List<StateOption> getUpdatedPaletteList() {
         List<StateOption> palleteOptions = new ArrayList<>();
         int counter = 0;
-        for (String value : state.jsonResponse.palettes) {
-            palleteOptions.add(new StateOption(Integer.toString(counter++), value));
-        }
-        if (handler.config.sortPalettes) {
-            palleteOptions.sort(Comparator.comparing(o -> "0".equals(o.getValue()) ? "" : o.getLabel()));
+        List<String> responsePalettes = state.jsonResponse.palettes;
+        if (responsePalettes != null) {
+            for (String value : responsePalettes) {
+                palleteOptions.add(new StateOption(Integer.toString(counter++), value));
+            }
+            if (handler.config.sortPalettes) {
+                palleteOptions.sort(Comparator.comparing(o -> "0".equals(o.getValue()) ? "" : o.getLabel()));
+            }
+        } else {
+            logger.debug(
+                    "Palettes in JSON response are empty (either bridge isn't initialized properly (yet) or WLED firmware does not return them)");
         }
         return palleteOptions;
     }

--- a/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/handlers/WLedSegmentHandler.java
+++ b/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/handlers/WLedSegmentHandler.java
@@ -285,7 +285,11 @@ public class WLedSegmentHandler extends BaseThingHandler {
             WledApi localAPI = localBridgeHandler.api;
             if (localAPI != null) {
                 updateStatus(ThingStatus.ONLINE);
-                updateStateDescriptionProviders();
+                if (bridge.getStatus() == ThingStatus.ONLINE) {
+                    // only update the providers once the bridge is ready, otherwise this will be done once it goes
+                    // online via bridgeStatusChanged()
+                    updateStateDescriptionProviders();
+                }
                 if (!localBridgeHandler.hasWhite) {
                     logger.debug("WLED is not setup to use RGBW, so removing un-needed white channels");
                     removeWhiteChannels();


### PR DESCRIPTION
Looks like the bridge hasn't pulled all information from the API (yet). From the logs in the bug report I do not see when the bridge went online, but judging from the code the only 2 options for the palettes being `null` are:

1. too early initialization of the segment handler while the bridge is still fetching the status
2. missing "palettes" field in the response from the "/json" endpoint from the firmware.

I am now waiting for the bridge to be ONLINE before running the stateprovider updates and in addition I added a `null` check in case the firmware lacks providing the field (in that case gson doesn't create an empty `ArrayList` which we have otherwise).

Fixes #21215

<!--
Thanks for contributing to the openHAB project!
Please describe the goal and effect of your PR here.
Pay attention to the below notes and to *the guidelines* for this repository.
Feel free to delete any comment sections in the template (starting with "<!--").

ATTENTION: Don't use "git merge" when working with your pull request branch!
This can clutter your Git history and make your PR unusable.
Use "git rebase" instead. See this forum post for further details:
https://community.openhab.org/t/rebase-your-code-or-how-to-fix-your-git-history-before-requesting-a-pull/129358

All PRs should be created using the "main" branch as base.
Important bugfixes are cherry-picked by maintainers to the patch release branch after a PR has been merged.

Add one or more appropriate labels to make your PR show up in the release notes.
E.g. enhancement, bug, documentation, new binding
This can only be done by yourself if you already contributed to this repo.

If your PR's code is not backward compatible with previous releases (which
should be avoided), add a message to the release notes by filing another PR:
https://github.com/openhab/openhab-distro/blob/main/distributions/openhab/src/main/resources/bin/update.lst

# Title

Provide a short summary in the *Title* above. It will show up in the release notes.
For example:
- [homematic] Improve communication with weak signal devices
- [timemachine][WIP] Initial contribution

# Description

Please give a few sentences describing the overall goals of the pull request.
Give enough details to make the improvement and changes of the PR understandable
to both developers and tech-savy users.

Please keep the following in mind:
- What is the classification of the PR, e.g. Bugfix, Improvement, Novel Addition, ... ?
- Did you describe the PRs motivation and goal?
- Did you provide a link to any prior discussion, e.g. an issue or community forum thread?
- Did you describe new features for the end user?
- Did you describe any noteworthy changes in usage for the end user?
- Was the documentation updated accordingly, e.g. the add-on README?
- Does your contribution follow the coding guidelines:
  https://www.openhab.org/docs/developer/guidelines.html
- Did you check for any (relevant) issues from the static code analysis:
  https://www.openhab.org/docs/developer/bindings/#include-the-binding-in-the-build
- Did you sign-off your work:
  https://www.openhab.org/docs/developer/contributing.html#sign-your-work

# Testing

Your pull request will automatically be built and available under the following folder:
https://openhab.jfrog.io/ui/native/libs-pullrequest-local/org/openhab/addons/bundles/

It is a good practice to add a URL to your built JAR in this pull request description,
so it is easier for the community to test your Add-on.
If your pull request contains a new binding, it will likely take some time
before it is reviewed and processed by maintainers.
That said, consider submitting your Add-on in the Marketplace:
https://community.openhab.org/c/marketplace/69

Don't forget to submit a thread about your Add-on in the openHAB community:
https://community.openhab.org/c/add-ons 
-->
