### PR TITLE
[unifi] Keep Protect trigger channels across channel rebuilds

### DIFF
--- a/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/protect/handler/UnifiProtectCameraHandler.java
+++ b/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/protect/handler/UnifiProtectCameraHandler.java
@@ -1099,14 +1099,17 @@ public class UnifiProtectCameraHandler extends UnifiProtectAbstractDeviceHandler
             Set<String> activeChannelIds, @Nullable String label) {
         ChannelUID uid = new ChannelUID(thing.getUID(), channelId);
         activeChannelIds.add(channelId);
-        if (thing.getChannel(uid) == null) {
-            ChannelBuilder cb = ChannelBuilder.create(uid, null)
-                    .withType(new ChannelTypeUID(channelTypeNamespace, channelTypeId)).withKind(ChannelKind.TRIGGER);
-            if (label != null) {
-                cb.withLabel(translationService.getTranslation(label));
-            }
-            channelAdd.add(cb.build());
+        // Unconditional, exactly like addChannel: addRemoveChannels REPLACES the thing's whole
+        // channel list with channelAdd, so skipping a channel because it already exists REMOVES
+        // it from the thing. With an existence check here every full rebuild flipped the trigger
+        // channels between present and stripped, and any event that arrived while stripped was
+        // silently dropped (hasChannel gates both the trigger and the contact update).
+        ChannelBuilder cb = ChannelBuilder.create(uid, null)
+                .withType(new ChannelTypeUID(channelTypeNamespace, channelTypeId)).withKind(ChannelKind.TRIGGER);
+        if (label != null) {
+            cb.withLabel(translationService.getTranslation(label));
         }
+        channelAdd.add(cb.build());
     }
 
     private Sequence getSnapshotSequence(String channelId) {


### PR DESCRIPTION
## Problem

After any reload of the binding (or disable/enable of a camera thing), each Protect camera **randomly keeps or loses its trigger channels** (`motion-start/-update`, `smart-detect-zone-start/-update`, line/loiter/audio, ring). While they're gone, `handleEvent`'s `hasChannel` guard silently drops every motion/smart-detect event for that camera — the contact update sits behind the same guard, so rules and contacts go quiet while snapshots keep updating, which makes the camera look half-alive. On my 5-camera NVR one camera recorded 20 detections in an afternoon with zero reaching openHAB, while a neighbouring camera worked perfectly.

## Cause

`addRemoveChannels()` ends with `updateThing(editThing().withChannels(channelAdd).build())`, which **replaces the thing's whole channel list** — but `addTriggerChannel` only added its channel when it did **not** already exist. So every full rebuild flips the trigger channels: an existing channel is skipped from the replacement list (stripped), the next rebuild re-adds it. The number of rebuilds per (re)initialization isn't constant, so the end state after a reload is effectively random per camera.

Easy to reproduce on any camera with smart detection: disable/enable the camera thing repeatedly and watch `smart-detect-zone-start/-update` disappear and reappear in the thing's channel list.

## Change

Add the trigger channel unconditionally, exactly like `addChannel` already does for state channels.

Verified live: before the change, disable/enable flipped a camera 2/2 → 0/2 trigger channels; with it, repeated disable/enable cycles stay 2/2, and the camera that had been silently dropping detections went from 0 reactions to ~240/12h immediately after deployment.
