### PR TITLE
[matter] Avoid UNKNOWN status flap on reconnect for sleepy nodes

### DIFF
--- a/bundles/org.openhab.binding.matter/src/main/java/org/openhab/binding/matter/internal/handler/ControllerHandler.java
+++ b/bundles/org.openhab.binding.matter/src/main/java/org/openhab/binding/matter/internal/handler/ControllerHandler.java
@@ -166,7 +166,7 @@ public class ControllerHandler extends BaseBridgeHandler implements MatterClient
             BigInteger nodeId = handler.getNodeId();
             linkedNodes.put(nodeId, handler);
             // A freshly linked handler has no node data yet. Drop any "already enumerated" marker so the full data is
-            // actually (re)requested for it. Otherwise requestAllNodeDataIfNeeded skips the request for sleepy nodes
+            // actually (re)requested for it. Otherwise the reconnect handling skips the request for sleepy nodes
             // that were enumerated before their Thing existed (e.g. discovered via a scan), leaving the Thing online
             // but without any channels.
             enumeratedNodes.remove(nodeId);
@@ -262,7 +262,7 @@ public class ControllerHandler extends BaseBridgeHandler implements MatterClient
             case STRUCTURECHANGED:
                 // A structure change means the node's endpoints/clusters changed, so the channels must be rebuilt
                 // from fresh data. Drop the "already enumerated" marker first: otherwise the data request that the
-                // reconnect's Connected event triggers is skipped for sleepy nodes (see requestAllNodeDataIfNeeded),
+                // reconnect's Connected event triggers is skipped for sleepy nodes,
                 // leaving the Thing online but with stale channels. Same marker handling as removeNode/dispose.
                 enumeratedNodes.remove(message.nodeId);
                 updateNode(message.nodeId);

--- a/bundles/org.openhab.binding.matter/src/main/java/org/openhab/binding/matter/internal/handler/ControllerHandler.java
+++ b/bundles/org.openhab.binding.matter/src/main/java/org/openhab/binding/matter/internal/handler/ControllerHandler.java
@@ -243,9 +243,21 @@ public class ControllerHandler extends BaseBridgeHandler implements MatterClient
                 if (props != null) {
                     handlePhysicalProperties(message.nodeId, props);
                 }
-                updateEndpointStatuses(message.nodeId, ThingStatus.UNKNOWN, ThingStatusDetail.NONE,
-                        translationService.getTranslation(THING_STATUS_DETAIL_CONTROLLER_WAITING_FOR_DATA));
-                requestAllNodeDataIfNeeded(message.nodeId);
+                // Skip the expensive requestAllNodeData re-enumeration for sleepy/ICD nodes that have
+                // already been fully enumerated once in this session. Subsequent attribute changes arrive via
+                // matter.js subscriptions, so re-reading every cluster on every reconnect wastes radio time
+                // and is what drove the 2-3 minute offline/online flap on Thread door locks.
+                NodeHandler nodeHandler = linkedNodes.get(message.nodeId);
+                boolean skip = enumeratedNodes.contains(message.nodeId) && nodeHandler != null
+                        && !nodeHandler.shouldRefreshOnReconnect();
+                if (skip) {
+                    logger.debug("Skipping requestAllNodeData for {} (already enumerated, sleepy)", message.nodeId);
+                    updateEndpointStatuses(message.nodeId, ThingStatus.ONLINE, ThingStatusDetail.NONE, "");
+                } else {
+                    updateEndpointStatuses(message.nodeId, ThingStatus.UNKNOWN, ThingStatusDetail.NONE,
+                            translationService.getTranslation(THING_STATUS_DETAIL_CONTROLLER_WAITING_FOR_DATA));
+                    requestAllNodeData(message.nodeId);
+                }
                 break;
             case STRUCTURECHANGED:
                 // A structure change means the node's endpoints/clusters changed, so the channels must be rebuilt
@@ -428,23 +440,6 @@ public class ControllerHandler extends BaseBridgeHandler implements MatterClient
         if (timeout != null) {
             timeout.cancel(false);
         }
-    }
-
-    /**
-     * Skip the expensive {@code requestAllNodeData} re-enumeration for sleepy/ICD nodes that have
-     * already been fully enumerated once in this session. Subsequent attribute changes arrive via
-     * matter.js subscriptions, so re-reading every cluster on every reconnect wastes radio time
-     * and is what drove the 2-3 minute offline/online flap on Thread door locks.
-     */
-    private void requestAllNodeDataIfNeeded(BigInteger nodeId) {
-        NodeHandler handler = linkedNodes.get(nodeId);
-        boolean skip = enumeratedNodes.contains(nodeId) && handler != null && !handler.shouldRefreshOnReconnect();
-        if (skip) {
-            logger.debug("Skipping requestAllNodeData for {} (already enumerated, sleepy)", nodeId);
-            updateEndpointStatuses(nodeId, ThingStatus.ONLINE, ThingStatusDetail.NONE, "");
-            return;
-        }
-        requestAllNodeData(nodeId);
     }
 
     /**

--- a/bundles/org.openhab.binding.matter/src/test/java/org/openhab/binding/matter/internal/handler/ControllerHandlerTest.java
+++ b/bundles/org.openhab.binding.matter/src/test/java/org/openhab/binding/matter/internal/handler/ControllerHandlerTest.java
@@ -99,7 +99,7 @@ public class ControllerHandlerTest {
      * A structure change must force a full data refresh even for a sleepy node that was already enumerated.
      * matter.js reports a structure change while the node stays connected; the binding reacts by reconnecting
      * (updateNode -> initializeNode), whose resulting Connected event drives the data request. For sleepy nodes
-     * requestAllNodeDataIfNeeded skips that request, so without clearing the "enumerated" marker on the structure
+     * reconnect handling skips that request, so without clearing the "enumerated" marker on the structure
      * change the channels are never rebuilt.
      */
     @Test

--- a/bundles/org.openhab.binding.matter/src/test/java/org/openhab/binding/matter/internal/handler/ControllerHandlerTest.java
+++ b/bundles/org.openhab.binding.matter/src/test/java/org/openhab/binding/matter/internal/handler/ControllerHandlerTest.java
@@ -13,6 +13,7 @@
 package org.openhab.binding.matter.internal.handler;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -38,6 +39,9 @@ import org.openhab.binding.matter.internal.client.dto.ws.NodeStateMessage;
 import org.openhab.binding.matter.internal.controller.MatterControllerClient;
 import org.openhab.binding.matter.internal.util.TranslationService;
 import org.openhab.core.thing.Bridge;
+import org.openhab.core.thing.Thing;
+import org.openhab.core.thing.ThingStatus;
+import org.openhab.core.thing.ThingStatusDetail;
 
 /**
  * Tests for {@link ControllerHandler} node refresh behavior.
@@ -134,6 +138,31 @@ public class ControllerHandlerTest {
         handler.onEvent(nodeState(NODE_ID, NodeState.CONNECTED));
 
         verify(client, never()).requestAllNodeData(any());
+    }
+
+    /**
+     * A plain reconnect (Connected without a preceding structure change) of an already enumerated sleepy
+     * node must not set the endpoint status to UNKNOWN before restoring ONLINE.
+     */
+    @Test
+    public void reconnectDoesNotSetUnknownForSleepyNode() throws Exception {
+        NodeHandler nodeHandler = mock(NodeHandler.class);
+        when(nodeHandler.shouldRefreshOnReconnect()).thenReturn(false);
+        when(nodeHandler.getNodeId()).thenReturn(NODE_ID);
+
+        Thing childThing = mock(Thing.class);
+        when(childThing.getHandler()).thenReturn(nodeHandler);
+        when(bridge.getThings()).thenReturn(List.of(childThing));
+
+        Map<BigInteger, NodeHandler> linkedNodes = getField(handler, "linkedNodes");
+        linkedNodes.put(NODE_ID, nodeHandler);
+        Set<BigInteger> enumeratedNodes = getField(handler, "enumeratedNodes");
+        enumeratedNodes.add(NODE_ID);
+
+        handler.onEvent(nodeState(NODE_ID, NodeState.CONNECTED));
+
+        verify(nodeHandler, never()).setEndpointStatus(eq(ThingStatus.UNKNOWN), any(), any());
+        verify(nodeHandler).setEndpointStatus(ThingStatus.ONLINE, ThingStatusDetail.NONE, "");
     }
 
     private void linkEnumeratedNode(BigInteger nodeId, boolean sleepy) throws Exception {


### PR DESCRIPTION
When a Matter/Thread device completes a routine subscription renewal or reconnect, ControllerHandler.onEvent(CONNECTED) was unconditionally setting the Thing status to UNKNOWN: Waiting for data before checking if data re-enumeration could be skipped.

For already-enumerated sleepy nodes, this caused a brief millisecond-level status flap from ONLINE to UNKNOWN to ONLINE.

This change evaluates whether re-enumeration can be skipped directly in case CONNECTED:
- For sleepy nodes already enumerated, skips setting UNKNOWN and sets status directly to ONLINE.
- For new/non-sleepy nodes, sets UNKNOWN and fetches cluster data as before.
- Inlines the logic and removes the unused requestAllNodeDataIfNeeded helper method.
- Adds reconnectDoesNotSetUnknownForSleepyNode test to ControllerHandlerTest.

Fixes https://github.com/openhab/openhab-addons/issues/20682