### PR TITLE
[jrubyscripting] Upgrade to JRuby 10.1.1.0 (Ruby 4.0 Compatibility)

### DIFF
--- a/bundles/org.openhab.automation.jrubyscripting/pom.xml
+++ b/bundles/org.openhab.automation.jrubyscripting/pom.xml
@@ -16,23 +16,9 @@
   <properties>
     <jruby.version>10.1.1.0</jruby.version>
 
-    <bnd.importpackage><![CDATA[!org.jruby.*,\
-  !org.ruby_lang.*,\
-  !com.headius.*,\
-  !ch.randelshofer.*,\
-  !com.jcraft.*,\
-  !com.kenai.jffi.*,\
-  !jnr.*,\
-  !org.objectweb.asm.*,\
-  !org.jcodings.*,\
-  !org.joni.*,\
-  !org.ow2.asm.*,\
-  !org.joda.*,\
-  !me.qmx.jitescript.*,\
-  !org.yaml.snakeyaml.*,\
-  !com.dylibso.chicory.*,\
-  !io.roastedroot.redline.*,\
-  org.crac;resolution:=optional,\
+    <bnd.importpackage><![CDATA[org.crac;resolution:=optional,\
+  com.dylibso.chicory.annotations;resolution:=optional,\
+  org.joda.convert;resolution:=optional,\
   com.sun.nio.*;resolution:=optional,\
   com.sun.security.*;resolution:=optional,\
   org.apache.tools.ant.*;resolution:=optional,\
@@ -42,6 +28,7 @@
   android.os;resolution:=optional,\
   jakarta.annotation;resolution:=optional,\
   jdk.crac.management;resolution:=optional]]></bnd.importpackage>
+
   </properties>
 
   <dependencies>
@@ -60,32 +47,10 @@
         <artifactId>maven-dependency-plugin</artifactId>
         <executions>
           <execution>
-            <id>embed-jruby-dependencies</id>
-            <goals>
-              <goal>unpack-dependencies</goal>
-            </goals>
-            <phase>generate-resources</phase>
+            <id>embed-dependencies</id>
             <configuration>
-              <includeGroupIds>org.jruby,
-                org.ruby-lang,
-                jnr,
-                com.headius,
-                com.jcraft,
-                com.kenai.jffi,
-                com.github.jnr,
-                com.dylibso.chicory,
-                io.roastedroot,
-                org.objectweb.asm,
-                org.jcodings,
-                org.joni,
-                joda-time,
-                me.qmx.jitescript,
-                org.ow2.asm,
-                ch.randelshofer,
-                org.yaml</includeGroupIds>
-              <includeTypes>jar</includeTypes>
-              <outputDirectory>${project.build.outputDirectory}</outputDirectory>
-              <excludes>META-INF/*.SF,META-INF/*.DSA,META-INF/*.RSA,META-INF/MANIFEST.MF,**/module-info.class</excludes>
+              <!-- jruby isn't a flat jar. We want its transitive dependencies -->
+              <excludeTransitive>false</excludeTransitive>
             </configuration>
           </execution>
         </executions>

--- a/bundles/org.openhab.automation.jrubyscripting/pom.xml
+++ b/bundles/org.openhab.automation.jrubyscripting/pom.xml
@@ -11,21 +11,86 @@
   </parent>
 
   <artifactId>org.openhab.automation.jrubyscripting</artifactId>
-
   <name>openHAB Add-ons :: Bundles :: Automation :: JRuby Scripting</name>
 
   <properties>
-    <bnd.importpackage>com.sun.nio.*;resolution:=optional,com.sun.security.*;resolution:=optional,org.apache.tools.ant.*;resolution:=optional,org.bouncycastle.*;resolution:=optional,org.joda.*;resolution:=optional,sun.management.*;resolution:=optional,sun.nio.*;resolution:=optional,jakarta.annotation;resolution:=optional,jdk.crac.management;resolution:=optional</bnd.importpackage>
-    <jruby.version>10.0.6.0</jruby.version>
+    <jruby.version>10.1.1.0</jruby.version>
+
+    <bnd.importpackage><![CDATA[!org.jruby.*,\
+  !org.ruby_lang.*,\
+  !com.headius.*,\
+  !ch.randelshofer.*,\
+  !com.jcraft.*,\
+  !com.kenai.jffi.*,\
+  !jnr.*,\
+  !org.objectweb.asm.*,\
+  !org.jcodings.*,\
+  !org.joni.*,\
+  !org.ow2.asm.*,\
+  !org.joda.*,\
+  !me.qmx.jitescript.*,\
+  !org.yaml.snakeyaml.*,\
+  !com.dylibso.chicory.*,\
+  !io.roastedroot.redline.*,\
+  org.crac;resolution:=optional,\
+  com.sun.nio.*;resolution:=optional,\
+  com.sun.security.*;resolution:=optional,\
+  org.apache.tools.ant.*;resolution:=optional,\
+  org.bouncycastle.*;resolution:=optional,\
+  sun.management.*;resolution:=optional,\
+  sun.nio.*;resolution:=optional,\
+  android.os;resolution:=optional,\
+  jakarta.annotation;resolution:=optional,\
+  jdk.crac.management;resolution:=optional]]></bnd.importpackage>
   </properties>
 
   <dependencies>
     <dependency>
       <groupId>org.jruby</groupId>
-      <artifactId>jruby-complete</artifactId>
+      <artifactId>jruby</artifactId>
       <version>${jruby.version}</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>embed-jruby-dependencies</id>
+            <goals>
+              <goal>unpack-dependencies</goal>
+            </goals>
+            <phase>generate-resources</phase>
+            <configuration>
+              <includeGroupIds>org.jruby,
+                org.ruby-lang,
+                jnr,
+                com.headius,
+                com.jcraft,
+                com.kenai.jffi,
+                com.github.jnr,
+                com.dylibso.chicory,
+                io.roastedroot,
+                org.objectweb.asm,
+                org.jcodings,
+                org.joni,
+                joda-time,
+                me.qmx.jitescript,
+                org.ow2.asm,
+                ch.randelshofer,
+                org.yaml</includeGroupIds>
+              <includeTypes>jar</includeTypes>
+              <outputDirectory>${project.build.outputDirectory}</outputDirectory>
+              <excludes>META-INF/*.SF,META-INF/*.DSA,META-INF/*.RSA,META-INF/MANIFEST.MF,**/module-info.class</excludes>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 
 </project>

--- a/bundles/org.openhab.automation.jrubyscripting/src/main/java/org/openhab/automation/jrubyscripting/internal/JRubyScriptEngineConfiguration.java
+++ b/bundles/org.openhab.automation.jrubyscripting/src/main/java/org/openhab/automation/jrubyscripting/internal/JRubyScriptEngineConfiguration.java
@@ -241,7 +241,7 @@ public class JRubyScriptEngineConfiguration {
 
     /**
      * Run bundle install or update.
-     * 
+     *
      * This is to be called at start up or configuration change,
      * so that gems are available when user scripts are run.
      *
@@ -249,7 +249,7 @@ public class JRubyScriptEngineConfiguration {
      * @param update when true, run Bundler update, otherwise run Bundler install
      */
     public void bundlerInit(ScriptEngine engine, boolean update) {
-        String operation = update ? "update" : "install";
+        String operation = update ? "update --all" : "install";
         String code = """
                 require "jruby"
                 JRuby.runtime.instance_config.update_native_env_enabled = false
@@ -257,7 +257,8 @@ public class JRubyScriptEngineConfiguration {
                 require "bundler"
                 require "bundler/cli"
 
-                Bundler::CLI.start(["%s"])
+                args = "%s".split
+                Bundler::CLI.start(args)
                 """.formatted(operation);
 
         try {
@@ -302,7 +303,7 @@ public class JRubyScriptEngineConfiguration {
 
     /**
      * Install a gems in ScriptEngine
-     * 
+     *
      * @param engine Engine to install gems
      */
     synchronized void configureGems(ScriptEngine engine, boolean update) {


### PR DESCRIPTION
This is a "major version" upgrade bringing us from Ruby 3.4 to Ruby 4.0 compatibility

Due to the [deprecation of jruby-complete](https://github.com/jruby/jruby/pull/9512) artifact in JRuby's packaging, we're switching to the `jruby` artifact. 

Notes:
- jar size: 10.0.6.0: 35M vs 10.1.1.0 42M
- It seems to work on my "production" installation

@ccutrer do we want to upgrade now, or wait for more revisions from JRuby?

