### PR TITLE
[matter] Avoid redundant status update events when status is unchanged

### DIFF
--- a/bundles/org.openhab.binding.matter/src/main/java/org/openhab/binding/matter/internal/handler/ControllerHandler.java
+++ b/bundles/org.openhab.binding.matter/src/main/java/org/openhab/binding/matter/internal/handler/ControllerHandler.java
@@ -252,7 +252,7 @@ public class ControllerHandler extends BaseBridgeHandler implements MatterClient
                         && !nodeHandler.shouldRefreshOnReconnect();
                 if (skip) {
                     logger.debug("Skipping requestAllNodeData for {} (already enumerated, sleepy)", message.nodeId);
-                    updateEndpointStatuses(message.nodeId, ThingStatus.ONLINE, ThingStatusDetail.NONE, "");
+                    updateEndpointStatuses(message.nodeId, ThingStatus.ONLINE, ThingStatusDetail.NONE, null);
                 } else {
                     updateEndpointStatuses(message.nodeId, ThingStatus.UNKNOWN, ThingStatusDetail.NONE,
                             translationService.getTranslation(THING_STATUS_DETAIL_CONTROLLER_WAITING_FOR_DATA));
@@ -574,7 +574,7 @@ public class ControllerHandler extends BaseBridgeHandler implements MatterClient
     }
 
     private void updateEndpointStatuses(BigInteger nodeId, ThingStatus status, ThingStatusDetail detail,
-            String details) {
+            @Nullable String details) {
         for (Thing thing : getThing().getThings()) {
             ThingHandler handler = thing.getHandler();
             if (handler instanceof NodeHandler endpointHandler) {

--- a/bundles/org.openhab.binding.matter/src/main/java/org/openhab/binding/matter/internal/handler/MatterBaseThingHandler.java
+++ b/bundles/org.openhab.binding.matter/src/main/java/org/openhab/binding/matter/internal/handler/MatterBaseThingHandler.java
@@ -22,7 +22,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledFuture;
@@ -274,8 +273,8 @@ public abstract class MatterBaseThingHandler extends BaseThingHandler
     public void setEndpointStatus(ThingStatus status, ThingStatusDetail detail, String description) {
         logger.debug("setEndpointStatus {} {} {} {}", status, detail, description, getNodeId());
         ThingStatusInfo current = getThing().getStatusInfo();
-        if (current.getStatus() != status || current.getStatusDetail() != detail
-                || !Objects.equals(current.getDescription(), description)) {
+        String currentDesc = current.getDescription() == null ? "" : current.getDescription();
+        if (current.getStatus() != status || current.getStatusDetail() != detail || !currentDesc.equals(description)) {
             updateStatus(status, detail, description);
         }
     }

--- a/bundles/org.openhab.binding.matter/src/main/java/org/openhab/binding/matter/internal/handler/MatterBaseThingHandler.java
+++ b/bundles/org.openhab.binding.matter/src/main/java/org/openhab/binding/matter/internal/handler/MatterBaseThingHandler.java
@@ -22,6 +22,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledFuture;
@@ -64,6 +65,7 @@ import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.Thing;
 import org.openhab.core.thing.ThingStatus;
 import org.openhab.core.thing.ThingStatusDetail;
+import org.openhab.core.thing.ThingStatusInfo;
 import org.openhab.core.thing.ThingTypeUID;
 import org.openhab.core.thing.binding.BaseThingHandler;
 import org.openhab.core.thing.binding.BaseThingHandlerFactory;
@@ -271,7 +273,11 @@ public abstract class MatterBaseThingHandler extends BaseThingHandler
      */
     public void setEndpointStatus(ThingStatus status, ThingStatusDetail detail, String description) {
         logger.debug("setEndpointStatus {} {} {} {}", status, detail, description, getNodeId());
-        updateStatus(status, detail, description);
+        ThingStatusInfo current = getThing().getStatusInfo();
+        if (current.getStatus() != status || current.getStatusDetail() != detail
+                || !Objects.equals(current.getDescription(), description)) {
+            updateStatus(status, detail, description);
+        }
     }
 
     /**

--- a/bundles/org.openhab.binding.matter/src/main/java/org/openhab/binding/matter/internal/handler/MatterBaseThingHandler.java
+++ b/bundles/org.openhab.binding.matter/src/main/java/org/openhab/binding/matter/internal/handler/MatterBaseThingHandler.java
@@ -64,7 +64,6 @@ import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.Thing;
 import org.openhab.core.thing.ThingStatus;
 import org.openhab.core.thing.ThingStatusDetail;
-import org.openhab.core.thing.ThingStatusInfo;
 import org.openhab.core.thing.ThingTypeUID;
 import org.openhab.core.thing.binding.BaseThingHandler;
 import org.openhab.core.thing.binding.BaseThingHandlerFactory;
@@ -270,13 +269,9 @@ public abstract class MatterBaseThingHandler extends BaseThingHandler
      * @param detail The detail of the status.
      * @param description The description of the status.
      */
-    public void setEndpointStatus(ThingStatus status, ThingStatusDetail detail, String description) {
+    public void setEndpointStatus(ThingStatus status, ThingStatusDetail detail, @Nullable String description) {
         logger.debug("setEndpointStatus {} {} {} {}", status, detail, description, getNodeId());
-        ThingStatusInfo current = getThing().getStatusInfo();
-        String currentDesc = current.getDescription() == null ? "" : current.getDescription();
-        if (current.getStatus() != status || current.getStatusDetail() != detail || !currentDesc.equals(description)) {
-            updateStatus(status, detail, description);
-        }
+        updateStatus(status, detail, description);
     }
 
     /**

--- a/bundles/org.openhab.binding.matter/src/test/java/org/openhab/binding/matter/internal/handler/ControllerHandlerTest.java
+++ b/bundles/org.openhab.binding.matter/src/test/java/org/openhab/binding/matter/internal/handler/ControllerHandlerTest.java
@@ -162,7 +162,7 @@ public class ControllerHandlerTest {
         handler.onEvent(nodeState(NODE_ID, NodeState.CONNECTED));
 
         verify(nodeHandler, never()).setEndpointStatus(eq(ThingStatus.UNKNOWN), any(), any());
-        verify(nodeHandler).setEndpointStatus(ThingStatus.ONLINE, ThingStatusDetail.NONE, "");
+        verify(nodeHandler).setEndpointStatus(ThingStatus.ONLINE, ThingStatusDetail.NONE, null);
     }
 
     private void linkEnumeratedNode(BigInteger nodeId, boolean sleepy) throws Exception {


### PR DESCRIPTION
Calling setEndpointStatus with a status and statusDetail identical to the Thing's current state causes openHAB core to re-evaluate status info and fire a ThingStatusInfoChangedEvent, for example:

```
2026-07-29 03:17:04.182 [INFO ] [ab.event.ThingStatusInfoChangedEvent] - Thing 'matter:node:main:frontDoor' changed from ONLINE to ONLINE
```

This change guards setEndpointStatus in MatterBaseThingHandler to skip updateStatus() if the target status and statusDetail match the Thing's current status info.