### PR TITLE
[shelly] Fix BLU Gateway memory crash and firmware 2.0 issues

### DIFF
--- a/bundles/org.openhab.binding.shelly/README.md
+++ b/bundles/org.openhab.binding.shelly/README.md
@@ -259,6 +259,11 @@ Follow these steps to add the Shelly BLU Device to openHAB:
 
 Try moving the device to force status updates.
 
+#### Custom oh-blu-scanner.js
+
+The binding automatically manages the installation of `oh-blu-scanner.js` on the gateway device.
+See [Advanced Users](doc/AdvancedUsers.md) for how to change the script's log level (DEBUG/TRACE) or override the installed script for prototyping.
+
 Every time an event is received sensors#lastUpdate and channels are updated with the reported values.
 `device#wifiSignal` indicates the Bluetooth signal strength and gets updated when the device sends an event.
 

--- a/bundles/org.openhab.binding.shelly/doc/AdvancedUsers.md
+++ b/bundles/org.openhab.binding.shelly/doc/AdvancedUsers.md
@@ -85,6 +85,22 @@ This can be achieved by
 When the IP address changes for a device you need to delete the Thing and then re-discover the device.
 In this case channel linkage gets lost and you need to re-link the channels/items.
 
+## Custom oh-blu-scanner.js Script
+
+BLU support works via a small script, `oh-blu-scanner.js`, that the binding installs on the Shelly BLU Gateway device. The script only listens for BTHome BLE advertisements and forwards them (lightly pre-filtered, e.g. dropping redundant repeats) to the binding; the binding does the actual BTHome payload decoding. This keeps the on-device script small and avoids running out of memory on the gateway (see the BLU device discovery section in the README for the overall setup). This section covers two advanced customization options: adjusting the script's log level, and overriding the installed script for prototyping.
+
+### Log Level (DEBUG/TRACE)
+
+The script logs at these levels, each including everything more severe than itself (`TRACE` is the most verbose): `ERROR`, `WARN`, `INFO` (default), `DEBUG`, `TRACE`. Only `WARN` (e.g. failing to start, unable to decode a packet) and `INFO` (e.g. a new device found) messages are emitted for actual events during normal operation; `DEBUG` and `TRACE` exist purely for diagnostics and are otherwise silent (`TRACE` additionally dumps every received raw BTHome packet).
+To change the level at runtime without editing the script, set the KVS key `oh-blu-scanner.log_level` on the gateway device to one of these names (Web UI: Settings > Key-Value Store, or via the `KVS.Set` RPC) — this is read once when the script starts, and also survives the automatic re-sync since KVS storage is separate from the script code.
+
+### Overriding the Script
+
+Whenever the Thing is initialized (e.g. on openHAB restart, or when the Thing is disabled/re-enabled), the binding checks the script version installed on the device and only re-installs `oh-blu-scanner.js` from the JAR if it differs, which overwrites any edit made directly on the device.
+To use a modified version of the script instead, place a file with the same name in `<openHAB userdata>/shelly/oh-blu-scanner.js`. When present, the binding uploads this file to the gateway device instead of the version bundled in the JAR, and it is not touched by the automatic re-sync.
+
+Note: Use this only for specific prototyping or testing your own changes. In general, let the binding manage the script and its installation - this ensures compatibility between the binding and the script.
+
 ## Log optimization
 
 The binding provides channels (e.g. heartBeat, currentWatts), which might cause a lot of log output, especially when having multiple dozen Shellys.

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/ShellyBindingConstants.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/ShellyBindingConstants.java
@@ -12,10 +12,7 @@
  */
 package org.openhab.binding.shelly.internal;
 
-import java.io.File;
-
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.openhab.core.OpenHAB;
 
 /**
  * The {@link ShellyBindingConstants} class defines common constants, which are
@@ -342,10 +339,6 @@ public class ShellyBindingConstants {
 
     public static final String BUNDLE_RESOURCE_SNIPLETS = "sniplets"; // where to find code sniplets in the bundle
     public static final String BUNDLE_RESOURCE_SCRIPTS = "scripts"; // where to find scrips in the bundle
-
-    // A file placed here with the same name as a bundled script (e.g. oh-blu-scanner.js) is uploaded to the
-    // device instead of the version embedded in the JAR, e.g. to raise its log level or test local edits.
-    public static final String USERDATA_SCRIPT_FOLDER = OpenHAB.getUserDataFolder() + File.separator + BINDING_ID;
 
     public static final int DEFAULT_LOCAL_PORT = 8080;
 }

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/ShellyBindingConstants.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/ShellyBindingConstants.java
@@ -12,7 +12,10 @@
  */
 package org.openhab.binding.shelly.internal;
 
+import java.io.File;
+
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.core.OpenHAB;
 
 /**
  * The {@link ShellyBindingConstants} class defines common constants, which are
@@ -336,6 +339,10 @@ public class ShellyBindingConstants {
 
     public static final String BUNDLE_RESOURCE_SNIPLETS = "sniplets"; // where to find code sniplets in the bundle
     public static final String BUNDLE_RESOURCE_SCRIPTS = "scripts"; // where to find scrips in the bundle
+
+    // A file placed here with the same name as a bundled script (e.g. oh-blu-scanner.js) is uploaded to the
+    // device instead of the version embedded in the JAR, e.g. to raise its log level or test local edits.
+    public static final String USERDATA_SCRIPT_FOLDER = OpenHAB.getUserDataFolder() + File.separator + BINDING_ID;
 
     public static final int DEFAULT_LOCAL_PORT = 8080;
 }

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/ShellyBindingConstants.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/ShellyBindingConstants.java
@@ -283,6 +283,9 @@ public class ShellyBindingConstants {
     public static final String SHELLY_API_FW_110 = "v1.10"; // FW 1.10 or newer detected, activates some add feature
     public static final String SHELLY2_API_MIN_FWVERSION = "v0.10.1"; // Gen 2 minimum FW
 
+    // Unprefixed (unlike the "v"-prefixed Gen1 constants above) to match Gen2+ profile.fwVersion (e.g. "1.2.3")
+    public static final String SHELLY2_API_FW_BLEAUTOSCAN = "2.0"; // FW 2.0+: BLE.SetConfig enable flag removed
+
     // Alarm types/messages
     public static final String ALARM_TYPE_NONE = "NONE";
     public static final String ALARM_TYPE_RESTARTED = "RESTARTED";

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/BTHomeDecoder.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/BTHomeDecoder.java
@@ -1,0 +1,341 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.shelly.internal.api2;
+
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
+
+/**
+ * {@link BTHomeDecoder} decodes a BTHome v2 sensor payload (https://bthome.io/format/).
+ *
+ * <p>
+ * This used to run on-device inside {@code oh-blu-scanner.js}. It was ported here so the mJS script
+ * only has to do cheap pre-filtering (BTHome service UUID match, device-info-byte encryption/version
+ * check, packet-id peek for duplicate-packet dropping) and forward the raw payload, freeing up script
+ * size/CPU time on the constrained Shelly gateway. The device-info byte (encryption flag + BTHome
+ * version) is validated on-device before the raw payload is ever forwarded, so it is not re-checked
+ * here.
+ * </p>
+ *
+ * @author Markus Michels - Initial contribution
+ */
+@NonNullByDefault
+public class BTHomeDecoder {
+    // Bump together with EVENT_DATA_VERSION in oh-blu-scanner.js whenever the wire format changes
+    public static final int SCRIPT_DATA_VERSION = 2;
+
+    private static final int DIMMER_STEPS_ID = 0x3c;
+    private static final int TEXT_ID = 0x53;
+    private static final int RAW_ID = 0x54;
+
+    private enum Type {
+        UINT8,
+        INT8,
+        UINT16,
+        INT16,
+        UINT24,
+        INT24,
+        UINT32,
+        INT32
+    }
+
+    private static final class BthObject {
+        private final String name;
+        private final Type type;
+        private final double factor;
+
+        BthObject(String name, Type type, double factor) {
+            this.name = name;
+            this.type = type;
+            this.factor = factor;
+        }
+    }
+
+    private static final Map<Integer, BthObject> BTH = new HashMap<>();
+
+    private static void put(int id, String name, Type type, double factor) {
+        BTH.put(id, new BthObject(name, type, factor));
+    }
+
+    static {
+        // https://bthome.io/format/ - object id => {name, type, scale factor}. pid (0x00) must stay in this
+        // table even though the script already peeked it, or decoding would fail as "unknown type" immediately.
+        put(0x00, "pid", Type.UINT8, 1);
+        put(0x01, "Battery", Type.UINT8, 1);
+        put(0x02, "Temperature", Type.INT16, 0.01);
+        put(0x03, "Humidity", Type.UINT16, 0.01);
+        put(0x04, "Pressure", Type.UINT24, 0.01);
+        put(0x05, "Illuminance", Type.UINT24, 0.01);
+        put(0x06, "Mass_kg", Type.UINT16, 0.01);
+        put(0x07, "Mass_lb", Type.UINT16, 0.01);
+        put(0x08, "Dewpoint", Type.INT16, 0.01);
+        put(0x09, "Count", Type.UINT8, 1);
+        put(0x0a, "Energy", Type.UINT24, 0.001);
+        put(0x0b, "Power_W", Type.UINT24, 0.01);
+        put(0x0c, "Voltage", Type.UINT16, 0.001);
+        put(0x0d, "PM2_5", Type.UINT16, 1);
+        put(0x0e, "PM10", Type.UINT16, 1);
+        put(0x0f, "GenericBoolean", Type.UINT8, 1);
+        put(0x10, "Power", Type.UINT8, 1);
+        put(0x11, "Opening", Type.UINT8, 1);
+        put(0x12, "Co2", Type.UINT16, 1);
+        put(0x13, "TVOC", Type.UINT16, 1);
+        put(0x14, "Moisture16", Type.UINT16, 0.01);
+        put(0x15, "BatteryLow", Type.UINT8, 1);
+        put(0x16, "BatteryCharging", Type.UINT8, 1);
+        put(0x17, "CarbonMonoxide", Type.UINT8, 1);
+        put(0x18, "Cold", Type.UINT8, 1);
+        put(0x19, "Connectivity", Type.UINT8, 1);
+        put(0x1a, "Door", Type.UINT8, 1);
+        put(0x1b, "GarageDoor", Type.UINT8, 1);
+        put(0x1c, "Gas", Type.UINT8, 1);
+        put(0x1d, "Heat", Type.UINT8, 1);
+        put(0x1e, "Light", Type.UINT8, 1);
+        put(0x1f, "Lock", Type.UINT8, 1);
+        put(0x20, "Moisture", Type.UINT8, 1);
+        put(0x21, "Motion", Type.UINT8, 1);
+        put(0x22, "Moving", Type.UINT8, 1);
+        put(0x23, "Occupancy", Type.UINT8, 1);
+        put(0x24, "Plug", Type.UINT8, 1);
+        put(0x25, "Presence", Type.UINT8, 1);
+        put(0x26, "Problem", Type.UINT8, 1);
+        put(0x27, "Running", Type.UINT8, 1);
+        put(0x28, "Safety", Type.UINT8, 1);
+        put(0x29, "Smoke", Type.UINT8, 1);
+        put(0x2a, "Sound", Type.UINT8, 1);
+        put(0x2b, "Tamper", Type.UINT8, 1);
+        put(0x2c, "Vibration", Type.UINT8, 1);
+        put(0x2d, "Window", Type.UINT8, 1);
+        put(0x2e, "Humidity", Type.UINT8, 1);
+        put(0x2f, "Moisture8", Type.UINT8, 1);
+        put(0x3a, "Button", Type.UINT8, 1);
+        put(0x3c, "Dimmer", Type.UINT16, 1); // special-cased below, see DIMMER_STEPS_ID
+        put(0x3d, "Count", Type.UINT16, 1);
+        put(0x3e, "Count", Type.UINT32, 1);
+        put(0x3f, "Rotation", Type.INT16, 0.1);
+        put(0x40, "Distance_mm", Type.UINT16, 1);
+        put(0x41, "Distance_m", Type.UINT16, 0.1);
+        put(0x42, "Duration", Type.UINT24, 0.001);
+        put(0x43, "Current", Type.UINT16, 0.001);
+        put(0x44, "Speed", Type.UINT16, 0.01);
+        put(0x45, "Temperature", Type.INT16, 0.1);
+        put(0x46, "UVIndex", Type.UINT8, 0.1);
+        put(0x47, "Volume", Type.UINT16, 0.1);
+        put(0x48, "Volume", Type.UINT16, 1);
+        put(0x49, "VolumeFlowRate", Type.UINT16, 0.001);
+        put(0x4a, "Voltage", Type.UINT16, 0.1);
+        put(0x4b, "Gas", Type.UINT24, 0.001);
+        put(0x4c, "Gas", Type.UINT32, 0.001);
+        put(0x4d, "Energy", Type.UINT32, 0.001);
+        put(0x4e, "Volume", Type.UINT32, 0.001);
+        put(0x4f, "Water", Type.UINT32, 0.001);
+        put(0x50, "Timestamp", Type.UINT32, 1);
+        put(0x51, "Acceleration", Type.UINT16, 0.001);
+        put(0x52, "Gyroscope", Type.UINT16, 0.001);
+        // Variable-length (length-prefixed); Type/factor are unused placeholders, see decode()'s TEXT_ID/RAW_ID
+        // handling
+        put(TEXT_ID, "bthText", Type.UINT8, 1); // UTF-8 string
+        put(RAW_ID, "bthRaw", Type.UINT8, 1); // lower-case hex string
+        put(0x55, "VolumeStorage", Type.UINT32, 0.001);
+        put(0x56, "Conductivity", Type.UINT16, 1);
+        put(0x57, "Temperature", Type.INT8, 1);
+        put(0x58, "Temperature", Type.INT8, 0.35);
+        put(0x59, "Count", Type.INT8, 1);
+        put(0x5a, "Count", Type.INT16, 1);
+        put(0x5b, "Count", Type.INT32, 1);
+        put(0x5c, "Power_W", Type.INT32, 0.01);
+        put(0x5d, "Current", Type.INT16, 0.001);
+        put(0x5e, "Direction", Type.UINT16, 0.01);
+        put(0x5f, "Precipitation", Type.UINT16, 0.1);
+        put(0x60, "Channel", Type.UINT8, 1);
+        put(0x61, "RotationalSpeed", Type.UINT16, 1);
+        put(0x62, "SpeedSigned", Type.INT32, 0.000001);
+        put(0x63, "AccelerationSigned", Type.INT32, 0.000001);
+        put(0x64, "LightLevel", Type.UINT8, 1);
+        put(0x65, "SettingsRevision", Type.UINT8, 1);
+        put(0xF0, "DeviceId", Type.UINT16, 1);
+        put(0xF1, "Firmware32", Type.UINT32, 1);
+        put(0xF2, "Firmware24", Type.UINT24, 1);
+    }
+
+    private BTHomeDecoder() {
+    }
+
+    private static int byteSize(Type type) {
+        switch (type) {
+            case UINT8:
+            case INT8:
+                return 1;
+            case UINT16:
+            case INT16:
+                return 2;
+            case UINT24:
+            case INT24:
+                return 3;
+            case UINT32:
+            case INT32:
+                return 4;
+            default:
+                return 0;
+        }
+    }
+
+    private static long readValue(byte[] buffer, int offset, int size) {
+        long value = 0;
+        for (int i = 0; i < size; i++) {
+            value |= (buffer[offset + i] & 0xFFL) << (8 * i);
+        }
+        return value;
+    }
+
+    private static double decodeValue(Type type, byte[] buffer, int offset) {
+        int size = byteSize(type);
+        long raw = readValue(buffer, offset, size);
+        switch (type) {
+            case INT8:
+                return (byte) raw;
+            case INT16:
+                return (short) raw;
+            case INT24:
+                return raw >= 0x800000 ? raw - 0x1000000 : raw;
+            case INT32:
+                return (int) raw;
+            default: // unsigned types
+                return raw;
+        }
+    }
+
+    /**
+     * Decodes a BTHome v2 payload (hex string, device-info byte already stripped by the caller) into a
+     * {@link JsonObject} using the same field names {@code oh-blu-scanner.js} used to emit when it still
+     * decoded on-device, so the result can be merged into {@link Shelly2NotifyBluEventData} via Gson and
+     * reuses that class's existing scalar/array handling.
+     *
+     * @param hex raw BTHome object bytes (without the leading device-info byte), lower-case hex, no separators
+     * @return decoded fields; includes {@code "code": "BTH_UNKNOWN_TYPE"} if decoding stopped on an
+     *         unrecognized object id (matching what the on-device decoder used to report)
+     */
+    public static JsonObject decode(String hex) {
+        JsonObject result = new JsonObject();
+        byte[] buffer = hexToBytes(hex);
+        if (buffer == null) {
+            return result;
+        }
+
+        int offset = 0;
+        while (offset < buffer.length) {
+            int id = buffer[offset++] & 0xFF;
+            BthObject obj = BTH.get(id);
+            if (obj == null) {
+                result.addProperty("code", "BTH_UNKNOWN_TYPE");
+                break;
+            }
+
+            int size = byteSize(obj.type);
+            if (offset + size > buffer.length) {
+                break;
+            }
+
+            if (id == DIMMER_STEPS_ID) {
+                if (offset + 2 > buffer.length) {
+                    break;
+                }
+                JsonObject dimmer = new JsonObject();
+                dimmer.addProperty("direction", buffer[offset] & 0xFF);
+                dimmer.addProperty("steps", buffer[offset + 1] & 0xFF);
+                result.add(obj.name, dimmer);
+                offset += 2;
+                continue;
+            }
+
+            if (id == TEXT_ID || id == RAW_ID) {
+                int len = buffer[offset] & 0xFF;
+                if (offset + 1 + len > buffer.length) {
+                    break;
+                }
+                String payload = id == TEXT_ID ? new String(buffer, offset + 1, len, StandardCharsets.UTF_8)
+                        : bytesToHex(buffer, offset + 1, len);
+                result.addProperty(obj.name, payload);
+                offset += 1 + len;
+                continue;
+            }
+
+            double value = decodeValue(obj.type, buffer, offset) * obj.factor;
+            addValue(result, obj.name, value);
+            offset += size;
+        }
+
+        return result;
+    }
+
+    // DTO fields with an array adapter (repeated BTHome objects, e.g. WS90 Speed/Direction); every other
+    // name is a scalar field, so merging a JsonArray onto it would make Gson's fromJson throw.
+    private static final Set<String> ARRAY_CAPABLE_NAMES = Set.of("Button", "Temperature", "Rotation", "Speed",
+            "Direction");
+
+    private static void addValue(JsonObject result, String name, double value) {
+        JsonElement existing = result.get(name);
+        JsonPrimitive number = isWholeNumber(value) ? new JsonPrimitive((long) value) : new JsonPrimitive(value);
+        if (!ARRAY_CAPABLE_NAMES.contains(name)) {
+            result.add(name, number); // scalar field: last reading wins
+        } else if (existing == null) {
+            result.add(name, number);
+        } else if (existing.isJsonArray()) {
+            existing.getAsJsonArray().add(number);
+        } else {
+            JsonArray array = new JsonArray();
+            array.add(existing);
+            array.add(number);
+            result.add(name, array);
+        }
+    }
+
+    private static boolean isWholeNumber(double value) {
+        return value == Math.floor(value) && !Double.isInfinite(value);
+    }
+
+    private static String bytesToHex(byte[] buffer, int offset, int len) {
+        StringBuilder hex = new StringBuilder(len * 2);
+        for (int i = 0; i < len; i++) {
+            hex.append(String.format("%02x", buffer[offset + i] & 0xFF));
+        }
+        return hex.toString();
+    }
+
+    private static byte @Nullable [] hexToBytes(String hex) {
+        int len = hex.length();
+        if (len % 2 != 0) {
+            return null;
+        }
+        byte[] data = new byte[len / 2];
+        for (int i = 0; i < len; i += 2) {
+            int hi = Character.digit(hex.charAt(i), 16);
+            int lo = Character.digit(hex.charAt(i + 1), 16);
+            if (hi < 0 || lo < 0) {
+                return null;
+            }
+            data[i / 2] = (byte) ((hi << 4) + lo);
+        }
+        return data;
+    }
+}

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/BTHomeDecoder.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/BTHomeDecoder.java
@@ -42,7 +42,7 @@ import com.google.gson.JsonPrimitive;
 @NonNullByDefault
 public class BTHomeDecoder {
     // Bump together with EVENT_DATA_VERSION in oh-blu-scanner.js whenever the wire format changes
-    public static final int SCRIPT_DATA_VERSION = 2;
+    static final int SCRIPT_DATA_VERSION = 2;
 
     private static final int DIMMER_STEPS_ID = 0x3c;
     private static final int TEXT_ID = 0x53;
@@ -235,7 +235,7 @@ public class BTHomeDecoder {
      * @return decoded fields; includes {@code "code": "BTH_UNKNOWN_TYPE"} if decoding stopped on an
      *         unrecognized object id (matching what the on-device decoder used to report)
      */
-    public static JsonObject decode(String hex) {
+    static JsonObject decode(String hex) {
         JsonObject result = new JsonObject();
         byte[] buffer = hexToBytes(hex);
         if (buffer == null) {

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/Shelly2ApiRpc.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/Shelly2ApiRpc.java
@@ -21,12 +21,14 @@ import static org.openhab.binding.shelly.internal.util.ShellyUtils.*;
 
 import java.io.BufferedReader;
 import java.io.EOFException;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.UncheckedIOException;
 import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -294,18 +296,31 @@ public class Shelly2ApiRpc extends Shelly2ApiClient implements ShellyApiInterfac
                 return;
             }
 
-            // get script code from bundle resources
-            String file = BUNDLE_RESOURCE_SCRIPTS + "/" + script;
-            ClassLoader cl = Shelly2ApiRpc.class.getClassLoader();
-            if (cl != null) {
-                try (InputStream inputStream = cl.getResourceAsStream(file)) {
-                    if (inputStream != null) {
-                        code = new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8)).lines()
-                                .collect(Collectors.joining("\n"));
+            // a user-supplied file overrides the version bundled in the JAR, e.g. to enable DEBUG/TRACE
+            File userFile = new File(USERDATA_SCRIPT_FOLDER, script);
+            if (userFile.isFile()) {
+                try {
+                    code = Files.readString(userFile.toPath(), StandardCharsets.UTF_8);
+                    logger.info("{}: Using custom script {} from {}", thingName, script, userFile);
+                } catch (IOException e) {
+                    logger.warn("{}: Unable to read custom script {}, falling back to bundled version", thingName,
+                            userFile, e);
+                }
+            }
+
+            if (code.isEmpty()) {
+                String file = BUNDLE_RESOURCE_SCRIPTS + "/" + script;
+                ClassLoader cl = Shelly2ApiRpc.class.getClassLoader();
+                if (cl != null) {
+                    try (InputStream inputStream = cl.getResourceAsStream(file)) {
+                        if (inputStream != null) {
+                            code = new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8))
+                                    .lines().collect(Collectors.joining("\n"));
+                        }
+                    } catch (IOException | UncheckedIOException e) {
+                        logger.debug("{}: Installation of script {} failed: Unable to read {} from bundle resources!",
+                                thingName, script, file, e);
                     }
-                } catch (IOException | UncheckedIOException e) {
-                    logger.debug("{}: Installation of script {} failed: Unable to read {} from bundle resources!",
-                            thingName, script, file, e);
                 }
             }
 

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/Shelly2ApiRpc.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/Shelly2ApiRpc.java
@@ -16,7 +16,7 @@ import static org.openhab.binding.shelly.internal.ShellyBindingConstants.*;
 import static org.openhab.binding.shelly.internal.api.ShellyApiLightUtil.*;
 import static org.openhab.binding.shelly.internal.api1.Shelly1ApiJsonDTO.*;
 import static org.openhab.binding.shelly.internal.api2.Shelly2ApiJsonDTO.*;
-import static org.openhab.binding.shelly.internal.api2.ShellyBluJsonDTO.SHELLY2_BLU_GWSCRIPT;
+import static org.openhab.binding.shelly.internal.api2.ShellyBluJsonDTO.*;
 import static org.openhab.binding.shelly.internal.util.ShellyUtils.*;
 
 import java.io.BufferedReader;
@@ -111,11 +111,6 @@ public class Shelly2ApiRpc extends Shelly2ApiClient implements ShellyApiInterfac
     private @Nullable Shelly2AuthChallenge authInfo;
     private final WebSocketClient client;
     private final ScheduledExecutorService scheduler;
-
-    // Plus devices support up to 3 scripts, Pro devices up to 10
-    // We need to find a free script id when uploading our script
-    // We want to limit script ids being checked, so define a max id
-    private static final int MAX_SCRIPT_ID = 15;
 
     // Pro/Plus RGBW(W) PM: RPC method family per settings.lights[i].apiComponent tag - replaces per-call-site
     // profile-string checks (SHELLY2_PROFILE_CCTX2.equals(...)) with a single lookup, correct for hybrid profiles.
@@ -408,7 +403,7 @@ public class Shelly2ApiRpc extends Shelly2ApiClient implements ShellyApiInterfac
                 parms.append = false;
                 int length = code.length(), processed = 0, chunk = 1;
                 do {
-                    int nextlen = Math.min(1024, length - processed);
+                    int nextlen = Math.min(SCRIPT_CHUNK_SIZE, length - processed);
                     parms.code = code.substring(processed, processed + nextlen);
                     logger.debug("{}: Uploading chunk {} of script (total {} chars, {} processed)", thingName, chunk,
                             length, processed);

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/Shelly2ApiRpc.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/Shelly2ApiRpc.java
@@ -209,35 +209,41 @@ public class Shelly2ApiRpc extends Shelly2ApiClient implements ShellyApiInterfac
                 logger.debug("{}: BLU Gateway support is {} for this device", thingName,
                         enableBluGateway ? "enabled" : "disabled");
                 if (enableBluGateway) {
-                    boolean restart = false;
-                    ShellyVersionComparator versionComparator = new ShellyVersionComparator();
-                    if (versionComparator.compare(profile.fwVersion, SHELLY2_API_FW_BLEAUTOSCAN) >= 0) {
-                        // FW 2.0 removed the BLE enable/observer config; scanning auto-activates when the
-                        // script starts, so calling setBluetooth() here would only get rejected by the device
-                        installScript(SHELLY2_BLU_GWSCRIPT, true);
+                    if (profile.fwVersion.isEmpty()) {
+                        // fw version not resolved yet (e.g. transient during device boot); skip for now rather
+                        // than risk taking the legacy BLE.SetConfig branch on an actual FW 2.0+ device
+                        logger.debug("{}: Firmware version unknown, skipping BLU Gateway setup for now", thingName);
                     } else {
-                        boolean bluetooth = getBool(dc.ble.enable);
-                        boolean observer = dc.ble.observer != null && getBool(dc.ble.observer.enable);
-                        if (!bluetooth) {
-                            logger.debug("{}: Bluetooth will be enabled to activate BLU Gateway mode", thingName);
-                        }
-                        if (observer) {
-                            logger.debug("{}: Shelly Cloud Bluetooth Gateway conflicts with openHAB, disabling it",
-                                    thingName);
-                        }
-                        if (!bluetooth || observer) {
-                            logger.info("{}: Setup openHAB BLU Gateway", thingName);
-                            restart = setBluetooth(true);
-                            bluetooth = true; // setBluetooth() didn't throw, so BLE.SetConfig succeeded
+                        boolean restart = false;
+                        ShellyVersionComparator versionComparator = new ShellyVersionComparator();
+                        if (versionComparator.compare(profile.fwVersion, SHELLY2_API_FW_BLEAUTOSCAN) >= 0) {
+                            // FW 2.0 removed the BLE enable/observer config; scanning auto-activates when the
+                            // script starts, so calling setBluetooth() here would only get rejected by the device
+                            installScript(SHELLY2_BLU_GWSCRIPT, true);
+                        } else {
+                            boolean bluetooth = getBool(dc.ble.enable);
+                            boolean observer = dc.ble.observer != null && getBool(dc.ble.observer.enable);
+                            if (!bluetooth) {
+                                logger.debug("{}: Bluetooth will be enabled to activate BLU Gateway mode", thingName);
+                            }
+                            if (observer) {
+                                logger.debug("{}: Shelly Cloud Bluetooth Gateway conflicts with openHAB, disabling it",
+                                        thingName);
+                            }
+                            if (!bluetooth || observer) {
+                                logger.info("{}: Setup openHAB BLU Gateway", thingName);
+                                restart = setBluetooth(true);
+                                bluetooth = true; // setBluetooth() didn't throw, so BLE.SetConfig succeeded
+                            }
+
+                            installScript(SHELLY2_BLU_GWSCRIPT, enableBluGateway && bluetooth);
                         }
 
-                        installScript(SHELLY2_BLU_GWSCRIPT, enableBluGateway && bluetooth);
-                    }
-
-                    if (restart) {
-                        logger.info("{}: Restart device to activate BLU Gateway", thingName);
-                        deviceReboot();
-                        getThing().reinitializeThing();
+                        if (restart) {
+                            logger.info("{}: Restart device to activate BLU Gateway", thingName);
+                            deviceReboot();
+                            getThing().reinitializeThing();
+                        }
                     }
                 }
             }

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/Shelly2ApiRpc.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/Shelly2ApiRpc.java
@@ -214,22 +214,31 @@ public class Shelly2ApiRpc extends Shelly2ApiClient implements ShellyApiInterfac
                 logger.debug("{}: BLU Gateway support is {} for this device", thingName,
                         enableBluGateway ? "enabled" : "disabled");
                 if (enableBluGateway) {
-                    boolean bluetooth = getBool(dc.ble.enable);
-                    boolean observer = dc.ble.observer != null && getBool(dc.ble.observer.enable);
-                    if (!bluetooth) {
-                        logger.warn("{}: Bluetooth will be enabled to activate BLU Gateway mode", thingName);
-                    }
-                    if (observer) {
-                        logger.warn("{}: Shelly Cloud Bluetooth Gateway conflicts with openHAB, disabling it",
-                                thingName);
-                    }
                     boolean restart = false;
-                    if (!bluetooth || observer) {
-                        logger.info("{}: Setup openHAB BLU Gateway", thingName);
+                    ShellyVersionComparator versionComparator = new ShellyVersionComparator();
+                    if (versionComparator.compare(profile.fwVersion, SHELLY2_API_FW_BLEAUTOSCAN) >= 0) {
+                        // FW 2.0 removed BLE.SetConfig's enable flag, but still call it to make sure Bluetooth
+                        // is enabled and any conflicting Shelly Cloud BLE observer gets disabled
                         restart = setBluetooth(true);
-                    }
+                        installScript(SHELLY2_BLU_GWSCRIPT, true);
+                    } else {
+                        boolean bluetooth = getBool(dc.ble.enable);
+                        boolean observer = dc.ble.observer != null && getBool(dc.ble.observer.enable);
+                        if (!bluetooth) {
+                            logger.debug("{}: Bluetooth will be enabled to activate BLU Gateway mode", thingName);
+                        }
+                        if (observer) {
+                            logger.debug("{}: Shelly Cloud Bluetooth Gateway conflicts with openHAB, disabling it",
+                                    thingName);
+                        }
+                        if (!bluetooth || observer) {
+                            logger.info("{}: Setup openHAB BLU Gateway", thingName);
+                            restart = setBluetooth(true);
+                            bluetooth = true; // setBluetooth() didn't throw, so BLE.SetConfig succeeded
+                        }
 
-                    installScript(SHELLY2_BLU_GWSCRIPT, enableBluGateway && bluetooth);
+                        installScript(SHELLY2_BLU_GWSCRIPT, enableBluGateway && bluetooth);
+                    }
 
                     if (restart) {
                         logger.info("{}: Restart device to activate BLU Gateway", thingName);

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/Shelly2ApiRpc.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/Shelly2ApiRpc.java
@@ -212,9 +212,8 @@ public class Shelly2ApiRpc extends Shelly2ApiClient implements ShellyApiInterfac
                     boolean restart = false;
                     ShellyVersionComparator versionComparator = new ShellyVersionComparator();
                     if (versionComparator.compare(profile.fwVersion, SHELLY2_API_FW_BLEAUTOSCAN) >= 0) {
-                        // FW 2.0 removed BLE.SetConfig's enable flag, but still call it to make sure Bluetooth
-                        // is enabled and any conflicting Shelly Cloud BLE observer gets disabled
-                        restart = setBluetooth(true);
+                        // FW 2.0 removed the BLE enable/observer config; scanning auto-activates when the
+                        // script starts, so calling setBluetooth() here would only get rejected by the device
                         installScript(SHELLY2_BLU_GWSCRIPT, true);
                     } else {
                         boolean bluetooth = getBool(dc.ble.enable);

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/ShellyBluApi.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/ShellyBluApi.java
@@ -19,6 +19,8 @@ import static org.openhab.binding.shelly.internal.util.ShellyUtils.*;
 
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ScheduledExecutorService;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -52,6 +54,10 @@ import org.openhab.core.thing.ThingTypeUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonSyntaxException;
+
 /**
  * {@link ShellyBluApi} handles the Shelly BLU Bluetooth Low Energy device protocol.
  *
@@ -80,6 +86,7 @@ public class ShellyBluApi extends Shelly2ApiRpc {
     private static final int PID_CYCLE_TRESHOLD = 50;
     private long lastTimeStampPacket = 0;
     private static final int PACKET_TIMESTAMP_TRESHOLD = 10;
+    private @Nullable Integer warnedDataVersion;
 
     /**
      * Regular constructor - called by Thing handler
@@ -201,6 +208,13 @@ public class ShellyBluApi extends Shelly2ApiRpc {
             for (Shelly2NotifyEvent e : events) {
                 String event = getString(e.event);
                 Shelly2NotifyBluEventData blu = e.blu;
+                if (blu != null && blu.raw != null) {
+                    blu = decodeRawBTHomeData(blu);
+                    String alarmCode = blu.alarmCode;
+                    if (alarmCode != null) {
+                        t.postEvent(alarmCode, false);
+                    }
+                }
                 if (event.startsWith(SHELLY2_EVENT_BLUPREFIX)) {
                     if (blu != null) {
                         logger.debug("{}: BLU event {} received from address {}, pid={} (JSON={})", thingName, event,
@@ -402,6 +416,41 @@ public class ShellyBluApi extends Shelly2ApiRpc {
         } catch (ShellyApiException e) {
             logger.debug("{}: Unable to process event", thingName, e);
             t.incProtErrors();
+        }
+    }
+
+    /**
+     * Decodes the raw BTHome payload forwarded by {@code oh-blu-scanner.js} and merges the result onto
+     * {@code blu}'s own fields via Gson.
+     *
+     * @param blu event data with a non-null {@code raw} field
+     * @return {@code blu} merged with the decoded fields, or unchanged if decoding/merging failed
+     */
+    private Shelly2NotifyBluEventData decodeRawBTHomeData(Shelly2NotifyBluEventData blu) {
+        String raw = blu.raw;
+        if (raw == null) {
+            return blu;
+        }
+        Integer version = blu.dataVersion;
+        if ((version == null || version != BTHomeDecoder.SCRIPT_DATA_VERSION)
+                && !Objects.equals(version, warnedDataVersion)) {
+            logger.warn(
+                    "{}: BLU event data version {} doesn't match the binding's expected version {}; the installed oh-blu-scanner.js might be outdated or a custom override, decoding could be incomplete",
+                    thingName, version, BTHomeDecoder.SCRIPT_DATA_VERSION);
+            warnedDataVersion = version;
+        }
+        JsonObject decoded = BTHomeDecoder.decode(raw);
+        JsonObject merged = gson.toJsonTree(blu).getAsJsonObject();
+        for (Map.Entry<String, JsonElement> entry : decoded.entrySet()) {
+            merged.add(entry.getKey(), entry.getValue());
+        }
+        try {
+            Shelly2NotifyBluEventData result = gson.fromJson(merged, Shelly2NotifyBluEventData.class);
+            return result != null ? result : blu;
+        } catch (JsonSyntaxException | NumberFormatException e) {
+            logger.warn("{}: Unable to merge decoded BTHome data {} onto event, keeping original event", thingName,
+                    decoded, e);
+            return blu;
         }
     }
 

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/ShellyBluApi.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/ShellyBluApi.java
@@ -87,6 +87,7 @@ public class ShellyBluApi extends Shelly2ApiRpc {
     private long lastTimeStampPacket = 0;
     private static final int PACKET_TIMESTAMP_TRESHOLD = 10;
     private @Nullable Integer warnedDataVersion;
+    private boolean warnedDataVersionSet;
 
     /**
      * Regular constructor - called by Thing handler
@@ -433,11 +434,12 @@ public class ShellyBluApi extends Shelly2ApiRpc {
         }
         Integer version = blu.dataVersion;
         if ((version == null || version != BTHomeDecoder.SCRIPT_DATA_VERSION)
-                && !Objects.equals(version, warnedDataVersion)) {
+                && (!warnedDataVersionSet || !Objects.equals(version, warnedDataVersion))) {
             logger.warn(
                     "{}: BLU event data version {} doesn't match the binding's expected version {}; the installed oh-blu-scanner.js might be outdated or a custom override, decoding could be incomplete",
                     thingName, version, BTHomeDecoder.SCRIPT_DATA_VERSION);
             warnedDataVersion = version;
+            warnedDataVersionSet = true;
         }
         JsonObject decoded = BTHomeDecoder.decode(raw);
         JsonObject merged = gson.toJsonTree(blu).getAsJsonObject();

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/ShellyBluJsonDTO.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/ShellyBluJsonDTO.java
@@ -12,9 +12,13 @@
  */
 package org.openhab.binding.shelly.internal.api2;
 
+import static org.openhab.binding.shelly.internal.ShellyBindingConstants.BINDING_ID;
+
+import java.io.File;
 import java.lang.reflect.Type;
 
 import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.core.OpenHAB;
 
 import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonDeserializer;
@@ -29,8 +33,13 @@ import com.google.gson.annotations.SerializedName;
  */
 public class ShellyBluJsonDTO {
 
-    // BLU events
+    public static final String USERDATA_SCRIPT_FOLDER = OpenHAB.getUserDataFolder() + File.separator + BINDING_ID;
     public static final String SHELLY2_BLU_GWSCRIPT = "oh-blu-scanner.js";
+    // Plus devices support up to 3 scripts, Pro devices up to 10; limit how many script ids we probe for a free slot
+    public static final int MAX_SCRIPT_ID = 15;
+    public static final int SCRIPT_CHUNK_SIZE = 512; // chunk size for upload
+
+    // BLU events
     public static final String SHELLY2_EVENT_BLUPREFIX = "oh-blu.";
     public static final String SHELLY2_EVENT_BLUSCAN = SHELLY2_EVENT_BLUPREFIX + "scan_result";
     public static final String SHELLY2_EVENT_BLUDATA = SHELLY2_EVENT_BLUPREFIX + "data";

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/ShellyBluJsonDTO.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/ShellyBluJsonDTO.java
@@ -82,6 +82,10 @@ public class ShellyBluJsonDTO {
         public @Nullable String packet;
         public @Nullable String addr;
         public @Nullable String name;
+        // Raw BTHome payload forwarded by the script; "ver" guards against a stale/custom script format
+        public @Nullable String raw;
+        @SerializedName("ver")
+        public @Nullable Integer dataVersion;
         public @Nullable Boolean encryption;
         @SerializedName("code") // oh-blu.alarm: BTH_ENCRYPTED, BTH_UNKNOWN_TYPE
         public @Nullable String alarmCode;

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/ShellyBluJsonDTO.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/ShellyBluJsonDTO.java
@@ -45,20 +45,12 @@ public class ShellyBluJsonDTO {
     public static final String SHELLY2_EVENT_BLUDATA = SHELLY2_EVENT_BLUPREFIX + "data";
     public static final String SHELLY2_EVENT_BLUALARM = SHELLY2_EVENT_BLUPREFIX + "alarm";
 
-    // BTHome samples
-    // BLU Button 1
+    // BTHome samples (script forwards the raw BTHome payload; the binding decodes it via BTHomeDecoder)
     // {"component":"script:2", "id":2, "event":"oh-blu.scan_result",
-    // "data":{"addr":"bc:02:6e:c3:a6:c7","rssi":-62,"tx_power":-128}, "ts":1682877414.21}
+    // "data":{"addr":"bc:02:6e:c3:a6:c7","name":"SBBT-002C","rssi":-62,"tx_power":-128}, "ts":1682877414.21}
     // {"component":"script:2", "id":2, "event":"oh-blu.data",
-    // "data":{"encryption":false,"BTHome_version":2,"pid":205,"Battery":100,"Button":1,"addr":"b4:35:22:fd:b3:81","rssi":-68},
+    // "data":{"addr":"b4:35:22:fd:b3:81","rssi":-68,"pid":205,"ver":2,"raw":"0001cd0100640b0500"},
     // "ts":1682877399.22}
-    //
-    // BLU Door Window
-    // {"component":"script:2", "id":2, "event":"oh-blu.scan_result",
-    // "data":{"addr":"bc:02:6e:c3:a6:c7","rssi":-62,"tx_power":-128}, "ts":1682877414.21}
-    // {"component":"script:2", "id":2, "event":"oh-blu.data",
-    // "data":{"encryption":false,"BTHome_version":2,"pid":38,"Battery":100,"Illuminance":0,"Window":1,"Rotation":0,"addr":"bc:02:6e:c3:a6:c7","rssi":-62},
-    // "ts":1682877414.25}
 
     // Handles BTHome fields that a single-button device sends as a scalar but a multi-button device sends as an array.
     // Without this adapter, a plain Gson instance would throw JsonSyntaxException on scalar payloads for T[] fields.
@@ -88,18 +80,14 @@ public class ShellyBluJsonDTO {
             public @Nullable Integer steps;
         }
 
-        public @Nullable String packet;
         public @Nullable String addr;
         public @Nullable String name;
         // Raw BTHome payload forwarded by the script; "ver" guards against a stale/custom script format
         public @Nullable String raw;
         @SerializedName("ver")
         public @Nullable Integer dataVersion;
-        public @Nullable Boolean encryption;
         @SerializedName("code") // oh-blu.alarm: BTH_ENCRYPTED, BTH_UNKNOWN_TYPE
         public @Nullable String alarmCode;
-        @SerializedName("BTHome_version")
-        public @Nullable Integer bthVersion;
         public @Nullable Integer pid;
         @SerializedName("Battery")
         public @Nullable Integer battery;

--- a/bundles/org.openhab.binding.shelly/src/main/resources/scripts/oh-blu-scanner.js
+++ b/bundles/org.openhab.binding.shelly/src/main/resources/scripts/oh-blu-scanner.js
@@ -16,7 +16,24 @@ let ALLTERCO_MFD_ID = JSON.parse("0x" + ALLTERCO_MFD_ID_STR);
 let BTHOME_SVC_ID = JSON.parse("0x" + BTHOME_SVC_ID_STR);
 let SCAN_DURATION = BLE.Scanner.INFINITE_SCAN;
 
-let DEBUG = false;
+// Log levels, each includes everything more severe than itself (TRACE shows DEBUG+INFO+WARN+ERROR too)
+let LVL_ERROR = 0;
+let LVL_WARN = 1;
+let LVL_INFO = 2;
+let LVL_DEBUG = 3;
+let LVL_TRACE = 4;
+let LOG_LEVEL = LVL_INFO;
+
+// LOG_LEVEL persisted in KVS survives the binding's script re-sync (a hardcoded value here would get
+// silently reverted on the next resync since the binding reinstalls whenever the code differs from this file)
+Shelly.call("KVS.GetMany", { match: "oh-blu-scanner.*" }, function (res) {
+  if (!res || !res.items) return;
+  let name = res.items["oh-blu-scanner.log_level"];
+  if (typeof name !== "string") return;
+  let levels = { "ERROR": LVL_ERROR, "WARN": LVL_WARN, "INFO": LVL_INFO, "DEBUG": LVL_DEBUG, "TRACE": LVL_TRACE };
+  let level = levels[name.toUpperCase()];
+  if (typeof level !== "undefined") LOG_LEVEL = level;
+});
 
 // Cache objects for Shelly Blu devices and last packet IDs
 // SHELLY_BLU_CACHE[addr]: device name if Shelly BLU, false if a known non-Shelly BTHome device
@@ -173,7 +190,7 @@ let BTHomeDecoder = {
     result["encryption"] = _dib & 0x1 ? true : false;
     result["BTHome_version"] = _dib >> 5;
     if (result["encryption"]) {
-      console.log("BTH: encrypted payload, cannot decode");
+      if (LOG_LEVEL >= LVL_WARN) console.log("BTH: encrypted payload, cannot decode");
       result["alarmCode"] = "BTH_ENCRYPTED";
       return result; // Can not handle encrypted data
     }
@@ -187,7 +204,7 @@ let BTHomeDecoder = {
 
       let _bth = BTH[bthIdx];
       if (typeof _bth === "undefined") {
-        console.log("BTH: unknown type", bthIdx);
+        if (LOG_LEVEL >= LVL_WARN) console.log("BTH: unknown type", bthIdx);
         result["alarmCode"] = "BTH_UNKNOWN_TYPE";
         break;
       }
@@ -207,7 +224,7 @@ let BTHomeDecoder = {
       if (bthIdx === BTH_DIMMERSTEPS_INDEX) {
         let valueDimSize = 2; // Fixed size for dimmer steps is 2 bytes
         if (buffer.length < valueDimSize) {
-          console.log("BTH: buffer too short for Dimmer event");
+          if (LOG_LEVEL >= LVL_WARN) console.log("BTH: buffer too short for Dimmer event");
           continue;
         }
 
@@ -243,6 +260,16 @@ let BTHomeDecoder = {
   }
 };
 
+// Hex dump helper, only used under TRACE (padStart not available in the Shelly JS engine)
+function bufToHex(buffer) {
+  let hex = "";
+  for (let i = 0; i < buffer.length; i++) {
+    let hexValue = buffer.at(i).toString(16);
+    hex += (hexValue.length === 1 ? "0" + hexValue : hexValue) + " ";
+  }
+  return hex.trim();
+}
+
 // Shelly BLU BLE data parser wrapper
 let ShellyBLUParser = {
   getData: function (res) {
@@ -271,7 +298,7 @@ function scanCB(ev, res) {
     let found = false;
     for (let prefix of ALLTERCO_DEVICE_NAME_PREFIX) {
       if (res.local_name.indexOf(prefix) === 0) {
-        console.log('New device found: address=', res.addr, ', name=', res.local_name);
+        if (LOG_LEVEL >= LVL_INFO) console.log('New device found: address=', res.addr, ', name=', res.local_name);
         Shelly.emitEvent("oh-blu.scan_result", {"addr":res.addr, "name":res.local_name, "rssi":res.rssi, "tx_power":res.tx_power_level});
         SHELLY_BLU_CACHE[res.addr] = res.local_name;
         found = true;
@@ -279,28 +306,30 @@ function scanCB(ev, res) {
       }
     }
     if (!found) {
-      console.log('Unknown device: ', res.local_name);
+      if (LOG_LEVEL >= LVL_INFO) console.log('Unknown device: ', res.local_name);
       SHELLY_BLU_CACHE[res.addr] = false;
       return;
     }
   }
 
+  if (LOG_LEVEL >= LVL_TRACE) console.log('Raw BTHome packet from ', res.addr, ': ', bufToHex(res.service_data[BTHOME_SVC_ID_STR]));
+
   let BTHparsed = ShellyBLUParser.getData(res);
   if (BTHparsed === null) {
-    console.log("Failed to parse BTH data");
+    if (LOG_LEVEL >= LVL_WARN) console.log("Failed to parse BTH data");
     return;
   }
 
   if (BTHparsed.alarmCode) {
-    console.log("BLU alarm:", BTHparsed.alarmCode, "addr=", res.addr);
+    if (LOG_LEVEL >= LVL_WARN) console.log("BLU alarm:", BTHparsed.alarmCode, "addr=", res.addr);
     Shelly.emitEvent("oh-blu.alarm", {"addr":res.addr, "code":BTHparsed.alarmCode});
   }
 
   if (typeof LAST_PID[res.addr] === 'undefined' || BTHparsed.pid !== LAST_PID[res.addr]) {
-    if (DEBUG) console.log('Parsed BTH data from device ', res.local_name, ': ', JSON.stringify(BTHparsed));
+    if (LOG_LEVEL >= LVL_TRACE) console.log('Parsed BTH data from device ', res.local_name, ': ', JSON.stringify(BTHparsed));
     Shelly.emitEvent("oh-blu.data", BTHparsed);
     LAST_PID[res.addr] = BTHparsed.pid;
-  } else if (DEBUG) {
+  } else if (LOG_LEVEL >= LVL_DEBUG) {
     console.log("Drop redundant packet with pid ", BTHparsed.pid);
   }
 }
@@ -310,16 +339,16 @@ function scanCB(ev, res) {
 function startBLEScan() {
     let bleScanSuccess = BLE.Scanner.Start({ duration_ms: SCAN_DURATION, active: true }, scanCB);
     if( bleScanSuccess === null ) {
-        console.log('Unable to start OH-BLU Scanner.');
+        if (LOG_LEVEL >= LVL_WARN) console.log('Unable to start OH-BLU Scanner.');
         Timer.set(3000, false, startBLEScan);
     } else {
-        console.log('Success: OH-BLU Event Gateway running');
+        if (LOG_LEVEL >= LVL_INFO) console.log('Success: OH-BLU Event Gateway running');
     }
  }
- 
+
 let BLEConfig = Shelly.getComponentConfig('ble');
 if(BLEConfig.enable === false) {
-    console.log('Error: BLE not enabled, unable to start OH-BLU Scanner');
+    if (LOG_LEVEL >= LVL_ERROR) console.log('Error: BLE not enabled, unable to start OH-BLU Scanner');
 } else {
     Timer.set(1000, false, startBLEScan);
 }

--- a/bundles/org.openhab.binding.shelly/src/main/resources/scripts/oh-blu-scanner.js
+++ b/bundles/org.openhab.binding.shelly/src/main/resources/scripts/oh-blu-scanner.js
@@ -1,10 +1,5 @@
 /*
  * This script uses the BLE scan functionality to pass scan results and BLU data to openHAB.
- * It gets automatically installed / updated by the binding when BLU support is enabled in the thing configuration.
- * The script only pre-filters BTHome advertisements and does basic checks (encryption/version flag, packet id for
- * duplicate-packet dropping); full BTHome object decoding happens on the binding side (see BTHomeDecoder.java) to
- * keep the on-device script small and release CPU/memory on the (often battery-powered) gateway device.
- *
  * @author Markus Michels - Initial contribution
  * @author Udo Hartmann - Add support for decoding multi button inputs
  * @author Igor Jasan - Sensor parameter fixing, decoding of dimmer
@@ -18,11 +13,9 @@ let ALLTERCO_MFD_ID = JSON.parse("0x" + ALLTERCO_MFD_ID_STR);
 let BTHOME_SVC_ID = JSON.parse("0x" + BTHOME_SVC_ID_STR);
 let SCAN_DURATION = BLE.Scanner.INFINITE_SCAN;
 
-// Bump together with BTHomeDecoder.SCRIPT_DATA_VERSION in the binding whenever this wire format changes;
-// the binding logs a warning if it sees a version it doesn't expect (e.g. a stale custom script override).
+// Bump together with BTHomeDecoder.SCRIPT_DATA_VERSION in the binding
 let EVENT_DATA_VERSION = 2;
 
-// Log levels, each includes everything more severe than itself (TRACE shows DEBUG+INFO+WARN+ERROR too)
 let LVL_ERROR = 0;
 let LVL_WARN = 1;
 let LVL_INFO = 2;
@@ -30,8 +23,7 @@ let LVL_DEBUG = 3;
 let LVL_TRACE = 4;
 let LOG_LEVEL = LVL_INFO;
 
-// LOG_LEVEL persisted in KVS survives the binding's script re-sync (a hardcoded value here would get
-// silently reverted on the next resync since the binding reinstalls whenever the code differs from this file)
+// LOG_LEVEL persisted in KVS survives the binding's script re-sync
 Shelly.call("KVS.GetMany", { match: "oh-blu-scanner.*" }, function (res) {
   if (!res || !res.items) return;
   let name = res.items["oh-blu-scanner.log_level"];
@@ -41,12 +33,11 @@ Shelly.call("KVS.GetMany", { match: "oh-blu-scanner.*" }, function (res) {
   if (typeof level !== "undefined") LOG_LEVEL = level;
 });
 
-// Cache objects for Shelly Blu devices and last packet IDs
 // SHELLY_BLU_CACHE[addr]: device name if Shelly BLU, false if a known non-Shelly BTHome device
 let SHELLY_BLU_CACHE = {};
 let LAST_PID = {};
 
-// Hex dump helper (no separators - used both for TRACE logging and as the raw payload sent to the binding)
+// No separators - also used as the raw payload sent to the binding
 function bufToHex(buffer) {
   let hex = "";
   for (let i = 0; i < buffer.length; i++) {
@@ -56,7 +47,6 @@ function bufToHex(buffer) {
   return hex;
 }
 
-// BLE scan callback function
 function scanCB(ev, res) {
   if (ev !== BLE.Scanner.SCAN_RESULT) return;
   if (typeof res.service_data === 'undefined' || typeof res.service_data[BTHOME_SVC_ID_STR] === 'undefined') return;
@@ -92,8 +82,7 @@ function scanCB(ev, res) {
     return;
   }
 
-  // Device Info Byte: bit 0 = encryption flag, bits 5-7 = BTHome version. This is the only byte inspected
-  // on-device; full object decoding (temperature, humidity, ...) now happens on the binding side.
+  // Device Info Byte: bit 0 = encryption flag, bits 5-7 = BTHome version.
   let dib = buffer.at(0);
   if (dib & 0x1) {
     if (LOG_LEVEL >= LVL_WARN) console.log("BTH: encrypted payload, cannot decode");
@@ -105,8 +94,7 @@ function scanCB(ev, res) {
     return;
   }
 
-  // Packet ID (object 0x00) is always the first object when present; peek it without a full decode so
-  // redundant packets can still be dropped on-device, reducing WebSocket noise from repeated advertisements.
+  // Packet ID (object 0x00) is always the first object when present
   let pid;
   if (buffer.length >= 3 && buffer.at(1) === 0x00) {
     pid = buffer.at(2);
@@ -121,8 +109,7 @@ function scanCB(ev, res) {
   Shelly.emitEvent("oh-blu.data", {"addr":res.addr, "rssi":res.rssi, "pid":pid, "ver":EVENT_DATA_VERSION, "raw":bufToHex(buffer.slice(1))});
 }
 
-// retry several times to start the scanner if script was started before
-// BLE infrastructure was up in the Shelly
+// Retries in case script started before BLE infra was up
 function startBLEScan() {
     let bleScanSuccess = BLE.Scanner.Start({ duration_ms: SCAN_DURATION, active: true }, scanCB);
     if( bleScanSuccess === null ) {
@@ -135,7 +122,7 @@ function startBLEScan() {
 
 let BLEConfig = Shelly.getComponentConfig('ble');
 if(BLEConfig.enable === false) {
-    if (LOG_LEVEL >= LVL_ERROR) console.log('Error: BLE not enabled, unable to start OH-BLU Scanner');
+    if (LOG_LEVEL >= LVL_WARN) console.log('Error: BLE not enabled, unable to start OH-BLU Scanner');
 } else {
     Timer.set(1000, false, startBLEScan);
 }

--- a/bundles/org.openhab.binding.shelly/src/main/resources/scripts/oh-blu-scanner.js
+++ b/bundles/org.openhab.binding.shelly/src/main/resources/scripts/oh-blu-scanner.js
@@ -24,10 +24,9 @@ let LVL_TRACE = 4;
 let LOG_LEVEL = LVL_INFO;
 
 // LOG_LEVEL persisted in KVS survives the binding's script re-sync
-Shelly.call("KVS.GetMany", { match: "oh-blu-scanner.*" }, function (res) {
-  if (!res || !res.items) return;
-  let name = res.items["oh-blu-scanner.log_level"];
-  if (typeof name !== "string") return;
+Shelly.call("KVS.Get", { key: "oh-blu-scanner.log_level" }, function (res) {
+  if (!res || typeof res.value !== "string") return;
+  let name = res.value;
   let levels = { "ERROR": LVL_ERROR, "WARN": LVL_WARN, "INFO": LVL_INFO, "DEBUG": LVL_DEBUG, "TRACE": LVL_TRACE };
   let level = levels[name.toUpperCase()];
   if (typeof level !== "undefined") LOG_LEVEL = level;
@@ -37,21 +36,22 @@ Shelly.call("KVS.GetMany", { match: "oh-blu-scanner.*" }, function (res) {
 let SHELLY_BLU_CACHE = {};
 let LAST_PID = {};
 
-// Bounds SHELLY_BLU_CACHE/LAST_PID so an infinite scan seeing many rotating/random
-// BLE addresses over time can't grow memory usage without limit.
-let CACHE_ORDER = [];
+// Bounds only the negative entries (non-Shelly addresses) so an infinite scan seeing many
+// rotating/random BLE addresses over time can't grow memory usage without limit. Recognized
+// Shelly BLU devices are never evicted.
+let NEGATIVE_CACHE_ORDER = [];
 let MAX_CACHE_SIZE = 128;
 
 function cacheSet(addr, value) {
-  if (typeof SHELLY_BLU_CACHE[addr] === 'undefined') {
-    CACHE_ORDER.push(addr);
-    if (CACHE_ORDER.length > MAX_CACHE_SIZE) {
-      let evictAddr = CACHE_ORDER.shift();
-      delete SHELLY_BLU_CACHE[evictAddr];
-      delete LAST_PID[evictAddr];
-    }
-  }
   SHELLY_BLU_CACHE[addr] = value;
+  if (value !== false) return;
+
+  NEGATIVE_CACHE_ORDER.push(addr);
+  if (NEGATIVE_CACHE_ORDER.length > MAX_CACHE_SIZE) {
+    let evictAddr = NEGATIVE_CACHE_ORDER.shift();
+    delete SHELLY_BLU_CACHE[evictAddr];
+    delete LAST_PID[evictAddr];
+  }
 }
 
 // No separators - also used as the raw payload sent to the binding

--- a/bundles/org.openhab.binding.shelly/src/main/resources/scripts/oh-blu-scanner.js
+++ b/bundles/org.openhab.binding.shelly/src/main/resources/scripts/oh-blu-scanner.js
@@ -16,7 +16,10 @@ let ALLTERCO_MFD_ID = JSON.parse("0x" + ALLTERCO_MFD_ID_STR);
 let BTHOME_SVC_ID = JSON.parse("0x" + BTHOME_SVC_ID_STR);
 let SCAN_DURATION = BLE.Scanner.INFINITE_SCAN;
 
+let DEBUG = false;
+
 // Cache objects for Shelly Blu devices and last packet IDs
+// SHELLY_BLU_CACHE[addr]: device name if Shelly BLU, false if a known non-Shelly BTHome device
 let SHELLY_BLU_CACHE = {};
 let LAST_PID = {};
 
@@ -34,7 +37,7 @@ let BTH_DIMMERSTEPS_INDEX = 0x3c;   // Dimmer (Wheel) Steps object ID
 
 // BTHome object definitions: id => {name, type, optional scale factor}
 // https://bthome.io/format/
-let BTH = [];
+let BTH = {};
 BTH[0x00] = { n: "pid", t: uint8 };                                           // Packet ID
 BTH[0x01] = { n: "Battery", t: uint8, u: "%" };                               // Battery level in percent
 BTH[0x02] = { n: "Temperature", t: int16, f: 0.01 };                          // Temperature in C (scaled by 0.01)
@@ -129,20 +132,6 @@ function getByteSize(type) {
   return 255;
 }
 
-// Helper function: buffer to hex string
-// padStart function not available in Shelly JS engine
-function bufToHex(buffer) {
-  let hex = "";
-  for (let i = 0; i < buffer.length; i++) {
-    let hexValue = buffer.at(i).toString(16);
-    if (hexValue.length === 1) {
-      hex += "0" + hexValue + " ";
-    } else {
-      hex += hexValue + " ";
-    }
-  }
-  return hex.trim();
-}
 let BTHomeDecoder = {
   // Convert unsigned integer to signed based on bit size
   utoi: function (num, bitsz) {
@@ -192,8 +181,6 @@ let BTHomeDecoder = {
     
     buffer = buffer.slice(1); // Remove header byte
 
-    let dimmer = [];
-
     while (buffer.length > 0) {
       let bthIdx = buffer.at(0); // Object ID
       buffer = buffer.slice(1);
@@ -234,7 +221,6 @@ let BTHomeDecoder = {
           steps: stepsByte
         };
 
-        //dimmer.push(dimmerEvent);
         result[_bth.n] = dimmerEvent;
         
         buffer = buffer.slice(valueDimSize);
@@ -253,9 +239,6 @@ let BTHomeDecoder = {
       buffer = buffer.slice(valueSize);
     }
 
-    // Add events as arrays to the result
-    if (dimmer.length > 0) result["Dimmer"] = dimmer;
-
     return result;
   }
 };
@@ -266,14 +249,10 @@ let ShellyBLUParser = {
     let service_data = res.service_data[BTHOME_SVC_ID_STR];
     if (!service_data) return null;
 
-    let hexDump = bufToHex(service_data);
-    // console.log("Received BTHome RAW packet (hex):", hexDump);
-    
     let result = BTHomeDecoder.unpack(service_data);
     if (!result) return null;
     result.addr = res.addr;
     result.rssi = res.rssi;
-    result.packet = hexDump;
     return result;
   }
 };
@@ -283,7 +262,10 @@ function scanCB(ev, res) {
   if (ev !== BLE.Scanner.SCAN_RESULT) return;
   if (typeof res.service_data === 'undefined' || typeof res.service_data[BTHOME_SVC_ID_STR] === 'undefined') return;
 
-  if (typeof SHELLY_BLU_CACHE[res.addr] === 'undefined') {
+  let cached = SHELLY_BLU_CACHE[res.addr];
+  if (cached === false) return;
+
+  if (typeof cached === 'undefined') {
     if (typeof res.local_name !== "string") return;
 
     let found = false;
@@ -291,16 +273,19 @@ function scanCB(ev, res) {
       if (res.local_name.indexOf(prefix) === 0) {
         console.log('New device found: address=', res.addr, ', name=', res.local_name);
         Shelly.emitEvent("oh-blu.scan_result", {"addr":res.addr, "name":res.local_name, "rssi":res.rssi, "tx_power":res.tx_power_level});
-        SHELLY_BLU_CACHE[res.addr] = res.local_name;        
+        SHELLY_BLU_CACHE[res.addr] = res.local_name;
         found = true;
+        break;
       }
     }
     if (!found) {
-        console.log('Unknown device: ', res.local_name);
+      console.log('Unknown device: ', res.local_name);
+      SHELLY_BLU_CACHE[res.addr] = false;
+      return;
     }
   }
- 
-  let BTHparsed = ShellyBLUParser.getData(res); // skip if parsing failed
+
+  let BTHparsed = ShellyBLUParser.getData(res);
   if (BTHparsed === null) {
     console.log("Failed to parse BTH data");
     return;
@@ -311,12 +296,11 @@ function scanCB(ev, res) {
     Shelly.emitEvent("oh-blu.alarm", {"addr":res.addr, "code":BTHparsed.alarmCode});
   }
 
-  // skip, we are deduping results
   if (typeof LAST_PID[res.addr] === 'undefined' || BTHparsed.pid !== LAST_PID[res.addr]) {
-    console.log('Parsed BTH data from device ', res.local_name, ': ', JSON.stringify(BTHparsed));
+    if (DEBUG) console.log('Parsed BTH data from device ', res.local_name, ': ', JSON.stringify(BTHparsed));
     Shelly.emitEvent("oh-blu.data", BTHparsed);
     LAST_PID[res.addr] = BTHparsed.pid;
-  } else {
+  } else if (DEBUG) {
     console.log("Drop redundant packet with pid ", BTHparsed.pid);
   }
 }

--- a/bundles/org.openhab.binding.shelly/src/main/resources/scripts/oh-blu-scanner.js
+++ b/bundles/org.openhab.binding.shelly/src/main/resources/scripts/oh-blu-scanner.js
@@ -1,8 +1,10 @@
 /*
  * This script uses the BLE scan functionality to pass scan results and BLU data to openHAB.
  * It gets automatically installed / updated by the binding when BLU support is enabled in the thing configuration.
- * Decoding of event data is based on the BTHome standard.
- * 
+ * The script only pre-filters BTHome advertisements and does basic checks (encryption/version flag, packet id for
+ * duplicate-packet dropping); full BTHome object decoding happens on the binding side (see BTHomeDecoder.java) to
+ * keep the on-device script small and release CPU/memory on the (often battery-powered) gateway device.
+ *
  * @author Markus Michels - Initial contribution
  * @author Udo Hartmann - Add support for decoding multi button inputs
  * @author Igor Jasan - Sensor parameter fixing, decoding of dimmer
@@ -15,6 +17,10 @@ let BTHOME_SVC_ID_STR = "fcd2";
 let ALLTERCO_MFD_ID = JSON.parse("0x" + ALLTERCO_MFD_ID_STR);
 let BTHOME_SVC_ID = JSON.parse("0x" + BTHOME_SVC_ID_STR);
 let SCAN_DURATION = BLE.Scanner.INFINITE_SCAN;
+
+// Bump together with BTHomeDecoder.SCRIPT_DATA_VERSION in the binding whenever this wire format changes;
+// the binding logs a warning if it sees a version it doesn't expect (e.g. a stale custom script override).
+let EVENT_DATA_VERSION = 2;
 
 // Log levels, each includes everything more severe than itself (TRACE shows DEBUG+INFO+WARN+ERROR too)
 let LVL_ERROR = 0;
@@ -40,249 +46,15 @@ Shelly.call("KVS.GetMany", { match: "oh-blu-scanner.*" }, function (res) {
 let SHELLY_BLU_CACHE = {};
 let LAST_PID = {};
 
-// Data types enumeration
-let uint8 = 0;
-let int8 = 1;
-let uint16 = 2;
-let int16 = 3;
-let uint24 = 4;
-let int24 = 5;
-let uint32 = 6;
-let int32 = 7;
-
-let BTH_DIMMERSTEPS_INDEX = 0x3c;   // Dimmer (Wheel) Steps object ID
-
-// BTHome object definitions: id => {name, type, optional scale factor}
-// https://bthome.io/format/
-let BTH = {};
-BTH[0x00] = { n: "pid", t: uint8 };                                           // Packet ID
-BTH[0x01] = { n: "Battery", t: uint8, u: "%" };                               // Battery level in percent
-BTH[0x02] = { n: "Temperature", t: int16, f: 0.01 };                          // Temperature in C (scaled by 0.01)
-BTH[0x03] = { n: "Humidity", t: uint16, f: 0.01 };                            // Relative humidity % (scaled by 0.01)
-BTH[0x04] = { n: "Pressure", t: uint24, f: 0.01 };                            // Pressure (scaled by 0.01)
-BTH[0x05] = { n: "Illuminance", t: uint24, f: 0.01 };                         // Light level (scaled by 0.01)
-BTH[0x06] = { n: "Mass_kg", t: uint16, f: 0.01, u: "kg" };                    // Mass in kilograms (scaled by 0.01)
-BTH[0x07] = { n: "Mass_lb", t: uint16, f: 0.01, u: "lb" };                    // Mass in pounds (scaled by 0.01)
-BTH[0x08] = { n: "Dewpoint", t: int16, f: 0.01 };                             // Dewpoint temperature (scaled by 0.01)
-BTH[0x09] = { n: "Count", t: uint8 };                                         // Count
-BTH[0x0c] = { n: "Voltage", t: uint16, f: 0.001 };                            // Voltage in Volts (scaled by 0.001)
-BTH[0x0f] = { n: "GenericBoolean", t: uint8 };                                // Generic boolean false/true status (boolean)
-BTH[0x10] = { n: "Power", t: uint8 };                                         // Power off/on status (boolean)
-BTH[0x11] = { n: "Opening", t: uint8 };                                       // Opening closed/open status (boolean)
-BTH[0x12] = { n: "Co2", t: uint16 };                                          // CO2 concentration ppm
-BTH[0x13] = { n: "TVOC", t: uint16 };                                         // TVOC Air Quality ug/m3
-BTH[0x14] = { n: "Moisture16", t: uint16, f: 0.01 };                          // Moisture (scaled by 0.01)
-BTH[0x15] = { n: "BatteryLow", t: uint8 };                                    // Battery low flag: 0=normal, 1=low
-BTH[0x16] = { n: "BatteryCharging", t: uint8 };                               // Battery charging status (boolean)
-BTH[0x17] = { n: "CarbonMonoxide", t: uint8 };                                // Carbon Monoxide not detected/detected status (boolean)
-BTH[0x18] = { n: "Cold", t: uint8 };                                          // Cold normal/cold status (boolean)
-BTH[0x19] = { n: "Connectivity", t: uint8 };                                  // Connectivity disconnected/connected status (boolean)
-BTH[0x1a] = { n: "Door", t: uint8 };                                          // Door open/close status (boolean)
-BTH[0x1b] = { n: "GarageDoor", t: uint8 };                                    // Garage Door closed/open status (boolean)
-BTH[0x1c] = { n: "Gas", t: uint8 };                                           // Gas clear/detected status (boolean)
-BTH[0x1d] = { n: "Heat", t: uint8 };                                          // Heat normal/hot status (boolean)
-BTH[0x1e] = { n: "Light", t: uint8 };                                         // Light no light/light detected status (boolean)
-BTH[0x1f] = { n: "Lock", t: uint8 };                                          // Lock locked/unlocked status (boolean)
-BTH[0x20] = { n: "Moisture", t: uint8 };                                      // Moisture/Rain detection boolean
-BTH[0x21] = { n: "Motion", t: uint8 };                                        // Motion clear/detected status (boolean)
-BTH[0x22] = { n: "Moving", t: uint8 };                                        // Moving not moving/moving status (boolean)
-BTH[0x23] = { n: "Occupancy", t: uint8 };                                     // Occupancy clear/detected status (boolean)
-BTH[0x24] = { n: "Plug", t: uint8 };                                          // Plug unplugged/plugged in status (boolean)
-BTH[0x25] = { n: "Presence", t: uint8 };                                      // Presence away/home status (boolean)
-BTH[0x26] = { n: "Problem", t: uint8 };                                       // Problem OK/problem status (boolean)
-BTH[0x27] = { n: "Running", t: uint8 };                                       // Running not running/running status (boolean)
-BTH[0x28] = { n: "Safety", t: uint8 };                                        // Safety unsafe/safe status (boolean)
-BTH[0x29] = { n: "Smoke", t: uint8 };                                         // Smoke clear/detected status (boolean)
-BTH[0x2a] = { n: "Sound", t: uint8 };                                         // Sound clear/detected status (boolean)
-BTH[0x2b] = { n: "Tamper", t: uint8 };                                        // Tamper off/on status (boolean)
-BTH[0x2c] = { n: "Vibration", t: uint8 };                                     // Vibration clear/detected status (boolean)
-BTH[0x2d] = { n: "Window", t: uint8 };                                        // Window closed/open status (boolean)
-BTH[0x2e] = { n: "Humidity", t: uint8 };                                      // Humidity (alternative uint8 format)
-BTH[0x2f] = { n: "Moisture8", t: uint8 };                                     // Moisture (alternative uint8 format)
-BTH[0x3a] = { n: "Button", t: uint8 };                                        // Button press events
-BTH[0x3c] = { n: "Dimmer", t: uint16 };                                       // Dimmer event (2 bytes: direction up/down + steps)
-BTH[0x3d] = { n: "Count", t: uint16 };                                        // Count
-BTH[0x3e] = { n: "Count", t: uint32 };                                        // Count
-BTH[0x3f] = { n: "Rotation", t: int16, f: 0.1 };                              // Rotation (scaled by 0.1)
-BTH[0x40] = { n: "Distance_mm", t: uint16, u: "mm" };                         // Distance in millimeters
-BTH[0x41] = { n: "Distance_m", t: uint16, f: 0.1, u: "m" };                   // Distance in meters (scaled by 0.1)
-BTH[0x42] = { n: "Duration", t: uint24, f: 0.001, u: "s" };                   // Duration in seconds (scaled by 0.001)
-BTH[0x43] = { n: "Current", t: uint16, f: 0.001 };                            // Electrical current (scaled by 0.001)
-BTH[0x44] = { n: "Speed", t: uint16, f: 0.01 };                               // Speed (scaled by 0.01)
-BTH[0x45] = { n: "Temperature", t: int16, f: 0.1 };                           // Temperature alternative format (scaled by 0.1)
-BTH[0x46] = { n: "UVIndex", t: uint8, f: 0.1 };                               // UV index (scaled by 0.1)
-BTH[0x47] = { n: "Volume", t: uint16, f: 0.1, u: "L" };                       // Volume in L (scaled by 0.1)        
-BTH[0x48] = { n: "Volume", t: uint16, u: "mL" };                              // Volume in mL         
-BTH[0x49] = { n: "VolumeFlowRate", t: uint16, f: 0.001, u: "m3/hr" };         // Volume Flow Rate in m3/hr (scaled by 0.001)         
-BTH[0x4a] = { n: "Voltage", t: uint16, f: 0.1 };                              // Voltage in Volts (scaled by 0.1)
-BTH[0x4b] = { n: "Gas", t: uint24, f: 0.001 };                                // Gas volume (scaled by 0.001)       
-BTH[0x4c] = { n: "Gas", t: uint32, f: 0.001 };                                // Gas volume (scaled by 0.001)       
-BTH[0x4e] = { n: "Volume", t: uint32, f: 0.001, u: "L" };                     // Volume in L (scaled by 0.001)        
-BTH[0x4f] = { n: "Water", t: uint32, f: 0.001, u: "L" };                      // Water in L (scaled by 0.001)        
-BTH[0x50] = { n: "Timestamp", t: uint32 };                                    // Timestamp (epoch time)
-BTH[0x51] = { n: "Acceleration", t: uint16, f: 0.001 };                       // Acceleration (scaled by 0.001)          
-BTH[0x53] = { n: "text", t: uint32 };                                         // text sensor with a variable length
-BTH[0x54] = { n: "raw", t: uint32 };                                          // raw sensor with a variable length
-BTH[0x55] = { n: "VolumeStorage", t: uint32, f: 0.001, u: "L" };              // Volume Storage in L (scaled by 0.001)
-BTH[0x56] = { n: "Conductivity", t: uint16 };                                 // Conductivity      
-BTH[0x57] = { n: "Temperature", t: int8 };                                    // Temperature alternative format
-BTH[0x58] = { n: "Temperature", t: int8, f: 0.35 };                           // Temperature alternative format (scaled by 0.35)
-BTH[0x59] = { n: "Count", t: int8 };                                          // Count
-BTH[0x5a] = { n: "Count", t: int16 };                                         // Count
-BTH[0x5b] = { n: "Count", t: int32 };                                         // Count
-BTH[0x5d] = { n: "Current", t: int16, f: 0.001 };                             // Electrical current (scaled by 0.001)
-BTH[0x5e] = { n: "Direction", t: uint16, f: 0.01 };                           // Direction (scaled by 0.01)
-BTH[0x5f] = { n: "Precipitation", t: uint16, f: 0.1 };                        // Precipitation (scaled by 0.1)
-BTH[0x60] = { n: "Channel", t: uint8 };                                       // Channel
-BTH[0x64] = { n: "LightLevel", t: uint8 };                                    // Light level 0=dark, 1=twilight, 2=bright
-BTH[0xF0] = { n: "DeviceId", t: uint16};                                      // Device type ID
-BTH[0xF1] = { n: "Firmware32", t: uint32};                                    // Firmware version in 1.2.3.4 format
-BTH[0xF2] = { n: "Firmware24", t: uint24};                                    // Firmware version in 1.2.3 format
-
-// Helper function to get byte size of data type
-function getByteSize(type) {                                     
-  if (type === uint8 || type === int8) return 1;
-  if (type === uint16 || type === int16) return 2;
-  if (type === uint24 || type === int24) return 3;
-  if (type === uint32 || type === int32) return 4;
-  //impossible as advertisements are much smaller;
-  return 255;
-}
-
-let BTHomeDecoder = {
-  // Convert unsigned integer to signed based on bit size
-  utoi: function (num, bitsz) {
-    let mask = 1 << (bitsz - 1);
-    return num & mask ? num - (1 << bitsz) : num;
-  },
-  
-  getUInt8:    function (buffer) { if (buffer.length < 1) return null;  return buffer.at(0); },
-  getInt8:     function (buffer) { let val = this.getUInt8(buffer);    return val !== null ? this.utoi(val, 8) : null; },
-  getInt16LE:  function (buffer) { let val = this.getUInt16LE(buffer); return val !== null ? this.utoi(val, 16) : null; },
-  getInt24LE:  function (buffer) { let val = this.getUInt24LE(buffer); return val !== null ? this.utoi(val, 24) : null; },
-  getInt32LE:  function (buffer) { let val = this.getUInt32LE(buffer); return val !== null ? this.utoi(val, 32) : null; },
-  getUInt16LE: function (buffer) { if (buffer.length < 2) return null; return (buffer.at(1) << 8) | buffer.at(0); },
-  getUInt24LE: function (buffer) { if (buffer.length < 3) return null; return (buffer.at(2) << 16) | (buffer.at(1) << 8) | buffer.at(0); },
-  getUInt32LE: function (buffer) { if (buffer.length < 4) return null; return (buffer.at(3) << 24) | (buffer.at(2) << 16) | (buffer.at(1) << 8) | buffer.at(0); },
-  
-  // Decode value buffer according to type
-  getBufValue: function (type, buffer) {
-    if (buffer.length < getByteSize(type)) return null;
-    let res = null;
-    if (type === uint8) res = this.getUInt8(buffer);
-    else if (type === int8) res = this.getInt8(buffer);
-    else if (type === uint16) res = this.getUInt16LE(buffer);
-    else if (type === int16) res = this.getInt16LE(buffer);
-    else if (type === uint24) res = this.getUInt24LE(buffer);
-    else if (type === int24) res = this.getInt24LE(buffer);
-    else if (type === uint32) res = this.getUInt32LE(buffer);
-    else if (type === int32) res = this.getInt32LE(buffer);
-    return res;
-  },
-  
-  // Unpack BTHome payload string to object with decoded values
-  unpack: function (buffer) {
-    // beacons might not provide BTH service data
-    if (typeof buffer !== "string" || buffer.length === 0) return null;
-    
-    let result = {};
-    let _dib = buffer.at(0); // Device Info Byte
-    result["encryption"] = _dib & 0x1 ? true : false;
-    result["BTHome_version"] = _dib >> 5;
-    if (result["encryption"]) {
-      if (LOG_LEVEL >= LVL_WARN) console.log("BTH: encrypted payload, cannot decode");
-      result["alarmCode"] = "BTH_ENCRYPTED";
-      return result; // Can not handle encrypted data
-    }
-    if (result["BTHome_version"] !== 2) return null; // Can not handle BT version != 2
-    
-    buffer = buffer.slice(1); // Remove header byte
-
-    while (buffer.length > 0) {
-      let bthIdx = buffer.at(0); // Object ID
-      buffer = buffer.slice(1);
-
-      let _bth = BTH[bthIdx];
-      if (typeof _bth === "undefined") {
-        if (LOG_LEVEL >= LVL_WARN) console.log("BTH: unknown type", bthIdx);
-        result["alarmCode"] = "BTH_UNKNOWN_TYPE";
-        break;
-      }
-
-      let valueSize = getByteSize(_bth.t);
-      let rawBuffer = buffer.slice(0, valueSize);
-      let _value = this.getBufValue(_bth.t, rawBuffer);
-
-      if (_value === null) {
-        break;
-      }
-
-      // Apply scaling factor if defined
-      if (typeof _bth.f !== "undefined") _value *= _bth.f;
-
-      // Special handling for Dimmer-Steps-Event (0x3c)
-      if (bthIdx === BTH_DIMMERSTEPS_INDEX) {
-        let valueDimSize = 2; // Fixed size for dimmer steps is 2 bytes
-        if (buffer.length < valueDimSize) {
-          if (LOG_LEVEL >= LVL_WARN) console.log("BTH: buffer too short for Dimmer event");
-          continue;
-        }
-
-        // Extract the two bytes separately
-        const directionByte = buffer.at(0);
-        const stepsByte = buffer.at(1);
-
-        // Create a new object with the parsed values
-        let dimmerEvent = {
-          direction: directionByte,
-          steps: stepsByte
-        };
-
-        result[_bth.n] = dimmerEvent;
-        
-        buffer = buffer.slice(valueDimSize);
-        continue;
-      }
-      
-      // Default handling
-      if (result[_bth.n] !== undefined && Array.isArray(result[_bth.n])) {
-        result[_bth.n].push(_value);
-      } else if (result[_bth.n] !== undefined) {
-        result[_bth.n] = [result[_bth.n], _value];
-      } else {
-        result[_bth.n] = _value;
-      }
-
-      buffer = buffer.slice(valueSize);
-    }
-
-    return result;
-  }
-};
-
-// Hex dump helper, only used under TRACE (padStart not available in the Shelly JS engine)
+// Hex dump helper (no separators - used both for TRACE logging and as the raw payload sent to the binding)
 function bufToHex(buffer) {
   let hex = "";
   for (let i = 0; i < buffer.length; i++) {
     let hexValue = buffer.at(i).toString(16);
-    hex += (hexValue.length === 1 ? "0" + hexValue : hexValue) + " ";
+    hex += hexValue.length === 1 ? "0" + hexValue : hexValue;
   }
-  return hex.trim();
+  return hex;
 }
-
-// Shelly BLU BLE data parser wrapper
-let ShellyBLUParser = {
-  getData: function (res) {
-    let service_data = res.service_data[BTHOME_SVC_ID_STR];
-    if (!service_data) return null;
-
-    let result = BTHomeDecoder.unpack(service_data);
-    if (!result) return null;
-    result.addr = res.addr;
-    result.rssi = res.rssi;
-    return result;
-  }
-};
 
 // BLE scan callback function
 function scanCB(ev, res) {
@@ -312,26 +84,41 @@ function scanCB(ev, res) {
     }
   }
 
-  if (LOG_LEVEL >= LVL_TRACE) console.log('Raw BTHome packet from ', res.addr, ': ', bufToHex(res.service_data[BTHOME_SVC_ID_STR]));
+  let buffer = res.service_data[BTHOME_SVC_ID_STR];
+  if (LOG_LEVEL >= LVL_TRACE) console.log('Raw BTHome packet from ', res.addr, ': ', bufToHex(buffer));
 
-  let BTHparsed = ShellyBLUParser.getData(res);
-  if (BTHparsed === null) {
+  if (typeof buffer !== "string" || buffer.length === 0) {
     if (LOG_LEVEL >= LVL_WARN) console.log("Failed to parse BTH data");
     return;
   }
 
-  if (BTHparsed.alarmCode) {
-    if (LOG_LEVEL >= LVL_WARN) console.log("BLU alarm:", BTHparsed.alarmCode, "addr=", res.addr);
-    Shelly.emitEvent("oh-blu.alarm", {"addr":res.addr, "code":BTHparsed.alarmCode});
+  // Device Info Byte: bit 0 = encryption flag, bits 5-7 = BTHome version. This is the only byte inspected
+  // on-device; full object decoding (temperature, humidity, ...) now happens on the binding side.
+  let dib = buffer.at(0);
+  if (dib & 0x1) {
+    if (LOG_LEVEL >= LVL_WARN) console.log("BTH: encrypted payload, cannot decode");
+    Shelly.emitEvent("oh-blu.alarm", {"addr":res.addr, "code":"BTH_ENCRYPTED"});
+    return;
+  }
+  if ((dib >> 5) !== 2) {
+    if (LOG_LEVEL >= LVL_WARN) console.log("Failed to parse BTH data");
+    return;
   }
 
-  if (typeof LAST_PID[res.addr] === 'undefined' || BTHparsed.pid !== LAST_PID[res.addr]) {
-    if (LOG_LEVEL >= LVL_TRACE) console.log('Parsed BTH data from device ', res.local_name, ': ', JSON.stringify(BTHparsed));
-    Shelly.emitEvent("oh-blu.data", BTHparsed);
-    LAST_PID[res.addr] = BTHparsed.pid;
-  } else if (LOG_LEVEL >= LVL_DEBUG) {
-    console.log("Drop redundant packet with pid ", BTHparsed.pid);
+  // Packet ID (object 0x00) is always the first object when present; peek it without a full decode so
+  // redundant packets can still be dropped on-device, reducing WebSocket noise from repeated advertisements.
+  let pid;
+  if (buffer.length >= 3 && buffer.at(1) === 0x00) {
+    pid = buffer.at(2);
   }
+  if (typeof pid !== "undefined" && LAST_PID[res.addr] === pid) {
+    if (LOG_LEVEL >= LVL_DEBUG) console.log("Drop redundant packet with pid ", pid);
+    return;
+  }
+  if (typeof pid !== "undefined") LAST_PID[res.addr] = pid;
+
+  if (LOG_LEVEL >= LVL_TRACE) console.log('Forwarding BTH data from device ', res.local_name, ', pid=', pid);
+  Shelly.emitEvent("oh-blu.data", {"addr":res.addr, "rssi":res.rssi, "pid":pid, "ver":EVENT_DATA_VERSION, "raw":bufToHex(buffer.slice(1))});
 }
 
 // retry several times to start the scanner if script was started before

--- a/bundles/org.openhab.binding.shelly/src/main/resources/scripts/oh-blu-scanner.js
+++ b/bundles/org.openhab.binding.shelly/src/main/resources/scripts/oh-blu-scanner.js
@@ -37,6 +37,23 @@ Shelly.call("KVS.GetMany", { match: "oh-blu-scanner.*" }, function (res) {
 let SHELLY_BLU_CACHE = {};
 let LAST_PID = {};
 
+// Bounds SHELLY_BLU_CACHE/LAST_PID so an infinite scan seeing many rotating/random
+// BLE addresses over time can't grow memory usage without limit.
+let CACHE_ORDER = [];
+let MAX_CACHE_SIZE = 128;
+
+function cacheSet(addr, value) {
+  if (typeof SHELLY_BLU_CACHE[addr] === 'undefined') {
+    CACHE_ORDER.push(addr);
+    if (CACHE_ORDER.length > MAX_CACHE_SIZE) {
+      let evictAddr = CACHE_ORDER.shift();
+      delete SHELLY_BLU_CACHE[evictAddr];
+      delete LAST_PID[evictAddr];
+    }
+  }
+  SHELLY_BLU_CACHE[addr] = value;
+}
+
 // No separators - also used as the raw payload sent to the binding
 function bufToHex(buffer) {
   let hex = "";
@@ -62,14 +79,14 @@ function scanCB(ev, res) {
       if (res.local_name.indexOf(prefix) === 0) {
         if (LOG_LEVEL >= LVL_INFO) console.log('New device found: address=', res.addr, ', name=', res.local_name);
         Shelly.emitEvent("oh-blu.scan_result", {"addr":res.addr, "name":res.local_name, "rssi":res.rssi, "tx_power":res.tx_power_level});
-        SHELLY_BLU_CACHE[res.addr] = res.local_name;
+        cacheSet(res.addr, res.local_name);
         found = true;
         break;
       }
     }
     if (!found) {
       if (LOG_LEVEL >= LVL_INFO) console.log('Unknown device: ', res.local_name);
-      SHELLY_BLU_CACHE[res.addr] = false;
+      cacheSet(res.addr, false);
       return;
     }
   }

--- a/bundles/org.openhab.binding.shelly/src/test/java/org/openhab/binding/shelly/internal/api2/BTHomeDecoderTest.java
+++ b/bundles/org.openhab.binding.shelly/src/test/java/org/openhab/binding/shelly/internal/api2/BTHomeDecoderTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.shelly.internal.api2;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.jupiter.api.Test;
+
+import com.google.gson.JsonObject;
+
+/**
+ * Unit tests for {@link BTHomeDecoder}.
+ *
+ * @author Markus Michels - Initial contribution
+ */
+@NonNullByDefault
+public class BTHomeDecoderTest {
+
+    @Test
+    void decodesSingleScalarObject() {
+        JsonObject result = BTHomeDecoder.decode("0155");
+        assertThat(result.get("Battery").getAsInt(), is(equalTo(85)));
+    }
+
+    @Test
+    void decodesScaledSignedObject() {
+        JsonObject result = BTHomeDecoder.decode("026608");
+        assertThat(result.get("Temperature").getAsDouble(), is(equalTo(21.50)));
+    }
+
+    @Test
+    void decodesNegativeSignedObject() {
+        JsonObject result = BTHomeDecoder.decode("57f6");
+        assertThat(result.get("Temperature").getAsInt(), is(equalTo(-10)));
+    }
+
+    @Test
+    void stopsOnUnknownObjectIdAndReportsCode() {
+        JsonObject result = BTHomeDecoder.decode("015566");
+        assertThat(result.get("Battery").getAsInt(), is(equalTo(85)));
+        assertThat(result.get("code").getAsString(), is(equalTo("BTH_UNKNOWN_TYPE")));
+    }
+
+    @Test
+    void accumulatesRepeatedArrayCapableObjectIdIntoArray() {
+        JsonObject result = BTHomeDecoder.decode("3f0a003f1400");
+        assertThat(result.get("Rotation").getAsJsonArray().size(), is(equalTo(2)));
+        assertThat(result.get("Rotation").getAsJsonArray().get(0).getAsDouble(), is(equalTo(1.0)));
+        assertThat(result.get("Rotation").getAsJsonArray().get(1).getAsDouble(), is(equalTo(2.0)));
+    }
+
+    @Test
+    void repeatedNonArrayCapableObjectIdOverwritesInsteadOfArray() {
+        JsonObject result = BTHomeDecoder.decode("0155014b");
+        assertThat(result.get("Battery").isJsonArray(), is(false));
+        assertThat(result.get("Battery").getAsInt(), is(equalTo(75)));
+    }
+
+    @Test
+    void decodesDimmerAsDirectionAndSteps() {
+        JsonObject result = BTHomeDecoder.decode("3c0103");
+        JsonObject dimmer = result.get("Dimmer").getAsJsonObject();
+        assertThat(dimmer.get("direction").getAsInt(), is(equalTo(1)));
+        assertThat(dimmer.get("steps").getAsInt(), is(equalTo(3)));
+    }
+
+    @Test
+    void stopsCleanlyOnTruncatedTrailingObject() {
+        JsonObject result = BTHomeDecoder.decode("015502");
+        assertThat(result.get("Battery").getAsInt(), is(equalTo(85)));
+        assertThat(result.has("Temperature"), is(false));
+    }
+
+    @Test
+    void returnsEmptyResultOnOddLengthHex() {
+        JsonObject result = BTHomeDecoder.decode("015");
+        assertThat(result.entrySet().isEmpty(), is(true));
+    }
+
+    @Test
+    void returnsEmptyResultOnInvalidHexCharacter() {
+        JsonObject result = BTHomeDecoder.decode("01zz");
+        assertThat(result.entrySet().isEmpty(), is(true));
+    }
+
+    @Test
+    void decodesVariableLengthTextAndRawObjects() {
+        JsonObject result = BTHomeDecoder.decode("530241425401ff");
+        assertThat(result.get("bthText").getAsString(), is(equalTo("AB")));
+        assertThat(result.get("bthRaw").getAsString(), is(equalTo("ff")));
+        assertThat(result.has("text"), is(false));
+        assertThat(result.has("raw"), is(false));
+    }
+
+    @Test
+    void textAndRawObjectsPreserveAlignmentOfFollowingObject() {
+        JsonObject result = BTHomeDecoder.decode("5301410155");
+        assertThat(result.get("bthText").getAsString(), is(equalTo("A")));
+        assertThat(result.get("Battery").getAsInt(), is(equalTo(85)));
+    }
+}

--- a/bundles/org.openhab.binding.shelly/src/test/java/org/openhab/binding/shelly/internal/api2/ShellyBluApiTest.java
+++ b/bundles/org.openhab.binding.shelly/src/test/java/org/openhab/binding/shelly/internal/api2/ShellyBluApiTest.java
@@ -144,6 +144,49 @@ public class ShellyBluApiTest {
         verify(thingMock).postEvent("BTH_UNKNOWN_TYPE", false);
     }
 
+    @Test
+    void onNotifyEventDecodesRawBTHomePayloadFromScript() throws Exception {
+        ShellyBluApi api = buildBluApi();
+        String rawDataPacket = """
+                {"src": "shellyblugw-test", "params": {"events": [{"event": "oh-blu.data",
+                 "data": {"addr": "aa:bb:cc:dd:ee:ff", "pid": 5, "ver": 2, "raw": "0005015502660803ae15"}}]}}
+                """;
+
+        api.onNotifyEvent(rawDataPacket);
+
+        ShellyStatusSensor sensorData = api.getSensorStatus();
+        assertThat("battery decoded from raw payload", sensorData.bat.value, is(equalTo(85.0)));
+        assertThat("temperature decoded from raw payload", sensorData.tmp.tC, is(equalTo(21.50)));
+        assertThat("humidity decoded from raw payload", sensorData.hum.value, is(equalTo(55.50)));
+    }
+
+    @Test
+    void onNotifyEventPostsAlarmForUnknownObjectTypeInRawPayload() throws Exception {
+        ShellyBluApi api = buildBluApi();
+        String rawUnknownTypePacket = """
+                {"src": "shellyblugw-test", "params": {"events": [{"event": "oh-blu.data",
+                 "data": {"addr": "aa:bb:cc:dd:ee:ff", "pid": 1, "ver": 2, "raw": "0155fe"}}]}}
+                """;
+
+        api.onNotifyEvent(rawUnknownTypePacket);
+
+        verify(thingMock).postEvent("BTH_UNKNOWN_TYPE", false);
+    }
+
+    @Test
+    void onNotifyEventOverwritesRepeatedScalarObjectInsteadOfThrowing() throws Exception {
+        ShellyBluApi api = buildBluApi();
+        String repeatedBatteryPacket = """
+                {"src": "shellyblugw-test", "params": {"events": [{"event": "oh-blu.data",
+                 "data": {"addr": "aa:bb:cc:dd:ee:ff", "pid": 9, "ver": 2, "raw": "0155014b"}}]}}
+                """;
+
+        assertDoesNotThrow(() -> api.onNotifyEvent(repeatedBatteryPacket));
+
+        ShellyStatusSensor sensorData = api.getSensorStatus();
+        assertThat("last Battery reading wins", sensorData.bat.value, is(equalTo(75.0)));
+    }
+
     private ShellyBluApi buildBluApi() {
         return buildBluApi(THING_TYPE_SHELLYBLUBUTTON1);
     }

--- a/bundles/org.openhab.binding.shelly/src/test/java/org/openhab/binding/shelly/internal/api2/ShellyBluApiTest.java
+++ b/bundles/org.openhab.binding.shelly/src/test/java/org/openhab/binding/shelly/internal/api2/ShellyBluApiTest.java
@@ -14,6 +14,7 @@ package org.openhab.binding.shelly.internal.api2;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -187,6 +188,20 @@ public class ShellyBluApiTest {
         assertThat("last Battery reading wins", sensorData.bat.value, is(equalTo(75.0)));
     }
 
+    @Test
+    void missingDataVersionIsTrackedAsWarnedInsteadOfSilentlyIgnored() throws Exception {
+        ShellyBluApi api = buildBluApi();
+        String packetWithoutVersion = """
+                {"src": "shellyblugw-test", "params": {"events": [{"event": "oh-blu.data",
+                 "data": {"addr": "aa:bb:cc:dd:ee:ff", "pid": 1, "raw": "0005015502660803ae15"}}]}}
+                """;
+
+        api.onNotifyEvent(packetWithoutVersion);
+
+        assertThat("missing version must still be recorded as warned", getField(api, "warnedDataVersionSet"), is(true));
+        assertThat(getField(api, "warnedDataVersion"), is(nullValue()));
+    }
+
     private ShellyBluApi buildBluApi() {
         return buildBluApi(THING_TYPE_SHELLYBLUBUTTON1);
     }
@@ -222,6 +237,12 @@ public class ShellyBluApiTest {
         Field f = target.getClass().getDeclaredField(fieldName);
         f.setAccessible(true);
         f.set(target, value);
+    }
+
+    private static @Nullable Object getField(Object target, String fieldName) throws Exception {
+        Field f = target.getClass().getDeclaredField(fieldName);
+        f.setAccessible(true);
+        return f.get(target);
     }
 
     private static NetworkAddressService nullNas() {


### PR DESCRIPTION
# Description

This PR resolves out-of-memory crashes reported for the BLU Gateway feature, where the on-device `oh-blu-scanner.js` script would run out of memory or crash on Shelly gateway devices when receiving certain BTHome sensor data.
The root cause was that all BTHome sensor payload decoding used to run on the constrained gateway device itself; this PR moves that decoding into the binding, leaving the on-device script with only lightweight pre-filtering.
This also fixes the BLU Gateway feature breaking entirely on devices running firmware 2.0, where a Bluetooth setting the binding relied on was removed.

Fixes:
* Shelly BLU Gateway support works again on devices running firmware 2.0 (a Bluetooth setting the binding relied on was removed in that firmware).
* The on-device BLU gateway script no longer runs out of memory or crashes when receiving BTHome sensor data — decoding was moved off the device and into the binding.
* Sensor data using an unrecognized/unsupported format no longer crashes the script; the binding now reports this safely instead.
* The on-device log-level lookup (`KVS.GetMany`) never actually worked, so the DEBUG/TRACE override below was silently ignored — now fixed.
* The on-device address cache could grow without bound when many rotating/random BLE addresses are seen over an extended scan, risking the same kind of memory pressure this PR otherwise fixes — now bounded, without evicting recognized Shelly BLU devices.
* Removed a redundant Bluetooth-config call on the firmware 2.0 activation path that could throw and abort BLU Gateway setup on some devices.

Changes:
* Added an optional DEBUG/TRACE log level for the BLU gateway script, switchable at runtime via the device's Key-Value Store, to help diagnose BLU sensor issues (see Advanced Users documentation).
* Added the ability to override the installed BLU gateway script with your own version for prototyping, without the binding's automatic script sync overwriting it (see Advanced Users documentation).

# Testing

* Verify BLU Gateway devices still discover and report data from BLU sensors (buttons, door/window, H&T, etc.) after updating.
* Verify a BLU Gateway device running firmware 2.0 activates BLU Gateway mode successfully (previously failed).
* Verify the gateway device does not run out of memory / restart unexpectedly over extended operation.

See also [#21276](https://github.com/openhab/openhab-addons/issues/21276) for the original report and community discussion of the memory issue.

## Acceptance criteria

- [x] Implementation done
- [x] Documentation is up-to-date
- [x] Verified by Community
- [x] Ready for Review 

Closing:
- #21276
- #19777
- #16344

## Backport assessment

This PR combines a refactor (moving BTHome decoding off-device) with two concrete bug fixes (firmware 2.0 BLE Gateway activation, and a script crash on malformed BTHome data). The two bug fixes could be cherry-picked individually to a patch branch if needed; the refactor is the vehicle that fixes the underlying memory issue and is not easily separable from it.
