### PR TITLE
[logreader] Correct connection type

### DIFF
--- a/bundles/org.openhab.binding.logreader/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.binding.logreader/src/main/resources/OH-INF/addon/addon.xml
@@ -6,6 +6,6 @@
 	<type>binding</type>
 	<name>LogReader Binding</name>
 	<description>Binding that reads through log files and searches e.g. errors and warnings</description>
-	<connection>local</connection>
+	<connection>none</connection>
 
 </addon:addon>


### PR DESCRIPTION
This binding works only on local log files.