### PR TITLE
[systeminfo] Correction connection type

### DIFF
--- a/bundles/org.openhab.binding.systeminfo/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.binding.systeminfo/src/main/resources/OH-INF/addon/addon.xml
@@ -6,5 +6,5 @@
 	<type>binding</type>
 	<name>Systeminfo Binding</name>
 	<description>This binding provides information about the operating system and the hardware.</description>
-	<connection>local</connection>
+	<connection>none</connection>
 </addon:addon>


### PR DESCRIPTION
This binding uses only on host system metrics