### PR TITLE
[squeezebox] Fix `NumberFormatException` when parsing status result JSON

### DIFF
--- a/bundles/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/dto/StatusResultDTO.java
+++ b/bundles/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/dto/StatusResultDTO.java
@@ -79,9 +79,6 @@ public class StatusResultDTO {
     @SerializedName("remote")
     public String remote;
 
-    @SerializedName("repeating_stream")
-    public Integer repeatingStream;
-
     @SerializedName("seq_no")
     public Integer sequenceNumber;
 


### PR DESCRIPTION
Fixes #21300 

No need to backport as not critical

Signed-off-by: Mark Hilbush <mark@hilbush.com>
