### PR TITLE
[bluetooth.bluez] Unplugging/replugging USB adapter breaks bluetooth connectivity

### DIFF
--- a/bundles/org.openhab.binding.bluetooth.bluez/src/main/java/org/openhab/binding/bluetooth/bluez/internal/DeviceManagerWrapper.java
+++ b/bundles/org.openhab.binding.bluetooth.bluez/src/main/java/org/openhab/binding/bluetooth/bluez/internal/DeviceManagerWrapper.java
@@ -52,17 +52,8 @@ public class DeviceManagerWrapper {
     public synchronized @Nullable BluetoothAdapter getAdapter(BluetoothAddress address) {
         DeviceManager deviceManager = this.deviceManager;
         if (deviceManager != null) {
-            // we don't use `deviceManager.getAdapter` here since it might perform a scan if the adapter is missing.
             String addr = address.toString();
-            List<BluetoothAdapter> adapters = deviceManager.getAdapters();
-            if (adapters != null) {
-                for (BluetoothAdapter btAdapter : adapters) {
-                    String btAddr = btAdapter.getAddress();
-                    if (addr.equalsIgnoreCase(btAddr)) {
-                        return btAdapter;
-                    }
-                }
-            }
+            return deviceManager.getAdapter(addr);
         }
         return null;
     }


### PR DESCRIPTION
While testing an USB device in a VM I noticed, that the USB adapter only worked for a single time. When the adapter is removed from the VM the device in OpenHAB transitions to the state first to

```
  OFFLINE
  COMMUNICATION_ERROR
  Adapter removed
```

and then to

```
  OFFLINE
  COMMUNICATION_ERROR
  Native adapter could not be found for address 'XX:XX:XX:XX:XX:XX'
```

so far this makes sense. But when the adapter is reattached, I would expect the adapter to transition to online, but that does not happen. The adapter stays in the OFFLINE state.

Debugging showed, that DeviceManager#getAdapters() does not list the reattached adapter. However placing a breakpoint before that call and invoking DeviceManager#scanForBluetoothAdapters in the debugger at that point restores functionality.

Here the documentation in the code becomes misleading:

  > we don't use `deviceManager.getAdapter` here since it might perform
  > a scan if the adapter is missing.

This statement is wrong. The code in DeviceManager#getAdapters reads:

```java
    public List<BluetoothAdapter> getAdapters() {
        if (bluetoothAdaptersByMac.isEmpty()) {
            scanForBluetoothAdapters();
        }
        return new ArrayList<>(bluetoothAdaptersByMac.values());
    }
```

so if only a single adapter is present, this code will cause a call to scanForBluetoothAdapters in any case. For Debian Trixie (13.6) a test adapter is present, that will cause this bug to show up:

> BluetoothAdapter [adapter=org.bluez:/org/bluez/test:interface org.bluez.Adapter1, getBluetoothType()=ADAPTER, getDbusPath()=/org/bluez/test]

On my main desktop for example only the primary bluetooth adapter is present, which would mask the issue.

Instead of trying to keep a non working optimization this change directly calls into DriverManager#getAdapter(btaddress). This will use its cache first and if that fails issue a scan.

Scan in this case also only means, that the DBUS introspection data is parsed, not a bluetooth scan or something similar.
