### PR TITLE
[kaleidescape] Fix erroneous update instructions

### DIFF
--- a/bundles/org.openhab.binding.kaleidescape/src/main/resources/OH-INF/thing/channels.xml
+++ b/bundles/org.openhab.binding.kaleidescape/src/main/resources/OH-INF/thing/channels.xml
@@ -68,7 +68,7 @@
 			<property name="Control Protocol ID">unknown</property>
 			<property name="System Version">unknown</property>
 			<property name="Protocol Version">unknown</property>
-			<property name="thingTypeVersion">4</property>
+			<property name="thingTypeVersion">5</property>
 		</properties>
 
 		<config-description-ref uri="thing-type:kaleidescape:kaleidescapedevice"/>
@@ -99,7 +99,7 @@
 			<property name="Control Protocol ID">unknown</property>
 			<property name="System Version">unknown</property>
 			<property name="Protocol Version">unknown</property>
-			<property name="thingTypeVersion">4</property>
+			<property name="thingTypeVersion">5</property>
 		</properties>
 
 		<config-description-ref uri="thing-type:kaleidescape:kaleidescapedevice"/>
@@ -130,7 +130,7 @@
 			<property name="Control Protocol ID">unknown</property>
 			<property name="System Version">unknown</property>
 			<property name="Protocol Version">unknown</property>
-			<property name="thingTypeVersion">4</property>
+			<property name="thingTypeVersion">5</property>
 		</properties>
 
 		<config-description-ref uri="thing-type:kaleidescape:kaleidescapedevice"/>

--- a/bundles/org.openhab.binding.kaleidescape/src/main/resources/OH-INF/update/instructions.xml
+++ b/bundles/org.openhab.binding.kaleidescape/src/main/resources/OH-INF/update/instructions.xml
@@ -113,6 +113,52 @@
 				<type>kaleidescape:search</type>
 			</add-channel>
 		</instruction-set>
+
+		<instruction-set targetVersion="5">
+			<!-- remove the channels that were erroneously added above via the wrong group id -->
+			<remove-channel id="sendcmd" groupIds="c1-alto_ui"/>
+			<remove-channel id="endtime" groupIds="c1-alto_ui"/>
+			<remove-channel id="play_mode" groupIds="c1-alto_ui"/>
+			<remove-channel id="title_length" groupIds="c1-alto_ui"/>
+			<remove-channel id="title_loc" groupIds="c1-alto_ui"/>
+			<remove-channel id="chapter_length" groupIds="c1-alto_ui"/>
+			<remove-channel id="chapter_loc" groupIds="c1-alto_ui"/>
+			<remove-channel id="search" groupIds="c1-alto_ui"/>
+
+			<!-- apply the missing updates again with the correct group id -->
+			<update-channel id="play_mode" groupIds="ui">
+				<type>kaleidescape:movie_play_mode</type>
+			</update-channel>
+			<update-channel id="title_length" groupIds="ui">
+				<type>kaleidescape:title_length</type>
+			</update-channel>
+			<update-channel id="title_loc" groupIds="ui">
+				<type>kaleidescape:title_loc</type>
+			</update-channel>
+			<update-channel id="chapter_length" groupIds="ui">
+				<type>kaleidescape:chapter_length</type>
+			</update-channel>
+			<update-channel id="chapter_loc" groupIds="ui">
+				<type>kaleidescape:chapter_loc</type>
+			</update-channel>
+
+			<!-- in case the channels were added by a newly created thing, remove them -->
+			<!-- because the add below will fail if channel already exists -->
+			<remove-channel id="sendcmd" groupIds="ui"/>
+			<remove-channel id="endtime" groupIds="ui"/>
+			<remove-channel id="search" groupIds="ui"/>
+
+			<!-- add the channels with the correct group -->
+			<add-channel id="sendcmd" groupIds="ui">
+				<type>kaleidescape:sendcmd</type>
+			</add-channel>
+			<add-channel id="endtime" groupIds="ui">
+				<type>kaleidescape:endtime</type>
+			</add-channel>
+			<add-channel id="search" groupIds="ui">
+				<type>kaleidescape:search</type>
+			</add-channel>
+		</instruction-set>
 	</thing-type>
 
 	<thing-type uid="kaleidescape:alto">
@@ -160,6 +206,52 @@
 				<type>kaleidescape:search</type>
 			</add-channel>
 		</instruction-set>
+
+		<instruction-set targetVersion="5">
+			<!-- remove the channels that were erroneously added above via the wrong group id -->
+			<remove-channel id="sendcmd" groupIds="c1-alto_ui"/>
+			<remove-channel id="endtime" groupIds="c1-alto_ui"/>
+			<remove-channel id="play_mode" groupIds="c1-alto_ui"/>
+			<remove-channel id="title_length" groupIds="c1-alto_ui"/>
+			<remove-channel id="title_loc" groupIds="c1-alto_ui"/>
+			<remove-channel id="chapter_length" groupIds="c1-alto_ui"/>
+			<remove-channel id="chapter_loc" groupIds="c1-alto_ui"/>
+			<remove-channel id="search" groupIds="c1-alto_ui"/>
+
+			<!-- apply the missing updates again with the correct group id -->
+			<update-channel id="play_mode" groupIds="ui">
+				<type>kaleidescape:movie_play_mode</type>
+			</update-channel>
+			<update-channel id="title_length" groupIds="ui">
+				<type>kaleidescape:title_length</type>
+			</update-channel>
+			<update-channel id="title_loc" groupIds="ui">
+				<type>kaleidescape:title_loc</type>
+			</update-channel>
+			<update-channel id="chapter_length" groupIds="ui">
+				<type>kaleidescape:chapter_length</type>
+			</update-channel>
+			<update-channel id="chapter_loc" groupIds="ui">
+				<type>kaleidescape:chapter_loc</type>
+			</update-channel>
+
+			<!-- in case the channels were added by a newly created thing, remove them -->
+			<!-- because the add below will fail if channel already exists -->
+			<remove-channel id="sendcmd" groupIds="ui"/>
+			<remove-channel id="endtime" groupIds="ui"/>
+			<remove-channel id="search" groupIds="ui"/>
+
+			<!-- add the channels with the correct group -->
+			<add-channel id="sendcmd" groupIds="ui">
+				<type>kaleidescape:sendcmd</type>
+			</add-channel>
+			<add-channel id="endtime" groupIds="ui">
+				<type>kaleidescape:endtime</type>
+			</add-channel>
+			<add-channel id="search" groupIds="ui">
+				<type>kaleidescape:search</type>
+			</add-channel>
+		</instruction-set>
 	</thing-type>
 
 	<thing-type uid="kaleidescape:strato">
@@ -204,6 +296,52 @@
 				<type>kaleidescape:sendcmd</type>
 			</update-channel>
 			<add-channel id="search" groupIds="strato_ui">
+				<type>kaleidescape:search</type>
+			</add-channel>
+		</instruction-set>
+
+		<instruction-set targetVersion="5">
+			<!-- remove the channels that were erroneously added above via the wrong group id -->
+			<remove-channel id="sendcmd" groupIds="strato_ui"/>
+			<remove-channel id="endtime" groupIds="strato_ui"/>
+			<remove-channel id="play_mode" groupIds="strato_ui"/>
+			<remove-channel id="title_length" groupIds="strato_ui"/>
+			<remove-channel id="title_loc" groupIds="strato_ui"/>
+			<remove-channel id="chapter_length" groupIds="strato_ui"/>
+			<remove-channel id="chapter_loc" groupIds="strato_ui"/>
+			<remove-channel id="search" groupIds="strato_ui"/>
+
+			<!-- apply the missing updates again with the correct group id -->
+			<update-channel id="play_mode" groupIds="ui">
+				<type>kaleidescape:movie_play_mode</type>
+			</update-channel>
+			<update-channel id="title_length" groupIds="ui">
+				<type>kaleidescape:title_length</type>
+			</update-channel>
+			<update-channel id="title_loc" groupIds="ui">
+				<type>kaleidescape:title_loc</type>
+			</update-channel>
+			<update-channel id="chapter_length" groupIds="ui">
+				<type>kaleidescape:chapter_length</type>
+			</update-channel>
+			<update-channel id="chapter_loc" groupIds="ui">
+				<type>kaleidescape:chapter_loc</type>
+			</update-channel>
+
+			<!-- in case the channels were added by a newly created thing, remove them -->
+			<!-- because the add below will fail if channel already exists -->
+			<remove-channel id="sendcmd" groupIds="ui"/>
+			<remove-channel id="endtime" groupIds="ui"/>
+			<remove-channel id="search" groupIds="ui"/>
+
+			<!-- add the channels with the correct group -->
+			<add-channel id="sendcmd" groupIds="ui">
+				<type>kaleidescape:sendcmd</type>
+			</add-channel>
+			<add-channel id="endtime" groupIds="ui">
+				<type>kaleidescape:endtime</type>
+			</add-channel>
+			<add-channel id="search" groupIds="ui">
 				<type>kaleidescape:search</type>
 			</add-channel>
 		</instruction-set>


### PR DESCRIPTION
Starting in OH 4.2.0, channel update instructions for `cinemaone`, `alto` and `strato` thing types were applied to the wrong group id. As a result some spurious channels were created that are unusable. This PR removes any spurious channels and re-applies the channel updates and additions correctly.

Not a breaking change because the spurious channels were never usable. It was also verified that any of the new channels (`sendcmd`, `endtime` & `search`) that were created by via a new Thing maintained their item links after this update was run.

In the worst case scenario that the Thing continually reports NOT_YET_READY status after this update runs, deleting and re-creating the thing will resolve the issue.

<img width="748" height="728" alt="strato channel errors" src="https://github.com/user-attachments/assets/1adf00e5-394c-4fc7-8e28-9130c7f303ec" />
