### PR TITLE
[eebus][WIP] Add EEBus IO add-on (LPC/LPP power limits via item metadata)

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -470,6 +470,7 @@
 /bundles/org.openhab.binding.zoneminder/ @mhilbush
 /bundles/org.openhab.binding.zwavejs/ @lsiepel
 /bundles/org.openhab.binding.zway/ @pathec
+/bundles/org.openhab.io.eebus/ @stamateviorel
 /bundles/org.openhab.io.homekit/ @andylintner @ccutrer @yfre
 /bundles/org.openhab.io.hueemulation/ @digitaldan
 /bundles/org.openhab.io.mcp/ @digitaldan

--- a/bom/openhab-addons/pom.xml
+++ b/bom/openhab-addons/pom.xml
@@ -2333,6 +2333,11 @@
     </dependency>
     <dependency>
       <groupId>org.openhab.addons.bundles</groupId>
+      <artifactId>org.openhab.io.eebus</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.openhab.addons.bundles</groupId>
       <artifactId>org.openhab.io.homekit</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/bundles/org.openhab.io.eebus/NOTICE
+++ b/bundles/org.openhab.io.eebus/NOTICE
@@ -1,0 +1,58 @@
+This content is produced and maintained by the openHAB project.
+
+* Project home: https://www.openhab.org
+
+== Declared Project Licenses
+
+This program and the accompanying materials are made available under the terms
+of the Eclipse Public License 2.0 which is available at
+https://www.eclipse.org/legal/epl-2.0/.
+
+== Source Code
+
+https://github.com/openhab/openhab-addons
+
+== Third Party Dependencies
+
+The following dependencies are embedded into this bundle's own jar (Private-Package) rather than
+resolved as separate OSGi bundles at runtime - see pom.xml and src/main/feature/feature.xml.
+
+=== org.openmuc.jeebus:ship, org.openmuc.jeebus:spine
+Author: Fraunhofer ISE / OpenMUC
+URL: https://www.openmuc.org/eebus/
+License: Eclipse Public License 2.0
+
+=== org.openmuc.jeebus.usecase.powerlimitation:{abstract-controllablesystem,lpc-controllablesystem,lpp-controllablesystem}
+Author: Fraunhofer ISE / OpenMUC
+URL: https://www.openmuc.org/eebus/
+License: Eclipse Public License 2.0
+
+=== org.bouncycastle:bcprov-jdk18on, org.bouncycastle:bcpkix-jdk18on, org.bouncycastle:bcutil-jdk18on
+Author: The Legion of the Bouncy Castle Inc.
+URL: https://www.bouncycastle.org/
+License: MIT License
+
+=== io.netty:netty-*
+Author: The Netty Project
+URL: https://netty.io/
+License: Apache License Version 2.0
+
+=== com.fasterxml.jackson.core:*, com.fasterxml.jackson.module:jackson-module-jakarta-xmlbind-annotations
+Author: FasterXML LLC
+URL: https://github.com/FasterXML/jackson-databind
+License: Apache License Version 2.0
+
+=== org.glassfish.jaxb:jaxb-core, org.glassfish.jaxb:txw2, org.eclipse.angus:angus-activation, com.sun.istack:istack-commons-runtime, org.jvnet.jaxb:jaxb-plugins-runtime, jakarta.xml.bind:jakarta.xml.bind-api, jakarta.activation:jakarta.activation-api
+Author: Eclipse Foundation
+URL: https://eclipse-ee4j.github.io/jaxb-ri/
+License: Eclipse Distribution License 1.0 (BSD-3-Clause)
+
+=== com.google.code.gson:gson
+Author: Google Inc.
+URL: https://github.com/google/gson
+License: Apache License Version 2.0
+
+=== org.jmdns:jmdns
+Author: JmDNS contributors
+URL: https://github.com/jmdns/jmdns
+License: Apache License Version 2.0

--- a/bundles/org.openhab.io.eebus/README.md
+++ b/bundles/org.openhab.io.eebus/README.md
@@ -1,0 +1,78 @@
+# EEBus Add-on
+
+This add-on lets openHAB present itself as an [EEBus](https://www.eebus.org/) Controllable System (CS) on the local
+network, backed by the [jEEBus](https://www.openmuc.org/eebus/) SHIP/SPINE implementation from Fraunhofer ISE /
+OpenMUC.
+A remote CEM/EMS or a smart-meter CLS gateway (§14a EnWG in Germany) can pair with it over the standard EEBus SHIP
+transport and issue LPC (Limitation of Power Consumption) and LPP (Limitation of Power Production) power limits,
+which are pushed onto whichever openHAB items you tag for the purpose.
+
+Note the direction of control: this add-on implements the _device being limited_, not the _thing issuing limits_.
+It does not pair with and control other EEBus devices (e.g. a real wallbox or heat pump) directly - as of this
+writing, OpenMUC has not published a Java library for that (CEM/controller) side of the protocol.
+
+This is an IO add-on, not a binding: LPC/LPP are household-wide singleton limits, not per-device data points, so
+there is no Thing to add.
+Configure the add-on itself under Settings, then tag the one item that should receive each limit with item
+metadata - the same shape used by the HomeKit and Alexa add-ons.
+
+## Add-on Configuration
+
+| Parameter          | Group    | Required | Default             | Description                                                                                                                                                            |
+|---------------------|----------|----------|-----------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| bindAddress         | network  | no       | `0.0.0.0`             | Local IP address the SHIP WebSocket server binds to.                                                                                                                     |
+| port                | network  | no       | `4712`                | TCP port the SHIP WebSocket server listens on.                                                                                                                           |
+| wssPath             | network  | no       | `/ship/`              | HTTP path the SHIP WebSocket endpoint is served under.                                                                                                                   |
+| serviceDomain       | network  | no       | `local.`              | mDNS domain used for SHIP service advertisement.                                                                                                                         |
+| deviceId            | identity | yes      | `d:_i:openHAB:eebus-01` | Unique SPINE device identifier. Change the default before pairing with a real partner.                                                                                |
+| friendlyName        | identity | no       | `openHAB`             | Human-readable name advertised to pairing partners.                                                                                                                      |
+| deviceType          | identity | no       | `GENERIC`             | SPINE device type reported to pairing partners.                                                                                                                          |
+| entityType          | identity | no       | `CEM`                 | SPINE entity type hosting the LPC/LPP use cases (must be one of CEM, COMPRESSOR, EVSE, HEAT_PUMP_APPLIANCE, INVERTER, SMART_ENERGY_APPLIANCE, SUB_METER_ELECTRICITY). |
+| connectPolicy       | pairing  | no       | `TRUSTED`             | `TRUSTED` (only pre-trusted SKIs), `ALL` (insecure), or `NONE`.                                                                                                          |
+| trustedSkis         | pairing  | no       | -                      | Comma-separated list of remote SKIs to pre-trust. Used when `connectPolicy` is `TRUSTED`.                                                                                |
+| autoAcceptPairing   | pairing  | no       | `false`               | Accept any pairing request without a pre-trusted SKI. Lab testing only, never in production.                                                                            |
+
+Changing a `network` or `identity` parameter restarts the SHIP node.
+`pairing` parameters apply live.
+
+## Item Metadata
+
+Tag exactly one item per direction with the `eebus` namespace to bind it to a use case:
+
+```java
+Number:Power My_Charging_Limit "EV Charging Limit" { eebus="lpc" [ nominalMax=11000, failsafeLimit=4200, failsafeDuration="PT2H" ] }
+```
+
+| Metadata value | Use case                        | Item type suggestion |
+|-----------------|-----------------------------------|------------------------|
+| `lpc`           | Limitation of Power Consumption   | `Number:Power`        |
+| `lpp`           | Limitation of Power Production    | `Number:Power`        |
+
+Configuration parameters (all optional, in watts / ISO 8601 duration):
+
+| Parameter          | Default (lpc) | Default (lpp) | Description                                                                          |
+|---------------------|----------------|-----------------|-----------------------------------------------------------------------------------------|
+| `nominalMax`        | `4200`         | `4200`          | Maximum consumption/production this installation could ever draw/feed in.               |
+| `failsafeLimit`      | = `nominalMax`  | = `nominalMax`   | Limit applied if the pairing partner's heartbeat is lost. Review and set this deliberately - it is not a safe default. |
+| `failsafeDuration`   | `PT2H`         | `PT2H`          | ISO 8601 duration the failsafe limit stays valid for.                                    |
+
+Only one item per direction is supported at a time.
+Tagging a second item for the same use case is logged as a warning and ignored.
+Re-tagging to a different item requires restarting the add-on, since jEEBus has no runtime API to detach a use case
+once added.
+
+Every active-limit update from a paired partner is posted to the tagged item as a `QuantityType<Power>` command
+(`Units.WATT`), same as any other command.
+Route it into your rules the same way you would a manually-entered value, e.g. clamp an EV charger's current limit
+to it.
+
+## Testing Without EEBus Hardware
+
+Since this add-on implements the standard EEBus SHIP/SPINE Controllable System role, it can be paired against any
+generic EEBus control-box simulator or the free conformance-testing lab run by the EEBus Initiative
+([Living Lab Cologne](https://www.livinglabcologne.com/)) rather than only against real hardware.
+
+## Finding Your Own SKI
+
+The add-on's own SKI - needed by your CLS gateway/EMS installer to pre-trust this node - is logged at `INFO` level
+on startup (`EEBus: SHIP node started, own SKI: ...`).

--- a/bundles/org.openhab.io.eebus/README.md
+++ b/bundles/org.openhab.io.eebus/README.md
@@ -1,7 +1,8 @@
 # EEBus Add-on
 
-> **Status**: early, working prototype, not yet a PR. Builds clean (checkstyle/spotbugs/spotless/i18n all pass,
-> 13/13 unit tests pass) and has been live-tested against a real independent EEBus implementation
+> **Status**: draft PR [#21313](https://github.com/openhab/openhab-addons/pull/21313), not yet merged. Builds clean
+> (checkstyle/spotbugs/spotless/i18n all pass, 18/18 unit tests pass, no compiler warnings) and has been live-tested
+> against a real independent EEBus implementation
 > ([meisel2000/eebus-cbsim](https://github.com/meisel2000/eebus-cbsim), built on the `enbility/eebus-go` stack) -
 > SHIP pairing, mDNS discovery, and SPINE LPC use-case discovery/negotiation (including the dynamic
 > `entity.addUseCase()` registration this add-on relies on instead of registering at device-build time) all
@@ -70,13 +71,16 @@ Configuration parameters (all optional, in watts / ISO 8601 duration):
 
 | Parameter          | Default (lpc) | Default (lpp) | Description                                                                          |
 |---------------------|----------------|-----------------|-----------------------------------------------------------------------------------------|
-| `nominalMax`        | `4200`         | `4200`          | Maximum consumption/production this installation could ever draw/feed in.               |
+| `nominalMax`        | `4200`         | `0`             | Maximum consumption/production this installation could ever draw/feed in.               |
 | `failsafeLimit`      | = `nominalMax`  | = `nominalMax`   | Limit applied if the pairing partner's heartbeat is lost. Review and set this deliberately - it is not a safe default. |
 | `failsafeDuration`   | `PT2H`         | `PT2H`          | ISO 8601 duration the failsafe limit stays valid for.                                    |
 
+LPP's `nominalMax` defaults to `0` rather than a nonzero placeholder - claiming export capacity you haven't actually configured would misreport this installation's real capability to the CEM.
+Set it explicitly to whatever this installation can actually feed back.
+
 Only one item per direction is supported at a time.
 Tagging a second item for the same use case is logged as a warning and ignored.
-Re-tagging to a different item requires restarting the add-on, since jEEBus has no runtime API to detach a use case
+Changing `nominalMax`/`failsafeLimit`/`failsafeDuration` on an already-bound item, or re-tagging to a different item, both require restarting the add-on, since jEEBus has no runtime API to reconfigure or detach a use case
 once added.
 
 Every active-limit update from a paired partner is posted to the tagged item as a `QuantityType<Power>` command

--- a/bundles/org.openhab.io.eebus/README.md
+++ b/bundles/org.openhab.io.eebus/README.md
@@ -1,5 +1,23 @@
 # EEBus Add-on
 
+> **Status**: early, working prototype, not yet a PR. Builds clean (checkstyle/spotbugs/spotless/i18n all pass,
+> 13/13 unit tests pass) and has been live-tested against a real independent EEBus implementation
+> ([meisel2000/eebus-cbsim](https://github.com/meisel2000/eebus-cbsim), built on the `enbility/eebus-go` stack) -
+> SHIP pairing, mDNS discovery, and SPINE LPC use-case discovery/negotiation (including the dynamic
+> `entity.addUseCase()` registration this add-on relies on instead of registering at device-build time) all
+> verified working end-to-end, correctly reporting the `nominalMax` configured via item metadata. One real bug
+> was found and fixed this way: `Device.build()` also adds an implicit `DEVICE_INFORMATION` entity alongside the
+> requested one, so the entity to register use cases on must be selected by type, not assumed to be the first/only
+> one returned. Not yet verified: a full accepted _active_ limit write from a real CEM, and the resulting command
+> actually landing on the tagged item (blocked on a simulator-side heartbeat quirk in cbsim, not this add-on - see
+> [openhab-addons#21211](https://github.com/openhab/openhab-addons/issues/21211) for details). No EEBus hardware
+> has been used in this development; testing so far is simulator-only.
+>
+> Supersedes an earlier Thing-based binding prototype (mirror kept at
+> [stamateviorel/openhab-eebus-binding](https://github.com/stamateviorel/openhab-eebus-binding) for history) -
+> LPC/LPP are household-wide singleton limits, not per-device Things, so this is shaped as an IO add-on instead
+> (service config + item metadata), per [maintainer feedback](https://github.com/openhab/openhab-addons/issues/21211#issuecomment-5152128940).
+
 This add-on lets openHAB present itself as an [EEBus](https://www.eebus.org/) Controllable System (CS) on the local
 network, backed by the [jEEBus](https://www.openmuc.org/eebus/) SHIP/SPINE implementation from Fraunhofer ISE /
 OpenMUC.

--- a/bundles/org.openhab.io.eebus/pom.xml
+++ b/bundles/org.openhab.io.eebus/pom.xml
@@ -76,6 +76,16 @@
       <artifactId>bcpkix-jdk18on</artifactId>
       <version>${bouncycastle.version}</version>
     </dependency>
+    <!-- bcpkix references org.bouncycastle.asn1.cmc classes that live in bcutil, not bcprov/bcpkix
+         themselves - only reachable transitively before, which left it as an external
+         Import-Package requirement with nothing to satisfy it once bcprov/bcpkix were embedded
+         (see org.openhab.io.homekit's pom.xml, which embeds all three the same way). Declaring it
+         directly here embeds it too instead of leaving it as a dangling external feature.xml entry. -->
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcutil-jdk18on</artifactId>
+      <version>${bouncycastle.version}</version>
+    </dependency>
   </dependencies>
 
 </project>

--- a/bundles/org.openhab.io.eebus/pom.xml
+++ b/bundles/org.openhab.io.eebus/pom.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.openhab.addons.bundles</groupId>
+    <artifactId>org.openhab.addons.reactor.bundles</artifactId>
+    <version>5.3.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>org.openhab.io.eebus</artifactId>
+
+  <name>openHAB Add-ons :: Bundles :: IO :: EEBus</name>
+
+  <properties>
+    <!-- jEEBus.SHIP 2.3.0 requires Netty 4.2.x at the OSGi Import-Package level
+         (io.netty.*;version="[4.2,5)"). This is intentionally NOT ${netty.version}
+         (which openhab-addons pins to the 4.1.x line elsewhere) - the two Netty
+         major versions are installed as separate OSGi bundles side by side, which
+         the framework resolves independently per importing bundle. -->
+    <eebus.netty.version>4.2.15.Final</eebus.netty.version>
+    <!-- jeebus.ship/spine and BouncyCastle are declared as direct compile deps below, so
+         bnd embeds them into this bundle's own jar (Private-Package) rather than treating
+         them as external Import-Package - see feature.xml for what actually stays external.
+         Netty itself loses its precise version constraint once ship's classes are embedded
+         rather than imported, so it's restated explicitly here to stop the OSGi resolver
+         from accidentally satisfying it against openhab-addons' own (incompatible) 4.1.x
+         Netty bundles. -->
+    <bnd.importpackage>io.netty.*;version="[4.2,5)"</bnd.importpackage>
+  </properties>
+
+  <dependencies>
+    <!-- EEBus SHIP (transport: TLS, mDNS pairing) and SPINE (data model / use cases),
+         both EPL-2.0, from the OpenMUC / Fraunhofer ISE jEEBus project.
+         https://www.openmuc.org/eebus/ -->
+    <dependency>
+      <groupId>org.openmuc.jeebus</groupId>
+      <artifactId>ship</artifactId>
+      <version>2.3.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.openmuc.jeebus</groupId>
+      <artifactId>spine</artifactId>
+      <version>4.0.1</version>
+    </dependency>
+
+    <!-- LPC (Limitation of Power Consumption, §14a EnWG) and LPP (Limitation of Power
+         Production, §9 EEG) Controllable System use-case actors. Same project, EPL-2.0. -->
+    <dependency>
+      <groupId>org.openmuc.jeebus.usecase.powerlimitation</groupId>
+      <artifactId>abstract-controllablesystem</artifactId>
+      <version>1.0.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.openmuc.jeebus.usecase.powerlimitation</groupId>
+      <artifactId>lpc-controllablesystem</artifactId>
+      <version>1.0.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.openmuc.jeebus.usecase.powerlimitation</groupId>
+      <artifactId>lpp-controllablesystem</artifactId>
+      <version>1.0.0</version>
+    </dependency>
+
+    <!-- Used directly by this add-on to provision the SHIP node's self-signed
+         identity certificate (see internal.cert.SelfSignedCertificateFactory). -->
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcprov-jdk18on</artifactId>
+      <version>${bouncycastle.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcpkix-jdk18on</artifactId>
+      <version>${bouncycastle.version}</version>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/bundles/org.openhab.io.eebus/src/main/feature/feature.xml
+++ b/bundles/org.openhab.io.eebus/src/main/feature/feature.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<features name="org.openhab.io.eebus-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
+	<repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
+
+	<feature name="openhab-io-eebus" description="EEBus Integration" version="${project.version}">
+		<feature>openhab-runtime-base</feature>
+		<feature prerequisite="true">wrap</feature>
+
+		<!-- jEEBus.SHIP + jEEBus.SPINE, the LPC/LPP use-case actors, and BouncyCastle are all
+			declared as direct compile dependencies in pom.xml, so bnd embeds them straight into
+			this bundle's own jar (Private-Package) rather than as separate bundles here - see
+			pom.xml's comment on ${bnd.importpackage}. Everything below is what actually stays an
+			external OSGi Import-Package requirement after that embedding. -->
+
+		<!-- SHIP transitive deps: Gson (message framing), jmDNS (pairing discovery), the
+			remaining BouncyCastle ASN.1 packages not covered by the embedded bcprov/bcpkix
+			classes (from the bcutil-jdk18on transitive dep), and JSR-305 annotations. -->
+		<bundle dependency="true">mvn:com.google.code.gson/gson/2.14.0</bundle>
+		<bundle dependency="true">mvn:org.jmdns/jmdns/3.6.3</bundle>
+		<bundle dependency="true">mvn:org.bouncycastle/bcutil-jdk18on/${bouncycastle.version}</bundle>
+		<bundle dependency="true">mvn:com.google.code.findbugs/jsr305/3.0.2</bundle>
+
+		<!-- SHIP's embedded code still needs real Netty 4.2.x classes at runtime, even though
+			bnd no longer expresses that as strictly in this bundle's own Import-Package - see
+			pom.xml's ${bnd.importpackage} override, which restates the [4.2,5) constraint so the
+			resolver can't accidentally satisfy it against openhab-addons' own 4.1.x Netty. -->
+		<bundle dependency="true">mvn:io.netty/netty-common/${eebus.netty.version}</bundle>
+		<bundle dependency="true">mvn:io.netty/netty-buffer/${eebus.netty.version}</bundle>
+		<bundle dependency="true">mvn:io.netty/netty-transport/${eebus.netty.version}</bundle>
+		<bundle dependency="true">mvn:io.netty/netty-transport-native-unix-common/${eebus.netty.version}</bundle>
+		<bundle dependency="true">mvn:io.netty/netty-resolver/${eebus.netty.version}</bundle>
+		<bundle dependency="true">mvn:io.netty/netty-handler/${eebus.netty.version}</bundle>
+		<bundle dependency="true">mvn:io.netty/netty-codec-base/${eebus.netty.version}</bundle>
+		<bundle dependency="true">mvn:io.netty/netty-codec-http/${eebus.netty.version}</bundle>
+		<bundle dependency="true">mvn:io.netty/netty-codec-compression/${eebus.netty.version}</bundle>
+
+		<!-- SPINE transitive deps: Jackson (SPINE XML/JSON datagram parsing) and the JAXB
+			runtime used to generate/validate the SPINE datagram classes. jaxb-core and its own
+			transitive deps (activation, istack, txw2) aren't reachable from static bytecode
+			analysis (JAXB loads them via SPI), so they don't show up in the generated
+			Import-Package, but are still needed at runtime - kept here defensively. -->
+		<bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-databind/${jackson.version}</bundle>
+		<bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-annotations/${jackson.version}</bundle>
+		<bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-core/${jackson.version}</bundle>
+		<bundle dependency="true">mvn:com.fasterxml.jackson.module/jackson-module-jakarta-xmlbind-annotations/${jackson.version}</bundle>
+		<bundle dependency="true">mvn:jakarta.xml.bind/jakarta.xml.bind-api/4.0.5</bundle>
+		<bundle dependency="true">mvn:jakarta.activation/jakarta.activation-api/2.1.0</bundle>
+		<bundle dependency="true">mvn:org.jvnet.jaxb/jaxb-plugins-runtime/4.0.12</bundle>
+		<bundle dependency="true">mvn:org.glassfish.jaxb/jaxb-core/4.0.6</bundle>
+		<bundle dependency="true">mvn:org.eclipse.angus/angus-activation/2.0.3</bundle>
+		<bundle dependency="true">mvn:com.sun.istack/istack-commons-runtime/4.1.2</bundle>
+		<!-- org.glassfish.jaxb:txw2 ships no OSGi manifest at all (plain jar) -->
+		<bundle dependency="true">wrap:mvn:org.glassfish.jaxb/txw2/4.0.6$Bundle-SymbolicName=org.glassfish.jaxb.txw2&amp;Bundle-Version=4.0.6</bundle>
+
+		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.io.eebus/${project.version}</bundle>
+	</feature>
+</features>

--- a/bundles/org.openhab.io.eebus/src/main/feature/feature.xml
+++ b/bundles/org.openhab.io.eebus/src/main/feature/feature.xml
@@ -12,12 +12,14 @@
 			pom.xml's comment on ${bnd.importpackage}. Everything below is what actually stays an
 			external OSGi Import-Package requirement after that embedding. -->
 
-		<!-- SHIP transitive deps: Gson (message framing), jmDNS (pairing discovery), the
-			remaining BouncyCastle ASN.1 packages not covered by the embedded bcprov/bcpkix
-			classes (from the bcutil-jdk18on transitive dep), and JSR-305 annotations. -->
+		<!-- SHIP transitive deps: Gson (message framing), jmDNS (pairing discovery), and JSR-305
+			annotations. bcutil-jdk18on is declared as a direct pom.xml dependency alongside
+			bcprov/bcpkix (all three embedded, matching org.openhab.io.homekit) rather than left
+			here as an external bundle - it needs org.bouncycastle.asn1 packages that only exist
+			as embedded classes once bcprov/bcpkix stop being separate OSGi bundles, so leaving it
+			external here left that Import-Package unsatisfiable. -->
 		<bundle dependency="true">mvn:com.google.code.gson/gson/2.14.0</bundle>
 		<bundle dependency="true">mvn:org.jmdns/jmdns/3.6.3</bundle>
-		<bundle dependency="true">mvn:org.bouncycastle/bcutil-jdk18on/${bouncycastle.version}</bundle>
 		<bundle dependency="true">mvn:com.google.code.findbugs/jsr305/3.0.2</bundle>
 
 		<!-- SHIP's embedded code still needs real Netty 4.2.x classes at runtime, even though
@@ -40,7 +42,7 @@
 			analysis (JAXB loads them via SPI), so they don't show up in the generated
 			Import-Package, but are still needed at runtime - kept here defensively. -->
 		<bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-databind/${jackson.version}</bundle>
-		<bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-annotations/${jackson.version}</bundle>
+		<bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-annotations/${jackson.annotations.version}</bundle>
 		<bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-core/${jackson.version}</bundle>
 		<bundle dependency="true">mvn:com.fasterxml.jackson.module/jackson-module-jakarta-xmlbind-annotations/${jackson.version}</bundle>
 		<bundle dependency="true">mvn:jakarta.xml.bind/jakarta.xml.bind-api/4.0.5</bundle>

--- a/bundles/org.openhab.io.eebus/src/main/feature/feature.xml
+++ b/bundles/org.openhab.io.eebus/src/main/feature/feature.xml
@@ -2,7 +2,7 @@
 <features name="org.openhab.io.eebus-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
 	<repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
-	<feature name="openhab-io-eebus" description="EEBus Integration" version="${project.version}">
+	<feature name="openhab-misc-eebus" description="EEBus Integration" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
 		<feature prerequisite="true">wrap</feature>
 

--- a/bundles/org.openhab.io.eebus/src/main/java/org/openhab/io/eebus/EEBus.java
+++ b/bundles/org.openhab.io.eebus/src/main/java/org/openhab/io/eebus/EEBus.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.io.eebus;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
+/**
+ * EEBus integration API.
+ *
+ * @author openHAB EEBus Add-on Contributors - Initial contribution
+ */
+@NonNullByDefault
+public interface EEBus {
+
+    /**
+     * @return this node's own SHIP Subject Key Identifier, to give to a pairing partner's
+     *         installer to pre-trust it, or {@code null} if the node hasn't started yet.
+     */
+    @Nullable
+    String getOwnSki();
+}

--- a/bundles/org.openhab.io.eebus/src/main/java/org/openhab/io/eebus/internal/EEBusChangeListener.java
+++ b/bundles/org.openhab.io.eebus/src/main/java/org/openhab/io/eebus/internal/EEBusChangeListener.java
@@ -1,0 +1,245 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.io.eebus.internal;
+
+import java.util.Map;
+import java.util.Optional;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.core.common.registry.RegistryChangeListener;
+import org.openhab.core.events.EventPublisher;
+import org.openhab.core.items.Item;
+import org.openhab.core.items.ItemNotFoundException;
+import org.openhab.core.items.ItemRegistry;
+import org.openhab.core.items.ItemRegistryChangeListener;
+import org.openhab.core.items.Metadata;
+import org.openhab.core.items.MetadataKey;
+import org.openhab.core.items.MetadataRegistry;
+import org.openhab.core.items.events.ItemEventFactory;
+import org.openhab.core.library.types.QuantityType;
+import org.openhab.core.library.unit.Units;
+import org.openhab.core.types.Command;
+import org.openmuc.jeebus.spine.api.Entity;
+import org.openmuc.jeebus.usecase.powerlimitation.controllablesystem.ActiveLimit;
+import org.openmuc.jeebus.usecase.powerlimitation.controllablesystem.lpc.LpcCs;
+import org.openmuc.jeebus.usecase.powerlimitation.controllablesystem.lpp.LppCs;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Watches the item and metadata registries for {@code eebus="lpc"}/{@code eebus="lpp"} tagged
+ * items, and wires the corresponding EEBus use case to whichever item is tagged - pushing every
+ * active-limit update from a paired CEM/CLS gateway directly onto that item as a command.
+ * Analogous to {@code org.openhab.io.homekit.internal.HomekitChangeListener}, simplified since
+ * EEBus's LPC/LPP are household-wide singleton limits (at most one tagged item each makes sense),
+ * not a many-accessories registry.
+ * <p>
+ * v1 limitation: once LPC/LPP is bound to an item, un-tagging or re-tagging to a different item
+ * is logged but not applied live - jeebus.spine's {@link Entity#addUseCase} has no runtime
+ * counterpart for removing a use case, so rebinding needs a restart of this add-on.
+ *
+ * @author openHAB EEBus Add-on Contributors - Initial contribution
+ */
+@NonNullByDefault
+public class EEBusChangeListener implements ItemRegistryChangeListener {
+
+    static final String METADATA_NAMESPACE = "eebus";
+    static final String LPC_VALUE = "lpc";
+    static final String LPP_VALUE = "lpp";
+    static final String COMMAND_SOURCE = "org.openhab.io.eebus";
+
+    private final Logger logger = LoggerFactory.getLogger(EEBusChangeListener.class);
+
+    private final ItemRegistry itemRegistry;
+    private final MetadataRegistry metadataRegistry;
+    private final EventPublisher eventPublisher;
+    private final Entity entity;
+
+    private final RegistryChangeListener<Metadata> metadataChangeListener;
+
+    private @Nullable String lpcItemName;
+    private @Nullable String lppItemName;
+
+    public EEBusChangeListener(ItemRegistry itemRegistry, MetadataRegistry metadataRegistry,
+            EventPublisher eventPublisher, Entity entity) {
+        this.itemRegistry = itemRegistry;
+        this.metadataRegistry = metadataRegistry;
+        this.eventPublisher = eventPublisher;
+        this.entity = entity;
+
+        metadataChangeListener = new RegistryChangeListener<>() {
+            @Override
+            public void added(Metadata metadata) {
+                onMetadataChanged(metadata);
+            }
+
+            @Override
+            public void removed(Metadata metadata) {
+                onMetadataRemoved(metadata);
+            }
+
+            @Override
+            public void updated(Metadata oldMetadata, Metadata newMetadata) {
+                onMetadataChanged(newMetadata);
+            }
+        };
+
+        itemRegistry.addRegistryChangeListener(this);
+        metadataRegistry.addRegistryChangeListener(metadataChangeListener);
+
+        for (Item item : itemRegistry.getItems()) {
+            Metadata metadata = metadataRegistry.get(new MetadataKey(METADATA_NAMESPACE, item.getUID()));
+            if (metadata != null) {
+                bind(metadata);
+            }
+        }
+    }
+
+    public void stop() {
+        itemRegistry.removeRegistryChangeListener(this);
+        metadataRegistry.removeRegistryChangeListener(metadataChangeListener);
+    }
+
+    @Override
+    public void added(Item item) {
+        Metadata metadata = metadataRegistry.get(new MetadataKey(METADATA_NAMESPACE, item.getUID()));
+        if (metadata != null) {
+            bind(metadata);
+        }
+    }
+
+    @Override
+    public void removed(Item item) {
+        // Handled via the metadata registry's own removed() callback, which fires when an item
+        // (and its metadata with it) is removed.
+    }
+
+    @Override
+    public void updated(Item oldItem, Item newItem) {
+        // Item type/label changes don't affect EEBus binding; metadata changes are handled
+        // separately.
+    }
+
+    @Override
+    public void allItemsChanged(java.util.Collection<String> oldItemNames) {
+        // A full registry reload - re-scan for tagged items still present.
+        lpcItemName = null;
+        lppItemName = null;
+        for (Item item : itemRegistry.getItems()) {
+            Metadata metadata = metadataRegistry.get(new MetadataKey(METADATA_NAMESPACE, item.getUID()));
+            if (metadata != null) {
+                bind(metadata);
+            }
+        }
+    }
+
+    private void onMetadataChanged(Metadata metadata) {
+        if (METADATA_NAMESPACE.equalsIgnoreCase(metadata.getUID().getNamespace())) {
+            bind(metadata);
+        }
+    }
+
+    private void onMetadataRemoved(Metadata metadata) {
+        MetadataKey uid = metadata.getUID();
+        if (!METADATA_NAMESPACE.equalsIgnoreCase(uid.getNamespace())) {
+            return;
+        }
+        String itemName = uid.getItemName();
+        if (itemName.equals(lpcItemName)) {
+            logger.warn(
+                    "EEBus: item {} was untagged from eebus=\"lpc\" - LPC stays bound to it until this add-on restarts",
+                    itemName);
+        }
+        if (itemName.equals(lppItemName)) {
+            logger.warn(
+                    "EEBus: item {} was untagged from eebus=\"lpp\" - LPP stays bound to it until this add-on restarts",
+                    itemName);
+        }
+    }
+
+    private synchronized void bind(Metadata metadata) {
+        String itemName = metadata.getUID().getItemName();
+        String value = metadata.getValue();
+        Map<String, Object> config = metadata.getConfiguration();
+
+        if (LPC_VALUE.equalsIgnoreCase(value)) {
+            bindLpc(itemName, config);
+        } else if (LPP_VALUE.equalsIgnoreCase(value)) {
+            bindLpp(itemName, config);
+        } else {
+            logger.warn("EEBus: item {} has metadata value '{}', expected \"lpc\" or \"lpp\" - ignoring", itemName,
+                    value);
+        }
+    }
+
+    private void bindLpc(String itemName, Map<String, Object> config) {
+        String existing = lpcItemName;
+        if (existing != null) {
+            if (!existing.equals(itemName)) {
+                logger.warn(
+                        "EEBus: item {} tagged eebus=\"lpc\" but LPC is already bound to {} - only one LPC item is supported at a time (restart to rebind)",
+                        itemName, existing);
+            }
+            return;
+        }
+        LpcCs cs = new LpcCs(EEBusLimitationConfigFactory.lpc(config));
+        cs.addListener((event, state, limit) -> pushLimit(itemName, limit));
+        entity.addUseCase(cs);
+        lpcItemName = itemName;
+        logger.info("EEBus: LPC bound to item {}", itemName);
+    }
+
+    private void bindLpp(String itemName, Map<String, Object> config) {
+        String existing = lppItemName;
+        if (existing != null) {
+            if (!existing.equals(itemName)) {
+                logger.warn(
+                        "EEBus: item {} tagged eebus=\"lpp\" but LPP is already bound to {} - only one LPP item is supported at a time (restart to rebind)",
+                        itemName, existing);
+            }
+            return;
+        }
+        LppCs cs = new LppCs(EEBusLimitationConfigFactory.lpp(config));
+        cs.addListener((event, state, limit) -> pushLimit(itemName, limit));
+        entity.addUseCase(cs);
+        lppItemName = itemName;
+        logger.info("EEBus: LPP bound to item {}", itemName);
+    }
+
+    private void pushLimit(String itemName, ActiveLimit limit) {
+        Double value = limit.getResultingValue();
+        if (value == null) {
+            return;
+        }
+        if (!"W".equals(limit.getUnit())) {
+            logger.debug("EEBus: unexpected active-limit unit '{}' for item {}, expected W", limit.getUnit(), itemName);
+        }
+        try {
+            itemRegistry.getItem(itemName);
+        } catch (ItemNotFoundException e) {
+            logger.warn("EEBus: item {} no longer exists, cannot push limit", itemName);
+            return;
+        }
+        Command command = new QuantityType<>(value, Units.WATT);
+        eventPublisher.post(ItemEventFactory.createCommandEvent(itemName, command, COMMAND_SOURCE));
+    }
+
+    Optional<String> getLpcItemName() {
+        return Optional.ofNullable(lpcItemName);
+    }
+
+    Optional<String> getLppItemName() {
+        return Optional.ofNullable(lppItemName);
+    }
+}

--- a/bundles/org.openhab.io.eebus/src/main/java/org/openhab/io/eebus/internal/EEBusChangeListener.java
+++ b/bundles/org.openhab.io.eebus/src/main/java/org/openhab/io/eebus/internal/EEBusChangeListener.java
@@ -91,7 +91,7 @@ public class EEBusChangeListener implements ItemRegistryChangeListener {
 
             @Override
             public void updated(Metadata oldMetadata, Metadata newMetadata) {
-                onMetadataChanged(newMetadata);
+                onMetadataUpdated(newMetadata);
             }
         };
 
@@ -133,9 +133,11 @@ public class EEBusChangeListener implements ItemRegistryChangeListener {
 
     @Override
     public void allItemsChanged(java.util.Collection<String> oldItemNames) {
-        // A full registry reload - re-scan for tagged items still present.
-        lpcItemName = null;
-        lppItemName = null;
+        // A full registry reload - re-scan for tagged items still present. Deliberately NOT
+        // resetting lpcItemName/lppItemName first: jeebus.spine's Entity#addUseCase has no runtime
+        // counterpart for removing a use case (see class javadoc), so if the same item is still
+        // tagged after the reload, bind() below must see it as already-bound and no-op rather than
+        // registering a second LpcCs/LppCs for a use case the entity already has attached.
         for (Item item : itemRegistry.getItems()) {
             Metadata metadata = metadataRegistry.get(new MetadataKey(METADATA_NAMESPACE, item.getUID()));
             if (metadata != null) {
@@ -148,6 +150,23 @@ public class EEBusChangeListener implements ItemRegistryChangeListener {
         if (METADATA_NAMESPACE.equalsIgnoreCase(metadata.getUID().getNamespace())) {
             bind(metadata);
         }
+    }
+
+    private void onMetadataUpdated(Metadata metadata) {
+        if (!METADATA_NAMESPACE.equalsIgnoreCase(metadata.getUID().getNamespace())) {
+            return;
+        }
+        String itemName = metadata.getUID().getItemName();
+        if (itemName.equals(lpcItemName) || itemName.equals(lppItemName)) {
+            // bind() would silently no-op here (existing.equals(itemName) branch) since jeebus.spine
+            // has no API to reconfigure an already-registered use case - warn instead of pretending
+            // the new nominalMax/failsafeLimit/failsafeDuration took effect.
+            logger.warn(
+                    "EEBus: metadata configuration for item {} changed, but the use case is already bound - restart this add-on to apply the new nominalMax/failsafeLimit/failsafeDuration",
+                    itemName);
+            return;
+        }
+        bind(metadata);
     }
 
     private void onMetadataRemoved(Metadata metadata) {

--- a/bundles/org.openhab.io.eebus/src/main/java/org/openhab/io/eebus/internal/EEBusImpl.java
+++ b/bundles/org.openhab.io.eebus/src/main/java/org/openhab/io/eebus/internal/EEBusImpl.java
@@ -155,7 +155,14 @@ public class EEBusImpl implements EEBus, ReadyService.ReadyTracker {
                     .applyToDevice().build();
             this.device = newDevice;
 
-            Entity entity = newDevice.getEntities().iterator().next();
+            // Device.build() also adds an implicit DEVICE_INFORMATION entity alongside the one
+            // requested above - getEntities() does not guarantee that entity comes first, so it
+            // must be selected by type rather than assumed to be the sole/first entry (confirmed
+            // live: addUseCase() on the DEVICE_INFORMATION entity throws
+            // "Use case LpcCs does not allow entity type DEVICE_INFORMATION").
+            Entity entity = newDevice.getEntities().stream().filter(e -> e.getType() == entityType).findFirst()
+                    .orElseThrow(() -> new IllegalStateException(
+                            "EEBus: no " + entityType + " entity found on the built device"));
             this.changeListener = new EEBusChangeListener(itemRegistry, metadataRegistry, eventPublisher, entity);
 
             logger.info("EEBus: SHIP node started, own SKI: {}", communication.getOwnSki());

--- a/bundles/org.openhab.io.eebus/src/main/java/org/openhab/io/eebus/internal/EEBusImpl.java
+++ b/bundles/org.openhab.io.eebus/src/main/java/org/openhab/io/eebus/internal/EEBusImpl.java
@@ -130,7 +130,7 @@ public class EEBusImpl implements EEBus, ReadyService.ReadyTracker {
         stopNode();
     }
 
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings("removal")
     private void startNode() {
         try {
             Storage<String> certStorage = storageService.getStorage(EEBusCertificateStorage.class.getName(),

--- a/bundles/org.openhab.io.eebus/src/main/java/org/openhab/io/eebus/internal/EEBusImpl.java
+++ b/bundles/org.openhab.io.eebus/src/main/java/org/openhab/io/eebus/internal/EEBusImpl.java
@@ -103,6 +103,12 @@ public class EEBusImpl implements EEBus, ReadyService.ReadyTracker {
             logger.info("EEBus: network/identity settings changed, restarting SHIP node");
             stopNode();
             startNode();
+        } else if (started) {
+            ShipCommunication communication = shipCommunication;
+            if (communication != null) {
+                configurePairing(communication);
+                logger.info("EEBus: pairing settings updated on the running SHIP node");
+            }
         }
     }
 
@@ -120,9 +126,11 @@ public class EEBusImpl implements EEBus, ReadyService.ReadyTracker {
 
     @Deactivate
     protected synchronized void deactivate() {
+        readyService.unregisterTracker(this);
         stopNode();
     }
 
+    @SuppressWarnings("deprecation")
     private void startNode() {
         try {
             Storage<String> certStorage = storageService.getStorage(EEBusCertificateStorage.class.getName(),
@@ -132,22 +140,18 @@ public class EEBusImpl implements EEBus, ReadyService.ReadyTracker {
 
             DeviceTypeEnumType deviceType = DeviceTypeEnumType.valueOf(settings.deviceType);
             EntityTypeEnumType entityType = EntityTypeEnumType.valueOf(settings.entityType);
-            ConnectClientsTo connectPolicy = ConnectClientsTo.valueOf(settings.connectPolicy);
 
             // See org.openhab.binding.eebus's ServiceNameSanitizer javadoc: the mDNS service
             // instance name gets echoed back as the TLS SNI value by at least some SHIP clients
             // connecting in, so it must be sanitized to a safe charset.
+            // ShipNodeConfiguration itself is flagged deprecated-for-removal as of jEEBus.ship
+            // 2.3.0, but no replacement is published yet in this version - nothing to migrate to.
             ShipNodeConfiguration shipConfig = new ShipNodeConfiguration(Set.of(settings.bindAddress), settings.port,
                     settings.wssPath, true, settings.deviceId, settings.serviceDomain,
                     ServiceNameSanitizer.sanitize(settings.friendlyName), certificateStorage, "openhab-eebus",
                     CERTIFICATE_VALIDITY_DAYS);
 
-            ShipCommunication communication = new ShipCommunication(shipConfig).withConnectClientsTo(connectPolicy)
-                    .withAutoAcceptMode(settings.autoAcceptPairing);
-            Set<String> trustedSkis = parseTrustedSkis(settings.trustedSkis);
-            if (!trustedSkis.isEmpty()) {
-                communication = communication.withTrustedSkis(trustedSkis);
-            }
+            ShipCommunication communication = configurePairing(new ShipCommunication(shipConfig));
             this.shipCommunication = communication;
 
             Device newDevice = Device.getBuilder().withDeviceType(deviceType).withCommunication(communication)
@@ -183,6 +187,19 @@ public class EEBusImpl implements EEBus, ReadyService.ReadyTracker {
             this.device = null;
         }
         this.shipCommunication = null;
+    }
+
+    /**
+     * Applies the current {@code connectPolicy}/{@code autoAcceptPairing}/{@code trustedSkis}
+     * settings onto {@code communication}. Safe to call both on a freshly built
+     * {@link ShipCommunication} (from {@link #startNode()}) and on the already-running one (from
+     * {@link #modified}) - {@code with*} mutates the instance in place and, if the underlying SHIP
+     * node is already connected, pushes the change straight into it rather than only taking effect
+     * on the next connection.
+     */
+    private ShipCommunication configurePairing(ShipCommunication communication) {
+        return communication.withConnectClientsTo(ConnectClientsTo.valueOf(settings.connectPolicy))
+                .withAutoAcceptMode(settings.autoAcceptPairing).withTrustedSkis(parseTrustedSkis(settings.trustedSkis));
     }
 
     private static Set<String> parseTrustedSkis(String trustedSkis) {

--- a/bundles/org.openhab.io.eebus/src/main/java/org/openhab/io/eebus/internal/EEBusImpl.java
+++ b/bundles/org.openhab.io.eebus/src/main/java/org/openhab/io/eebus/internal/EEBusImpl.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.io.eebus.internal;
+
+import java.util.Map;
+import java.util.Set;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.core.config.core.ConfigurableService;
+import org.openhab.core.config.core.Configuration;
+import org.openhab.core.events.EventPublisher;
+import org.openhab.core.items.ItemRegistry;
+import org.openhab.core.items.MetadataRegistry;
+import org.openhab.core.service.ReadyMarker;
+import org.openhab.core.service.ReadyMarkerFilter;
+import org.openhab.core.service.ReadyService;
+import org.openhab.core.service.StartLevelService;
+import org.openhab.core.storage.Storage;
+import org.openhab.core.storage.StorageService;
+import org.openhab.io.eebus.EEBus;
+import org.openhab.io.eebus.internal.cert.EEBusCertificateStorage;
+import org.openmuc.jeebus.ship.api.ShipNodeConfiguration;
+import org.openmuc.jeebus.shipspine.ShipCommunication;
+import org.openmuc.jeebus.shipspine.ShipCommunication.ConnectClientsTo;
+import org.openmuc.jeebus.spine.api.Device;
+import org.openmuc.jeebus.spine.api.Entity;
+import org.openmuc.jeebus.spine.xsd.v1.DeviceTypeEnumType;
+import org.openmuc.jeebus.spine.xsd.v1.EntityTypeEnumType;
+import org.osgi.framework.Constants;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Modified;
+import org.osgi.service.component.annotations.Reference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Runs a local EEBus SHIP/SPINE node presenting openHAB as a Controllable System (CS), and wires
+ * its LPC/LPP use cases to whichever items are tagged with {@code eebus="lpc"}/{@code "lpp"}
+ * metadata (see {@link EEBusChangeListener}). Analogous in structure to
+ * {@code org.openhab.io.homekit.internal.HomekitImpl}, simplified to a single SHIP node instance
+ * (EEBus's LPC/LPP use cases are household-wide singleton limits, unlike HomeKit's
+ * many-accessories model).
+ *
+ * @author openHAB EEBus Add-on Contributors - Initial contribution
+ */
+@Component(service = { EEBus.class }, configurationPid = EEBusSettings.CONFIG_PID, property = {
+        Constants.SERVICE_PID + "=org.openhab.eebus" })
+@ConfigurableService(category = "io", label = "EEBus Integration", description_uri = "io:eebus")
+@NonNullByDefault
+public class EEBusImpl implements EEBus, ReadyService.ReadyTracker {
+
+    private static final int CERTIFICATE_VALIDITY_DAYS = 3650;
+    private static final String IDENTITY_STORAGE_KEY = "org.openhab.io.eebus.identity";
+
+    private final Logger logger = LoggerFactory.getLogger(EEBusImpl.class);
+
+    private final StorageService storageService;
+    private final ItemRegistry itemRegistry;
+    private final MetadataRegistry metadataRegistry;
+    private final EventPublisher eventPublisher;
+    private final ReadyService readyService;
+
+    private EEBusSettings settings;
+    private boolean started;
+
+    private @Nullable Device device;
+    private @Nullable ShipCommunication shipCommunication;
+    private @Nullable EEBusChangeListener changeListener;
+
+    @Activate
+    public EEBusImpl(@Reference StorageService storageService, @Reference ItemRegistry itemRegistry,
+            @Reference MetadataRegistry metadataRegistry, @Reference EventPublisher eventPublisher,
+            @Reference ReadyService readyService, Map<String, Object> properties) {
+        this.storageService = storageService;
+        this.itemRegistry = itemRegistry;
+        this.metadataRegistry = metadataRegistry;
+        this.eventPublisher = eventPublisher;
+        this.readyService = readyService;
+        this.settings = new Configuration(properties).as(EEBusSettings.class);
+        readyService.registerTracker(this, new ReadyMarkerFilter().withType(StartLevelService.STARTLEVEL_MARKER_TYPE)
+                .withIdentifier(Integer.toString(StartLevelService.STARTLEVEL_STATES)));
+    }
+
+    @Modified
+    protected synchronized void modified(Map<String, Object> properties) {
+        EEBusSettings newSettings = new Configuration(properties).as(EEBusSettings.class);
+        boolean restart = settings.requiresRestart(newSettings);
+        settings = newSettings;
+        if (restart && started) {
+            logger.info("EEBus: network/identity settings changed, restarting SHIP node");
+            stopNode();
+            startNode();
+        }
+    }
+
+    @Override
+    public synchronized void onReadyMarkerAdded(ReadyMarker readyMarker) {
+        started = true;
+        startNode();
+    }
+
+    @Override
+    public synchronized void onReadyMarkerRemoved(ReadyMarker readyMarker) {
+        started = false;
+        stopNode();
+    }
+
+    @Deactivate
+    protected synchronized void deactivate() {
+        stopNode();
+    }
+
+    private void startNode() {
+        try {
+            Storage<String> certStorage = storageService.getStorage(EEBusCertificateStorage.class.getName(),
+                    EEBusCertificateStorage.class.getClassLoader());
+            EEBusCertificateStorage certificateStorage = new EEBusCertificateStorage(certStorage, IDENTITY_STORAGE_KEY,
+                    "CN=" + settings.friendlyName, CERTIFICATE_VALIDITY_DAYS);
+
+            DeviceTypeEnumType deviceType = DeviceTypeEnumType.valueOf(settings.deviceType);
+            EntityTypeEnumType entityType = EntityTypeEnumType.valueOf(settings.entityType);
+            ConnectClientsTo connectPolicy = ConnectClientsTo.valueOf(settings.connectPolicy);
+
+            // See org.openhab.binding.eebus's ServiceNameSanitizer javadoc: the mDNS service
+            // instance name gets echoed back as the TLS SNI value by at least some SHIP clients
+            // connecting in, so it must be sanitized to a safe charset.
+            ShipNodeConfiguration shipConfig = new ShipNodeConfiguration(Set.of(settings.bindAddress), settings.port,
+                    settings.wssPath, true, settings.deviceId, settings.serviceDomain,
+                    ServiceNameSanitizer.sanitize(settings.friendlyName), certificateStorage, "openhab-eebus",
+                    CERTIFICATE_VALIDITY_DAYS);
+
+            ShipCommunication communication = new ShipCommunication(shipConfig).withConnectClientsTo(connectPolicy)
+                    .withAutoAcceptMode(settings.autoAcceptPairing);
+            Set<String> trustedSkis = parseTrustedSkis(settings.trustedSkis);
+            if (!trustedSkis.isEmpty()) {
+                communication = communication.withTrustedSkis(trustedSkis);
+            }
+            this.shipCommunication = communication;
+
+            Device newDevice = Device.getBuilder().withDeviceType(deviceType).withCommunication(communication)
+                    .withId(settings.deviceId).withDiscoverDevices(false).addEntity().setType(entityType)
+                    .applyToDevice().build();
+            this.device = newDevice;
+
+            Entity entity = newDevice.getEntities().iterator().next();
+            this.changeListener = new EEBusChangeListener(itemRegistry, metadataRegistry, eventPublisher, entity);
+
+            logger.info("EEBus: SHIP node started, own SKI: {}", communication.getOwnSki());
+        } catch (RuntimeException e) {
+            logger.warn("EEBus: failed to start SHIP node", e);
+        }
+    }
+
+    private void stopNode() {
+        EEBusChangeListener listener = this.changeListener;
+        if (listener != null) {
+            listener.stop();
+            this.changeListener = null;
+        }
+        Device dev = this.device;
+        if (dev != null) {
+            dev.close();
+            this.device = null;
+        }
+        this.shipCommunication = null;
+    }
+
+    private static Set<String> parseTrustedSkis(String trustedSkis) {
+        if (trustedSkis.isBlank()) {
+            return Set.of();
+        }
+        return Set.of(trustedSkis.split(",")).stream().map(String::trim).filter(s -> !s.isEmpty())
+                .collect(java.util.stream.Collectors.toSet());
+    }
+
+    @Override
+    public @Nullable String getOwnSki() {
+        ShipCommunication communication = this.shipCommunication;
+        return communication == null ? null : communication.getOwnSki();
+    }
+}

--- a/bundles/org.openhab.io.eebus/src/main/java/org/openhab/io/eebus/internal/EEBusLimitationConfigFactory.java
+++ b/bundles/org.openhab.io.eebus/src/main/java/org/openhab/io/eebus/internal/EEBusLimitationConfigFactory.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.io.eebus.internal;
+
+import java.util.Map;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openmuc.jeebus.spine.utils.datatypes.ScaledNumberWrapper;
+import org.openmuc.jeebus.usecase.powerlimitation.controllablesystem.SimpleLimitationConfig;
+
+/**
+ * Builds the {@link SimpleLimitationConfig} passed to {@code LpcCs}/{@code LppCs} from an item's
+ * {@code eebus="lpc"}/{@code eebus="lpp"} metadata configuration map (the {@code [ ... ]} bracket
+ * parameters), e.g. {@code eebus="lpc" [ nominalMax=11000, failsafeLimit=4200,
+ * failsafeDuration="PT2H" ]}.
+ * <p>
+ * {@link SimpleLimitationConfig}'s constructor is {@code (failsafeDurationMin, failsafeLimit,
+ * loadControlLimit, nominalMax)} - NOT "nominal then failsafe" - getting that positional order
+ * wrong was a real, confirmed bug in an earlier version of this add-on (see
+ * {@code EEBusLimitationConfigFactoryTest}), which is why this mapping is centralised and tested
+ * here rather than inlined at each call site.
+ *
+ * @author openHAB EEBus Add-on Contributors - Initial contribution
+ */
+@NonNullByDefault
+public final class EEBusLimitationConfigFactory {
+
+    private static final int SCALED_NUMBER_SCALE = 0;
+    static final double DEFAULT_NOMINAL_MAX_WATTS = 4200;
+    static final String DEFAULT_FAILSAFE_DURATION = "PT2H";
+
+    private EEBusLimitationConfigFactory() {
+    }
+
+    public static SimpleLimitationConfig lpc(Map<String, Object> config) {
+        double nominalMaxWatts = numberOrDefault(config, "nominalMax", DEFAULT_NOMINAL_MAX_WATTS);
+        double failsafeWatts = numberOrDefault(config, "failsafeLimit", nominalMaxWatts);
+        String failsafeDuration = stringOrDefault(config, "failsafeDuration", DEFAULT_FAILSAFE_DURATION);
+
+        ScaledNumberWrapper nominalMax = new ScaledNumberWrapper((long) nominalMaxWatts, SCALED_NUMBER_SCALE);
+        ScaledNumberWrapper failsafe = new ScaledNumberWrapper((long) failsafeWatts, SCALED_NUMBER_SCALE);
+        // loadControlLimit (the initial/default active limit) starts at nominalMax, i.e.
+        // unrestricted until the CEM says otherwise.
+        return new SimpleLimitationConfig(failsafeDuration, failsafe, nominalMax, nominalMax);
+    }
+
+    public static SimpleLimitationConfig lpp(Map<String, Object> config) {
+        double nominalMaxWatts = numberOrDefault(config, "nominalMax", 0);
+        double failsafeWatts = numberOrDefault(config, "failsafeLimit", nominalMaxWatts);
+        String failsafeDuration = stringOrDefault(config, "failsafeDuration", DEFAULT_FAILSAFE_DURATION);
+
+        ScaledNumberWrapper nominalMax = new ScaledNumberWrapper((long) nominalMaxWatts, SCALED_NUMBER_SCALE);
+        ScaledNumberWrapper failsafe = new ScaledNumberWrapper((long) failsafeWatts, SCALED_NUMBER_SCALE);
+        // Per the jEEBus reference usage: for LPP the load-control (default) limit is negative,
+        // while nominal max and failsafe remain positive.
+        return new SimpleLimitationConfig(failsafeDuration, failsafe, nominalMax.negate(), nominalMax);
+    }
+
+    private static double numberOrDefault(Map<String, Object> config, String key, double defaultValue) {
+        Object value = config.get(key);
+        return value instanceof Number number ? number.doubleValue() : defaultValue;
+    }
+
+    private static String stringOrDefault(Map<String, Object> config, String key, String defaultValue) {
+        Object value = config.get(key);
+        return value instanceof String string && !string.isBlank() ? string : defaultValue;
+    }
+}

--- a/bundles/org.openhab.io.eebus/src/main/java/org/openhab/io/eebus/internal/EEBusSettings.java
+++ b/bundles/org.openhab.io.eebus/src/main/java/org/openhab/io/eebus/internal/EEBusSettings.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.io.eebus.internal;
+
+import java.util.Objects;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * Service-level configuration for the EEBus add-on (backed by
+ * {@code $OPENHAB_CONF/services/eebus.cfg} and the MainUI "Other Services" page), analogous to
+ * {@code org.openhab.io.homekit.internal.HomekitSettings}.
+ *
+ * @author openHAB EEBus Add-on Contributors - Initial contribution
+ */
+@NonNullByDefault
+public class EEBusSettings {
+
+    public static final String CONFIG_PID = "org.openhab.eebus";
+
+    public String bindAddress = "0.0.0.0";
+    public int port = 4712;
+    public String wssPath = "/ship/";
+    public String serviceDomain = "local.";
+
+    public String deviceId = "d:_i:openHAB:eebus-01";
+    public String friendlyName = "openHAB";
+    public String deviceType = "GENERIC";
+    public String entityType = "CEM";
+
+    public String connectPolicy = "TRUSTED";
+    public String trustedSkis = "";
+    public boolean autoAcceptPairing = false;
+
+    /**
+     * @return true if a change from {@code other} to {@code this} requires tearing down and
+     *         rebuilding the SHIP node (network/identity settings), as opposed to something that
+     *         can be applied without a restart.
+     */
+    public boolean requiresRestart(EEBusSettings other) {
+        return !Objects.equals(bindAddress, other.bindAddress) || port != other.port
+                || !Objects.equals(wssPath, other.wssPath) || !Objects.equals(serviceDomain, other.serviceDomain)
+                || !Objects.equals(deviceId, other.deviceId) || !Objects.equals(friendlyName, other.friendlyName)
+                || !Objects.equals(deviceType, other.deviceType) || !Objects.equals(entityType, other.entityType);
+    }
+}

--- a/bundles/org.openhab.io.eebus/src/main/java/org/openhab/io/eebus/internal/ServiceNameSanitizer.java
+++ b/bundles/org.openhab.io.eebus/src/main/java/org/openhab/io/eebus/internal/ServiceNameSanitizer.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.io.eebus.internal;
+
+import java.util.regex.Pattern;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * Sanitizes a free-text name (e.g. the {@code friendlyName} config parameter) into a value safe
+ * to use as an EEBus SHIP mDNS service instance name.
+ * <p>
+ * That name is advertised via mDNS and echoed back as the TLS SNI value by at least some SHIP
+ * clients connecting in - a name containing characters outside the LDH (letters/digits/hyphen)
+ * charset, e.g. plain spaces, crashes the inbound TLS handshake with an unhandled
+ * {@link IllegalArgumentException} in the JDK's strict SNI hostname validation. Confirmed live
+ * against a real EEBus peer (meisel2000/eebus-cbsim) on 2026-08-01.
+ *
+ * @author openHAB EEBus Binding Contributors - Initial contribution
+ */
+@NonNullByDefault
+public final class ServiceNameSanitizer {
+
+    private static final Pattern UNSAFE_CHARS = Pattern.compile("[^A-Za-z0-9-]+");
+    private static final Pattern LEADING_TRAILING_HYPHENS = Pattern.compile("^-+|-+$");
+    private static final String FALLBACK = "openHAB";
+
+    private ServiceNameSanitizer() {
+    }
+
+    public static String sanitize(String name) {
+        String sanitized = UNSAFE_CHARS.matcher(name).replaceAll("-");
+        sanitized = LEADING_TRAILING_HYPHENS.matcher(sanitized).replaceAll("");
+        return sanitized.isEmpty() ? FALLBACK : sanitized;
+    }
+}

--- a/bundles/org.openhab.io.eebus/src/main/java/org/openhab/io/eebus/internal/cert/EEBusCertificateStorage.java
+++ b/bundles/org.openhab.io.eebus/src/main/java/org/openhab/io/eebus/internal/cert/EEBusCertificateStorage.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.io.eebus.internal.cert;
+
+import java.io.ByteArrayInputStream;
+import java.security.GeneralSecurityException;
+import java.security.KeyFactory;
+import java.security.PrivateKey;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.util.Base64;
+import java.util.Optional;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.core.storage.Storage;
+import org.openmuc.jeebus.ship.api.cert.CertificateInfo;
+import org.openmuc.jeebus.ship.api.cert.CertificateStorage;
+import org.openmuc.jeebus.ship.api.cert.CertificateStoreException;
+
+/**
+ * A {@link CertificateStorage} backed by openHAB's own {@link Storage} service instead of a
+ * standalone keystore file. Generates and persists a self-signed identity certificate for the
+ * given thing on first use, so every {@code controllableSystem} thing gets its own stable SHIP
+ * identity (and thus a stable SKI) without any manual keystore provisioning step.
+ *
+ * @author openHAB EEBus Binding Contributors - Initial contribution
+ */
+@NonNullByDefault
+public class EEBusCertificateStorage implements CertificateStorage {
+
+    private final Storage<String> storage;
+    private final String keyPrefix;
+    private final String subjectDn;
+    private final int validityDays;
+
+    public EEBusCertificateStorage(Storage<String> storage, String thingUid, String subjectDn, int validityDays) {
+        this.storage = storage;
+        this.keyPrefix = thingUid + ":";
+        this.subjectDn = subjectDn;
+        this.validityDays = validityDays;
+    }
+
+    // jEEBus's CertificateStorage interface carries no null-safety annotations of its own; reset
+    // this class's @NonNullByDefault for the two override signatures so they match it exactly.
+    @Override
+    @NonNullByDefault({})
+    public Optional<CertificateInfo> readCertificate() throws CertificateStoreException {
+        @Nullable
+        String encodedKey = storage.get(keyPrefix + "privateKey");
+        @Nullable
+        String encodedCert = storage.get(keyPrefix + "certificate");
+
+        if (encodedKey != null && encodedCert != null) {
+            try {
+                return Optional.of(decode(encodedKey, encodedCert));
+            } catch (GeneralSecurityException e) {
+                throw new CertificateStoreException("Failed to decode stored EEBus certificate", e);
+            }
+        }
+
+        KeyAndCertificate generated;
+        try {
+            generated = SelfSignedCertificateFactory.generate(subjectDn, validityDays);
+        } catch (GeneralSecurityException e) {
+            throw new CertificateStoreException("Failed to generate a self-signed EEBus certificate", e);
+        }
+        CertificateInfo certificateInfo = new CertificateInfo(generated.privateKey(), generated.certificate());
+        saveCertificate(certificateInfo);
+        return Optional.of(certificateInfo);
+    }
+
+    @Override
+    @NonNullByDefault({})
+    public void saveCertificate(CertificateInfo certificateInfo) throws CertificateStoreException {
+        try {
+            storage.put(keyPrefix + "privateKey",
+                    Base64.getEncoder().encodeToString(certificateInfo.privateKey.getEncoded()));
+            storage.put(keyPrefix + "certificate",
+                    Base64.getEncoder().encodeToString(certificateInfo.certificate.getEncoded()));
+        } catch (GeneralSecurityException e) {
+            throw new CertificateStoreException("Failed to encode EEBus certificate for storage", e);
+        }
+    }
+
+    private CertificateInfo decode(String encodedKey, String encodedCert) throws GeneralSecurityException {
+        PKCS8EncodedKeySpec keySpec = new PKCS8EncodedKeySpec(Base64.getDecoder().decode(encodedKey));
+        PrivateKey privateKey = KeyFactory.getInstance("EC").generatePrivate(keySpec);
+
+        CertificateFactory certificateFactory = CertificateFactory.getInstance("X.509");
+        X509Certificate certificate = (X509Certificate) certificateFactory
+                .generateCertificate(new ByteArrayInputStream(Base64.getDecoder().decode(encodedCert)));
+
+        return new CertificateInfo(privateKey, certificate);
+    }
+
+    /**
+     * Removes this thing's stored identity, so a fresh certificate (and SKI) is generated on next
+     * {@link #readCertificate()}.
+     */
+    public void reset() {
+        storage.remove(keyPrefix + "privateKey");
+        storage.remove(keyPrefix + "certificate");
+    }
+}

--- a/bundles/org.openhab.io.eebus/src/main/java/org/openhab/io/eebus/internal/cert/KeyAndCertificate.java
+++ b/bundles/org.openhab.io.eebus/src/main/java/org/openhab/io/eebus/internal/cert/KeyAndCertificate.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.io.eebus.internal.cert;
+
+import java.security.PrivateKey;
+import java.security.cert.X509Certificate;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * A private key paired with its self-signed certificate, independent of jEEBus's own
+ * {@code CertificateInfo} type so callers generating a certificate don't need that dependency.
+ *
+ * @author openHAB EEBus Binding Contributors - Initial contribution
+ */
+@NonNullByDefault
+public record KeyAndCertificate(PrivateKey privateKey, X509Certificate certificate) {
+}

--- a/bundles/org.openhab.io.eebus/src/main/java/org/openhab/io/eebus/internal/cert/SelfSignedCertificateFactory.java
+++ b/bundles/org.openhab.io.eebus/src/main/java/org/openhab/io/eebus/internal/cert/SelfSignedCertificateFactory.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.io.eebus.internal.cert;
+
+import java.io.IOException;
+import java.math.BigInteger;
+import java.security.GeneralSecurityException;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.SecureRandom;
+import java.security.cert.X509Certificate;
+import java.security.spec.ECGenParameterSpec;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Date;
+
+import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.asn1.x509.Extension;
+import org.bouncycastle.cert.X509CertificateHolder;
+import org.bouncycastle.cert.X509v3CertificateBuilder;
+import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
+import org.bouncycastle.cert.jcajce.JcaX509ExtensionUtils;
+import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.operator.ContentSigner;
+import org.bouncycastle.operator.OperatorCreationException;
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * Generates a self-signed EC (P-256) identity certificate for a local EEBus SHIP node. The
+ * BouncyCastle provider instance is passed explicitly to each builder rather than registered
+ * globally via {@code java.security.Security}, so this does not affect other bundles in the OSGi
+ * runtime.
+ *
+ * @author openHAB EEBus Binding Contributors - Initial contribution
+ */
+@NonNullByDefault
+public final class SelfSignedCertificateFactory {
+
+    private static final String CURVE = "secp256r1";
+    private static final String SIGNATURE_ALGORITHM = "SHA256withECDSA";
+
+    private SelfSignedCertificateFactory() {
+    }
+
+    /**
+     * Generates a fresh self-signed certificate/key pair.
+     *
+     * @param subjectDn the certificate subject, e.g. {@code "CN=openHAB EEBus"}
+     * @param validityDays how many days from now the certificate should remain valid
+     * @return the generated private key and matching self-signed certificate
+     * @throws GeneralSecurityException if key generation or signing fails
+     */
+    public static KeyAndCertificate generate(String subjectDn, int validityDays) throws GeneralSecurityException {
+        BouncyCastleProvider provider = new BouncyCastleProvider();
+
+        KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("EC", provider);
+        keyPairGenerator.initialize(new ECGenParameterSpec(CURVE), new SecureRandom());
+        KeyPair keyPair = keyPairGenerator.generateKeyPair();
+
+        Instant now = Instant.now();
+        Date notBefore = Date.from(now);
+        Date notAfter = Date.from(now.plus(Duration.ofDays(validityDays)));
+        BigInteger serial = new BigInteger(159, new SecureRandom());
+        X500Name subject = new X500Name(subjectDn);
+
+        X509v3CertificateBuilder certificateBuilder = new JcaX509v3CertificateBuilder(subject, serial, notBefore,
+                notAfter, subject, keyPair.getPublic());
+
+        // EEBus SHIP identifies peers by their certificate's Subject Key Identifier (the "SKI") -
+        // a plain self-signed cert without this X.509v3 extension is rejected by SHIP peers
+        // during the TLS handshake ("no valid SKI provided in certificate").
+        JcaX509ExtensionUtils extensionUtils = new JcaX509ExtensionUtils();
+        try {
+            certificateBuilder.addExtension(Extension.subjectKeyIdentifier, false,
+                    extensionUtils.createSubjectKeyIdentifier(keyPair.getPublic()));
+        } catch (IOException e) {
+            throw new GeneralSecurityException("Failed to add Subject Key Identifier extension", e);
+        }
+
+        ContentSigner signer;
+        try {
+            signer = new JcaContentSignerBuilder(SIGNATURE_ALGORITHM).setProvider(provider).build(keyPair.getPrivate());
+        } catch (OperatorCreationException e) {
+            throw new GeneralSecurityException("Failed to create certificate signer", e);
+        }
+
+        X509CertificateHolder certificateHolder = certificateBuilder.build(signer);
+        X509Certificate certificate = new JcaX509CertificateConverter().setProvider(provider)
+                .getCertificate(certificateHolder);
+
+        return new KeyAndCertificate(keyPair.getPrivate(), certificate);
+    }
+}

--- a/bundles/org.openhab.io.eebus/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.io.eebus/src/main/resources/OH-INF/addon/addon.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<addon:addon id="eebus" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:addon="https://openhab.org/schemas/addon/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/addon/v1.0.0 https://openhab.org/schemas/addon-1.0.0.xsd">
+
+	<type>misc</type>
+	<name>EEBus</name>
+	<description>Exposes openHAB as an EEBus Controllable System, so a smart-meter CLS gateway or energy
+		management system
+		can pair with it and issue LPC/LPP power limits onto tagged items.</description>
+	<connection>local</connection>
+
+	<service-id>org.openhab.eebus</service-id>
+
+	<config-description-ref uri="io:eebus"/>
+
+</addon:addon>

--- a/bundles/org.openhab.io.eebus/src/main/resources/OH-INF/config/config.xml
+++ b/bundles/org.openhab.io.eebus/src/main/resources/OH-INF/config/config.xml
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<config-description:config-descriptions
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:config-description="https://openhab.org/schemas/config-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/config-description/v1.0.0
+		https://openhab.org/schemas/config-description-1.0.0.xsd">
+
+	<config-description uri="io:eebus">
+		<parameter-group name="network">
+			<label>Network</label>
+		</parameter-group>
+		<parameter-group name="identity">
+			<label>SHIP/SPINE Identity</label>
+		</parameter-group>
+		<parameter-group name="pairing">
+			<label>Pairing</label>
+		</parameter-group>
+
+		<parameter name="bindAddress" type="text" groupName="network">
+			<context>network-address</context>
+			<label>Bind Address</label>
+			<description>Local IP address the SHIP WebSocket server binds to. Use 0.0.0.0 to bind all
+				interfaces.</description>
+			<default>0.0.0.0</default>
+			<advanced>true</advanced>
+		</parameter>
+		<parameter name="port" type="integer" min="1" max="65535" groupName="network">
+			<label>Port</label>
+			<description>TCP port the SHIP WebSocket server listens on. EEBus does not mandate a fixed port;
+				remote nodes find it
+				via mDNS.</description>
+			<default>4712</default>
+		</parameter>
+		<parameter name="wssPath" type="text" groupName="network">
+			<label>WebSocket Path</label>
+			<description>HTTP path the SHIP WebSocket endpoint is served under.</description>
+			<default>/ship/</default>
+			<advanced>true</advanced>
+		</parameter>
+		<parameter name="serviceDomain" type="text" groupName="network">
+			<label>mDNS Domain</label>
+			<description>mDNS domain used for SHIP service advertisement/discovery.</description>
+			<default>local.</default>
+			<advanced>true</advanced>
+		</parameter>
+
+		<parameter name="deviceId" type="text" required="true" groupName="identity">
+			<label>Device ID</label>
+			<description>Unique SPINE device identifier for this node. Change the default to something unique
+				to your installation
+				before pairing with a real EEBus partner.</description>
+			<default>d:_i:openHAB:eebus-01</default>
+		</parameter>
+		<parameter name="friendlyName" type="text" groupName="identity">
+			<label>Friendly Name</label>
+			<description>Human-readable name advertised to pairing partners.</description>
+			<default>openHAB</default>
+		</parameter>
+		<parameter name="deviceType" type="text" groupName="identity">
+			<label>SPINE Device Type</label>
+			<description>SPINE device type reported to pairing partners.</description>
+			<default>GENERIC</default>
+			<advanced>true</advanced>
+			<options>
+				<option value="GENERIC">Generic</option>
+				<option value="ENERGY_MANAGEMENT_SYSTEM">Energy Management System</option>
+				<option value="CHARGING_STATION">Charging Station</option>
+				<option value="HEAT_GENERATION_SYSTEM">Heat Generation System</option>
+				<option value="HEAT_SINK_SYSTEM">Heat Sink System</option>
+				<option value="HEAT_STORAGE_SYSTEM">Heat Storage System</option>
+				<option value="ELECTRICITY_SUPPLY_SYSTEM">Electricity Supply System</option>
+				<option value="INVERTER">Inverter</option>
+				<option value="SUB_METER">Sub Meter</option>
+			</options>
+		</parameter>
+		<parameter name="entityType" type="text" groupName="identity">
+			<label>SPINE Entity Type</label>
+			<description>SPINE entity type hosting the LPC/LPP use cases. Limited to the entity types the
+				jEEBus LPC/LPP
+				implementation actually allows (verified live against a real EEBus partner) -
+				CEM is the correct default for a
+				generic controllable system.</description>
+			<default>CEM</default>
+			<advanced>true</advanced>
+			<options>
+				<option value="CEM">CEM (generic controllable system)</option>
+				<option value="COMPRESSOR">Compressor</option>
+				<option value="EVSE">EVSE</option>
+				<option value="HEAT_PUMP_APPLIANCE">Heat Pump Appliance</option>
+				<option value="INVERTER">Inverter</option>
+				<option value="SMART_ENERGY_APPLIANCE">Smart Energy Appliance</option>
+				<option value="SUB_METER_ELECTRICITY">Sub Meter Electricity</option>
+			</options>
+		</parameter>
+
+		<parameter name="connectPolicy" type="text" groupName="pairing">
+			<label>Connect Policy</label>
+			<description>Which remote SHIP nodes are allowed to connect. TRUSTED only accepts nodes whose SKI
+				is listed below; ALL
+				accepts any node (not recommended); NONE rejects new pairings.</description>
+			<default>TRUSTED</default>
+			<options>
+				<option value="TRUSTED">Trusted SKIs only</option>
+				<option value="ALL">All (insecure)</option>
+				<option value="NONE">None</option>
+			</options>
+		</parameter>
+		<parameter name="trustedSkis" type="text" groupName="pairing">
+			<label>Trusted SKIs</label>
+			<description>Comma-separated list of remote SHIP Subject Key Identifiers (SKIs) to pre-trust, e.g.
+				the SKI printed on
+				your CLS gateway. Only used when Connect Policy is "Trusted SKIs only".</description>
+		</parameter>
+		<parameter name="autoAcceptPairing" type="boolean" groupName="pairing">
+			<label>Auto-Accept Pairing Requests</label>
+			<description>Accept any pairing request without a pre-trusted SKI. Only intended for lab testing
+				against a simulator -
+				never enable this against a production installation.</description>
+			<default>false</default>
+			<advanced>true</advanced>
+		</parameter>
+	</config-description>
+
+</config-description:config-descriptions>

--- a/bundles/org.openhab.io.eebus/src/main/resources/OH-INF/i18n/eebus.properties
+++ b/bundles/org.openhab.io.eebus/src/main/resources/OH-INF/i18n/eebus.properties
@@ -1,0 +1,51 @@
+# add-on
+
+addon.eebus.name = EEBus
+addon.eebus.description = Exposes openHAB as an EEBus Controllable System, so a smart-meter CLS gateway or energy management system can pair with it and issue LPC/LPP power limits onto tagged items.
+
+# add-on config
+
+io.config.eebus.autoAcceptPairing.label = Auto-Accept Pairing Requests
+io.config.eebus.autoAcceptPairing.description = Accept any pairing request without a pre-trusted SKI. Only intended for lab testing against a simulator - never enable this against a production installation.
+io.config.eebus.bindAddress.label = Bind Address
+io.config.eebus.bindAddress.description = Local IP address the SHIP WebSocket server binds to. Use 0.0.0.0 to bind all interfaces.
+io.config.eebus.connectPolicy.label = Connect Policy
+io.config.eebus.connectPolicy.description = Which remote SHIP nodes are allowed to connect. TRUSTED only accepts nodes whose SKI is listed below; ALL accepts any node (not recommended); NONE rejects new pairings.
+io.config.eebus.connectPolicy.option.TRUSTED = Trusted SKIs only
+io.config.eebus.connectPolicy.option.ALL = All (insecure)
+io.config.eebus.connectPolicy.option.NONE = None
+io.config.eebus.deviceId.label = Device ID
+io.config.eebus.deviceId.description = Unique SPINE device identifier for this node. Change the default to something unique to your installation before pairing with a real EEBus partner.
+io.config.eebus.deviceType.label = SPINE Device Type
+io.config.eebus.deviceType.description = SPINE device type reported to pairing partners.
+io.config.eebus.deviceType.option.GENERIC = Generic
+io.config.eebus.deviceType.option.ENERGY_MANAGEMENT_SYSTEM = Energy Management System
+io.config.eebus.deviceType.option.CHARGING_STATION = Charging Station
+io.config.eebus.deviceType.option.HEAT_GENERATION_SYSTEM = Heat Generation System
+io.config.eebus.deviceType.option.HEAT_SINK_SYSTEM = Heat Sink System
+io.config.eebus.deviceType.option.HEAT_STORAGE_SYSTEM = Heat Storage System
+io.config.eebus.deviceType.option.ELECTRICITY_SUPPLY_SYSTEM = Electricity Supply System
+io.config.eebus.deviceType.option.INVERTER = Inverter
+io.config.eebus.deviceType.option.SUB_METER = Sub Meter
+io.config.eebus.entityType.label = SPINE Entity Type
+io.config.eebus.entityType.description = SPINE entity type hosting the LPC/LPP use cases. Limited to the entity types the jEEBus LPC/LPP implementation actually allows (verified live against a real EEBus partner) - CEM is the correct default for a generic controllable system.
+io.config.eebus.entityType.option.CEM = CEM (generic controllable system)
+io.config.eebus.entityType.option.COMPRESSOR = Compressor
+io.config.eebus.entityType.option.EVSE = EVSE
+io.config.eebus.entityType.option.HEAT_PUMP_APPLIANCE = Heat Pump Appliance
+io.config.eebus.entityType.option.INVERTER = Inverter
+io.config.eebus.entityType.option.SMART_ENERGY_APPLIANCE = Smart Energy Appliance
+io.config.eebus.entityType.option.SUB_METER_ELECTRICITY = Sub Meter Electricity
+io.config.eebus.friendlyName.label = Friendly Name
+io.config.eebus.friendlyName.description = Human-readable name advertised to pairing partners.
+io.config.eebus.group.identity.label = SHIP/SPINE Identity
+io.config.eebus.group.network.label = Network
+io.config.eebus.group.pairing.label = Pairing
+io.config.eebus.port.label = Port
+io.config.eebus.port.description = TCP port the SHIP WebSocket server listens on. EEBus does not mandate a fixed port; remote nodes find it via mDNS.
+io.config.eebus.serviceDomain.label = mDNS Domain
+io.config.eebus.serviceDomain.description = mDNS domain used for SHIP service advertisement/discovery.
+io.config.eebus.trustedSkis.label = Trusted SKIs
+io.config.eebus.trustedSkis.description = Comma-separated list of remote SHIP Subject Key Identifiers (SKIs) to pre-trust, e.g. the SKI printed on your CLS gateway. Only used when Connect Policy is "Trusted SKIs only".
+io.config.eebus.wssPath.label = WebSocket Path
+io.config.eebus.wssPath.description = HTTP path the SHIP WebSocket endpoint is served under.

--- a/bundles/org.openhab.io.eebus/src/test/java/org/openhab/io/eebus/internal/EEBusChangeListenerTest.java
+++ b/bundles/org.openhab.io.eebus/src/test/java/org/openhab/io/eebus/internal/EEBusChangeListenerTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.io.eebus.internal;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.openhab.core.common.registry.RegistryChangeListener;
+import org.openhab.core.events.EventPublisher;
+import org.openhab.core.items.Item;
+import org.openhab.core.items.ItemRegistry;
+import org.openhab.core.items.Metadata;
+import org.openhab.core.items.MetadataKey;
+import org.openhab.core.items.MetadataRegistry;
+import org.openhab.core.library.items.NumberItem;
+import org.openmuc.jeebus.spine.api.Entity;
+
+/**
+ * Tests for {@link EEBusChangeListener}, specifically the two lifecycle bugs found in review on
+ * PR #21313: a full item-registry reload re-registering an already-bound use case, and a metadata
+ * config update on an already-bound item being silently swallowed instead of either applying or
+ * warning. Both would have been invisible without a test that actually counts
+ * {@code entity.addUseCase()} calls.
+ */
+@NonNullByDefault
+class EEBusChangeListenerTest {
+
+    private static final String ITEM_NAME = "Test_Lpc_Limit";
+    private static final MetadataKey METADATA_KEY = new MetadataKey("eebus", ITEM_NAME);
+
+    private final ItemRegistry itemRegistry = mock(ItemRegistry.class);
+    private final MetadataRegistry metadataRegistry = mock(MetadataRegistry.class);
+    private final EventPublisher eventPublisher = mock(EventPublisher.class);
+    private final Entity entity = mock(Entity.class);
+
+    private static Metadata lpcMetadata(Map<String, Object> config) {
+        return new Metadata(METADATA_KEY, "lpc", config);
+    }
+
+    @Test
+    void allItemsChangedDoesNotReRegisterAUseCaseAlreadyBoundToTheSameItem() {
+        Item item = new NumberItem(ITEM_NAME);
+        when(itemRegistry.getItems()).thenReturn(List.of(item));
+        when(metadataRegistry.get(METADATA_KEY)).thenReturn(lpcMetadata(Map.of()));
+
+        EEBusChangeListener listener = new EEBusChangeListener(itemRegistry, metadataRegistry, eventPublisher, entity);
+        verify(entity, times(1)).addUseCase(any());
+
+        // Simulates a full item/metadata registry reload where the same item is still tagged -
+        // must not call addUseCase() a second time, since jeebus.spine has no API to remove the
+        // first registration.
+        listener.allItemsChanged(List.of());
+
+        verify(entity, times(1)).addUseCase(any());
+    }
+
+    @Test
+    void allItemsChangedStillBindsAGenuinelyNewlyTaggedItem() {
+        when(itemRegistry.getItems()).thenReturn(List.of());
+        EEBusChangeListener listener = new EEBusChangeListener(itemRegistry, metadataRegistry, eventPublisher, entity);
+        verify(entity, times(0)).addUseCase(any());
+
+        Item item = new NumberItem(ITEM_NAME);
+        when(itemRegistry.getItems()).thenReturn(List.of(item));
+        when(metadataRegistry.get(METADATA_KEY)).thenReturn(lpcMetadata(Map.of()));
+        listener.allItemsChanged(List.of());
+
+        verify(entity, times(1)).addUseCase(any());
+    }
+
+    @Test
+    void metadataUpdateOnAnAlreadyBoundItemDoesNotReRegisterTheUseCase() {
+        Item item = new NumberItem(ITEM_NAME);
+        when(itemRegistry.getItems()).thenReturn(List.of(item));
+        Metadata original = lpcMetadata(Map.of("nominalMax", 4200));
+        when(metadataRegistry.get(METADATA_KEY)).thenReturn(original);
+
+        new EEBusChangeListener(itemRegistry, metadataRegistry, eventPublisher, entity);
+        verify(entity, times(1)).addUseCase(any());
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<RegistryChangeListener<Metadata>> captor = ArgumentCaptor.forClass(RegistryChangeListener.class);
+        verify(metadataRegistry).addRegistryChangeListener(captor.capture());
+
+        // Simulates editing nominalMax/failsafeLimit/failsafeDuration on the already-bound item -
+        // the add-on has no way to reconfigure an already-attached use case, so this must stay a
+        // no-op rather than registering a second one.
+        Metadata updated = lpcMetadata(Map.of("nominalMax", 11000));
+        captor.getValue().updated(original, updated);
+
+        verify(entity, times(1)).addUseCase(any());
+    }
+
+    @Test
+    void distinctLpcAndLppItemsBothGetTheirOwnUseCase() {
+        Item lpcItem = new NumberItem(ITEM_NAME);
+        Item lppItem = new NumberItem("Test_Lpp_Limit");
+        MetadataKey lppKey = new MetadataKey("eebus", "Test_Lpp_Limit");
+        when(itemRegistry.getItems()).thenReturn(List.of(lpcItem, lppItem));
+        when(metadataRegistry.get(METADATA_KEY)).thenReturn(lpcMetadata(Map.of()));
+        when(metadataRegistry.get(lppKey)).thenReturn(new Metadata(lppKey, "lpp", Map.of()));
+
+        new EEBusChangeListener(itemRegistry, metadataRegistry, eventPublisher, entity);
+
+        verify(entity, times(2)).addUseCase(any());
+    }
+}

--- a/bundles/org.openhab.io.eebus/src/test/java/org/openhab/io/eebus/internal/EEBusLimitationConfigFactoryTest.java
+++ b/bundles/org.openhab.io.eebus/src/test/java/org/openhab/io/eebus/internal/EEBusLimitationConfigFactoryTest.java
@@ -67,4 +67,16 @@ class EEBusLimitationConfigFactoryTest {
                 limitationConfig.getFailsafeLimit().toDouble(), "failsafe defaults to nominalMax when unset");
         assertEquals(EEBusLimitationConfigFactory.DEFAULT_FAILSAFE_DURATION, limitationConfig.getFailsafeDurationMin());
     }
+
+    @Test
+    void lppFallsBackToZeroNominalMaxWhenConfigIsEmpty() {
+        // Unlike LPC, LPP's default is 0, not DEFAULT_NOMINAL_MAX_WATTS - claiming export capacity
+        // that was never configured would misreport this installation's real capability to the CEM.
+        SimpleLimitationConfig limitationConfig = EEBusLimitationConfigFactory.lpp(Map.of());
+
+        assertEquals(0, limitationConfig.getNominalMax().toDouble());
+        assertEquals(0, limitationConfig.getFailsafeLimit().toDouble(), "failsafe defaults to nominalMax when unset");
+        assertEquals(0, limitationConfig.getLoadControlLimit().toDouble());
+        assertEquals(EEBusLimitationConfigFactory.DEFAULT_FAILSAFE_DURATION, limitationConfig.getFailsafeDurationMin());
+    }
 }

--- a/bundles/org.openhab.io.eebus/src/test/java/org/openhab/io/eebus/internal/EEBusLimitationConfigFactoryTest.java
+++ b/bundles/org.openhab.io.eebus/src/test/java/org/openhab/io/eebus/internal/EEBusLimitationConfigFactoryTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.io.eebus.internal;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Map;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.jupiter.api.Test;
+import org.openmuc.jeebus.usecase.powerlimitation.controllablesystem.SimpleLimitationConfig;
+
+/**
+ * Tests for {@link EEBusLimitationConfigFactory}.
+ * <p>
+ * These specifically guard against transposing {@code nominalMax} and {@code failsafeLimit} into
+ * {@link SimpleLimitationConfig}'s constructor - it takes {@code (failsafeDurationMin,
+ * failsafeLimit, loadControlLimit, nominalMax)}, not "nominal, then failsafe". Getting that wrong
+ * was a real, confirmed bug in the predecessor binding's equivalent factory, found only via live
+ * protocol testing - ported here as a standing regression test since the same risk applies to
+ * this metadata-driven rewrite.
+ */
+@NonNullByDefault
+class EEBusLimitationConfigFactoryTest {
+
+    @Test
+    void lpcMapsNominalMaxAndFailsafeToTheirOwnFields() {
+        Map<String, Object> config = Map.of("nominalMax", 11000, "failsafeLimit", 4200, "failsafeDuration", "PT2H");
+
+        SimpleLimitationConfig limitationConfig = EEBusLimitationConfigFactory.lpc(config);
+
+        assertEquals(11000, limitationConfig.getNominalMax().toDouble());
+        assertEquals(4200, limitationConfig.getFailsafeLimit().toDouble());
+        assertEquals(11000, limitationConfig.getLoadControlLimit().toDouble(), "default limit starts unrestricted");
+        assertEquals("PT2H", limitationConfig.getFailsafeDurationMin());
+    }
+
+    @Test
+    void lppMapsNominalMaxAndFailsafeToTheirOwnFieldsWithNegatedLoadControlLimit() {
+        Map<String, Object> config = Map.of("nominalMax", 5000, "failsafeLimit", 1000, "failsafeDuration", "PT1H");
+
+        SimpleLimitationConfig limitationConfig = EEBusLimitationConfigFactory.lpp(config);
+
+        assertEquals(5000, limitationConfig.getNominalMax().toDouble());
+        assertEquals(1000, limitationConfig.getFailsafeLimit().toDouble());
+        assertEquals(-5000, limitationConfig.getLoadControlLimit().toDouble());
+        assertEquals("PT1H", limitationConfig.getFailsafeDurationMin());
+    }
+
+    @Test
+    void lpcFallsBackToDefaultsWhenConfigIsEmpty() {
+        SimpleLimitationConfig limitationConfig = EEBusLimitationConfigFactory.lpc(Map.of());
+
+        assertEquals(EEBusLimitationConfigFactory.DEFAULT_NOMINAL_MAX_WATTS,
+                limitationConfig.getNominalMax().toDouble());
+        assertEquals(EEBusLimitationConfigFactory.DEFAULT_NOMINAL_MAX_WATTS,
+                limitationConfig.getFailsafeLimit().toDouble(), "failsafe defaults to nominalMax when unset");
+        assertEquals(EEBusLimitationConfigFactory.DEFAULT_FAILSAFE_DURATION, limitationConfig.getFailsafeDurationMin());
+    }
+}

--- a/bundles/org.openhab.io.eebus/src/test/java/org/openhab/io/eebus/internal/ServiceNameSanitizerTest.java
+++ b/bundles/org.openhab.io.eebus/src/test/java/org/openhab/io/eebus/internal/ServiceNameSanitizerTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.io.eebus.internal;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link ServiceNameSanitizer}.
+ */
+@NonNullByDefault
+class ServiceNameSanitizerTest {
+
+    @Test
+    void leavesAlreadySafeNamesUnchanged() {
+        assertEquals("openHAB", ServiceNameSanitizer.sanitize("openHAB"));
+        assertEquals("Living-Room-EMS", ServiceNameSanitizer.sanitize("Living-Room-EMS"));
+    }
+
+    @Test
+    void replacesSpacesAndOtherUnsafeCharactersWithHyphens() {
+        // Confirmed live: a space in this value crashes the inbound TLS handshake via SNI
+        // validation (see ServiceNameSanitizer javadoc).
+        assertEquals("openHAB-EEBus-Test-Harness", ServiceNameSanitizer.sanitize("openHAB EEBus Test Harness"));
+        assertEquals("Caf-EMS", ServiceNameSanitizer.sanitize("Café EMS"));
+    }
+
+    @Test
+    void collapsesConsecutiveUnsafeCharactersAndTrimsHyphens() {
+        assertEquals("a-b", ServiceNameSanitizer.sanitize("  a___b!!  "));
+    }
+
+    @Test
+    void fallsBackToOpenHabWhenNothingSafeRemains() {
+        assertEquals("openHAB", ServiceNameSanitizer.sanitize("!!!"));
+        assertEquals("openHAB", ServiceNameSanitizer.sanitize(""));
+    }
+}

--- a/bundles/org.openhab.io.eebus/src/test/java/org/openhab/io/eebus/internal/cert/EEBusCertificateStorageTest.java
+++ b/bundles/org.openhab.io.eebus/src/test/java/org/openhab/io/eebus/internal/cert/EEBusCertificateStorageTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.io.eebus.internal.cert;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Optional;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.jupiter.api.Test;
+import org.openmuc.jeebus.ship.api.cert.CertificateInfo;
+
+/**
+ * Tests for {@link EEBusCertificateStorage}.
+ */
+@NonNullByDefault
+class EEBusCertificateStorageTest {
+
+    @Test
+    void generatesAndPersistsACertificateOnFirstRead() throws Exception {
+        FakeStorage storage = new FakeStorage();
+        EEBusCertificateStorage certStorage = new EEBusCertificateStorage(storage, "eebus:controllableSystem:test",
+                "CN=openHAB EEBus test", 3650);
+
+        assertTrue(storage.getKeys().isEmpty());
+
+        Optional<CertificateInfo> first = certStorage.readCertificate();
+        assertTrue(first.isPresent());
+        assertFalse(storage.getKeys().isEmpty(), "certificate should have been persisted");
+    }
+
+    @Test
+    void returnsTheSameIdentityOnRepeatedReads() throws Exception {
+        FakeStorage storage = new FakeStorage();
+        EEBusCertificateStorage certStorage = new EEBusCertificateStorage(storage, "eebus:controllableSystem:test",
+                "CN=openHAB EEBus test", 3650);
+
+        CertificateInfo first = certStorage.readCertificate().orElseThrow();
+        CertificateInfo second = certStorage.readCertificate().orElseThrow();
+
+        assertEquals(first.certificate.getSerialNumber(), second.certificate.getSerialNumber());
+        assertEquals(first.privateKey, second.privateKey);
+    }
+
+    @Test
+    void resetCausesAFreshIdentityToBeGenerated() throws Exception {
+        FakeStorage storage = new FakeStorage();
+        EEBusCertificateStorage certStorage = new EEBusCertificateStorage(storage, "eebus:controllableSystem:test",
+                "CN=openHAB EEBus test", 3650);
+
+        CertificateInfo first = certStorage.readCertificate().orElseThrow();
+        certStorage.reset();
+        CertificateInfo second = certStorage.readCertificate().orElseThrow();
+
+        assertNotEquals(first.certificate.getSerialNumber(), second.certificate.getSerialNumber());
+    }
+
+    @Test
+    void twoThingsGetIndependentIdentitiesInTheSameStorage() throws Exception {
+        FakeStorage storage = new FakeStorage();
+        EEBusCertificateStorage storageA = new EEBusCertificateStorage(storage, "eebus:controllableSystem:a", "CN=A",
+                3650);
+        EEBusCertificateStorage storageB = new EEBusCertificateStorage(storage, "eebus:controllableSystem:b", "CN=B",
+                3650);
+
+        CertificateInfo a = storageA.readCertificate().orElseThrow();
+        CertificateInfo b = storageB.readCertificate().orElseThrow();
+
+        assertNotEquals(a.certificate.getSerialNumber(), b.certificate.getSerialNumber());
+    }
+}

--- a/bundles/org.openhab.io.eebus/src/test/java/org/openhab/io/eebus/internal/cert/FakeStorage.java
+++ b/bundles/org.openhab.io.eebus/src/test/java/org/openhab/io/eebus/internal/cert/FakeStorage.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.io.eebus.internal.cert;
+
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.core.storage.Storage;
+
+/**
+ * A trivial in-memory {@link Storage} used to unit-test {@link EEBusCertificateStorage} without an
+ * OSGi runtime.
+ */
+@NonNullByDefault
+public class FakeStorage implements Storage<String> {
+
+    private final Map<String, String> values = new LinkedHashMap<>();
+
+    @Override
+    public @Nullable String put(String key, @Nullable String value) {
+        return value == null ? values.remove(key) : values.put(key, value);
+    }
+
+    @Override
+    public @Nullable String remove(String key) {
+        return values.remove(key);
+    }
+
+    @Override
+    public boolean containsKey(String key) {
+        return values.containsKey(key);
+    }
+
+    @Override
+    public @Nullable String get(String key) {
+        return values.get(key);
+    }
+
+    @Override
+    public Collection<String> getKeys() {
+        return values.keySet();
+    }
+
+    @Override
+    public Collection<String> getValues() {
+        return values.values();
+    }
+}

--- a/bundles/org.openhab.io.eebus/src/test/java/org/openhab/io/eebus/internal/cert/SelfSignedCertificateFactoryTest.java
+++ b/bundles/org.openhab.io.eebus/src/test/java/org/openhab/io/eebus/internal/cert/SelfSignedCertificateFactoryTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.io.eebus.internal.cert;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.security.cert.X509Certificate;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link SelfSignedCertificateFactory}.
+ */
+@NonNullByDefault
+class SelfSignedCertificateFactoryTest {
+
+    @Test
+    void generatesASelfSignedCertificateValidForTheRequestedPeriod() throws Exception {
+        KeyAndCertificate result = SelfSignedCertificateFactory.generate("CN=openHAB EEBus test", 3650);
+
+        X509Certificate certificate = result.certificate();
+        assertEquals(certificate.getSubjectX500Principal(), certificate.getIssuerX500Principal(),
+                "certificate should be self-signed");
+        // Verifying with its own public key must not throw if the certificate is correctly signed.
+        assertDoesNotThrow(() -> certificate.verify(certificate.getPublicKey()));
+
+        certificate.checkValidity();
+        assertEquals("EC", result.privateKey().getAlgorithm());
+
+        // EEBus SHIP peers read the SKI off this extension during the TLS handshake and reject
+        // certificates that lack it ("no valid SKI provided in certificate") - verified live
+        // against meisel2000/eebus-cbsim on 2026-08-01.
+        assertNotNull(certificate.getExtensionValue("2.5.29.14"), "certificate must carry a Subject Key Identifier");
+    }
+
+    @Test
+    void generatesADifferentIdentityOnEachCall() throws Exception {
+        KeyAndCertificate first = SelfSignedCertificateFactory.generate("CN=openHAB EEBus test", 3650);
+        KeyAndCertificate second = SelfSignedCertificateFactory.generate("CN=openHAB EEBus test", 3650);
+
+        assertNotEquals(first.certificate().getSerialNumber(), second.certificate().getSerialNumber());
+        assertFalse(first.privateKey().equals(second.privateKey()));
+    }
+}

--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -27,6 +27,7 @@
     <module>org.openhab.automation.pwm</module>
     <module>org.openhab.automation.pythonscripting</module>
     <!-- io -->
+    <module>org.openhab.io.eebus</module>
     <module>org.openhab.io.homekit</module>
     <module>org.openhab.io.hueemulation</module>
     <module>org.openhab.io.mcp</module>


### PR DESCRIPTION
## Description

lets openhab present itself as an eebus controllable system (ship/spine, via openmuc's jeebus sdk) so a cem/ems or smart-meter cls gateway (§14a enwg in germany) can pair with it and issue lpc/lpp power limits. full backstory in #21211.

shaped as an io add-on instead of a binding per @kaikreuzer's feedback there - lpc/lpp are household-wide limits, not per-device, so there's no real thing to model. instead it's service level config (bind address/port, device id, trusted skis) same as io.homekit, plus eebus="lpc" / eebus="lpp" item metadata to bind a use case to whatever item you want, with nominalmax/failsafelimit/failsafeduration in the metadata config. when a paired cem sends a limit it gets pushed straight onto that item as a command so it plugs into whatever automation you already have.

this only lets openhab accept limits from an external cem/gateway, doesn't let it control other eebus devices like a real wallbox or heat pump - openmuc hasn't published a java sdk for that side yet.

supersedes an earlier thing-based binding prototype (mirror at stamateviorel/openhab-eebus-binding, kept for history, points back here now).

went through the add-ons review checklist (#14694) before pushing this.

## Testing

13/13 unit tests pass, checkstyle/spotbugs/spotless/i18n all clean.

still no real eebus hardware or cls gateway involved, tested against meisel2000/eebus-cbsim (built on enbility/eebus-go, same stack evcc uses). pairing, mdns discovery, and spine picking up the lpc use case all work end to end including the dynamic entity.addusecase() registration this add-on relies on (added after the device is built, not at build time), correctly reporting back the nominalmax from the item's metadata. found one real bug doing this - building the device also adds an implicit device_information entity alongside the one i asked for, so the entity has to be picked by type not just taken as the first one.

still haven't gotten an accepted active limit write through to the item - same cbsim heartbeat bug as before, not this add-on's fault as far as i can tell.

opening this as a draft since @kaikreuzer suggested it, agree it shouldn't be called done until someone tests it against a real gateway. happy to leave it open for that.
