### PR TITLE
[pipertts] Upgrade to piper-jni 1.4.2 to fix native lib loading

### DIFF
--- a/bundles/org.openhab.voice.pipertts/README.md
+++ b/bundles/org.openhab.voice.pipertts/README.md
@@ -6,7 +6,7 @@ This voice service allows you to use [Piper](https://github.com/OHF-Voice/piper1
 ::: tip Note
 This add-on depends on native libraries that cannot be included with the openHAB distribution due to their license.
 The add-on will download these native dependencies automatically on first activation.
-In case your openHAB server has no internet connection, you need to download the [piper-jni JAR file](https://repo1.maven.org/maven2/io/github/jvoice-project/piper-jni/1.4.1/piper-jni-1.4.1.jar) and place it into `<OPENHAB_USERDATA>/piper/`.
+In case your openHAB server has no internet connection, you need to download the [piper-jni JAR file](https://repo1.maven.org/maven2/io/github/jvoice-project/piper-jni/1.4.2/piper-jni-1.4.2.jar) and place it into `<OPENHAB_USERDATA>/piper/`.
 :::
 
 ## Supported platforms

--- a/bundles/org.openhab.voice.pipertts/pom.xml
+++ b/bundles/org.openhab.voice.pipertts/pom.xml
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>io.github.jvoice-project</groupId>
       <artifactId>piper-jni</artifactId>
-      <version>1.4.1</version>
+      <version>1.4.2</version>
     </dependency>
   </dependencies>
 

--- a/bundles/org.openhab.voice.pipertts/src/main/java/org/openhab/voice/pipertts/internal/PiperTTSService.java
+++ b/bundles/org.openhab.voice.pipertts/src/main/java/org/openhab/voice/pipertts/internal/PiperTTSService.java
@@ -120,7 +120,7 @@ public class PiperTTSService extends AbstractCachedTTSService {
                 logger.debug("Using Piper version {}", piper.getPiperVersion());
                 ready = true;
             } catch (Throwable t) {
-                logger.warn("Piper registration failed, the add-on will not work: {}", t.getMessage(), t);
+                logger.error("Piper registration failed, the add-on will not work: {}", t.getMessage(), t);
             }
         });
         configChange(config);

--- a/bundles/org.openhab.voice.pipertts/src/main/java/org/openhab/voice/pipertts/internal/PiperTTSService.java
+++ b/bundles/org.openhab.voice.pipertts/src/main/java/org/openhab/voice/pipertts/internal/PiperTTSService.java
@@ -87,7 +87,7 @@ import io.github.jvoiceproject.piperjni.PiperVoice;
         + " Text-to-Speech", description_uri = SERVICE_CATEGORY + ":" + SERVICE_ID)
 public class PiperTTSService extends AbstractCachedTTSService {
     // piper-jni version from pom.xml
-    private static final String PIPER_VERSION = "1.4.1";
+    private static final String PIPER_VERSION = "1.4.2";
     private static final Path PIPER_FOLDER = Path.of(OpenHAB.getUserDataFolder(), "piper");
     private static final Path LIB_FOLDER = PIPER_FOLDER.resolve("lib-" + PIPER_VERSION);
     private static final Path JAR_FILE = PIPER_FOLDER.resolve("piper-jni-" + PIPER_VERSION + ".jar");
@@ -101,28 +101,26 @@ public class PiperTTSService extends AbstractCachedTTSService {
     private boolean ready = false;
     private @Nullable VoiceModel preloadedModel;
     private @Nullable PiperJNI piper;
-    private @Nullable Future<?> activateTask;
-    static {
-        System.setProperty("io.github.jvoiceproject.piperjni.libdir", LIB_FOLDER.toAbsolutePath().toString());
-    }
+    private final Future<?> activateTask;
 
     @Activate
-    public PiperTTSService(final @Reference TTSCache ttsCache) {
+    public PiperTTSService(final @Reference TTSCache ttsCache, Map<String, Object> config) {
         super(ttsCache);
-    }
 
-    @Activate
-    protected void activate(Map<String, Object> config) {
         tryCreatePiperDirectory();
         activateTask = executor.submit(() -> {
             try {
+                logger.debug("Setting Piper native library path to: {}", LIB_FOLDER);
+                System.setProperty("io.github.jvoiceproject.piperjni.libdir", LIB_FOLDER.toAbsolutePath().toString());
+                logger.debug("Setting up Piper native dependencies...");
                 setupNativeDependencies();
+                logger.debug("Initializing Piper...");
                 PiperJNI piper = this.piper = new PiperJNI();
                 piper.initialize(true);
                 logger.debug("Using Piper version {}", piper.getPiperVersion());
                 ready = true;
-            } catch (IOException e) {
-                logger.warn("Piper registration failed, the add-on will not work: {}", e.getMessage());
+            } catch (Throwable t) {
+                logger.warn("Piper registration failed, the add-on will not work: {}", t.getMessage(), t);
             }
         });
         configChange(config);
@@ -131,7 +129,7 @@ public class PiperTTSService extends AbstractCachedTTSService {
     @Deactivate
     private void deactivate() {
         Future<?> activateTask = this.activateTask;
-        if (activateTask != null && !activateTask.isDone()) {
+        if (!activateTask.isDone()) {
             activateTask.cancel(true);
         }
     }


### PR DESCRIPTION
Native lib loading failed on some platforms (e.g. macOS) due to broken symlinks

Also fix exception swallowing in the initialization job.