### PR TITLE
[shelly] Fix Gen1 flapping roller position

### DIFF
--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api1/Shelly1CoIoTVersion2.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api1/Shelly1CoIoTVersion2.java
@@ -169,6 +169,12 @@ public class Shelly1CoIoTVersion2 extends Shelly1CoIoTProtocol implements Shelly
                 updateChannel(updates, CHANNEL_GROUP_ROL_CONTROL, CHANNEL_ROL_CONTROL_STATE, getStringType(s.valueStr));
                 break;
             case "1103": // roller_0: S, rollerPos, 0-100, unknown -1
+                if (isRollerMoving(sensorUpdates)) {
+                    // The device can't report the live position while moving and instead keeps
+                    // sending the pre-move position, which would otherwise flip the channel back
+                    // and forth between the old and new position on every CoIoT update.
+                    break;
+                }
                 int pos = Math.max(SHELLY_MIN_ROLLER_POS, Math.min((int) value, SHELLY_MAX_ROLLER_POS));
                 logger.debug("{}: CoAP update roller position: control={}, position={}", thingName,
                         SHELLY_MAX_ROLLER_POS - pos, pos);
@@ -410,6 +416,19 @@ public class Shelly1CoIoTVersion2 extends Shelly1CoIoTProtocol implements Shelly
                 processed = false;
         }
         return processed;
+    }
+
+    /**
+     * Roller position ("1103") is only accurate once the roller has stopped; look up the roller state
+     * ("1102") from the same CoIoT update batch to tell whether it's currently moving.
+     */
+    private boolean isRollerMoving(List<CoIotSensor> sensorUpdates) {
+        for (CoIotSensor update : sensorUpdates) {
+            if ("1102".equals(update.id)) {
+                return !SHELLY_ALWD_ROLLER_TURN_STOP.equalsIgnoreCase(update.valueStr);
+            }
+        }
+        return false;
     }
 
     @Override

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/Shelly2ApiClient.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/Shelly2ApiClient.java
@@ -64,7 +64,6 @@ import org.openhab.binding.shelly.internal.api1.Shelly1ApiJsonDTO.ShellyStatusSe
 import org.openhab.binding.shelly.internal.api2.Shelly2ApiJsonDTO.Shelly2AuthChallenge;
 import org.openhab.binding.shelly.internal.api2.Shelly2ApiJsonDTO.Shelly2CBStatus;
 import org.openhab.binding.shelly.internal.api2.Shelly2ApiJsonDTO.Shelly2DeviceConfig.Shelly2ConfigFlood;
-import org.openhab.binding.shelly.internal.api2.Shelly2ApiJsonDTO.Shelly2DeviceConfig.Shelly2DevConfigCover;
 import org.openhab.binding.shelly.internal.api2.Shelly2ApiJsonDTO.Shelly2DeviceConfig.Shelly2DevConfigInput;
 import org.openhab.binding.shelly.internal.api2.Shelly2ApiJsonDTO.Shelly2DeviceConfig.Shelly2DevConfigPm1;
 import org.openhab.binding.shelly.internal.api2.Shelly2ApiJsonDTO.Shelly2DeviceConfig.Shelly2DevConfigSwitch;
@@ -75,7 +74,6 @@ import org.openhab.binding.shelly.internal.api2.Shelly2ApiJsonDTO.Shelly2DeviceC
 import org.openhab.binding.shelly.internal.api2.Shelly2ApiJsonDTO.Shelly2DeviceSettings;
 import org.openhab.binding.shelly.internal.api2.Shelly2ApiJsonDTO.Shelly2DeviceStatus.Shelly2DeviceStatusLight;
 import org.openhab.binding.shelly.internal.api2.Shelly2ApiJsonDTO.Shelly2DeviceStatus.Shelly2DeviceStatusResult;
-import org.openhab.binding.shelly.internal.api2.Shelly2ApiJsonDTO.Shelly2DeviceStatus.Shelly2DeviceStatusResult.Shelly2CoverStatus;
 import org.openhab.binding.shelly.internal.api2.Shelly2ApiJsonDTO.Shelly2DeviceStatus.Shelly2DeviceStatusResult.Shelly2DeviceStatusEm;
 import org.openhab.binding.shelly.internal.api2.Shelly2ApiJsonDTO.Shelly2DeviceStatus.Shelly2DeviceStatusResult.Shelly2DeviceStatusEmData;
 import org.openhab.binding.shelly.internal.api2.Shelly2ApiJsonDTO.Shelly2DeviceStatus.Shelly2DeviceStatusResult.Shelly2DeviceStatusFlood;
@@ -91,6 +89,10 @@ import org.openhab.binding.shelly.internal.api2.Shelly2ApiJsonDTO.Shelly2RelaySt
 import org.openhab.binding.shelly.internal.api2.Shelly2ApiJsonDTO.Shelly2RpcBaseMessage;
 import org.openhab.binding.shelly.internal.api2.Shelly2ApiJsonDTO.Shelly2RpcRequest.Shelly2RpcRequestParams;
 import org.openhab.binding.shelly.internal.api2.Shelly2ApiJsonDTO.Shelly2StatusEm1;
+import org.openhab.binding.shelly.internal.api2.dto.ShellyCoverJsonDTO.Shelly2CoverStatus;
+import org.openhab.binding.shelly.internal.api2.dto.ShellyCoverJsonDTO.Shelly2DevConfigCover;
+import org.openhab.binding.shelly.internal.api2.dto.ShellyCoverJsonDTO.Shelly2DevConfigCover.Shelly2DeviceConfigCoverObstructionDetection;
+import org.openhab.binding.shelly.internal.api2.dto.ShellyCoverJsonDTO.Shelly2DevConfigCover.Shelly2DeviceConfigCoverSafetySwitch;
 import org.openhab.binding.shelly.internal.config.ShellyApiConfiguration;
 import org.openhab.binding.shelly.internal.handler.ShellyBaseHandler;
 import org.openhab.binding.shelly.internal.handler.ShellyComponents;
@@ -996,20 +998,22 @@ public class Shelly2ApiClient extends ShellyHttpClient implements ShellyDiscover
         settings.id = id;
         settings.isValid = true;
         settings.defaultState = coverConfig.initialState;
-        settings.inputMode = mapValue(MAP_INPUT_MODE, coverConfig.inMode);
+        settings.inputMode = mapValue(MAP_INPUT_MODE, getString(coverConfig.inMode));
         settings.btnReverse = getBool(coverConfig.invertDirections) ? 1 : 0;
         settings.swapInputs = coverConfig.swapInputs;
         settings.maxtime = 0.0; // n/a
         settings.maxtimeOpen = coverConfig.maxtimeOpen;
         settings.maxtimeClose = coverConfig.maxtimeClose;
-        if (coverConfig.safetySwitch != null) {
-            settings.safetySwitch = coverConfig.safetySwitch.enable;
-            settings.safetyAction = coverConfig.safetySwitch.action;
+        Shelly2DeviceConfigCoverSafetySwitch safetySwitch = coverConfig.safetySwitch;
+        if (safetySwitch != null) {
+            settings.safetySwitch = safetySwitch.enable;
+            settings.safetyAction = safetySwitch.action;
         }
-        if (coverConfig.obstructionDetection != null) {
-            settings.obstacleAction = coverConfig.obstructionDetection.action;
-            settings.obstacleDelay = coverConfig.obstructionDetection.holdoff.intValue();
-            settings.obstaclePower = coverConfig.obstructionDetection.powerThr;
+        Shelly2DeviceConfigCoverObstructionDetection obstructionDetection = coverConfig.obstructionDetection;
+        if (obstructionDetection != null) {
+            settings.obstacleAction = obstructionDetection.action;
+            settings.obstacleDelay = getDouble(obstructionDetection.holdoff).intValue();
+            settings.obstaclePower = obstructionDetection.powerThr;
         }
         rollers.add(settings);
     }

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/Shelly2ApiClient.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/Shelly2ApiClient.java
@@ -1043,7 +1043,6 @@ public class Shelly2ApiClient extends ShellyHttpClient implements ShellyDiscover
         Integer csId = cs.id;
         if (csId == null) {
             csId = id;
-            cs.id = csId;
         }
         int rIdx = getRollerIdx(getProfile(), csId);
         if (status.rollers == null || rIdx < 0 || rIdx >= status.rollers.size()) {

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/Shelly2ApiClient.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/Shelly2ApiClient.java
@@ -1036,10 +1036,12 @@ public class Shelly2ApiClient extends ShellyHttpClient implements ShellyDiscover
             return false;
         }
 
-        if (cs.id == null) {
-            cs.id = id;
+        Integer csId = cs.id;
+        if (csId == null) {
+            csId = id;
+            cs.id = csId;
         }
-        int rIdx = getRollerIdx(getProfile(), cs.id);
+        int rIdx = getRollerIdx(getProfile(), csId);
         if (status.rollers == null || rIdx < 0 || rIdx >= status.rollers.size()) {
             return false;
         }
@@ -1047,32 +1049,36 @@ public class Shelly2ApiClient extends ShellyHttpClient implements ShellyDiscover
         boolean haveEmeter = status.emeters != null && rIdx >= 0 && rIdx < status.emeters.size();
         ShellySettingsEMeter emeter = haveEmeter ? status.emeters.get(rIdx) : new ShellySettingsEMeter();
         rs.isValid = emeter.isValid = haveEmeter;
-        if (cs.state != null) {
-            if (!getString(rs.state).equals(cs.state)) {
+        String csState = cs.state;
+        if (csState != null) {
+            if (!getString(rs.state).equals(csState)) {
                 logger.debug("{}: Roller status changed from {} to {}, updateChannels={}", thingName, rs.state,
-                        mapValue(MAP_ROLLER_STATE, cs.state), updateChannels);
+                        mapValue(MAP_ROLLER_STATE, csState), updateChannels);
             }
-            rs.state = mapValue(MAP_ROLLER_STATE, cs.state);
-            rs.calibrating = SHELLY2_RSTATE_CALIB.equals(cs.state);
+            rs.state = mapValue(MAP_ROLLER_STATE, csState);
+            rs.calibrating = SHELLY2_RSTATE_CALIB.equals(csState);
         }
         if (cs.currentPos != null) {
             rs.currentPos = cs.currentPos;
         }
-        if (cs.moveStartedAt != null) {
-            rs.duration = (int) (now() - cs.moveStartedAt.longValue());
+        Double csMoveStartedAt = cs.moveStartedAt;
+        if (csMoveStartedAt != null) {
+            rs.duration = (int) (now() - csMoveStartedAt.longValue());
         }
-        if (cs.temperature != null && getDouble(cs.temperature.tC) > getDouble(status.temperature)) {
+        Shelly2DeviceStatusTemp csTemperature = cs.temperature;
+        if (csTemperature != null && getDouble(csTemperature.tC) > getDouble(status.temperature)) {
             if (status.tmp == null) {
                 status.tmp = new ShellySensorTmp();
             }
-            status.temperature = status.tmp.tC = getDouble(cs.temperature.tC);
+            status.temperature = status.tmp.tC = getDouble(csTemperature.tC);
         }
         if (cs.apower != null) {
             rs.power = emeter.power = cs.apower;
         }
-        if (cs.aenergy != null) {
-            emeter.total = getDouble(cs.aenergy.total);
-            emeter.energyByMinute = byMinuteToWh(cs.aenergy.byMinute);
+        Shelly2Energy csAenergy = cs.aenergy;
+        if (csAenergy != null) {
+            emeter.total = getDouble(csAenergy.total);
+            emeter.energyByMinute = byMinuteToWh(csAenergy.byMinute);
         }
         if (cs.voltage != null) {
             emeter.voltage = cs.voltage;

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/Shelly2ApiJsonDTO.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/Shelly2ApiJsonDTO.java
@@ -657,26 +657,26 @@ public class Shelly2ApiJsonDTO {
             }
 
             public class Shelly2CoverStatus {
-                public Integer id;
-                public String source;
-                public String state;
-                public Double apower;
-                public Double voltage;
-                public Double current;
-                public Double pf;
-                public Shelly2Energy aenergy;
+                public @Nullable Integer id;
+                public @Nullable String source;
+                public @Nullable String state;
+                public @Nullable Double apower;
+                public @Nullable Double voltage;
+                public @Nullable Double current;
+                public @Nullable Double pf;
+                public @Nullable Shelly2Energy aenergy;
                 @SerializedName("current_pos")
-                public Integer currentPos;
+                public @Nullable Integer currentPos;
                 @SerializedName("target_pos")
-                public Integer targetPos;
+                public @Nullable Integer targetPos;
                 @SerializedName("move_timeout")
-                public Double moveTimeout;
+                public @Nullable Double moveTimeout;
                 @SerializedName("move_started_at")
-                public Double moveStartedAt;
+                public @Nullable Double moveStartedAt;
                 @SerializedName("pos_control")
-                public Boolean posControl;
-                public Shelly2DeviceStatusTemp temperature;
-                public ArrayList<String> errors;
+                public @Nullable Boolean posControl;
+                public @Nullable Shelly2DeviceStatusTemp temperature;
+                public @Nullable ArrayList<String> errors;
             }
 
             public class Shelly2DeviceStatusHumidity {

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/Shelly2ApiJsonDTO.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/Shelly2ApiJsonDTO.java
@@ -20,6 +20,8 @@ import org.openhab.binding.shelly.internal.api2.Shelly2ApiJsonDTO.Shelly2DevConf
 import org.openhab.binding.shelly.internal.api2.Shelly2ApiJsonDTO.Shelly2DeviceStatus.Shelly2DeviceStatusResult;
 import org.openhab.binding.shelly.internal.api2.Shelly2ApiJsonDTO.Shelly2RpcBaseMessage.Shelly2RpcMessageError;
 import org.openhab.binding.shelly.internal.api2.ShellyBluJsonDTO.Shelly2NotifyBluEventData;
+import org.openhab.binding.shelly.internal.api2.dto.ShellyCoverJsonDTO.Shelly2CoverStatus;
+import org.openhab.binding.shelly.internal.api2.dto.ShellyCoverJsonDTO.Shelly2DevConfigCover;
 
 import com.google.gson.annotations.SerializedName;
 
@@ -372,56 +374,6 @@ public class Shelly2ApiJsonDTO {
             public String name;
         }
 
-        public class Shelly2DevConfigCover {
-            public class Shelly2DeviceConfigCoverMotor {
-                @SerializedName("idle_power_thr")
-                public Double idlePowerThr;
-            }
-
-            public class Shelly2DeviceConfigCoverSafetySwitch {
-                public Boolean enable;
-                public String direction;
-                public String action;
-                @SerializedName("allowed_move")
-                public String allowedMove;
-            }
-
-            public class Shelly2DeviceConfigCoverObstructionDetection {
-                public Boolean enable;
-                public String direction;
-                public String action;
-                @SerializedName("power_thr")
-                public Integer powerThr;
-                public Double holdoff;
-            }
-
-            public String id;
-            public String name;
-            public Shelly2DeviceConfigCoverMotor motor;
-            @SerializedName("maxtime_open")
-            public Double maxtimeOpen;
-            @SerializedName("maxtime_close")
-            public Double maxtimeClose;
-            @SerializedName("initial_state")
-            public String initialState;
-            @SerializedName("invert_directions")
-            public Boolean invertDirections;
-            @SerializedName("in_mode")
-            public String inMode;
-            @SerializedName("swap_inputs")
-            public Boolean swapInputs;
-            @SerializedName("safety_switch")
-            public Shelly2DeviceConfigCoverSafetySwitch safetySwitch;
-            @SerializedName("power_limit")
-            public Integer powerLimit;
-            @SerializedName("voltage_limit")
-            public Integer voltageLimit;
-            @SerializedName("current_limit")
-            public Double currentLimit;
-            @SerializedName("obstruction_detection")
-            public Shelly2DeviceConfigCoverObstructionDetection obstructionDetection;
-        }
-
         public static class Shelly2ConfigSmoke {
             public Integer id;
             public Boolean alarm;
@@ -654,29 +606,6 @@ public class Shelly2ApiJsonDTO {
 
             public class Shelly2DeviceStatusMqqt {
                 public Boolean connected;
-            }
-
-            public class Shelly2CoverStatus {
-                public @Nullable Integer id;
-                public @Nullable String source;
-                public @Nullable String state;
-                public @Nullable Double apower;
-                public @Nullable Double voltage;
-                public @Nullable Double current;
-                public @Nullable Double pf;
-                public @Nullable Shelly2Energy aenergy;
-                @SerializedName("current_pos")
-                public @Nullable Integer currentPos;
-                @SerializedName("target_pos")
-                public @Nullable Integer targetPos;
-                @SerializedName("move_timeout")
-                public @Nullable Double moveTimeout;
-                @SerializedName("move_started_at")
-                public @Nullable Double moveStartedAt;
-                @SerializedName("pos_control")
-                public @Nullable Boolean posControl;
-                public @Nullable Shelly2DeviceStatusTemp temperature;
-                public @Nullable ArrayList<String> errors;
             }
 
             public class Shelly2DeviceStatusHumidity {

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/dto/ShellyCoverJsonDTO.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/dto/ShellyCoverJsonDTO.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.shelly.internal.api2.dto;
+
+import java.util.ArrayList;
+
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.shelly.internal.api2.Shelly2ApiJsonDTO.Shelly2DeviceStatusTemp;
+import org.openhab.binding.shelly.internal.api2.Shelly2ApiJsonDTO.Shelly2Energy;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * {@link ShellyCoverJsonDTO} includes constants and structures used for the Gen2+ cover/roller component's JSON
+ * mapping and processing.
+ *
+ * @author Markus Michels - Initial contribution
+ */
+public class ShellyCoverJsonDTO {
+
+    public static class Shelly2DevConfigCover {
+        public static class Shelly2DeviceConfigCoverMotor {
+            @SerializedName("idle_power_thr")
+            public @Nullable Double idlePowerThr;
+        }
+
+        public static class Shelly2DeviceConfigCoverSafetySwitch {
+            public @Nullable Boolean enable;
+            public @Nullable String direction;
+            public @Nullable String action;
+            @SerializedName("allowed_move")
+            public @Nullable String allowedMove;
+        }
+
+        public static class Shelly2DeviceConfigCoverObstructionDetection {
+            public @Nullable Boolean enable;
+            public @Nullable String direction;
+            public @Nullable String action;
+            @SerializedName("power_thr")
+            public @Nullable Integer powerThr;
+            public @Nullable Double holdoff;
+        }
+
+        public @Nullable String id;
+        public @Nullable String name;
+        public @Nullable Shelly2DeviceConfigCoverMotor motor;
+        @SerializedName("maxtime_open")
+        public @Nullable Double maxtimeOpen;
+        @SerializedName("maxtime_close")
+        public @Nullable Double maxtimeClose;
+        @SerializedName("initial_state")
+        public @Nullable String initialState;
+        @SerializedName("invert_directions")
+        public @Nullable Boolean invertDirections;
+        @SerializedName("in_mode")
+        public @Nullable String inMode;
+        @SerializedName("swap_inputs")
+        public @Nullable Boolean swapInputs;
+        @SerializedName("safety_switch")
+        public @Nullable Shelly2DeviceConfigCoverSafetySwitch safetySwitch;
+        @SerializedName("power_limit")
+        public @Nullable Integer powerLimit;
+        @SerializedName("voltage_limit")
+        public @Nullable Integer voltageLimit;
+        @SerializedName("current_limit")
+        public @Nullable Double currentLimit;
+        @SerializedName("obstruction_detection")
+        public @Nullable Shelly2DeviceConfigCoverObstructionDetection obstructionDetection;
+    }
+
+    public static class Shelly2CoverStatus {
+        public @Nullable Integer id;
+        public @Nullable String source;
+        public @Nullable String state;
+        public @Nullable Double apower;
+        public @Nullable Double voltage;
+        public @Nullable Double current;
+        public @Nullable Double pf;
+        public @Nullable Shelly2Energy aenergy;
+        @SerializedName("current_pos")
+        public @Nullable Integer currentPos;
+        @SerializedName("target_pos")
+        public @Nullable Integer targetPos;
+        @SerializedName("move_timeout")
+        public @Nullable Double moveTimeout;
+        @SerializedName("move_started_at")
+        public @Nullable Double moveStartedAt;
+        @SerializedName("pos_control")
+        public @Nullable Boolean posControl;
+        public @Nullable Shelly2DeviceStatusTemp temperature;
+        public @Nullable ArrayList<String> errors;
+    }
+}

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/handler/ShellyComponents.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/handler/ShellyComponents.java
@@ -171,19 +171,12 @@ public class ShellyComponents {
 
             String state = getString(control.state);
             int pos = -1;
-            switch (state) {
-                case SHELLY_ALWD_ROLLER_TURN_OPEN:
-                    pos = SHELLY_MAX_ROLLER_POS;
-                    break;
-                case SHELLY_ALWD_ROLLER_TURN_CLOSE:
-                    pos = SHELLY_MIN_ROLLER_POS;
-                    break;
-                case SHELLY_ALWD_ROLLER_TURN_STOP:
-                    if (control.currentPos != null) {
-                        // only valid in stop state
-                        pos = Math.max(SHELLY_MIN_ROLLER_POS, Math.min(control.currentPos, SHELLY_MAX_ROLLER_POS));
-                    }
-                    break;
+            // The device can't report the live position while moving; only trust currentPos once the
+            // roller has stopped. Pushing a synthetic 0/100 for the "open"/"close" (moving) states here
+            // caused the position channels to flip to that endpoint and then flip again to the real
+            // stopped position, even when the roller was only moving to a partial position (#14189).
+            if (SHELLY_ALWD_ROLLER_TURN_STOP.equals(state) && control.currentPos != null) {
+                pos = Math.max(SHELLY_MIN_ROLLER_POS, Math.min(control.currentPos, SHELLY_MAX_ROLLER_POS));
             }
             if (pos != -1) {
                 thingHandler.logger.debug("{}: Update roller position to {}/{}, state={}", thingHandler.thingName, pos,

--- a/bundles/org.openhab.binding.shelly/src/test/java/org/openhab/binding/shelly/internal/api1/Shelly1CoIoTVersion2Test.java
+++ b/bundles/org.openhab.binding.shelly/src/test/java/org/openhab/binding/shelly/internal/api1/Shelly1CoIoTVersion2Test.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.openhab.binding.shelly.internal.api.ShellyApiInterface;
 import org.openhab.binding.shelly.internal.api.ShellyDeviceProfile;
@@ -99,9 +100,12 @@ public class Shelly1CoIoTVersion2Test {
 
         v2.handleStatusUpdate(sensorUpdates, rollerPosDesc(), 0, posSensor, updates, new ShellyColorUtils());
 
-        assertThat(updates.get(mkChannelId(CHANNEL_GROUP_ROL_CONTROL, CHANNEL_ROL_CONTROL_POS)).toString(), is("30 %"));
-        assertThat(updates.get(mkChannelId(CHANNEL_GROUP_ROL_CONTROL, CHANNEL_ROL_CONTROL_CONTROL)).toString(),
-                is("70 %"));
+        State pos = updates.get(mkChannelId(CHANNEL_GROUP_ROL_CONTROL, CHANNEL_ROL_CONTROL_POS));
+        State control = updates.get(mkChannelId(CHANNEL_GROUP_ROL_CONTROL, CHANNEL_ROL_CONTROL_CONTROL));
+        Assertions.assertNotNull(pos);
+        Assertions.assertNotNull(control);
+        assertThat(pos.toString(), is("30 %"));
+        assertThat(control.toString(), is("70 %"));
     }
 
     @Test

--- a/bundles/org.openhab.binding.shelly/src/test/java/org/openhab/binding/shelly/internal/api1/Shelly1CoIoTVersion2Test.java
+++ b/bundles/org.openhab.binding.shelly/src/test/java/org/openhab/binding/shelly/internal/api1/Shelly1CoIoTVersion2Test.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.shelly.internal.api1;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.openhab.binding.shelly.internal.ShellyBindingConstants.*;
+import static org.openhab.binding.shelly.internal.ShellyDevices.*;
+import static org.openhab.binding.shelly.internal.util.ShellyUtils.mkChannelId;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.jupiter.api.Test;
+import org.openhab.binding.shelly.internal.api.ShellyApiInterface;
+import org.openhab.binding.shelly.internal.api.ShellyDeviceProfile;
+import org.openhab.binding.shelly.internal.api1.Shelly1CoapJSonDTO.CoIotDescrBlk;
+import org.openhab.binding.shelly.internal.api1.Shelly1CoapJSonDTO.CoIotDescrSen;
+import org.openhab.binding.shelly.internal.api1.Shelly1CoapJSonDTO.CoIotSensor;
+import org.openhab.binding.shelly.internal.handler.ShellyColorUtils;
+import org.openhab.binding.shelly.internal.handler.ShellyThingInterface;
+import org.openhab.core.types.State;
+
+/**
+ * Tests for {@link Shelly1CoIoTVersion2#handleStatusUpdate}, specifically the roller position ("1103") handling
+ * that regressed in #14189: the device keeps reporting the pre-move position while the roller is moving, which
+ * must not be published as a channel flicker.
+ *
+ * @author Markus Michels - Initial contribution
+ */
+@NonNullByDefault
+public class Shelly1CoIoTVersion2Test {
+
+    private Shelly1CoIoTVersion2 newProtocol() {
+        ShellyThingInterface handler = mock(ShellyThingInterface.class);
+        when(handler.getProfile()).thenReturn(new ShellyDeviceProfile(THING_TYPE_SHELLY25_ROLLER));
+        when(handler.getApi()).thenReturn(mock(ShellyApiInterface.class));
+        Map<String, CoIotDescrBlk> blkMap = new HashMap<>();
+        Map<String, CoIotDescrSen> sensorMap = new HashMap<>();
+        return new Shelly1CoIoTVersion2("test", handler, blkMap, sensorMap);
+    }
+
+    private CoIotSensor rollerStateSensor(String state) {
+        CoIotSensor s = new CoIotSensor();
+        s.id = "1102";
+        s.valueStr = state;
+        return s;
+    }
+
+    private CoIotSensor rollerPosSensor(double value) {
+        CoIotSensor s = new CoIotSensor();
+        s.id = "1103";
+        s.value = value;
+        return s;
+    }
+
+    private CoIotDescrSen rollerPosDesc() {
+        CoIotDescrSen sen = new CoIotDescrSen();
+        sen.id = "1103";
+        sen.desc = "rollerPos";
+        sen.type = "S";
+        sen.links = "";
+        return sen;
+    }
+
+    @Test
+    void rollerPositionSkippedWhileMoving() {
+        Shelly1CoIoTVersion2 v2 = newProtocol();
+        CoIotSensor posSensor = rollerPosSensor(0);
+        List<CoIotSensor> sensorUpdates = List.of(rollerStateSensor("open"), posSensor);
+        Map<String, State> updates = new HashMap<>();
+
+        v2.handleStatusUpdate(sensorUpdates, rollerPosDesc(), 0, posSensor, updates, new ShellyColorUtils());
+
+        assertThat(updates.containsKey(mkChannelId(CHANNEL_GROUP_ROL_CONTROL, CHANNEL_ROL_CONTROL_POS)), is(false));
+        assertThat(updates.containsKey(mkChannelId(CHANNEL_GROUP_ROL_CONTROL, CHANNEL_ROL_CONTROL_CONTROL)), is(false));
+    }
+
+    @Test
+    void rollerPositionAppliedWhenStopped() {
+        Shelly1CoIoTVersion2 v2 = newProtocol();
+        CoIotSensor posSensor = rollerPosSensor(30);
+        List<CoIotSensor> sensorUpdates = List.of(rollerStateSensor("stop"), posSensor);
+        Map<String, State> updates = new HashMap<>();
+
+        v2.handleStatusUpdate(sensorUpdates, rollerPosDesc(), 0, posSensor, updates, new ShellyColorUtils());
+
+        assertThat(updates.get(mkChannelId(CHANNEL_GROUP_ROL_CONTROL, CHANNEL_ROL_CONTROL_POS)).toString(), is("30 %"));
+        assertThat(updates.get(mkChannelId(CHANNEL_GROUP_ROL_CONTROL, CHANNEL_ROL_CONTROL_CONTROL)).toString(),
+                is("70 %"));
+    }
+
+    @Test
+    void rollerPositionAppliedWhenNoSiblingStateInBatch() {
+        // "1102" absent from this batch: isRollerMoving() must default to "not moving" so an isolated
+        // "1103" update (e.g. a periodic poll) still applies.
+        Shelly1CoIoTVersion2 v2 = newProtocol();
+        CoIotSensor posSensor = rollerPosSensor(50);
+        List<CoIotSensor> sensorUpdates = List.of(posSensor);
+        Map<String, State> updates = new HashMap<>();
+
+        v2.handleStatusUpdate(sensorUpdates, rollerPosDesc(), 0, posSensor, updates, new ShellyColorUtils());
+
+        assertThat(updates.containsKey(mkChannelId(CHANNEL_GROUP_ROL_CONTROL, CHANNEL_ROL_CONTROL_POS)), is(true));
+    }
+}

--- a/bundles/org.openhab.binding.shelly/src/test/java/org/openhab/binding/shelly/internal/api1/Shelly1CoIoTVersion2Test.java
+++ b/bundles/org.openhab.binding.shelly/src/test/java/org/openhab/binding/shelly/internal/api1/Shelly1CoIoTVersion2Test.java
@@ -36,9 +36,9 @@ import org.openhab.binding.shelly.internal.handler.ShellyThingInterface;
 import org.openhab.core.types.State;
 
 /**
- * Tests for {@link Shelly1CoIoTVersion2#handleStatusUpdate}, specifically the roller position ("1103") handling
- * that regressed in #14189: the device keeps reporting the pre-move position while the roller is moving, which
- * must not be published as a channel flicker.
+ * Tests for {@link Shelly1CoIoTVersion2#handleStatusUpdate}, specifically the roller position ("1103") handling:
+ * the device keeps reporting the pre-move position while the roller is moving, which must not be published as a
+ * channel flicker.
  *
  * @author Markus Michels - Initial contribution
  */

--- a/bundles/org.openhab.binding.shelly/src/test/java/org/openhab/binding/shelly/internal/api2/Shelly2GetDeviceProfileTest.java
+++ b/bundles/org.openhab.binding.shelly/src/test/java/org/openhab/binding/shelly/internal/api2/Shelly2GetDeviceProfileTest.java
@@ -31,6 +31,7 @@ import org.mockito.Mockito;
 import org.openhab.binding.shelly.internal.api.ShellyApiException;
 import org.openhab.binding.shelly.internal.api.ShellyDeviceProfile;
 import org.openhab.binding.shelly.internal.api1.Shelly1ApiJsonDTO.ShellySettingsDevice;
+import org.openhab.binding.shelly.internal.api1.Shelly1ApiJsonDTO.ShellySettingsRoller;
 import org.openhab.binding.shelly.internal.api2.Shelly2ApiJsonDTO.Shelly2DeviceConfig.Shelly2GetConfigResult;
 import org.openhab.binding.shelly.internal.api2.Shelly2ApiJsonDTO.Shelly2DeviceStatus.Shelly2DeviceStatusResult;
 import org.openhab.binding.shelly.internal.api2.Shelly2ApiJsonDTO.Shelly2DeviceStatus.Shelly2DeviceStatusResult.Shelly2DeviceStatusEmData;
@@ -156,6 +157,14 @@ public class Shelly2GetDeviceProfileTest {
         // in_mode must be present so mapValue in addRollerSettings doesn't receive null
         return parseConfig(gson, "{\"sys\":{\"device\":{},\"location\":{},\"ui_data\":{}}," + "\"wifi\":{},"
                 + "\"cover:0\":{\"in_mode\":\"single\",\"invert_directions\":false}}");
+    }
+
+    /** GetConfig with cover:0 including safety_switch and obstruction_detection */
+    private static Shelly2GetConfigResult withCover0SafetyAndObstruction(Gson gson) {
+        return parseConfig(gson, "{\"sys\":{\"device\":{},\"location\":{},\"ui_data\":{}},\"wifi\":{},"
+                + "\"cover:0\":{\"in_mode\":\"single\",\"invert_directions\":false,"
+                + "\"safety_switch\":{\"enable\":true,\"action\":\"stop\"},"
+                + "\"obstruction_detection\":{\"enable\":true,\"action\":\"stop\",\"power_thr\":150,\"holdoff\":2.5}}}");
     }
 
     /** GetConfig with cb:0 present (Pro CB) */
@@ -304,6 +313,29 @@ public class Shelly2GetDeviceProfileTest {
         assertThat(profile.numRollers, is(1));
         // No pm10/em0/em10 → else branch: roller count
         assertThat(profile.numMeters, is(1));
+    }
+
+    @Test
+    void discoveryRollerSafetySwitchAndObstructionMapped() throws ShellyApiException {
+        Gson gson = new Gson();
+        StubApiClient client = new StubApiClient(discoveryConfig(), withCover0SafetyAndObstruction(gson));
+        ShellyDeviceProfile profile = client.getDeviceProfile(THING_TYPE_SHELLYUNKNOWN, deviceInfo());
+        ShellySettingsRoller roller = Objects.requireNonNull(profile.settings.rollers).get(0);
+        assertThat(roller.safetySwitch, is(true));
+        assertThat(roller.safetyAction, is("stop"));
+        assertThat(roller.obstacleAction, is("stop"));
+        assertThat(roller.obstaclePower, is(150));
+        assertThat(roller.obstacleDelay, is(2));
+    }
+
+    @Test
+    void discoveryRollerWithoutSafetySwitchOrObstructionLeavesFieldsNull() throws ShellyApiException {
+        Gson gson = new Gson();
+        StubApiClient client = new StubApiClient(discoveryConfig(), withCover0(gson));
+        ShellyDeviceProfile profile = client.getDeviceProfile(THING_TYPE_SHELLYUNKNOWN, deviceInfo());
+        ShellySettingsRoller roller = Objects.requireNonNull(profile.settings.rollers).get(0);
+        assertThat(roller.safetySwitch, is(nullValue()));
+        assertThat(roller.obstacleAction, is(nullValue()));
     }
 
     @Test

--- a/bundles/org.openhab.binding.shelly/src/test/java/org/openhab/binding/shelly/internal/handler/ShellyComponentsTest.java
+++ b/bundles/org.openhab.binding.shelly/src/test/java/org/openhab/binding/shelly/internal/handler/ShellyComponentsTest.java
@@ -19,6 +19,8 @@ import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 import static org.openhab.binding.shelly.internal.ShellyBindingConstants.*;
 import static org.openhab.binding.shelly.internal.ShellyDevices.*;
+import static org.openhab.binding.shelly.internal.api1.Shelly1ApiJsonDTO.SHELLY_ALWD_ROLLER_TURN_CLOSE;
+import static org.openhab.binding.shelly.internal.api1.Shelly1ApiJsonDTO.SHELLY_ALWD_ROLLER_TURN_OPEN;
 import static org.openhab.binding.shelly.internal.api1.Shelly1ApiJsonDTO.SHELLY_API_INVTEMP;
 
 import java.util.ArrayList;
@@ -35,6 +37,7 @@ import org.openhab.binding.shelly.internal.api.ShellyApiInterface;
 import org.openhab.binding.shelly.internal.api.ShellyDeviceProfile;
 import org.openhab.binding.shelly.internal.api1.Shelly1ApiJsonDTO.ShellyEMNCurrentSettings;
 import org.openhab.binding.shelly.internal.api1.Shelly1ApiJsonDTO.ShellyEMNCurrentStatus;
+import org.openhab.binding.shelly.internal.api1.Shelly1ApiJsonDTO.ShellyRollerStatus;
 import org.openhab.binding.shelly.internal.api1.Shelly1ApiJsonDTO.ShellySettingsDimmer;
 import org.openhab.binding.shelly.internal.api1.Shelly1ApiJsonDTO.ShellySettingsEMeter;
 import org.openhab.binding.shelly.internal.api1.Shelly1ApiJsonDTO.ShellySettingsMeter;
@@ -174,6 +177,35 @@ public class ShellyComponentsTest {
         ShellyBaseHandler handler = relayUpdateHandler();
         ShellyComponents.updateRelay(handler, statusWithRelayIson(true), 0);
         verify(handler).updateChannel(anyString(), eq(CHANNEL_OUTPUT), eq(OnOffType.ON));
+    }
+
+    @Test
+    void updateRollerSkipsPositionWhileOpening() throws Exception {
+        // Regression (#14189, Copilot review on PR #21316): the shared Gen1/Gen2 poll path
+        // hardcoded pos=100 for "open" regardless of the actual target, flapping the position
+        // channel to 100 mid-move before the real value arrived once the roller stopped.
+        ShellyBaseHandler handler = relayUpdateHandler();
+        ShellyComponents.updateRoller(handler, rollerStatus(SHELLY_ALWD_ROLLER_TURN_OPEN, 40), 0);
+
+        verify(handler, never()).updateChannel(anyString(), eq(CHANNEL_ROL_CONTROL_POS), any());
+        verify(handler, never()).updateChannel(anyString(), eq(CHANNEL_ROL_CONTROL_CONTROL), any());
+    }
+
+    @Test
+    void updateRollerSkipsPositionWhileClosing() throws Exception {
+        ShellyBaseHandler handler = relayUpdateHandler();
+        ShellyComponents.updateRoller(handler, rollerStatus(SHELLY_ALWD_ROLLER_TURN_CLOSE, 60), 0);
+
+        verify(handler, never()).updateChannel(anyString(), eq(CHANNEL_ROL_CONTROL_POS), any());
+        verify(handler, never()).updateChannel(anyString(), eq(CHANNEL_ROL_CONTROL_CONTROL), any());
+    }
+
+    private static ShellyRollerStatus rollerStatus(String state, int currentPos) {
+        ShellyRollerStatus control = new ShellyRollerStatus();
+        control.isValid = true;
+        control.state = state;
+        control.currentPos = currentPos;
+        return control;
     }
 
     private static ShellyBaseHandler relayUpdateHandler() {


### PR DESCRIPTION
## Fix
- Fix Gen1 roller position/control channels briefly flipping to 0%/100% during a move before settling on the correct value once the roller stops.

## Change
- Harden Gen2 cover status handling against null fields.

Resolves #14189
