### PR TITLE
[chromecast] Stop a disposed Coordinator from reconnecting forever

### DIFF
--- a/bundles/org.openhab.binding.chromecast/src/main/java/org/openhab/binding/chromecast/internal/ChromecastScheduler.java
+++ b/bundles/org.openhab.binding.chromecast/src/main/java/org/openhab/binding/chromecast/internal/ChromecastScheduler.java
@@ -40,6 +40,15 @@ public class ChromecastScheduler {
     private @Nullable ScheduledFuture<?> connectFuture;
     private @Nullable ScheduledFuture<?> refreshFuture;
 
+    /**
+     * Set by {@link #destroy()}, after which this scheduler refuses to schedule anything else.
+     * Cancelling the outstanding futures is not enough on its own: a connection callback that is
+     * already running can outlive destroy() and call back in to schedule more work, and a fixed
+     * delay refresh installed at that point would stay scheduled indefinitely and keep the
+     * disposed coordinator reachable.
+     */
+    private boolean destroyed;
+
     public ChromecastScheduler(ScheduledExecutorService scheduler, long connectDelay, Runnable connectRunnable,
             long refreshRate, Runnable refreshRunnable) {
         this.scheduler = scheduler;
@@ -50,11 +59,16 @@ public class ChromecastScheduler {
     }
 
     public synchronized void destroy() {
+        destroyed = true;
         cancelConnect();
         cancelRefresh();
     }
 
     public synchronized void scheduleConnect() {
+        if (destroyed) {
+            logger.debug("Not scheduling connection, scheduler was destroyed");
+            return;
+        }
         cancelConnect();
         logger.debug("Scheduling connection");
         connectFuture = scheduler.schedule(connectRunnable, connectDelay, TimeUnit.SECONDS);
@@ -70,6 +84,10 @@ public class ChromecastScheduler {
     }
 
     public synchronized void scheduleRefresh() {
+        if (destroyed) {
+            logger.debug("Not scheduling refresh, scheduler was destroyed");
+            return;
+        }
         cancelRefresh();
         logger.debug("Scheduling refresh in {} seconds", refreshRate);
         // With an initial delay of 1 second the refresh job can be restarted when several channels are refreshed at

--- a/bundles/org.openhab.binding.chromecast/src/main/java/org/openhab/binding/chromecast/internal/handler/ChromecastHandler.java
+++ b/bundles/org.openhab.binding.chromecast/src/main/java/org/openhab/binding/chromecast/internal/handler/ChromecastHandler.java
@@ -287,6 +287,12 @@ public class ChromecastHandler extends BaseThingHandler {
             try {
                 chromeCast.connect();
 
+                if (destroyed) {
+                    // destroy() ran while this connect was in flight. The connection is already being
+                    // torn down, so updating status here would report a disposed handler as online.
+                    return;
+                }
+
                 statusUpdater.updateMediaStatus(null);
                 statusUpdater.updateStatus(ThingStatus.ONLINE);
 

--- a/bundles/org.openhab.binding.chromecast/src/main/java/org/openhab/binding/chromecast/internal/handler/ChromecastHandler.java
+++ b/bundles/org.openhab.binding.chromecast/src/main/java/org/openhab/binding/chromecast/internal/handler/ChromecastHandler.java
@@ -220,7 +220,16 @@ public class ChromecastHandler extends BaseThingHandler {
             DISCONNECTED
         }
 
-        private ConnectionState connectionState = ConnectionState.UNKNOWN;
+        private volatile ConnectionState connectionState = ConnectionState.UNKNOWN;
+
+        /**
+         * Set once {@link #destroy()} has run. The connect retry is scheduled from inside
+         * {@link #connect()}'s own failure path, which can run concurrently with (or be woken by the
+         * interrupt from) {@code destroy()}, so cancelling the futures is not by itself enough to stop
+         * the retry loop - the losing connect would simply re-arm it afterwards and this Coordinator
+         * would keep retrying, and keep calling back into an already disposed handler, forever.
+         */
+        private volatile boolean destroyed;
 
         private Coordinator(ChromecastHandler handler, Thing thing, ChromeCast chromeCast, long refreshRate) {
             this.chromeCast = chromeCast;
@@ -253,6 +262,7 @@ public class ChromecastHandler extends BaseThingHandler {
         }
 
         void destroy() {
+            destroyed = true;
             connectionState = ConnectionState.DISCONNECTING;
 
             chromeCast.unregisterConnectionListener(eventReceiver);
@@ -271,6 +281,9 @@ public class ChromecastHandler extends BaseThingHandler {
         }
 
         private void connect() {
+            if (destroyed) {
+                return;
+            }
             try {
                 chromeCast.connect();
 
@@ -279,6 +292,12 @@ public class ChromecastHandler extends BaseThingHandler {
 
                 connectionState = ConnectionState.CONNECTED;
             } catch (final IOException | GeneralSecurityException e) {
+                if (destroyed) {
+                    // destroy() ran while this connect was in flight (and may well be the reason it
+                    // failed). Rescheduling here would outlive the handler.
+                    logger.debug("Connect failed after dispose, not reconnecting: {}", e.getMessage());
+                    return;
+                }
                 logger.debug("Connect failed, trying to reconnect: {}", e.getMessage());
                 statusUpdater.updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.OFFLINE.COMMUNICATION_ERROR,
                         e.getMessage());
@@ -287,6 +306,9 @@ public class ChromecastHandler extends BaseThingHandler {
         }
 
         private void refresh() {
+            if (destroyed) {
+                return;
+            }
             commander.handleRefresh();
         }
     }

--- a/bundles/org.openhab.binding.chromecast/src/test/java/org/openhab/binding/chromecast/internal/ChromecastSchedulerTest.java
+++ b/bundles/org.openhab.binding.chromecast/src/test/java/org/openhab/binding/chromecast/internal/ChromecastSchedulerTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.chromecast.internal;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link ChromecastScheduler}.
+ *
+ * @author Jason Hubbard - Initial contribution
+ */
+@NonNullByDefault
+class ChromecastSchedulerTest {
+
+    private final ScheduledExecutorService executor = mock(ScheduledExecutorService.class);
+    private final ChromecastScheduler scheduler = new ChromecastScheduler(executor, 10, () -> {
+    }, 10, () -> {
+    });
+
+    @Test
+    void schedulesWhileAlive() {
+        scheduler.scheduleConnect();
+        scheduler.scheduleRefresh();
+
+        verify(executor).schedule(any(Runnable.class), anyLong(), any(TimeUnit.class));
+        verify(executor).scheduleWithFixedDelay(any(Runnable.class), anyLong(), anyLong(), any(TimeUnit.class));
+    }
+
+    @Test
+    void doesNotScheduleAfterDestroy() {
+        scheduler.destroy();
+        scheduler.scheduleConnect();
+        scheduler.scheduleRefresh();
+
+        verify(executor, never()).schedule(any(Runnable.class), anyLong(), any(TimeUnit.class));
+        verify(executor, never()).scheduleWithFixedDelay(any(Runnable.class), anyLong(), anyLong(),
+                any(TimeUnit.class));
+    }
+}


### PR DESCRIPTION
## The problem

`Coordinator.connect()` schedules its own retry from inside its failure path:

```java
} catch (final IOException | GeneralSecurityException e) {
    logger.debug("Connect failed, trying to reconnect: {}", e.getMessage());
    statusUpdater.updateStatus(ThingStatus.OFFLINE, ...);
    scheduler.scheduleConnect();   // <-- nothing checks whether destroy() already ran
}
```

`destroy()` cancels the connect and refresh futures, but it cannot stop a `connect()` that is already in flight — and `cancel(true)` interrupting that connect is itself likely to make it throw, which sends it straight into the branch that re-arms the retry. The Coordinator then outlives the handler that owned it and keeps retrying every 10 seconds forever, calling `updateStatus` on a disposed handler each time.

Because a config update disposes and re-initialises the handler, every address or port correction on a device that is currently unreachable is an opportunity to leak another one.

## How it shows up

Found on a Google Cast group whose leader speaker had moved, leaving the pinned `ipAddress`/`port` pointing at a dead endpoint. A single leaked Coordinator logged

```
Handler ChromecastHandler tried updating the thing status although the handler was already disposed.
```

every 10 seconds for weeks — 85k of them in one log rotation — and left the thing with no live handler and a status frozen at the last failure, which no config change could clear.

The failure mode compounds: disabling and re-enabling the thing does recover it, but a bounce is itself a dispose racing an in-flight connect, so it seeds more orphans than it clears. On a live system one bounce took the rate from 6 to ~560 of those WARNs per minute, where it stayed until openHAB was restarted.

## The change

Track destruction explicitly and check it before reconnecting or refreshing. `connectionState` becomes `volatile`, as it is read and written from both the handler thread and the scheduler pool.

Verified against the affected devices on openHAB 5.1.1; compiled against current `main` with JDK 21.
