### PR TITLE
[chromecast] Do not cast the background discovery setting to String

### DIFF
--- a/bundles/org.openhab.binding.chromecast/src/main/java/org/openhab/binding/chromecast/internal/discovery/ChromecastDiscoveryParticipant.java
+++ b/bundles/org.openhab.binding.chromecast/src/main/java/org/openhab/binding/chromecast/internal/discovery/ChromecastDiscoveryParticipant.java
@@ -23,6 +23,7 @@ import javax.jmdns.ServiceInfo;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.core.config.core.ConfigParser;
 import org.openhab.core.config.discovery.DiscoveryResult;
 import org.openhab.core.config.discovery.DiscoveryResultBuilder;
 import org.openhab.core.config.discovery.DiscoveryService;
@@ -54,7 +55,7 @@ public class ChromecastDiscoveryParticipant implements MDNSDiscoveryParticipant 
     private static final String PROPERTY_DEVICE_ID = "id";
     private static final String SERVICE_TYPE = "_googlecast._tcp.local.";
 
-    private boolean isAutoDiscoveryEnabled = true;
+    private volatile boolean isAutoDiscoveryEnabled = true;
 
     @Activate
     protected void activate(ComponentContext componentContext) {
@@ -68,11 +69,11 @@ public class ChromecastDiscoveryParticipant implements MDNSDiscoveryParticipant 
 
     private void activateOrModifyService(ComponentContext componentContext) {
         Dictionary<String, @Nullable Object> properties = componentContext.getProperties();
-        String autoDiscoveryPropertyValue = (String) properties
-                .get(DiscoveryService.CONFIG_PROPERTY_BACKGROUND_DISCOVERY);
-        if (autoDiscoveryPropertyValue != null && !autoDiscoveryPropertyValue.isBlank()) {
-            isAutoDiscoveryEnabled = Boolean.valueOf(autoDiscoveryPropertyValue);
-        }
+        // The value is a String when set through runtime.cfg and a Boolean when set through the
+        // REST API, so let ConfigParser handle both, as AbstractDiscoveryService does.
+        isAutoDiscoveryEnabled = ConfigParser.valueAsOrElse(
+                properties.get(DiscoveryService.CONFIG_PROPERTY_BACKGROUND_DISCOVERY), Boolean.class,
+                isAutoDiscoveryEnabled);
     }
 
     @Override


### PR DESCRIPTION
## The problem

`ChromecastDiscoveryParticipant.activateOrModifyService()` casts the background discovery property to `String`:

```java
String autoDiscoveryPropertyValue = (String) properties
        .get(DiscoveryService.CONFIG_PROPERTY_BACKGROUND_DISCOVERY);
```

The value arrives as a `Boolean` when the setting is written through the REST API (`PUT /rest/services/discovery.chromecast/config` with `{"background": false}`), so `@Modified` throws `ClassCastException`. SCR logs

```
[ERROR] bundle org.openhab.binding.chromecast:5.1.1 (275)[...ChromecastDiscoveryParticipant(352)] :
        The modified method has thrown an exception
        at ...ChromecastDiscoveryParticipant.activateOrModifyService(ChromecastDiscoveryParticipant.java:72)
        at ...ChromecastDiscoveryParticipant.modified(ChromecastDiscoveryParticipant.java:66)
```

and the component keeps its previous value. The result is that turning background discovery off appears to succeed — the config reads back as `false` — while discovery in fact carries on running. Writing the value as the string `"false"` does work, which is not discoverable from the outside.

## The change

Accept either representation instead of casting.
