### PR TITLE
[plivo] Add Plivo binding

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -325,6 +325,7 @@
 /bundles/org.openhab.binding.playstation/ @FluBBaOfWard
 /bundles/org.openhab.binding.plclogo/ @falkena
 /bundles/org.openhab.binding.plex/ @aronbeurskens
+/bundles/org.openhab.binding.plivo/ @sarveshpatil-plivo
 /bundles/org.openhab.binding.plugwise/ @wborn
 /bundles/org.openhab.binding.plugwiseha/ @lsiepel
 /bundles/org.openhab.binding.powermax/ @lolodomo

--- a/bom/openhab-addons/pom.xml
+++ b/bom/openhab-addons/pom.xml
@@ -1608,6 +1608,11 @@
     </dependency>
     <dependency>
       <groupId>org.openhab.addons.bundles</groupId>
+      <artifactId>org.openhab.binding.plivo</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.openhab.addons.bundles</groupId>
       <artifactId>org.openhab.binding.plugwise</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/bundles/org.openhab.binding.plivo/NOTICE
+++ b/bundles/org.openhab.binding.plivo/NOTICE
@@ -1,0 +1,13 @@
+This content is produced and maintained by the openHAB project.
+
+* Project home: https://www.openhab.org
+
+== Declared Project Licenses
+
+This program and the accompanying materials are made available under the terms
+of the Eclipse Public License 2.0 which is available at
+https://www.eclipse.org/legal/epl-2.0/.
+
+== Source Code
+
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.plivo/README.md
+++ b/bundles/org.openhab.binding.plivo/README.md
@@ -1,0 +1,362 @@
+# Plivo Binding
+
+This binding integrates with the [Plivo](https://www.plivo.com/) cloud communications platform.
+It allows sending and receiving SMS, MMS, and WhatsApp messages, as well as making and receiving voice calls with text-to-speech and DTMF input support.
+
+Typical use cases include:
+
+- Sending SMS/MMS alerts when events occur (door opens, alarm triggers, temperature threshold)
+- Receiving SMS commands to control your smart home ("status", "arm alarm", "turn on lights")
+- Making voice calls for critical alerts with text-to-speech
+- Receiving incoming calls with an interactive voice menu (press 1 for X, press 2 for Y)
+- Sending and receiving WhatsApp messages
+
+## Supported Things
+
+| Thing Type | Description                                                                            |
+| ---------- | -------------------------------------------------------------------------------------- |
+| `account`  | A Plivo account (bridge). Holds API credentials and shared settings.                   |
+| `phone`    | A Plivo phone number. Sends/receives messages and calls. Requires an `account` bridge. |
+
+## Discovery
+
+Once a Plivo Account bridge is added and goes online, the binding automatically discovers all phone numbers associated with the account and adds them to the inbox.
+You can also trigger a manual scan from the UI.
+
+The account bridge itself must be created manually with your [Plivo console](https://cx.plivo.com/) credentials.
+
+## Thing Configuration
+
+### `account` Bridge Configuration
+
+| Name                  | Type    | Description                                                         | Default | Required | Advanced |
+| --------------------- | ------- | ------------------------------------------------------------------- | ------- | -------- | -------- |
+| authId                | text    | Plivo Auth ID (starts with MA or SA)                                | N/A     | yes      | no       |
+| authToken             | text    | Plivo Auth Token                                                    | N/A     | yes      | no       |
+| publicUrl             | text    | Public-facing base URL for webhooks (e.g. `https://my.domain.com`)  | N/A     | no       | yes      |
+| autoConfigureWebhooks | boolean | Automatically create and assign a Plivo application via API         | true    | no       | yes      |
+| useCloudWebhook       | boolean | Use openHAB Cloud for webhook callbacks (no port forwarding needed) | false   | no       | yes      |
+
+The Auth ID and Auth Token can be found in the [Plivo console](https://cx.plivo.com/).
+
+To receive incoming messages and calls, and to place outbound voice calls, you need **one** of the following:
+
+- **openHAB Cloud Webhooks** (recommended): Set `useCloudWebhook` to `true`. Requires the openHAB Cloud Connector add-on to be installed and connected. No port forwarding or reverse proxy needed.
+- **Public URL**: Set `publicUrl` to a publicly-reachable URL for your openHAB instance. You can use a reverse proxy, port forwarding, or a service like ngrok.
+
+Outbound voice calls also require one of the above: unlike messaging, Plivo fetches the call flow from an answer URL that the binding hosts, so a publicly-reachable URL must be configured for `makeCall` and `makeTTSCall` to work.
+
+### `phone` Thing Configuration
+
+| Name            | Type    | Description                                                    | Default                                                     | Required | Advanced |
+| --------------- | ------- | ------------------------------------------------------------- | ----------------------------------------------------------- | -------- | -------- |
+| phoneNumber     | text    | Plivo phone number in E.164 format (e.g. +15551234567)        | N/A                                                         | yes      | no       |
+| voiceGreeting   | text    | Plivo XML template for incoming voice calls                   | See below                                                   | no       | yes      |
+| gatherResponse  | text    | Plivo XML returned after DTMF digits are gathered (fallback)  | `<Response><Speak>Thank you. Goodbye.</Speak></Response>`   | no       | yes      |
+| responseTimeout | integer | Seconds to wait for a rule to respond with XML (1-14)         | 10                                                          | no       | yes      |
+
+The default `voiceGreeting` includes a `<GetInput>` element that collects one DTMF digit:
+
+```xml
+<Response>
+  <GetInput action="{gatherUrl}" inputType="dtmf" numDigits="1">
+    <Speak>Hello. This is the openHAB smart home system. Press any key.</Speak>
+  </GetInput>
+  <Speak>No input received. Goodbye.</Speak>
+</Response>
+```
+
+The `{gatherUrl}` placeholder is automatically replaced with the correct webhook URL.
+
+## Channels
+
+### State Channels
+
+| Channel                | Type     | Description                                               |
+| ---------------------- | -------- | --------------------------------------------------------- |
+| last-message-body      | String   | Body text of the last received SMS/WhatsApp message       |
+| last-message-from      | String   | Phone number of the last message sender                   |
+| last-message-date      | DateTime | Timestamp of the last received message                    |
+| last-message-media-url | String   | URL of the first media attachment (MMS/WhatsApp)          |
+| last-message-uuid      | String   | Plivo Message UUID of the last received message           |
+| last-call-from         | String   | Phone number of the last incoming caller                  |
+| last-call-status       | String   | Status of the last call (ringing, in-progress, completed) |
+| last-call-date         | DateTime | Timestamp of the last incoming call                       |
+| last-dtmf-digits       | String   | Last DTMF digits received from a caller                   |
+
+### Trigger Channels
+
+| Channel            | Payload | Description                                 |
+| ------------------ | ------- | ------------------------------------------- |
+| sms-received       | JSON    | Triggered on incoming SMS/MMS               |
+| whatsapp-received  | JSON    | Triggered on incoming WhatsApp message      |
+| call-received      | JSON    | Triggered on incoming voice call            |
+| dtmf-received      | JSON    | Triggered when DTMF digits are gathered     |
+| message-status     | JSON    | Triggered on message delivery status change |
+| call-status-update | JSON    | Triggered on call status change             |
+
+Trigger channel payloads are JSON objects. Example `sms-received` payload:
+
+```json
+{"from":"+15559876543","to":"+15551234567","body":"Hello!","messageUuid":"...","type":"sms","mediaUrls":[]}
+```
+
+## Rule Actions
+
+Actions are available on `phone` things under the `plivo` scope.
+
+### SMS Actions
+
+| Action    | Parameters                                   | Description                                                                       |
+| --------- | -------------------------------------------- | --------------------------------------------------------------------------------- |
+| `sendSMS` | `String to, String message`                  | Send a plain SMS                                                                  |
+| `sendSMS` | `String to, String message, String mediaUrl` | Send an MMS with media. `message` is optional (may be `null`) to send media only. |
+
+### WhatsApp Actions
+
+| Action         | Parameters                                   | Description                                                                          |
+| -------------- | -------------------------------------------- | ------------------------------------------------------------------------------------ |
+| `sendWhatsApp` | `String to, String message`                  | Send a WhatsApp message                                                              |
+| `sendWhatsApp` | `String to, String message, String mediaUrl` | Send WhatsApp with media. `message` is optional (may be `null`) to send media only.  |
+
+WhatsApp freeform messages are only delivered within the 24-hour customer service window; the first contact (and any message outside that window) must use a pre-approved template configured in the Plivo console.
+
+### Voice Actions
+
+| Action            | Parameters                            | Description                                                     |
+| ----------------- | ------------------------------------- | -------------------------------------------------------------- |
+| `makeCall`        | `String to, String xml`               | Make a call with raw Plivo XML                                 |
+| `makeTTSCall`     | `String to, String text`              | Make a call with text-to-speech                                |
+| `makeTTSCall`     | `String to, String text, String voice`| TTS with voice selection (e.g. "WOMAN", "Polly.Joanna")        |
+| `respondWithXml`  | `String callUuid, String xml`         | Respond to an active call with Plivo XML (see Dynamic Voice)   |
+
+### Media URL Actions
+
+| Action                | Parameters         | Returns        | Description                                                     |
+| --------------------- | ------------------ | -------------- | --------------------------------------------------------------- |
+| `createItemMediaUrl`  | `String itemName`  | `String` (URL) | Create a temporary public URL from an openHAB Image item        |
+| `createProxyMediaUrl` | `String sourceUrl` | `String` (URL) | Create a temporary public URL that proxies a local/internal URL |
+
+These actions create time-limited (5 minute) public URLs for media that Plivo can fetch.
+This is useful for sending camera snapshots or locally-hosted media as MMS/WhatsApp attachments.
+Either `publicUrl` must be configured on the bridge or `useCloudWebhook` must be enabled for these actions to work.
+
+## Dynamic Voice Calls (respondWithXml)
+
+The binding supports fully interactive voice calls where rules control the call flow in real time.
+When an incoming call arrives or DTMF digits are pressed, the binding holds the HTTP response open and waits for a rule to provide Plivo XML via the `respondWithXml` action.
+
+**How it works:**
+
+1. Plivo sends a webhook (incoming call or DTMF input)
+1. The binding fires a trigger channel (`call-received` or `dtmf-received`)
+1. The binding waits up to `responseTimeout` seconds (default: 10) for a rule to call `respondWithXml`
+1. If the rule responds in time, that XML is returned to Plivo
+1. If the timeout expires, the default XML from the thing config is used as fallback
+
+The `{gatherUrl}` placeholder can be used in your XML to create multi-step menus.
+It is automatically replaced with the correct URL for the phone thing's gather endpoint.
+
+### Timeout Behavior
+
+If a rule does not call `respondWithXml` within the configured `responseTimeout` (default: 10 seconds), the binding returns the default XML from the thing configuration:
+
+- For incoming calls: the `voiceGreeting` config parameter
+- For DTMF gather: the `gatherResponse` config parameter
+
+This means existing rules that don't use `respondWithXml` continue to work as before.
+The timeout is configurable per phone thing via the `responseTimeout` advanced parameter (1-14 seconds).
+
+## Webhook Setup
+
+To receive incoming messages and calls, you need to configure webhooks so Plivo can reach your openHAB instance.
+
+### Option 1: openHAB Cloud Webhooks (Recommended)
+
+The simplest approach is to use the openHAB Cloud service to provide publicly-reachable webhook URLs.
+This eliminates the need for port forwarding, reverse proxies, or a public IP address.
+
+**Requirements:**
+
+- The [openHAB Cloud Connector](https://www.openhab.org/addons/integrations/openhabcloud/) add-on must be installed and connected
+
+**Setup:**
+
+1. Enable `useCloudWebhook` on the bridge (set to `true`)
+1. If not using auto-configure, copy the webhook URLs from the phone thing properties in the UI and paste them into the [Plivo console](https://cx.plivo.com/)
+
+```java
+Bridge plivo:account:myaccount "Plivo Account" [ authId="your_auth_id", authToken="your_auth_token", useCloudWebhook=true ] {
+    Thing phone myphone "My Plivo Number" [ phoneNumber="+15551234567" ]
+}
+```
+
+### Option 2: Public URL
+
+1. Set the `publicUrl` on the bridge (e.g. `https://my.domain.com`)
+1. The binding will automatically create a Plivo application with the webhook URLs and assign it to your phone number via the API
+
+If you disable `autoConfigureWebhooks`, you can manually create an application in the [Plivo console](https://cx.plivo.com/) and assign it to your number:
+
+- **Answer URL** (Voice): the `voiceWebhookUrl` property value
+- **Message URL** (Messaging): the `messageWebhookUrl` property value
+
+### URL Structure
+
+All webhook and media endpoints are served under `/plivo/callback/` on your openHAB instance.
+If using a reverse proxy, you must forward this entire path prefix.
+
+| Path                                  | Method | Purpose                                                |
+| ------------------------------------- | ------ | ------------------------------------------------------ |
+| `/plivo/callback/{thingUID}/sms`      | POST   | Incoming SMS/MMS/WhatsApp messages                     |
+| `/plivo/callback/{thingUID}/voice`    | POST   | Incoming voice calls                                   |
+| `/plivo/callback/{thingUID}/gather`   | POST   | DTMF input callbacks                                   |
+| `/plivo/callback/{thingUID}/status`   | POST   | Message/call status updates                            |
+| `/plivo/callback/{thingUID}/answer`   | POST   | Answer XML for outbound calls                          |
+| `/plivo/callback/media/{uuid}`        | GET    | Temporary media serving (for MMS/WhatsApp attachments) |
+
+The `{thingUID}` is the full thing UID (e.g. `plivo:phone:myaccount:myphone`).
+The `{uuid}` is a randomly generated identifier for temporary media entries.
+
+Incoming POST callbacks are authenticated using Plivo's `X-Plivo-Signature-V3` header; requests that fail signature validation are rejected with HTTP 403.
+
+**Example full URLs** (assuming `publicUrl` is `https://my.domain.com`):
+
+```text
+https://my.domain.com/plivo/callback/plivo:phone:myaccount:myphone/sms
+https://my.domain.com/plivo/callback/plivo:phone:myaccount:myphone/voice
+https://my.domain.com/plivo/callback/media/550e8400-e29b-41d4-a716-446655440000
+```
+
+## Full Example
+
+### Thing Configuration
+
+```java
+Bridge plivo:account:myaccount "Plivo Account" [ authId="your_auth_id", authToken="your_auth_token", publicUrl="https://my.domain.com" ] {
+    Thing phone myphone "My Plivo Number" [ phoneNumber="+15551234567" ]
+}
+```
+
+### Item Configuration
+
+```java
+String PlivoLastMessage "Last SMS [%s]" { channel="plivo:phone:myaccount:myphone:last-message-body" }
+String PlivoLastFrom "From [%s]" { channel="plivo:phone:myaccount:myphone:last-message-from" }
+DateTime PlivoLastDate "Received [%1$tF %1$tR]" { channel="plivo:phone:myaccount:myphone:last-message-date" }
+String PlivoLastCallFrom "Last Caller [%s]" { channel="plivo:phone:myaccount:myphone:last-call-from" }
+String PlivoLastDtmf "DTMF [%s]" { channel="plivo:phone:myaccount:myphone:last-dtmf-digits" }
+```
+
+### Rule Examples
+
+#### Send SMS Alert
+
+```javascript
+rules.when().item('FrontDoor').changed().to('OPEN').then(event => {
+    var plivoActions = actions.thingActions('plivo', 'plivo:phone:myaccount:myphone');
+    plivoActions.sendSMS('+15559876543', 'Alert: Front door was opened at ' + time.ZonedDateTime.now().toString());
+}).build('Door opened alert');
+```
+
+#### Send MMS with openHAB Image Item
+
+```javascript
+rules.when().item('MotionSensor').changed().to('ON').then(event => {
+    var plivoActions = actions.thingActions('plivo', 'plivo:phone:myaccount:myphone');
+    var mediaUrl = plivoActions.createItemMediaUrl('SecurityCamera');
+    if (mediaUrl !== null) {
+        plivoActions.sendSMS('+15559876543', 'Motion detected!', mediaUrl);
+    }
+}).build('Motion detected - send snapshot');
+```
+
+#### Receive SMS and Reply
+
+```javascript
+var ALLOWED_NUMBERS = ['+15559876543', '+15551112222'];
+
+rules.when().channel('plivo:phone:myaccount:myphone:sms-received').triggered().then(event => {
+    var payload = JSON.parse(event.receivedEvent);
+    if (ALLOWED_NUMBERS.indexOf(payload.from) === -1) {
+        return;
+    }
+    if (payload.body.toLowerCase().includes('status')) {
+        var plivoActions = actions.thingActions('plivo', 'plivo:phone:myaccount:myphone');
+        plivoActions.sendSMS(payload.from, 'All systems normal. Temperature: ' + items.IndoorTemp.state + ' F');
+    }
+}).build('Handle incoming SMS');
+```
+
+#### Make TTS Call for Critical Alert
+
+```javascript
+rules.when().item('SmokeDetector').changed().to('ON').then(event => {
+    var plivoActions = actions.thingActions('plivo', 'plivo:phone:myaccount:myphone');
+    plivoActions.makeTTSCall('+15559876543',
+        'Warning. Smoke has been detected in your home. Please check immediately.');
+}).build('Smoke alarm call');
+```
+
+#### Security Panel IVR
+
+```javascript
+rules.when().channel('plivo:phone:myaccount:myphone:call-received').triggered().then(event => {
+    var payload = JSON.parse(event.receivedEvent);
+    var plivoActions = actions.thingActions('plivo', 'plivo:phone:myaccount:myphone');
+
+    if (payload.from !== '+15559876543' && payload.from !== '+15551112222') {
+        plivoActions.respondWithXml(payload.callUuid, '<Response><Speak>Access denied.</Speak></Response>');
+        return;
+    }
+
+    plivoActions.respondWithXml(payload.callUuid,
+        '<Response><GetInput action="{gatherUrl}" inputType="dtmf" numDigits="1">' +
+        '<Speak>Security panel. Alarm is ' + items.AlarmSystem.state + '. ' +
+        'Press 1 to arm. Press 2 to disarm. Press 3 for sensor status.</Speak>' +
+        '</GetInput><Speak>No input. Goodbye.</Speak></Response>');
+}).build('Security panel - incoming call');
+
+rules.when().channel('plivo:phone:myaccount:myphone:dtmf-received').triggered().then(event => {
+    var payload = JSON.parse(event.receivedEvent);
+    var plivoActions = actions.thingActions('plivo', 'plivo:phone:myaccount:myphone');
+
+    switch (payload.digits) {
+        case '1':
+            items.AlarmSystem.sendCommand('ARM');
+            plivoActions.respondWithXml(payload.callUuid,
+                '<Response><Speak>Alarm armed. Goodbye.</Speak></Response>');
+            break;
+        case '2':
+            items.AlarmSystem.sendCommand('DISARM');
+            plivoActions.respondWithXml(payload.callUuid,
+                '<Response><Speak>Alarm disarmed. Goodbye.</Speak></Response>');
+            break;
+        case '3':
+            plivoActions.respondWithXml(payload.callUuid,
+                '<Response><Speak>Front door is ' + items.FrontDoor.state + '. Goodbye.</Speak></Response>');
+            break;
+    }
+}).build('Security panel - DTMF handler');
+```
+
+#### Outgoing Alert Call with Confirmation
+
+```javascript
+rules.when().item('SmokeDetector').changed().to('ON').then(event => {
+    var plivoActions = actions.thingActions('plivo', 'plivo:phone:myaccount:myphone');
+    plivoActions.makeCall('+15559876543',
+        '<Response><GetInput action="{gatherUrl}" inputType="dtmf" numDigits="1">' +
+        '<Speak>Emergency! Smoke detected in your home. Press 1 to acknowledge.</Speak>' +
+        '</GetInput><Speak>No response received. We will call again.</Speak></Response>');
+}).build('Fire alarm call');
+
+rules.when().channel('plivo:phone:myaccount:myphone:dtmf-received').triggered().then(event => {
+    var payload = JSON.parse(event.receivedEvent);
+    if (payload.digits === '1') {
+        items.FireAlarmAcknowledged.postUpdate('ON');
+        var plivoActions = actions.thingActions('plivo', 'plivo:phone:myaccount:myphone');
+        plivoActions.respondWithXml(payload.callUuid, '<Response><Speak>Acknowledged. Stay safe.</Speak></Response>');
+    }
+}).build('Fire alarm confirmation');
+```

--- a/bundles/org.openhab.binding.plivo/README.md
+++ b/bundles/org.openhab.binding.plivo/README.md
@@ -219,7 +219,10 @@ If using a reverse proxy, you must forward this entire path prefix.
 The `{thingUID}` is the full thing UID (e.g. `plivo:phone:myaccount:myphone`).
 The `{uuid}` is a randomly generated identifier for temporary media entries.
 
-Incoming callbacks are authenticated with Plivo's request signature. The binding validates every signature family Plivo may send, both the V3 family (`X-Plivo-Signature-V3` and `X-Plivo-Signature-Ma-V3`, used for voice and messaging) and the V2 family (`X-Plivo-Signature-V2` and `X-Plivo-Signature-Ma-V2`, which Plivo documents for messaging), and rejects requests that fail validation with HTTP 403.
+Incoming callbacks are authenticated with Plivo's request signature.
+Voice, gather, and answer callbacks require a V3-family signature (`X-Plivo-Signature-V3` or `X-Plivo-Signature-Ma-V3`).
+Messaging callbacks accept the documented V2 family (`X-Plivo-Signature-V2` or `X-Plivo-Signature-Ma-V2`) as well as the V3 family observed in live traffic.
+Requests that fail signature validation are rejected with HTTP 403.
 
 **Example full URLs** (assuming `publicUrl` is `https://my.domain.com`):
 

--- a/bundles/org.openhab.binding.plivo/README.md
+++ b/bundles/org.openhab.binding.plivo/README.md
@@ -39,6 +39,9 @@ The account bridge itself must be created manually with your [Plivo console](htt
 
 The Auth ID and Auth Token can be found in the [Plivo console](https://cx.plivo.com/).
 
+Use main account credentials (an Auth ID starting with `MA`).
+Plivo signs the `Ma-V2` and `Ma-V3` callback signatures with the main account Auth Token, so a subaccount (`SA`) can send messages and calls but cannot validate incoming callbacks.
+
 To receive incoming messages and calls, and to place outbound voice calls, you need **one** of the following:
 
 - **openHAB Cloud Webhooks** (recommended): Set `useCloudWebhook` to `true`. Requires the openHAB Cloud Connector add-on to be installed and connected. No port forwarding or reverse proxy needed.
@@ -120,6 +123,8 @@ Actions are available on `phone` things under the `plivo` scope.
 | `sendWhatsApp` | `String to, String message, String mediaUrl` | Send WhatsApp with media. `message` is optional (may be `null`) to send media only.  |
 
 WhatsApp freeform messages are only delivered within the 24-hour customer service window; the first contact (and any message outside that window) must use a pre-approved template configured in the Plivo console.
+The binding sends freeform messages only and does not support template messages, so outbound WhatsApp works for replies inside that window.
+Incoming WhatsApp messages are not affected and always trigger the `whatsapp-received` channel.
 
 ### Voice Actions
 

--- a/bundles/org.openhab.binding.plivo/README.md
+++ b/bundles/org.openhab.binding.plivo/README.md
@@ -208,8 +208,7 @@ If using a reverse proxy, you must forward this entire path prefix.
 
 | Path                                  | Method | Purpose                                                |
 | ------------------------------------- | ------ | ------------------------------------------------------ |
-| `/plivo/callback/{thingUID}/sms`      | POST   | Incoming SMS/MMS messages                              |
-| `/plivo/callback/{thingUID}/whatsapp` | POST   | Incoming WhatsApp messages                             |
+| `/plivo/callback/{thingUID}/sms`      | POST   | Incoming SMS, MMS, and WhatsApp messages               |
 | `/plivo/callback/{thingUID}/voice`    | POST   | Incoming voice calls                                   |
 | `/plivo/callback/{thingUID}/gather`   | POST   | DTMF input callbacks                                   |
 | `/plivo/callback/{thingUID}/status`   | POST   | Message/call status updates                            |

--- a/bundles/org.openhab.binding.plivo/README.md
+++ b/bundles/org.openhab.binding.plivo/README.md
@@ -208,7 +208,8 @@ If using a reverse proxy, you must forward this entire path prefix.
 
 | Path                                  | Method | Purpose                                                |
 | ------------------------------------- | ------ | ------------------------------------------------------ |
-| `/plivo/callback/{thingUID}/sms`      | POST   | Incoming SMS/MMS/WhatsApp messages                     |
+| `/plivo/callback/{thingUID}/sms`      | POST   | Incoming SMS/MMS messages                              |
+| `/plivo/callback/{thingUID}/whatsapp` | POST   | Incoming WhatsApp messages                             |
 | `/plivo/callback/{thingUID}/voice`    | POST   | Incoming voice calls                                   |
 | `/plivo/callback/{thingUID}/gather`   | POST   | DTMF input callbacks                                   |
 | `/plivo/callback/{thingUID}/status`   | POST   | Message/call status updates                            |
@@ -218,7 +219,7 @@ If using a reverse proxy, you must forward this entire path prefix.
 The `{thingUID}` is the full thing UID (e.g. `plivo:phone:myaccount:myphone`).
 The `{uuid}` is a randomly generated identifier for temporary media entries.
 
-Incoming POST callbacks are authenticated using Plivo's `X-Plivo-Signature-V3` header; requests that fail signature validation are rejected with HTTP 403.
+Incoming callbacks are authenticated with Plivo's request signature. The binding validates every signature family Plivo may send, both the V3 family (`X-Plivo-Signature-V3` and `X-Plivo-Signature-Ma-V3`, used for voice and messaging) and the V2 family (`X-Plivo-Signature-V2` and `X-Plivo-Signature-Ma-V2`, which Plivo documents for messaging), and rejects requests that fail validation with HTTP 403.
 
 **Example full URLs** (assuming `publicUrl` is `https://my.domain.com`):
 

--- a/bundles/org.openhab.binding.plivo/pom.xml
+++ b/bundles/org.openhab.binding.plivo/pom.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.openhab.addons.bundles</groupId>
+    <artifactId>org.openhab.addons.reactor.bundles</artifactId>
+    <version>5.3.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>org.openhab.binding.plivo</artifactId>
+
+  <name>openHAB Add-ons :: Bundles :: Plivo Binding</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.openhab.core.bundles</groupId>
+      <artifactId>org.openhab.core.io.rest</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/bundles/org.openhab.binding.plivo/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.plivo/src/main/feature/feature.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<features name="org.openhab.binding.plivo-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.6.0">
+	<repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
+
+	<feature name="openhab-binding-plivo" description="Plivo Binding" version="${project.version}">
+		<feature>openhab-runtime-base</feature>
+		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.plivo/${project.version}</bundle>
+	</feature>
+</features>

--- a/bundles/org.openhab.binding.plivo/src/main/java/org/openhab/binding/plivo/internal/PlivoBindingConstants.java
+++ b/bundles/org.openhab.binding.plivo/src/main/java/org/openhab/binding/plivo/internal/PlivoBindingConstants.java
@@ -69,7 +69,6 @@ public class PlivoBindingConstants {
 
     // Webhook path segments
     public static final String WEBHOOK_SMS = "sms";
-    public static final String WEBHOOK_WHATSAPP = "whatsapp";
     public static final String WEBHOOK_VOICE = "voice";
     public static final String WEBHOOK_GATHER = "gather";
     public static final String WEBHOOK_STATUS = "status";

--- a/bundles/org.openhab.binding.plivo/src/main/java/org/openhab/binding/plivo/internal/PlivoBindingConstants.java
+++ b/bundles/org.openhab.binding.plivo/src/main/java/org/openhab/binding/plivo/internal/PlivoBindingConstants.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.plivo.internal;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.core.thing.ThingTypeUID;
+
+/**
+ * The {@link PlivoBindingConstants} class defines common constants, which are
+ * used across the whole binding.
+ *
+ * @author Sarvesh Patil - Initial contribution
+ */
+@NonNullByDefault
+public class PlivoBindingConstants {
+
+    public static final String BINDING_ID = "plivo";
+
+    // Thing Type UIDs
+    public static final ThingTypeUID THING_TYPE_ACCOUNT = new ThingTypeUID(BINDING_ID, "account");
+    public static final ThingTypeUID THING_TYPE_PHONE = new ThingTypeUID(BINDING_ID, "phone");
+
+    // Channel IDs - Message state channels
+    public static final String CHANNEL_LAST_MESSAGE_BODY = "last-message-body";
+    public static final String CHANNEL_LAST_MESSAGE_FROM = "last-message-from";
+    public static final String CHANNEL_LAST_MESSAGE_DATE = "last-message-date";
+    public static final String CHANNEL_LAST_MESSAGE_MEDIA_URL = "last-message-media-url";
+    public static final String CHANNEL_LAST_MESSAGE_UUID = "last-message-uuid";
+
+    // Channel IDs - Call state channels
+    public static final String CHANNEL_LAST_CALL_FROM = "last-call-from";
+    public static final String CHANNEL_LAST_CALL_STATUS = "last-call-status";
+    public static final String CHANNEL_LAST_CALL_DATE = "last-call-date";
+    public static final String CHANNEL_LAST_DTMF_DIGITS = "last-dtmf-digits";
+
+    // Channel IDs - Trigger channels
+    public static final String CHANNEL_SMS_RECEIVED = "sms-received";
+    public static final String CHANNEL_WHATSAPP_RECEIVED = "whatsapp-received";
+    public static final String CHANNEL_CALL_RECEIVED = "call-received";
+    public static final String CHANNEL_DTMF_RECEIVED = "dtmf-received";
+    public static final String CHANNEL_MESSAGE_STATUS = "message-status";
+    public static final String CHANNEL_CALL_STATUS_TRIGGER = "call-status-update";
+
+    // Plivo API
+    public static final String API_BASE_URL = "https://api.plivo.com/v1/Account/";
+
+    // Webhook servlet
+    public static final String SERVLET_PATH = "/plivo/callback";
+
+    // Thing properties
+    public static final String PROPERTY_MESSAGE_WEBHOOK_URL = "messageWebhookUrl";
+    public static final String PROPERTY_VOICE_WEBHOOK_URL = "voiceWebhookUrl";
+    public static final String PROPERTY_STATUS_CALLBACK_URL = "statusCallbackUrl";
+
+    // Default Plivo XML templates
+    public static final String DEFAULT_VOICE_GREETING = "<Response><GetInput action=\"{gatherUrl}\" inputType=\"dtmf\" numDigits=\"1\"><Speak>Hello. This is the openHAB smart home system. Press any key.</Speak></GetInput><Speak>No input received. Goodbye.</Speak></Response>";
+    public static final String DEFAULT_GATHER_RESPONSE = "<Response><Speak>Thank you. Goodbye.</Speak></Response>";
+    public static final String EMPTY_XML_RESPONSE = "<Response/>";
+
+    // Webhook path segments
+    public static final String WEBHOOK_SMS = "sms";
+    public static final String WEBHOOK_WHATSAPP = "whatsapp";
+    public static final String WEBHOOK_VOICE = "voice";
+    public static final String WEBHOOK_GATHER = "gather";
+    public static final String WEBHOOK_STATUS = "status";
+    public static final String WEBHOOK_ANSWER = "answer";
+    public static final String WEBHOOK_MEDIA = "media";
+
+    // Outbound answer XML token parameter
+    public static final String ANSWER_TOKEN_PARAM = "token";
+
+    // Media serving
+    public static final int MEDIA_EXPIRY_MINUTES = 5;
+    public static final int MAX_PROXY_MEDIA_BYTES = 5 * 1024 * 1024;
+
+    // XML response timeout
+    public static final int DEFAULT_RESPONSE_TIMEOUT = 10;
+}

--- a/bundles/org.openhab.binding.plivo/src/main/java/org/openhab/binding/plivo/internal/PlivoHandlerFactory.java
+++ b/bundles/org.openhab.binding.plivo/src/main/java/org/openhab/binding/plivo/internal/PlivoHandlerFactory.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.plivo.internal;
+
+import static org.openhab.binding.plivo.internal.PlivoBindingConstants.*;
+
+import java.util.Set;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.jetty.client.HttpClient;
+import org.openhab.binding.plivo.internal.handler.PlivoAccountHandler;
+import org.openhab.binding.plivo.internal.handler.PlivoPhoneHandler;
+import org.openhab.binding.plivo.internal.service.PlivoCloudWebhookService;
+import org.openhab.binding.plivo.internal.servlet.PlivoCallbackServlet;
+import org.openhab.core.io.net.http.HttpClientFactory;
+import org.openhab.core.items.ItemRegistry;
+import org.openhab.core.thing.Bridge;
+import org.openhab.core.thing.Thing;
+import org.openhab.core.thing.ThingTypeUID;
+import org.openhab.core.thing.binding.BaseThingHandlerFactory;
+import org.openhab.core.thing.binding.ThingHandler;
+import org.openhab.core.thing.binding.ThingHandlerFactory;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * The {@link PlivoHandlerFactory} is responsible for creating things and thing handlers.
+ *
+ * @author Sarvesh Patil - Initial contribution
+ */
+@NonNullByDefault
+@Component(configurationPid = "binding.plivo", service = ThingHandlerFactory.class)
+public class PlivoHandlerFactory extends BaseThingHandlerFactory {
+
+    private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Set.of(THING_TYPE_ACCOUNT, THING_TYPE_PHONE);
+
+    private final HttpClient httpClient;
+    private final PlivoCallbackServlet callbackServlet;
+    private final ItemRegistry itemRegistry;
+    private final PlivoCloudWebhookService cloudWebhookService;
+
+    @Activate
+    public PlivoHandlerFactory(final @Reference HttpClientFactory httpClientFactory,
+            final @Reference PlivoCallbackServlet callbackServlet, final @Reference ItemRegistry itemRegistry,
+            final @Reference PlivoCloudWebhookService cloudWebhookService) {
+        this.callbackServlet = callbackServlet;
+        this.itemRegistry = itemRegistry;
+        this.cloudWebhookService = cloudWebhookService;
+        this.httpClient = httpClientFactory.getCommonHttpClient();
+    }
+
+    @Override
+    public boolean supportsThingType(ThingTypeUID thingTypeUID) {
+        return SUPPORTED_THING_TYPES_UIDS.contains(thingTypeUID);
+    }
+
+    @Override
+    protected @Nullable ThingHandler createHandler(Thing thing) {
+        ThingTypeUID thingTypeUID = thing.getThingTypeUID();
+
+        if (THING_TYPE_ACCOUNT.equals(thingTypeUID)) {
+            return new PlivoAccountHandler((Bridge) thing, httpClient, cloudWebhookService);
+        } else if (THING_TYPE_PHONE.equals(thingTypeUID)) {
+            return new PlivoPhoneHandler(thing, callbackServlet, itemRegistry);
+        }
+
+        return null;
+    }
+}

--- a/bundles/org.openhab.binding.plivo/src/main/java/org/openhab/binding/plivo/internal/PlivoHandlerFactory.java
+++ b/bundles/org.openhab.binding.plivo/src/main/java/org/openhab/binding/plivo/internal/PlivoHandlerFactory.java
@@ -18,7 +18,6 @@ import java.util.Set;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
-import org.eclipse.jetty.client.HttpClient;
 import org.openhab.binding.plivo.internal.handler.PlivoAccountHandler;
 import org.openhab.binding.plivo.internal.handler.PlivoPhoneHandler;
 import org.openhab.binding.plivo.internal.service.PlivoCloudWebhookService;
@@ -46,7 +45,7 @@ public class PlivoHandlerFactory extends BaseThingHandlerFactory {
 
     private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Set.of(THING_TYPE_ACCOUNT, THING_TYPE_PHONE);
 
-    private final HttpClient httpClient;
+    private final HttpClientFactory httpClientFactory;
     private final PlivoCallbackServlet callbackServlet;
     private final ItemRegistry itemRegistry;
     private final PlivoCloudWebhookService cloudWebhookService;
@@ -58,7 +57,7 @@ public class PlivoHandlerFactory extends BaseThingHandlerFactory {
         this.callbackServlet = callbackServlet;
         this.itemRegistry = itemRegistry;
         this.cloudWebhookService = cloudWebhookService;
-        this.httpClient = httpClientFactory.getCommonHttpClient();
+        this.httpClientFactory = httpClientFactory;
     }
 
     @Override
@@ -71,7 +70,8 @@ public class PlivoHandlerFactory extends BaseThingHandlerFactory {
         ThingTypeUID thingTypeUID = thing.getThingTypeUID();
 
         if (THING_TYPE_ACCOUNT.equals(thingTypeUID)) {
-            return new PlivoAccountHandler((Bridge) thing, httpClient, cloudWebhookService);
+            return new PlivoAccountHandler((Bridge) thing, httpClientFactory.getCommonHttpClient(),
+                    cloudWebhookService);
         } else if (THING_TYPE_PHONE.equals(thingTypeUID)) {
             return new PlivoPhoneHandler(thing, callbackServlet, itemRegistry);
         }

--- a/bundles/org.openhab.binding.plivo/src/main/java/org/openhab/binding/plivo/internal/action/PlivoActions.java
+++ b/bundles/org.openhab.binding.plivo/src/main/java/org/openhab/binding/plivo/internal/action/PlivoActions.java
@@ -77,14 +77,14 @@ public class PlivoActions implements ThingActions {
         }
         PlivoApiClient client = getApiClient(handler);
         if (client == null) {
-            logger.debug("Cannot send message: API client not available");
+            logger.warn("Cannot send message: the Plivo account is not available");
             return false;
         }
         try {
             client.sendMessage(handler.getPhoneNumber(), to, message, mediaUrl, handler.getStatusCallbackUrl());
             return true;
         } catch (PlivoApiException e) {
-            logger.debug("Failed to send message: {}", e.getMessage());
+            logger.warn("Failed to send message to {}: {}", to, e.getMessage());
             return false;
         }
     }
@@ -117,14 +117,14 @@ public class PlivoActions implements ThingActions {
         }
         PlivoApiClient client = getApiClient(handler);
         if (client == null) {
-            logger.debug("Cannot send WhatsApp message: API client not available");
+            logger.warn("Cannot send WhatsApp message: the Plivo account is not available");
             return false;
         }
         try {
             client.sendWhatsApp(handler.getPhoneNumber(), to, message, mediaUrl, handler.getStatusCallbackUrl());
             return true;
         } catch (PlivoApiException e) {
-            logger.debug("Failed to send WhatsApp message: {}", e.getMessage());
+            logger.warn("Failed to send WhatsApp message to {}: {}", to, e.getMessage());
             return false;
         }
     }
@@ -146,13 +146,14 @@ public class PlivoActions implements ThingActions {
         }
         PlivoApiClient client = getApiClient(handler);
         if (client == null) {
-            logger.debug("Cannot make call: API client not available");
+            logger.warn("Cannot make call: the Plivo account is not available");
             return false;
         }
 
         String answerBaseUrl = handler.getWebhookUrl(WEBHOOK_ANSWER);
         if (answerBaseUrl == null) {
-            logger.debug("Cannot make call: no public URL is configured to host the answer XML");
+            logger.warn(
+                    "Cannot make call: configure publicUrl or useCloudWebhook on the bridge so Plivo can fetch the answer XML");
             return false;
         }
 
@@ -164,7 +165,7 @@ public class PlivoActions implements ThingActions {
             client.makeCall(handler.getPhoneNumber(), to, answerUrl, handler.getStatusCallbackUrl());
             return true;
         } catch (PlivoApiException e) {
-            logger.debug("Failed to make call: {}", e.getMessage());
+            logger.warn("Failed to make call to {}: {}", to, e.getMessage());
             return false;
         }
     }
@@ -222,12 +223,12 @@ public class PlivoActions implements ThingActions {
                 String uuid = handler.getCallbackServlet().createMediaEntry(rawType.getBytes(), rawType.getMimeType());
                 return mediaBaseUrl + "/" + uuid;
             } else {
-                logger.debug("Item '{}' state is not RawType (Image), got: {}", itemName,
+                logger.warn("Cannot create a media URL: item '{}' is not an Image item (state is {})", itemName,
                         state.getClass().getSimpleName());
                 return null;
             }
         } catch (ItemNotFoundException e) {
-            logger.debug("Item '{}' not found", itemName);
+            logger.warn("Cannot create a media URL: item '{}' was not found", itemName);
             return null;
         }
     }
@@ -272,7 +273,7 @@ public class PlivoActions implements ThingActions {
         if (future != null) {
             future.complete(xml);
         } else {
-            logger.debug("No pending response found for CallUUID {}. The response timeout may have elapsed.", callUuid);
+            logger.warn("No pending response for CallUUID {}; the responseTimeout may have elapsed already.", callUuid);
         }
     }
 
@@ -295,7 +296,7 @@ public class PlivoActions implements ThingActions {
     private @Nullable PlivoPhoneHandler getHandler() {
         PlivoPhoneHandler handler = phoneHandler;
         if (handler == null) {
-            logger.debug("Plivo action invoked but thing handler is not set");
+            logger.warn("Plivo action invoked but the Thing handler is not set");
         }
         return handler;
     }

--- a/bundles/org.openhab.binding.plivo/src/main/java/org/openhab/binding/plivo/internal/action/PlivoActions.java
+++ b/bundles/org.openhab.binding.plivo/src/main/java/org/openhab/binding/plivo/internal/action/PlivoActions.java
@@ -1,0 +1,310 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.plivo.internal.action;
+
+import static org.openhab.binding.plivo.internal.PlivoBindingConstants.ANSWER_TOKEN_PARAM;
+import static org.openhab.binding.plivo.internal.PlivoBindingConstants.WEBHOOK_ANSWER;
+
+import java.util.concurrent.CompletableFuture;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.plivo.internal.api.PlivoApiClient;
+import org.openhab.binding.plivo.internal.api.PlivoApiException;
+import org.openhab.binding.plivo.internal.handler.PlivoAccountHandler;
+import org.openhab.binding.plivo.internal.handler.PlivoPhoneHandler;
+import org.openhab.core.automation.annotation.ActionInput;
+import org.openhab.core.automation.annotation.ActionOutput;
+import org.openhab.core.automation.annotation.RuleAction;
+import org.openhab.core.items.Item;
+import org.openhab.core.items.ItemNotFoundException;
+import org.openhab.core.library.types.RawType;
+import org.openhab.core.thing.binding.ThingActions;
+import org.openhab.core.thing.binding.ThingActionsScope;
+import org.openhab.core.thing.binding.ThingHandler;
+import org.openhab.core.types.State;
+import org.openhab.core.util.StringUtils;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ServiceScope;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Rule actions for the Plivo binding. Provides methods for sending SMS/MMS,
+ * WhatsApp messages, and making voice calls.
+ *
+ * @author Sarvesh Patil - Initial contribution
+ */
+@Component(scope = ServiceScope.PROTOTYPE, service = PlivoActions.class)
+@ThingActionsScope(name = "plivo")
+@NonNullByDefault
+public class PlivoActions implements ThingActions {
+
+    private final Logger logger = LoggerFactory.getLogger(PlivoActions.class);
+
+    private @NonNullByDefault({}) PlivoPhoneHandler phoneHandler;
+
+    @RuleAction(label = "send SMS", description = "Send an SMS message")
+    public @ActionOutput(label = "Success", type = "java.lang.Boolean") Boolean sendSMS(
+            @ActionInput(name = "to", label = "To", description = "Recipient phone number (E.164 format)", type = "java.lang.String", required = true) String to,
+            @ActionInput(name = "message", label = "Message", description = "Message body", type = "java.lang.String", required = true) String message) {
+        return sendSMS(to, message, null);
+    }
+
+    public static Boolean sendSMS(ThingActions actions, String to, String message) {
+        return ((PlivoActions) actions).sendSMS(to, message);
+    }
+
+    @RuleAction(label = "send MMS", description = "Send an MMS message with media")
+    public @ActionOutput(label = "Success", type = "java.lang.Boolean") Boolean sendSMS(
+            @ActionInput(name = "to", label = "To", description = "Recipient phone number (E.164 format)", type = "java.lang.String", required = true) String to,
+            @ActionInput(name = "message", label = "Message", description = "Message body (optional for MMS)", type = "java.lang.String", required = false) @Nullable String message,
+            @ActionInput(name = "mediaUrl", label = "Media URL", description = "URL of media to attach", type = "java.lang.String") @Nullable String mediaUrl) {
+        logger.trace("sendSMS called: to='{}', message='{}', mediaUrl='{}'", to, message, mediaUrl);
+        PlivoPhoneHandler handler = getHandler();
+        if (handler == null) {
+            return false;
+        }
+        PlivoApiClient client = getApiClient(handler);
+        if (client == null) {
+            logger.debug("Cannot send message: API client not available");
+            return false;
+        }
+        try {
+            client.sendMessage(handler.getPhoneNumber(), to, message, mediaUrl, handler.getStatusCallbackUrl());
+            return true;
+        } catch (PlivoApiException e) {
+            logger.debug("Failed to send message: {}", e.getMessage());
+            return false;
+        }
+    }
+
+    public static Boolean sendSMS(ThingActions actions, String to, @Nullable String message,
+            @Nullable String mediaUrl) {
+        return ((PlivoActions) actions).sendSMS(to, message, mediaUrl);
+    }
+
+    @RuleAction(label = "send WhatsApp", description = "Send a WhatsApp message")
+    public @ActionOutput(label = "Success", type = "java.lang.Boolean") Boolean sendWhatsApp(
+            @ActionInput(name = "to", label = "To", description = "Recipient phone number (E.164 format)", type = "java.lang.String", required = true) String to,
+            @ActionInput(name = "message", label = "Message", description = "Message body", type = "java.lang.String", required = true) String message) {
+        return sendWhatsApp(to, message, null);
+    }
+
+    public static Boolean sendWhatsApp(ThingActions actions, String to, String message) {
+        return ((PlivoActions) actions).sendWhatsApp(to, message);
+    }
+
+    @RuleAction(label = "send WhatsApp with media", description = "Send a WhatsApp message with media")
+    public @ActionOutput(label = "Success", type = "java.lang.Boolean") Boolean sendWhatsApp(
+            @ActionInput(name = "to", label = "To", description = "Recipient phone number (E.164 format)", type = "java.lang.String", required = true) String to,
+            @ActionInput(name = "message", label = "Message", description = "Message body (optional with media)", type = "java.lang.String", required = false) @Nullable String message,
+            @ActionInput(name = "mediaUrl", label = "Media URL", description = "URL of media to attach", type = "java.lang.String") @Nullable String mediaUrl) {
+        logger.trace("sendWhatsApp called: to='{}', message='{}', mediaUrl='{}'", to, message, mediaUrl);
+        PlivoPhoneHandler handler = getHandler();
+        if (handler == null) {
+            return false;
+        }
+        PlivoApiClient client = getApiClient(handler);
+        if (client == null) {
+            logger.debug("Cannot send WhatsApp message: API client not available");
+            return false;
+        }
+        try {
+            client.sendWhatsApp(handler.getPhoneNumber(), to, message, mediaUrl, handler.getStatusCallbackUrl());
+            return true;
+        } catch (PlivoApiException e) {
+            logger.debug("Failed to send WhatsApp message: {}", e.getMessage());
+            return false;
+        }
+    }
+
+    public static Boolean sendWhatsApp(ThingActions actions, String to, @Nullable String message,
+            @Nullable String mediaUrl) {
+        return ((PlivoActions) actions).sendWhatsApp(to, message, mediaUrl);
+    }
+
+    @RuleAction(label = "make call", description = "Make a voice call with Plivo XML")
+    public @ActionOutput(label = "Success", type = "java.lang.Boolean") Boolean makeCall(
+            @ActionInput(name = "to", label = "To", description = "Recipient phone number (E.164 format)", type = "java.lang.String", required = true) String to,
+            @ActionInput(name = "xml", label = "XML", description = "Plivo XML instructions for the call", type = "java.lang.String", required = true) String xml) {
+        logger.trace("makeCall called: to='{}', xml='{}'", to, xml);
+
+        PlivoPhoneHandler handler = getHandler();
+        if (handler == null) {
+            return false;
+        }
+        PlivoApiClient client = getApiClient(handler);
+        if (client == null) {
+            logger.debug("Cannot make call: API client not available");
+            return false;
+        }
+
+        String answerBaseUrl = handler.getWebhookUrl(WEBHOOK_ANSWER);
+        if (answerBaseUrl == null) {
+            logger.debug("Cannot make call: no public URL is configured to host the answer XML");
+            return false;
+        }
+
+        String processedXml = handler.replaceXmlPlaceholders(xml);
+        String token = handler.getCallbackServlet().createCallXmlEntry(processedXml);
+        String answerUrl = answerBaseUrl + "?" + ANSWER_TOKEN_PARAM + "=" + token;
+
+        try {
+            client.makeCall(handler.getPhoneNumber(), to, answerUrl, handler.getStatusCallbackUrl());
+            return true;
+        } catch (PlivoApiException e) {
+            logger.debug("Failed to make call: {}", e.getMessage());
+            return false;
+        }
+    }
+
+    public static Boolean makeCall(ThingActions actions, String to, String xml) {
+        return ((PlivoActions) actions).makeCall(to, xml);
+    }
+
+    @RuleAction(label = "make TTS call", description = "Make a voice call with text-to-speech")
+    public @ActionOutput(label = "Success", type = "java.lang.Boolean") Boolean makeTTSCall(
+            @ActionInput(name = "to", label = "To", description = "Recipient phone number (E.164 format)", type = "java.lang.String", required = true) String to,
+            @ActionInput(name = "text", label = "Text", description = "Text to speak", type = "java.lang.String", required = true) String text) {
+        return makeTTSCall(to, text, null);
+    }
+
+    public static Boolean makeTTSCall(ThingActions actions, String to, String text) {
+        return ((PlivoActions) actions).makeTTSCall(to, text);
+    }
+
+    @RuleAction(label = "make TTS call with voice", description = "Make a voice call with text-to-speech using a specific voice")
+    public @ActionOutput(label = "Success", type = "java.lang.Boolean") Boolean makeTTSCall(
+            @ActionInput(name = "to", label = "To", description = "Recipient phone number (E.164 format)", type = "java.lang.String", required = true) String to,
+            @ActionInput(name = "text", label = "Text", description = "Text to speak", type = "java.lang.String", required = true) String text,
+            @ActionInput(name = "voice", label = "Voice", description = "Voice to use (e.g. 'WOMAN', 'Polly.Joanna')", type = "java.lang.String") @Nullable String voice) {
+        logger.trace("makeTTSCall called: to='{}', text='{}', voice='{}'", to, text, voice);
+        String escapedText = StringUtils.escapeXml(text);
+        String voiceAttr = (voice != null && !voice.isBlank()) ? " voice=\"" + StringUtils.escapeXml(voice) + "\"" : "";
+        String xml = "<Response><Speak" + voiceAttr + ">" + escapedText + "</Speak></Response>";
+        return makeCall(to, xml);
+    }
+
+    public static Boolean makeTTSCall(ThingActions actions, String to, String text, @Nullable String voice) {
+        return ((PlivoActions) actions).makeTTSCall(to, text, voice);
+    }
+
+    @RuleAction(label = "create item media URL", description = "Create a temporary public URL for an openHAB Image item")
+    public @ActionOutput(label = "Media URL", type = "java.lang.String") @Nullable String createItemMediaUrl(
+            @ActionInput(name = "itemName", label = "Item Name", description = "Name of an Image item", type = "java.lang.String", required = true) String itemName) {
+        logger.trace("createItemMediaUrl called: itemName='{}'", itemName);
+
+        PlivoPhoneHandler handler = getHandler();
+        if (handler == null) {
+            return null;
+        }
+        String mediaBaseUrl = handler.getMediaBaseUrl();
+        if (mediaBaseUrl == null) {
+            logger.debug("Cannot create media URL: neither publicUrl nor useCloudWebhook is configured on bridge");
+            return null;
+        }
+
+        try {
+            Item item = handler.getItemRegistry().getItem(itemName);
+            State state = item.getState();
+            if (state instanceof RawType rawType) {
+                String uuid = handler.getCallbackServlet().createMediaEntry(rawType.getBytes(), rawType.getMimeType());
+                return mediaBaseUrl + "/" + uuid;
+            } else {
+                logger.debug("Item '{}' state is not RawType (Image), got: {}", itemName,
+                        state.getClass().getSimpleName());
+                return null;
+            }
+        } catch (ItemNotFoundException e) {
+            logger.debug("Item '{}' not found", itemName);
+            return null;
+        }
+    }
+
+    public static @Nullable String createItemMediaUrl(ThingActions actions, String itemName) {
+        return ((PlivoActions) actions).createItemMediaUrl(itemName);
+    }
+
+    @RuleAction(label = "create proxy media URL", description = "Create a temporary public URL that proxies a local/internal URL")
+    public @ActionOutput(label = "Media URL", type = "java.lang.String") @Nullable String createProxyMediaUrl(
+            @ActionInput(name = "sourceUrl", label = "Source URL", description = "Local URL to proxy (e.g. http://192.168.1.100/snapshot.jpg)", type = "java.lang.String", required = true) String sourceUrl) {
+        logger.trace("createProxyMediaUrl called: sourceUrl='{}'", sourceUrl);
+
+        PlivoPhoneHandler handler = getHandler();
+        if (handler == null) {
+            return null;
+        }
+        String mediaBaseUrl = handler.getMediaBaseUrl();
+        if (mediaBaseUrl == null) {
+            logger.debug("Cannot create media URL: neither publicUrl nor useCloudWebhook is configured on bridge");
+            return null;
+        }
+
+        String uuid = handler.getCallbackServlet().createProxyEntry(sourceUrl);
+        return mediaBaseUrl + "/" + uuid;
+    }
+
+    public static @Nullable String createProxyMediaUrl(ThingActions actions, String sourceUrl) {
+        return ((PlivoActions) actions).createProxyMediaUrl(sourceUrl);
+    }
+
+    @RuleAction(label = "respond with XML", description = "Respond to an active call with Plivo XML. Must be called during a call-received or dtmf-received trigger.")
+    public void respondWithXml(
+            @ActionInput(name = "callUuid", label = "Call UUID", description = "The CallUUID from the trigger event", type = "java.lang.String", required = true) String callUuid,
+            @ActionInput(name = "xml", label = "XML", description = "Plivo XML response (e.g. <Response><Speak>Hello</Speak></Response>)", type = "java.lang.String", required = true) String xml) {
+        logger.trace("respondWithXml called: callUuid='{}', xml='{}'", callUuid, xml);
+        PlivoPhoneHandler handler = getHandler();
+        if (handler == null) {
+            return;
+        }
+        CompletableFuture<String> future = handler.getCallbackServlet().getPendingResponse(callUuid);
+        if (future != null) {
+            future.complete(xml);
+        } else {
+            logger.debug("No pending response found for CallUUID {}. The response timeout may have elapsed.", callUuid);
+        }
+    }
+
+    public static void respondWithXml(ThingActions actions, String callUuid, String xml) {
+        ((PlivoActions) actions).respondWithXml(callUuid, xml);
+    }
+
+    @Override
+    public void setThingHandler(@Nullable ThingHandler handler) {
+        if (handler instanceof PlivoPhoneHandler plivoHandler) {
+            this.phoneHandler = plivoHandler;
+        }
+    }
+
+    @Override
+    public @Nullable ThingHandler getThingHandler() {
+        return phoneHandler;
+    }
+
+    private @Nullable PlivoPhoneHandler getHandler() {
+        PlivoPhoneHandler handler = phoneHandler;
+        if (handler == null) {
+            logger.debug("Plivo action invoked but thing handler is not set");
+        }
+        return handler;
+    }
+
+    private @Nullable PlivoApiClient getApiClient(PlivoPhoneHandler handler) {
+        PlivoAccountHandler accountHandler = handler.getAccountHandler();
+        if (accountHandler != null) {
+            return accountHandler.getApiClient();
+        }
+        return null;
+    }
+}

--- a/bundles/org.openhab.binding.plivo/src/main/java/org/openhab/binding/plivo/internal/api/PlivoApiClient.java
+++ b/bundles/org.openhab.binding.plivo/src/main/java/org/openhab/binding/plivo/internal/api/PlivoApiClient.java
@@ -1,0 +1,350 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.plivo.internal.api;
+
+import static org.openhab.binding.plivo.internal.PlivoBindingConstants.API_BASE_URL;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.api.ContentResponse;
+import org.eclipse.jetty.client.util.StringContentProvider;
+import org.eclipse.jetty.http.HttpHeader;
+import org.eclipse.jetty.http.HttpMethod;
+import org.eclipse.jetty.http.HttpStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+/**
+ * REST API client for the Plivo API. Handles authentication and request/response
+ * processing for sending SMS/MMS/WhatsApp messages, making calls, and managing
+ * phone numbers and applications.
+ *
+ * @author Sarvesh Patil - Initial contribution
+ */
+@NonNullByDefault
+public class PlivoApiClient {
+
+    private static final int TIMEOUT_SECONDS = 30;
+    private static final String CONTENT_TYPE_JSON = "application/json";
+    private static final String ANSWER_METHOD_POST = "POST";
+
+    private final Logger logger = LoggerFactory.getLogger(PlivoApiClient.class);
+
+    private final HttpClient httpClient;
+    private final String authId;
+    private final String authToken;
+    private final String baseUrl;
+    private final String authHeader;
+
+    public PlivoApiClient(HttpClient httpClient, String authId, String authToken) {
+        this.httpClient = httpClient;
+        this.authId = authId;
+        this.authToken = authToken;
+        this.baseUrl = API_BASE_URL + authId + "/";
+        this.authHeader = "Basic "
+                + Base64.getEncoder().encodeToString((authId + ":" + authToken).getBytes(StandardCharsets.UTF_8));
+    }
+
+    /**
+     * Validates the account credentials by fetching the account resource.
+     *
+     * @return true if the account is reachable and the Auth ID matches
+     * @throws PlivoApiException if the API call fails
+     */
+    public boolean validateAccount() throws PlivoApiException {
+        String response = get(baseUrl);
+        JsonObject json = JsonParser.parseString(response).getAsJsonObject();
+        JsonElement authIdElement = json.get("auth_id");
+        return authIdElement != null && authId.equals(authIdElement.getAsString());
+    }
+
+    /**
+     * Sends an SMS or MMS message.
+     *
+     * @param src the Plivo phone number to send from (E.164 format)
+     * @param dst the recipient phone number (E.164 format)
+     * @param text the message body
+     * @param mediaUrl optional media URL for MMS
+     * @param url optional delivery-report webhook URL
+     * @return the message UUID if successful
+     * @throws PlivoApiException if the API call fails
+     */
+    public String sendMessage(String src, String dst, @Nullable String text, @Nullable String mediaUrl,
+            @Nullable String url) throws PlivoApiException {
+        JsonObject body = new JsonObject();
+        body.addProperty("src", src);
+        body.addProperty("dst", dst);
+        body.addProperty("type", mediaUrl != null && !mediaUrl.isBlank() ? "mms" : "sms");
+        if (text != null && !text.isBlank()) {
+            body.addProperty("text", text);
+        }
+        if (mediaUrl != null && !mediaUrl.isBlank()) {
+            JsonArray mediaUrls = new JsonArray();
+            mediaUrls.add(mediaUrl);
+            body.add("media_urls", mediaUrls);
+        }
+        if (url != null && !url.isBlank()) {
+            body.addProperty("url", url);
+        }
+        return firstMessageUuid(post(baseUrl + "Message/", body.toString()));
+    }
+
+    /**
+     * Sends a WhatsApp message (freeform text and/or media).
+     *
+     * @param src the WhatsApp Business number to send from (E.164 format)
+     * @param dst the recipient phone number (E.164 format)
+     * @param text the message body
+     * @param mediaUrl optional media URL
+     * @param url optional delivery-report webhook URL
+     * @return the message UUID if successful
+     * @throws PlivoApiException if the API call fails
+     */
+    public String sendWhatsApp(String src, String dst, @Nullable String text, @Nullable String mediaUrl,
+            @Nullable String url) throws PlivoApiException {
+        JsonObject body = new JsonObject();
+        body.addProperty("src", src);
+        body.addProperty("dst", dst);
+        body.addProperty("type", "whatsapp");
+        if (text != null && !text.isBlank()) {
+            body.addProperty("text", text);
+        }
+        if (mediaUrl != null && !mediaUrl.isBlank()) {
+            JsonArray mediaUrls = new JsonArray();
+            mediaUrls.add(mediaUrl);
+            body.add("media_urls", mediaUrls);
+        }
+        if (url != null && !url.isBlank()) {
+            body.addProperty("url", url);
+        }
+        return firstMessageUuid(post(baseUrl + "Message/", body.toString()));
+    }
+
+    /**
+     * Initiates a voice call. Plivo fetches the call-flow XML from {@code answerUrl}
+     * when the call is answered.
+     *
+     * @param from the Plivo phone number to call from (E.164 format)
+     * @param to the recipient phone number (E.164 format)
+     * @param answerUrl the URL that returns the answer XML
+     * @param hangupUrl optional URL notified when the call ends
+     * @return the request UUID if successful
+     * @throws PlivoApiException if the API call fails
+     */
+    public String makeCall(String from, String to, String answerUrl, @Nullable String hangupUrl)
+            throws PlivoApiException {
+        JsonObject body = new JsonObject();
+        body.addProperty("from", from);
+        body.addProperty("to", to);
+        body.addProperty("answer_url", answerUrl);
+        body.addProperty("answer_method", ANSWER_METHOD_POST);
+        if (hangupUrl != null && !hangupUrl.isBlank()) {
+            body.addProperty("hangup_url", hangupUrl);
+            body.addProperty("hangup_method", ANSWER_METHOD_POST);
+        }
+        String response = post(baseUrl + "Call/", body.toString());
+        JsonObject json = JsonParser.parseString(response).getAsJsonObject();
+        JsonElement requestUuid = json.get("request_uuid");
+        return requestUuid != null && !requestUuid.isJsonNull() ? requestUuid.getAsString() : "";
+    }
+
+    /**
+     * Lists all phone numbers on the account.
+     *
+     * @return list of phone number info objects
+     * @throws PlivoApiException if the API call fails
+     */
+    public List<PlivoPhoneNumberInfo> listPhoneNumbers() throws PlivoApiException {
+        String response = get(baseUrl + "Number/");
+        JsonObject json = JsonParser.parseString(response).getAsJsonObject();
+        JsonArray objects = json.getAsJsonArray("objects");
+        List<PlivoPhoneNumberInfo> result = new ArrayList<>();
+        if (objects != null) {
+            for (int i = 0; i < objects.size(); i++) {
+                JsonObject entry = objects.get(i).getAsJsonObject();
+                result.add(new PlivoPhoneNumberInfo(getJsonString(entry, "number"), getJsonString(entry, "alias")));
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Creates or updates a Plivo application with the given webhook URLs and returns its app ID.
+     * An existing application with the same name is updated in place so repeated initializations
+     * do not create duplicates.
+     *
+     * @param appName the application name
+     * @param answerUrl the voice answer webhook URL
+     * @param messageUrl the inbound message webhook URL
+     * @param hangupUrl the call hangup webhook URL
+     * @return the application ID
+     * @throws PlivoApiException if the API call fails
+     */
+    public String createOrUpdateApplication(String appName, String answerUrl, String messageUrl, String hangupUrl)
+            throws PlivoApiException {
+        String existingAppId = findApplicationId(appName);
+
+        JsonObject body = new JsonObject();
+        body.addProperty("answer_url", answerUrl);
+        body.addProperty("answer_method", ANSWER_METHOD_POST);
+        body.addProperty("message_url", messageUrl);
+        body.addProperty("message_method", ANSWER_METHOD_POST);
+        body.addProperty("hangup_url", hangupUrl);
+        body.addProperty("hangup_method", ANSWER_METHOD_POST);
+
+        if (existingAppId != null) {
+            post(baseUrl + "Application/" + existingAppId + "/", body.toString());
+            return existingAppId;
+        }
+        body.addProperty("app_name", appName);
+        String response = post(baseUrl + "Application/", body.toString());
+        JsonObject json = JsonParser.parseString(response).getAsJsonObject();
+        return getJsonString(json, "app_id");
+    }
+
+    /**
+     * Assigns an application to a phone number.
+     *
+     * @param number the phone number in E.164 format
+     * @param appId the application ID
+     * @throws PlivoApiException if the API call fails
+     */
+    public void assignApplicationToNumber(String number, String appId) throws PlivoApiException {
+        JsonObject body = new JsonObject();
+        body.addProperty("app_id", appId);
+        String pathNumber = number.startsWith("+") ? number.substring(1) : number;
+        post(baseUrl + "Number/" + encode(pathNumber) + "/", body.toString());
+    }
+
+    public String getAuthToken() {
+        return authToken;
+    }
+
+    public String getAuthId() {
+        return authId;
+    }
+
+    private @Nullable String findApplicationId(String appName) throws PlivoApiException {
+        String response = get(baseUrl + "Application/");
+        JsonObject json = JsonParser.parseString(response).getAsJsonObject();
+        JsonArray objects = json.getAsJsonArray("objects");
+        if (objects != null) {
+            for (int i = 0; i < objects.size(); i++) {
+                JsonObject entry = objects.get(i).getAsJsonObject();
+                if (appName.equals(getJsonString(entry, "app_name"))) {
+                    return getJsonString(entry, "app_id");
+                }
+            }
+        }
+        return null;
+    }
+
+    private String firstMessageUuid(String response) {
+        JsonObject json = JsonParser.parseString(response).getAsJsonObject();
+        JsonArray uuids = json.getAsJsonArray("message_uuid");
+        if (uuids != null && uuids.size() > 0) {
+            return uuids.get(0).getAsString();
+        }
+        return "";
+    }
+
+    private String encode(String value) {
+        return URLEncoder.encode(value, StandardCharsets.UTF_8);
+    }
+
+    private String get(String url) throws PlivoApiException {
+        logger.trace("Plivo GET: {}", url);
+        try {
+            ContentResponse response = httpClient.newRequest(url) //
+                    .method(HttpMethod.GET) //
+                    .header(HttpHeader.AUTHORIZATION, authHeader) //
+                    .timeout(TIMEOUT_SECONDS, TimeUnit.SECONDS) //
+                    .send();
+            return handleResponse(response);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new PlivoApiException("Request interrupted", e);
+        } catch (ExecutionException | TimeoutException e) {
+            throw new PlivoApiException("Request failed: " + e.getMessage(), e);
+        }
+    }
+
+    private String post(String url, String jsonBody) throws PlivoApiException {
+        logger.trace("Plivo POST: {} body: {}", url, jsonBody);
+        try {
+            ContentResponse response = httpClient.newRequest(url) //
+                    .method(HttpMethod.POST) //
+                    .header(HttpHeader.AUTHORIZATION, authHeader) //
+                    .content(new StringContentProvider(CONTENT_TYPE_JSON, jsonBody, StandardCharsets.UTF_8)) //
+                    .timeout(TIMEOUT_SECONDS, TimeUnit.SECONDS) //
+                    .send();
+            return handleResponse(response);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new PlivoApiException("Request interrupted", e);
+        } catch (ExecutionException | TimeoutException e) {
+            throw new PlivoApiException("Request failed: " + e.getMessage(), e);
+        }
+    }
+
+    private String handleResponse(ContentResponse response) throws PlivoApiException {
+        int status = response.getStatus();
+        String content = response.getContentAsString();
+        logger.trace("Plivo response: status={}, content={}", status, content);
+
+        if (status >= 200 && status < 300) {
+            return content;
+        } else if (status == HttpStatus.UNAUTHORIZED_401) {
+            throw new PlivoApiException("Invalid Auth ID or Auth Token", true);
+        } else {
+            throw new PlivoApiException("Plivo API error (" + status + "): " + extractErrorMessage(content));
+        }
+    }
+
+    private String extractErrorMessage(String content) {
+        try {
+            JsonObject json = JsonParser.parseString(content).getAsJsonObject();
+            JsonElement errorElement = json.get("error");
+            if (errorElement != null && !errorElement.isJsonNull()) {
+                return errorElement.getAsString();
+            }
+            JsonElement messageElement = json.get("message");
+            if (messageElement != null && !messageElement.isJsonNull()) {
+                return messageElement.getAsString();
+            }
+        } catch (RuntimeException e) {
+            logger.trace("Could not parse Plivo error body: {}", e.getMessage());
+        }
+        return content;
+    }
+
+    private String getJsonString(JsonObject obj, String key) {
+        JsonElement element = obj.get(key);
+        return element != null && !element.isJsonNull() ? element.getAsString() : "";
+    }
+}

--- a/bundles/org.openhab.binding.plivo/src/main/java/org/openhab/binding/plivo/internal/api/PlivoApiClient.java
+++ b/bundles/org.openhab.binding.plivo/src/main/java/org/openhab/binding/plivo/internal/api/PlivoApiClient.java
@@ -79,7 +79,7 @@ public class PlivoApiClient {
      */
     public boolean validateAccount() throws PlivoApiException {
         String response = get(baseUrl);
-        JsonObject json = JsonParser.parseString(response).getAsJsonObject();
+        JsonObject json = parseObject(response);
         JsonElement authIdElement = json.get("auth_id");
         return authIdElement != null && authId.equals(authIdElement.getAsString());
     }
@@ -169,7 +169,7 @@ public class PlivoApiClient {
             body.addProperty("hangup_method", ANSWER_METHOD_POST);
         }
         String response = post(baseUrl + "Call/", body.toString());
-        JsonObject json = JsonParser.parseString(response).getAsJsonObject();
+        JsonObject json = parseObject(response);
         JsonElement requestUuid = json.get("request_uuid");
         return requestUuid != null && !requestUuid.isJsonNull() ? requestUuid.getAsString() : "";
     }
@@ -220,7 +220,7 @@ public class PlivoApiClient {
         }
         body.addProperty("app_name", appName);
         String response = post(baseUrl + "Application/", body.toString());
-        JsonObject json = JsonParser.parseString(response).getAsJsonObject();
+        JsonObject json = parseObject(response);
         return getJsonString(json, "app_id");
     }
 
@@ -272,7 +272,7 @@ public class PlivoApiClient {
         int offset = 0;
         while (true) {
             String url = baseUrl + resourcePath + "?limit=" + PAGE_LIMIT + "&offset=" + offset;
-            JsonObject json = JsonParser.parseString(get(url)).getAsJsonObject();
+            JsonObject json = parseObject(get(url));
             JsonArray objects = json.getAsJsonArray("objects");
             int fetched = objects != null ? objects.size() : 0;
             if (objects != null) {
@@ -288,8 +288,8 @@ public class PlivoApiClient {
         return all;
     }
 
-    private String firstMessageUuid(String response) {
-        JsonObject json = JsonParser.parseString(response).getAsJsonObject();
+    private String firstMessageUuid(String response) throws PlivoApiException {
+        JsonObject json = parseObject(response);
         JsonArray uuids = json.getAsJsonArray("message_uuid");
         if (uuids != null && uuids.size() > 0) {
             return uuids.get(0).getAsString();
@@ -365,6 +365,29 @@ public class PlivoApiClient {
             logger.trace("Could not parse Plivo error body: {}", e.getMessage());
         }
         return content;
+    }
+
+    /**
+     * Parses a Plivo response body into a JSON object. A response can carry a non-JSON body even
+     * with a 2xx status (for example an HTML error page from an intermediate proxy), so a parse
+     * failure is reported as a {@link PlivoApiException} instead of escaping as an unchecked
+     * exception that callers do not expect.
+     *
+     * @param content the raw response body
+     * @return the parsed JSON object
+     * @throws PlivoApiException if the body is not a JSON object
+     */
+    private JsonObject parseObject(String content) throws PlivoApiException {
+        try {
+            return JsonParser.parseString(content).getAsJsonObject();
+        } catch (RuntimeException e) {
+            throw new PlivoApiException("Unexpected Plivo response body: " + abbreviate(content), e);
+        }
+    }
+
+    private static String abbreviate(String content) {
+        String trimmed = content.strip();
+        return trimmed.length() <= 200 ? trimmed : trimmed.substring(0, 200) + "...";
     }
 
     private String getJsonString(JsonObject obj, String key) {

--- a/bundles/org.openhab.binding.plivo/src/main/java/org/openhab/binding/plivo/internal/api/PlivoApiClient.java
+++ b/bundles/org.openhab.binding.plivo/src/main/java/org/openhab/binding/plivo/internal/api/PlivoApiClient.java
@@ -50,6 +50,7 @@ import com.google.gson.JsonParser;
 public class PlivoApiClient {
 
     private static final int TIMEOUT_SECONDS = 30;
+    private static final int PAGE_LIMIT = 20;
     private static final String CONTENT_TYPE_JSON = "application/json";
     private static final String ANSWER_METHOD_POST = "POST";
 
@@ -180,15 +181,11 @@ public class PlivoApiClient {
      * @throws PlivoApiException if the API call fails
      */
     public List<PlivoPhoneNumberInfo> listPhoneNumbers() throws PlivoApiException {
-        String response = get(baseUrl + "Number/");
-        JsonObject json = JsonParser.parseString(response).getAsJsonObject();
-        JsonArray objects = json.getAsJsonArray("objects");
+        JsonArray objects = getAllObjects("Number/");
         List<PlivoPhoneNumberInfo> result = new ArrayList<>();
-        if (objects != null) {
-            for (int i = 0; i < objects.size(); i++) {
-                JsonObject entry = objects.get(i).getAsJsonObject();
-                result.add(new PlivoPhoneNumberInfo(getJsonString(entry, "number"), getJsonString(entry, "alias")));
-            }
+        for (int i = 0; i < objects.size(); i++) {
+            JsonObject entry = objects.get(i).getAsJsonObject();
+            result.add(new PlivoPhoneNumberInfo(getJsonString(entry, "number"), getJsonString(entry, "alias")));
         }
         return result;
     }
@@ -250,18 +247,45 @@ public class PlivoApiClient {
     }
 
     private @Nullable String findApplicationId(String appName) throws PlivoApiException {
-        String response = get(baseUrl + "Application/");
-        JsonObject json = JsonParser.parseString(response).getAsJsonObject();
-        JsonArray objects = json.getAsJsonArray("objects");
-        if (objects != null) {
-            for (int i = 0; i < objects.size(); i++) {
-                JsonObject entry = objects.get(i).getAsJsonObject();
-                if (appName.equals(getJsonString(entry, "app_name"))) {
-                    return getJsonString(entry, "app_id");
-                }
+        JsonArray objects = getAllObjects("Application/");
+        for (int i = 0; i < objects.size(); i++) {
+            JsonObject entry = objects.get(i).getAsJsonObject();
+            if (appName.equals(getJsonString(entry, "app_name"))) {
+                return getJsonString(entry, "app_id");
             }
         }
         return null;
+    }
+
+    /**
+     * Fetches all pages of a Plivo list resource and returns the concatenated {@code objects} array.
+     * Plivo paginates list responses, so following the {@code meta.next} link (and stopping when a
+     * page returns fewer than {@code limit} entries) avoids missing existing numbers or applications,
+     * which in turn prevents duplicate applications being created.
+     *
+     * @param resourcePath the list resource path relative to the account base (e.g. {@code Number/})
+     * @return every object across all pages
+     * @throws PlivoApiException if any page request fails
+     */
+    private JsonArray getAllObjects(String resourcePath) throws PlivoApiException {
+        JsonArray all = new JsonArray();
+        int offset = 0;
+        while (true) {
+            String url = baseUrl + resourcePath + "?limit=" + PAGE_LIMIT + "&offset=" + offset;
+            JsonObject json = JsonParser.parseString(get(url)).getAsJsonObject();
+            JsonArray objects = json.getAsJsonArray("objects");
+            int fetched = objects != null ? objects.size() : 0;
+            if (objects != null) {
+                all.addAll(objects);
+            }
+            JsonObject meta = json.getAsJsonObject("meta");
+            boolean hasNext = meta != null && meta.get("next") != null && !meta.get("next").isJsonNull();
+            if (fetched == 0 || fetched < PAGE_LIMIT || !hasNext) {
+                break;
+            }
+            offset += fetched;
+        }
+        return all;
     }
 
     private String firstMessageUuid(String response) {

--- a/bundles/org.openhab.binding.plivo/src/main/java/org/openhab/binding/plivo/internal/api/PlivoApiException.java
+++ b/bundles/org.openhab.binding.plivo/src/main/java/org/openhab/binding/plivo/internal/api/PlivoApiException.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.plivo.internal.api;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * Exception thrown by {@link PlivoApiClient} when an API call fails.
+ *
+ * @author Sarvesh Patil - Initial contribution
+ */
+@NonNullByDefault
+public class PlivoApiException extends Exception {
+
+    private static final long serialVersionUID = 1L;
+
+    private final boolean configurationError;
+
+    public PlivoApiException(String message) {
+        super(message);
+        this.configurationError = false;
+    }
+
+    public PlivoApiException(String message, boolean configurationError) {
+        super(message);
+        this.configurationError = configurationError;
+    }
+
+    public PlivoApiException(String message, Throwable cause) {
+        super(message, cause);
+        this.configurationError = false;
+    }
+
+    /**
+     * @return true if this error indicates a configuration problem (e.g. bad credentials)
+     */
+    public boolean isConfigurationError() {
+        return configurationError;
+    }
+}

--- a/bundles/org.openhab.binding.plivo/src/main/java/org/openhab/binding/plivo/internal/api/PlivoPhoneNumberInfo.java
+++ b/bundles/org.openhab.binding.plivo/src/main/java/org/openhab/binding/plivo/internal/api/PlivoPhoneNumberInfo.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.plivo.internal.api;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * DTO representing a Plivo phone number from the Number API.
+ *
+ * @author Sarvesh Patil - Initial contribution
+ */
+@NonNullByDefault
+public class PlivoPhoneNumberInfo {
+
+    public final String number;
+    public final String alias;
+
+    public PlivoPhoneNumberInfo(String number, String alias) {
+        this.number = number;
+        this.alias = alias;
+    }
+}

--- a/bundles/org.openhab.binding.plivo/src/main/java/org/openhab/binding/plivo/internal/api/PlivoSignatureValidator.java
+++ b/bundles/org.openhab.binding.plivo/src/main/java/org/openhab/binding/plivo/internal/api/PlivoSignatureValidator.java
@@ -12,6 +12,7 @@
  */
 package org.openhab.binding.plivo.internal.api;
 
+import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.security.InvalidKeyException;
 import java.security.MessageDigest;
@@ -27,23 +28,15 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 
 /**
- * Validates Plivo webhook request signatures using the V3 signing scheme.
+ * Validates Plivo webhook request signatures.
  * <p>
- * Plivo signs each webhook with an {@code X-Plivo-Signature-V3-Nonce} header plus one or more
- * signature headers: {@code X-Plivo-Signature-V3} is generated with the (sub)account Auth Token
- * that owns the request, while {@code X-Plivo-Signature-Ma-V3} is always generated with the main
- * account Auth Token. Voice callbacks carry the {@code V3} signature and messaging callbacks
- * (SMS/MMS/WhatsApp/status) carry the {@code Ma-V3} signature, but both are computed identically,
- * so this validator can check a request against any of the signatures supplied.
- * <p>
- * For a POST callback the signed string is built as follows. Take the request URL, drop its query
- * string, and append a literal {@code ?}. When the URL originally had a query string, append its
- * parameters sorted by key in ascending order and rendered as {@code key=value} pairs joined by
- * {@code &}, then a {@code .} separator. Next append the POST body parameters sorted by key in
- * ascending order as a {@code key}+{@code value} concatenation with no separators. Finally append
- * a {@code .} and the nonce. The signature is {@code Base64(HMAC-SHA256(authToken, signedString))}.
- * A signature header may carry several comma-separated signatures; the request is valid if any of
- * them matches.
+ * Plivo signs each webhook with one or more headers. The V3 family ({@code X-Plivo-Signature-V3} /
+ * {@code X-Plivo-Signature-Ma-V3}, nonce {@code X-Plivo-Signature-V3-Nonce}) is used for voice and is
+ * also seen on messaging. The V2 family ({@code X-Plivo-Signature-V2} / {@code X-Plivo-Signature-Ma-V2},
+ * nonce {@code X-Plivo-Signature-V2-Nonce}) is documented for messaging. A header may itself carry
+ * several comma-separated signatures. The caller validates each family it received and accepts the
+ * request when any signature matches. The per-family signed-string construction is documented on
+ * {@link #computeV3Signature} and {@link #computeV2Signature}.
  *
  * @author Sarvesh Patil - Initial contribution
  */
@@ -53,24 +46,22 @@ public class PlivoSignatureValidator {
     private static final String HMAC_SHA256 = "HmacSHA256";
 
     /**
-     * Validates a Plivo request signature.
+     * Validates a V3-family signature ({@code X-Plivo-Signature-V3} and/or {@code X-Plivo-Signature-Ma-V3}).
      *
      * @param url the full URL that Plivo requested
-     * @param params the POST parameters from the request
-     * @param signatureHeader a V3-family signature header value ({@code X-Plivo-Signature-V3} and/or
-     *            {@code X-Plivo-Signature-Ma-V3}); a single value may itself be comma-separated and
-     *            several headers may be joined with commas by the caller
-     * @param nonce the X-Plivo-Signature-V3-Nonce header value
+     * @param params the POST body parameters from the request
+     * @param signatureHeader the V3-family header value, which the caller may join with commas
+     * @param nonce the {@code X-Plivo-Signature-V3-Nonce} header value
      * @param authToken the Plivo Auth Token
      * @return true if the signature is valid
      */
-    public static boolean validate(String url, Map<String, String> params, @Nullable String signatureHeader,
+    public static boolean validateV3(String url, Map<String, String> params, @Nullable String signatureHeader,
             @Nullable String nonce, String authToken) {
         if (signatureHeader == null || signatureHeader.isBlank() || nonce == null || nonce.isBlank()) {
             return false;
         }
 
-        String expected = computeSignature(url, params, nonce, authToken);
+        String expected = computeV3Signature(url, params, nonce, authToken);
         byte[] expectedBytes = expected.getBytes(StandardCharsets.UTF_8);
         for (String candidate : signatureHeader.split(",")) {
             if (MessageDigest.isEqual(candidate.trim().getBytes(StandardCharsets.UTF_8), expectedBytes)) {
@@ -95,7 +86,7 @@ public class PlivoSignatureValidator {
      * @param authToken the Auth Token
      * @return the Base64-encoded HMAC-SHA256 signature
      */
-    public static String computeSignature(String url, Map<String, String> params, String nonce, String authToken) {
+    public static String computeV3Signature(String url, Map<String, String> params, String nonce, String authToken) {
         int queryIndex = url.indexOf('?');
         String base = queryIndex >= 0 ? url.substring(0, queryIndex) : url;
         String query = queryIndex >= 0 ? url.substring(queryIndex + 1) : "";
@@ -110,28 +101,80 @@ public class PlivoSignatureValidator {
         }
         data.append('.').append(nonce);
 
+        return hmacBase64(data.toString(), authToken);
+    }
+
+    /**
+     * Validates a Plivo V2-family signature ({@code X-Plivo-Signature-V2} and/or
+     * {@code X-Plivo-Signature-Ma-V2}). Plivo documents this family for messaging callbacks.
+     *
+     * @param url the full URL that Plivo requested
+     * @param signatureHeader the V2 signature header value, which the caller may join with commas
+     * @param nonce the {@code X-Plivo-Signature-V2-Nonce} header value
+     * @param authToken the Plivo Auth Token
+     * @return true if the signature is valid
+     */
+    public static boolean validateV2(String url, @Nullable String signatureHeader, @Nullable String nonce,
+            String authToken) {
+        if (signatureHeader == null || signatureHeader.isBlank() || nonce == null || nonce.isBlank()) {
+            return false;
+        }
+        String expected = computeV2Signature(url, nonce, authToken);
+        byte[] expectedBytes = expected.getBytes(StandardCharsets.UTF_8);
+        for (String candidate : signatureHeader.split(",")) {
+            if (MessageDigest.isEqual(candidate.trim().getBytes(StandardCharsets.UTF_8), expectedBytes)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Computes the expected V2 signature. The signed string is the request URL with its query string
+     * removed, followed immediately by the nonce.
+     *
+     * @param url the full URL Plivo requested
+     * @param nonce the signature nonce
+     * @param authToken the Auth Token
+     * @return the Base64-encoded HMAC-SHA256 signature
+     */
+    public static String computeV2Signature(String url, String nonce, String authToken) {
+        int queryIndex = url.indexOf('?');
+        String base = queryIndex >= 0 ? url.substring(0, queryIndex) : url;
+        return hmacBase64(base + nonce, authToken);
+    }
+
+    private static String hmacBase64(String data, String authToken) {
         try {
             Mac mac = Mac.getInstance(HMAC_SHA256);
             mac.init(new SecretKeySpec(authToken.getBytes(StandardCharsets.UTF_8), HMAC_SHA256));
-            byte[] hmac = mac.doFinal(data.toString().getBytes(StandardCharsets.UTF_8));
+            byte[] hmac = mac.doFinal(data.getBytes(StandardCharsets.UTF_8));
             return Base64.getEncoder().encodeToString(hmac);
         } catch (NoSuchAlgorithmException | InvalidKeyException e) {
             throw new IllegalStateException("Failed to compute HMAC-SHA256 signature", e);
         }
     }
 
+    private static String safeDecode(String s) {
+        try {
+            return URLDecoder.decode(s, StandardCharsets.UTF_8);
+        } catch (IllegalArgumentException e) {
+            // A malformed percent-encoding must not crash validation; sign the raw value instead.
+            return s;
+        }
+    }
+
     private static String sortedQueryString(String query) {
+        // Plivo signs the URL-decoded query params, so decode each key and value and sort by the key.
         TreeMap<String, String> sorted = new TreeMap<>();
         for (String pair : query.split("&")) {
             if (pair.isEmpty()) {
                 continue;
             }
             int eq = pair.indexOf('=');
-            if (eq >= 0) {
-                sorted.put(pair.substring(0, eq), pair.substring(eq + 1));
-            } else {
-                sorted.put(pair, "");
-            }
+            String key = eq >= 0 ? pair.substring(0, eq) : pair;
+            String value = eq >= 0 ? pair.substring(eq + 1) : "";
+            sorted.put(safeDecode(key), safeDecode(value));
         }
         StringBuilder sb = new StringBuilder();
         boolean first = true;

--- a/bundles/org.openhab.binding.plivo/src/main/java/org/openhab/binding/plivo/internal/api/PlivoSignatureValidator.java
+++ b/bundles/org.openhab.binding.plivo/src/main/java/org/openhab/binding/plivo/internal/api/PlivoSignatureValidator.java
@@ -34,9 +34,10 @@ import org.eclipse.jdt.annotation.Nullable;
  * {@code X-Plivo-Signature-Ma-V3}, nonce {@code X-Plivo-Signature-V3-Nonce}) is used for voice and is
  * also seen on messaging. The V2 family ({@code X-Plivo-Signature-V2} / {@code X-Plivo-Signature-Ma-V2},
  * nonce {@code X-Plivo-Signature-V2-Nonce}) is documented for messaging. A header may itself carry
- * several comma-separated signatures. The caller validates each family it received and accepts the
- * request when any signature matches. The per-family signed-string construction is documented on
- * {@link #computeV3Signature} and {@link #computeV2Signature}.
+ * several comma-separated signatures, and {@link #validateV3} / {@link #validateV2} accept the request
+ * when any signature in that header matches. {@link #validateCallback} selects the accepted family in a
+ * callback-aware way and never downgrades a failed V3 signature to V2. The per-family signed-string
+ * construction is documented on {@link #computeV3Signature} and {@link #computeV2Signature}.
  *
  * @author Sarvesh Patil - Initial contribution
  */
@@ -142,6 +143,56 @@ public class PlivoSignatureValidator {
         int queryIndex = url.indexOf('?');
         String base = queryIndex >= 0 ? url.substring(0, queryIndex) : url;
         return hmacBase64(base + nonce, authToken);
+    }
+
+    /**
+     * Validates a callback signature in a callback-aware way. A V3-family signature
+     * ({@code X-Plivo-Signature-V3} or {@code X-Plivo-Signature-Ma-V3}) is authoritative whenever it is
+     * present, so a failed V3 signature is never downgraded to the V2 family. When no V3 signature is
+     * sent, messaging callbacks may use the documented V2 family, while other callbacks (voice, gather,
+     * answer) require V3.
+     *
+     * @param messaging whether this is a messaging callback (SMS, WhatsApp, or a message status)
+     * @param url the full URL that Plivo requested
+     * @param params the POST body parameters
+     * @param authToken the Plivo Auth Token
+     * @param v3 the {@code X-Plivo-Signature-V3} header value, or null
+     * @param maV3 the {@code X-Plivo-Signature-Ma-V3} header value, or null
+     * @param v3Nonce the {@code X-Plivo-Signature-V3-Nonce} header value, or null
+     * @param v2 the {@code X-Plivo-Signature-V2} header value, or null
+     * @param maV2 the {@code X-Plivo-Signature-Ma-V2} header value, or null
+     * @param v2Nonce the {@code X-Plivo-Signature-V2-Nonce} header value, or null
+     * @return true if the request carries a valid signature for its callback type
+     */
+    public static boolean validateCallback(boolean messaging, String url, Map<String, String> params, String authToken,
+            @Nullable String v3, @Nullable String maV3, @Nullable String v3Nonce, @Nullable String v2,
+            @Nullable String maV2, @Nullable String v2Nonce) {
+        boolean v3Present = !isBlank(v3) || !isBlank(maV3);
+        if (v3Present) {
+            String v3Combined = messaging ? join(maV3, v3) : join(v3, maV3);
+            return validateV3(url, params, v3Combined, v3Nonce, authToken);
+        }
+        // No V3 signature was sent. Only messaging callbacks may use the documented V2 family.
+        if (!messaging) {
+            return false;
+        }
+        return validateV2(url, join(maV2, v2), v2Nonce, authToken);
+    }
+
+    private static boolean isBlank(@Nullable String s) {
+        return s == null || s.isBlank();
+    }
+
+    private static @Nullable String join(@Nullable String primary, @Nullable String secondary) {
+        boolean hasPrimary = !isBlank(primary);
+        boolean hasSecondary = !isBlank(secondary);
+        if (hasPrimary && hasSecondary) {
+            return primary + "," + secondary;
+        }
+        if (hasPrimary) {
+            return primary;
+        }
+        return hasSecondary ? secondary : null;
     }
 
     private static String hmacBase64(String data, String authToken) {

--- a/bundles/org.openhab.binding.plivo/src/main/java/org/openhab/binding/plivo/internal/api/PlivoSignatureValidator.java
+++ b/bundles/org.openhab.binding.plivo/src/main/java/org/openhab/binding/plivo/internal/api/PlivoSignatureValidator.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.plivo.internal.api;
+
+import java.nio.charset.StandardCharsets;
+import java.security.InvalidKeyException;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
+import java.util.Map;
+import java.util.TreeMap;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
+/**
+ * Validates Plivo webhook request signatures using the X-Plivo-Signature-V3 scheme.
+ * <p>
+ * Plivo signs each webhook with the {@code X-Plivo-Signature-V3} and
+ * {@code X-Plivo-Signature-V3-Nonce} headers. For a POST callback the signed
+ * string is the callback URL up to (and including) a literal {@code ?}, followed
+ * by the POST body parameters as a key+value concatenation in ascending key
+ * order with no separators, followed by {@code .} and the nonce. The signature
+ * is {@code Base64(HMAC-SHA256(authToken, signedString))}. The header may carry
+ * several comma-separated signatures; the request is valid if any of them match.
+ *
+ * @author Sarvesh Patil - Initial contribution
+ */
+@NonNullByDefault
+public class PlivoSignatureValidator {
+
+    private static final String HMAC_SHA256 = "HmacSHA256";
+
+    /**
+     * Validates a Plivo request signature.
+     *
+     * @param url the full URL that Plivo requested
+     * @param params the POST parameters from the request
+     * @param signatureHeader the X-Plivo-Signature-V3 header value (may be comma-separated)
+     * @param nonce the X-Plivo-Signature-V3-Nonce header value
+     * @param authToken the Plivo Auth Token
+     * @return true if the signature is valid
+     */
+    public static boolean validate(String url, Map<String, String> params, @Nullable String signatureHeader,
+            @Nullable String nonce, String authToken) {
+        if (signatureHeader == null || signatureHeader.isBlank() || nonce == null || nonce.isBlank()) {
+            return false;
+        }
+
+        String expected = computeSignature(url, params, nonce, authToken);
+        byte[] expectedBytes = expected.getBytes(StandardCharsets.UTF_8);
+        for (String candidate : signatureHeader.split(",")) {
+            if (MessageDigest.isEqual(candidate.trim().getBytes(StandardCharsets.UTF_8), expectedBytes)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Computes the expected X-Plivo-Signature-V3 for a POST callback.
+     *
+     * @param url the full URL Plivo requested
+     * @param params the POST parameters
+     * @param nonce the signature nonce
+     * @param authToken the Auth Token
+     * @return the Base64-encoded HMAC-SHA256 signature
+     */
+    public static String computeSignature(String url, Map<String, String> params, String nonce, String authToken) {
+        int queryIndex = url.indexOf('?');
+        String base = queryIndex >= 0 ? url.substring(0, queryIndex) : url;
+        String query = queryIndex >= 0 ? url.substring(queryIndex + 1) : "";
+
+        StringBuilder data = new StringBuilder(base).append('?');
+        if (!query.isEmpty()) {
+            data.append(sortedQueryString(query)).append('.');
+        }
+        TreeMap<String, String> sorted = new TreeMap<>(params);
+        for (Map.Entry<String, String> entry : sorted.entrySet()) {
+            data.append(entry.getKey()).append(entry.getValue());
+        }
+        data.append('.').append(nonce);
+
+        try {
+            Mac mac = Mac.getInstance(HMAC_SHA256);
+            mac.init(new SecretKeySpec(authToken.getBytes(StandardCharsets.UTF_8), HMAC_SHA256));
+            byte[] hmac = mac.doFinal(data.toString().getBytes(StandardCharsets.UTF_8));
+            return Base64.getEncoder().encodeToString(hmac);
+        } catch (NoSuchAlgorithmException | InvalidKeyException e) {
+            throw new IllegalStateException("Failed to compute HMAC-SHA256 signature", e);
+        }
+    }
+
+    private static String sortedQueryString(String query) {
+        TreeMap<String, String> sorted = new TreeMap<>();
+        for (String pair : query.split("&")) {
+            if (pair.isEmpty()) {
+                continue;
+            }
+            int eq = pair.indexOf('=');
+            if (eq >= 0) {
+                sorted.put(pair.substring(0, eq), pair.substring(eq + 1));
+            } else {
+                sorted.put(pair, "");
+            }
+        }
+        StringBuilder sb = new StringBuilder();
+        boolean first = true;
+        for (Map.Entry<String, String> entry : sorted.entrySet()) {
+            if (!first) {
+                sb.append('&');
+            }
+            sb.append(entry.getKey()).append('=').append(entry.getValue());
+            first = false;
+        }
+        return sb.toString();
+    }
+}

--- a/bundles/org.openhab.binding.plivo/src/main/java/org/openhab/binding/plivo/internal/api/PlivoSignatureValidator.java
+++ b/bundles/org.openhab.binding.plivo/src/main/java/org/openhab/binding/plivo/internal/api/PlivoSignatureValidator.java
@@ -27,15 +27,23 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 
 /**
- * Validates Plivo webhook request signatures using the X-Plivo-Signature-V3 scheme.
+ * Validates Plivo webhook request signatures using the V3 signing scheme.
  * <p>
- * Plivo signs each webhook with the {@code X-Plivo-Signature-V3} and
- * {@code X-Plivo-Signature-V3-Nonce} headers. For a POST callback the signed
- * string is the callback URL up to (and including) a literal {@code ?}, followed
- * by the POST body parameters as a key+value concatenation in ascending key
- * order with no separators, followed by {@code .} and the nonce. The signature
- * is {@code Base64(HMAC-SHA256(authToken, signedString))}. The header may carry
- * several comma-separated signatures; the request is valid if any of them match.
+ * Plivo signs each webhook with an {@code X-Plivo-Signature-V3-Nonce} header plus one or more
+ * signature headers: {@code X-Plivo-Signature-V3} is generated with the (sub)account Auth Token
+ * that owns the request, while {@code X-Plivo-Signature-Ma-V3} is always generated with the main
+ * account Auth Token. Voice callbacks carry the {@code V3} signature and messaging callbacks
+ * (SMS/MMS/WhatsApp/status) carry the {@code Ma-V3} signature, but both are computed identically,
+ * so this validator can check a request against any of the signatures supplied.
+ * <p>
+ * For a POST callback the signed string is built as follows. Take the request URL, drop its query
+ * string, and append a literal {@code ?}. When the URL originally had a query string, append its
+ * parameters sorted by key in ascending order and rendered as {@code key=value} pairs joined by
+ * {@code &}, then a {@code .} separator. Next append the POST body parameters sorted by key in
+ * ascending order as a {@code key}+{@code value} concatenation with no separators. Finally append
+ * a {@code .} and the nonce. The signature is {@code Base64(HMAC-SHA256(authToken, signedString))}.
+ * A signature header may carry several comma-separated signatures; the request is valid if any of
+ * them matches.
  *
  * @author Sarvesh Patil - Initial contribution
  */
@@ -49,7 +57,9 @@ public class PlivoSignatureValidator {
      *
      * @param url the full URL that Plivo requested
      * @param params the POST parameters from the request
-     * @param signatureHeader the X-Plivo-Signature-V3 header value (may be comma-separated)
+     * @param signatureHeader a V3-family signature header value ({@code X-Plivo-Signature-V3} and/or
+     *            {@code X-Plivo-Signature-Ma-V3}); a single value may itself be comma-separated and
+     *            several headers may be joined with commas by the caller
      * @param nonce the X-Plivo-Signature-V3-Nonce header value
      * @param authToken the Plivo Auth Token
      * @return true if the signature is valid
@@ -71,7 +81,13 @@ public class PlivoSignatureValidator {
     }
 
     /**
-     * Computes the expected X-Plivo-Signature-V3 for a POST callback.
+     * Computes the expected V3 signature for a POST callback.
+     * <p>
+     * The signed string is the request URL with its query string removed, followed by a literal
+     * {@code ?}. When the URL had a query string, its parameters are appended sorted by key as
+     * {@code key=value} pairs joined by {@code &}, followed by a {@code .} separator. The POST body
+     * parameters are then appended sorted by key as a {@code key}+{@code value} concatenation with
+     * no separators, and finally a {@code .} and the nonce are appended.
      *
      * @param url the full URL Plivo requested
      * @param params the POST parameters

--- a/bundles/org.openhab.binding.plivo/src/main/java/org/openhab/binding/plivo/internal/api/PlivoSignatureValidator.java
+++ b/bundles/org.openhab.binding.plivo/src/main/java/org/openhab/binding/plivo/internal/api/PlivoSignatureValidator.java
@@ -75,11 +75,17 @@ public class PlivoSignatureValidator {
     /**
      * Computes the expected V3 signature for a POST callback.
      * <p>
-     * The signed string is the request URL with its query string removed, followed by a literal
-     * {@code ?}. When the URL had a query string, its parameters are appended sorted by key as
-     * {@code key=value} pairs joined by {@code &}, followed by a {@code .} separator. The POST body
-     * parameters are then appended sorted by key as a {@code key}+{@code value} concatenation with
-     * no separators, and finally a {@code .} and the nonce are appended.
+     * The signed string starts with the request URL, its query string sorted by key and rewritten as
+     * {@code key=value} pairs joined by {@code &}. The POST body parameters are then appended sorted
+     * by key as a {@code key}+{@code value} concatenation with no separators, and finally a
+     * {@code .} and the nonce are appended.
+     * <p>
+     * Separators are only emitted when the part they introduce is actually present, mirroring
+     * Plivo's {@code construct_post_url()}: the {@code ?} is omitted entirely when there is neither
+     * a query string nor a body parameter, and the {@code .} between the query and the body
+     * parameters is omitted when there are no body parameters. An empty POST body therefore signs
+     * {@code base.nonce} (no query) or {@code base?query.nonce} (with a query) rather than the
+     * {@code base?.nonce} / {@code base?query..nonce} that an unconditional separator would give.
      *
      * @param url the full URL Plivo requested
      * @param params the POST parameters
@@ -92,13 +98,24 @@ public class PlivoSignatureValidator {
         String base = queryIndex >= 0 ? url.substring(0, queryIndex) : url;
         String query = queryIndex >= 0 ? url.substring(queryIndex + 1) : "";
 
-        StringBuilder data = new StringBuilder(base).append('?');
-        if (!query.isEmpty()) {
-            data.append(sortedQueryString(query)).append('.');
+        boolean hasQuery = !query.isEmpty();
+        boolean hasParams = !params.isEmpty();
+
+        StringBuilder data = new StringBuilder(base);
+        if (hasQuery || hasParams) {
+            data.append('?');
         }
-        TreeMap<String, String> sorted = new TreeMap<>(params);
-        for (Map.Entry<String, String> entry : sorted.entrySet()) {
-            data.append(entry.getKey()).append(entry.getValue());
+        if (hasQuery) {
+            data.append(sortedQueryString(query));
+        }
+        if (hasParams) {
+            if (hasQuery) {
+                data.append('.');
+            }
+            TreeMap<String, String> sorted = new TreeMap<>(params);
+            for (Map.Entry<String, String> entry : sorted.entrySet()) {
+                data.append(entry.getKey()).append(entry.getValue());
+            }
         }
         data.append('.').append(nonce);
 

--- a/bundles/org.openhab.binding.plivo/src/main/java/org/openhab/binding/plivo/internal/config/PlivoAccountConfiguration.java
+++ b/bundles/org.openhab.binding.plivo/src/main/java/org/openhab/binding/plivo/internal/config/PlivoAccountConfiguration.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.plivo.internal.config;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
+/**
+ * Configuration for the Plivo Account bridge.
+ *
+ * @author Sarvesh Patil - Initial contribution
+ */
+@NonNullByDefault
+public class PlivoAccountConfiguration {
+
+    public @Nullable String authId;
+    public @Nullable String authToken;
+    public @Nullable String publicUrl;
+    public boolean autoConfigureWebhooks = true;
+    public boolean useCloudWebhook = false;
+}

--- a/bundles/org.openhab.binding.plivo/src/main/java/org/openhab/binding/plivo/internal/config/PlivoPhoneConfiguration.java
+++ b/bundles/org.openhab.binding.plivo/src/main/java/org/openhab/binding/plivo/internal/config/PlivoPhoneConfiguration.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.plivo.internal.config;
+
+import static org.openhab.binding.plivo.internal.PlivoBindingConstants.*;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
+/**
+ * Configuration for a Plivo Phone Number thing.
+ *
+ * @author Sarvesh Patil - Initial contribution
+ */
+@NonNullByDefault
+public class PlivoPhoneConfiguration {
+
+    public @Nullable String phoneNumber;
+    public String voiceGreeting = DEFAULT_VOICE_GREETING;
+    public String gatherResponse = DEFAULT_GATHER_RESPONSE;
+    public int responseTimeout = DEFAULT_RESPONSE_TIMEOUT;
+}

--- a/bundles/org.openhab.binding.plivo/src/main/java/org/openhab/binding/plivo/internal/discovery/PlivoPhoneDiscoveryService.java
+++ b/bundles/org.openhab.binding.plivo/src/main/java/org/openhab/binding/plivo/internal/discovery/PlivoPhoneDiscoveryService.java
@@ -49,12 +49,19 @@ public class PlivoPhoneDiscoveryService extends AbstractThingHandlerDiscoverySer
     private final Logger logger = LoggerFactory.getLogger(PlivoPhoneDiscoveryService.class);
 
     public PlivoPhoneDiscoveryService() {
-        super(PlivoAccountHandler.class, Set.of(THING_TYPE_PHONE), TIMEOUT_SECONDS, false);
+        super(PlivoAccountHandler.class, Set.of(THING_TYPE_PHONE), TIMEOUT_SECONDS, true);
     }
 
     @Override
     public Set<ThingTypeUID> getSupportedThingTypes() {
         return Set.of(THING_TYPE_PHONE);
+    }
+
+    @Override
+    protected void startBackgroundDiscovery() {
+        // The README documents that phone numbers are discovered automatically once the account
+        // bridge comes online, so scan once as soon as the handler is available.
+        startScan();
     }
 
     @Override

--- a/bundles/org.openhab.binding.plivo/src/main/java/org/openhab/binding/plivo/internal/discovery/PlivoPhoneDiscoveryService.java
+++ b/bundles/org.openhab.binding.plivo/src/main/java/org/openhab/binding/plivo/internal/discovery/PlivoPhoneDiscoveryService.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.plivo.internal.discovery;
+
+import static org.openhab.binding.plivo.internal.PlivoBindingConstants.*;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.binding.plivo.internal.api.PlivoApiClient;
+import org.openhab.binding.plivo.internal.api.PlivoApiException;
+import org.openhab.binding.plivo.internal.api.PlivoPhoneNumberInfo;
+import org.openhab.binding.plivo.internal.handler.PlivoAccountHandler;
+import org.openhab.core.config.discovery.AbstractThingHandlerDiscoveryService;
+import org.openhab.core.config.discovery.DiscoveryResult;
+import org.openhab.core.config.discovery.DiscoveryResultBuilder;
+import org.openhab.core.thing.ThingTypeUID;
+import org.openhab.core.thing.ThingUID;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ServiceScope;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link PlivoPhoneDiscoveryService} discovers Plivo phone numbers
+ * associated with the account and adds them to the inbox.
+ *
+ * @author Sarvesh Patil - Initial contribution
+ */
+@Component(scope = ServiceScope.PROTOTYPE, service = PlivoPhoneDiscoveryService.class)
+@NonNullByDefault
+public class PlivoPhoneDiscoveryService extends AbstractThingHandlerDiscoveryService<PlivoAccountHandler> {
+
+    private static final int TIMEOUT_SECONDS = 10;
+
+    private final Logger logger = LoggerFactory.getLogger(PlivoPhoneDiscoveryService.class);
+
+    public PlivoPhoneDiscoveryService() {
+        super(PlivoAccountHandler.class, Set.of(THING_TYPE_PHONE), TIMEOUT_SECONDS, false);
+    }
+
+    @Override
+    public Set<ThingTypeUID> getSupportedThingTypes() {
+        return Set.of(THING_TYPE_PHONE);
+    }
+
+    @Override
+    protected void startScan() {
+        PlivoApiClient client = thingHandler.getApiClient();
+        if (client == null) {
+            logger.debug("Cannot discover phone numbers: API client not available");
+            return;
+        }
+
+        try {
+            List<PlivoPhoneNumberInfo> phoneNumbers = client.listPhoneNumbers();
+            ThingUID bridgeUID = thingHandler.getThing().getUID();
+
+            for (PlivoPhoneNumberInfo info : phoneNumbers) {
+                String thingId = info.number.replaceAll("[^a-zA-Z0-9]", "");
+                ThingUID thingUID = new ThingUID(THING_TYPE_PHONE, bridgeUID, thingId);
+
+                String label = "Plivo: " + (info.alias.isEmpty() ? info.number : info.alias);
+
+                DiscoveryResult result = DiscoveryResultBuilder.create(thingUID) //
+                        .withBridge(bridgeUID) //
+                        .withProperties(Map.of("phoneNumber", "+" + info.number)) //
+                        .withRepresentationProperty("phoneNumber") //
+                        .withLabel(label) //
+                        .build();
+
+                thingDiscovered(result);
+            }
+
+            logger.debug("Discovered {} Plivo phone numbers", phoneNumbers.size());
+        } catch (PlivoApiException e) {
+            logger.debug("Failed to discover phone numbers: {}", e.getMessage());
+        }
+    }
+
+    @Override
+    protected synchronized void stopScan() {
+        super.stopScan();
+        removeOlderResults(getTimestampOfLastScan());
+    }
+
+    @Override
+    public void dispose() {
+        super.dispose();
+        removeOlderResults(Instant.now());
+    }
+}

--- a/bundles/org.openhab.binding.plivo/src/main/java/org/openhab/binding/plivo/internal/discovery/PlivoPhoneDiscoveryService.java
+++ b/bundles/org.openhab.binding.plivo/src/main/java/org/openhab/binding/plivo/internal/discovery/PlivoPhoneDiscoveryService.java
@@ -92,7 +92,9 @@ public class PlivoPhoneDiscoveryService extends AbstractThingHandlerDiscoverySer
 
             logger.debug("Discovered {} Plivo phone numbers", phoneNumbers.size());
         } catch (PlivoApiException e) {
-            logger.debug("Failed to discover phone numbers: {}", e.getMessage());
+            logger.warn("Could not discover Plivo phone numbers: {}", e.getMessage());
+        } catch (RuntimeException e) {
+            logger.warn("Unexpected error discovering Plivo phone numbers", e);
         }
     }
 

--- a/bundles/org.openhab.binding.plivo/src/main/java/org/openhab/binding/plivo/internal/discovery/PlivoPhoneDiscoveryService.java
+++ b/bundles/org.openhab.binding.plivo/src/main/java/org/openhab/binding/plivo/internal/discovery/PlivoPhoneDiscoveryService.java
@@ -59,8 +59,6 @@ public class PlivoPhoneDiscoveryService extends AbstractThingHandlerDiscoverySer
 
     @Override
     protected void startBackgroundDiscovery() {
-        // The README documents that phone numbers are discovered automatically once the account
-        // bridge comes online, so scan once as soon as the handler is available.
         startScan();
     }
 

--- a/bundles/org.openhab.binding.plivo/src/main/java/org/openhab/binding/plivo/internal/handler/PlivoAccountHandler.java
+++ b/bundles/org.openhab.binding.plivo/src/main/java/org/openhab/binding/plivo/internal/handler/PlivoAccountHandler.java
@@ -52,9 +52,9 @@ public class PlivoAccountHandler extends BaseBridgeHandler {
     private final HttpClient httpClient;
     private final PlivoCloudWebhookService cloudWebhookService;
     private final Runnable webhookAvailabilityListener = this::onCloudWebhookAvailable;
-    private @Nullable PlivoApiClient apiClient;
-    private PlivoAccountConfiguration config = new PlivoAccountConfiguration();
-    private @Nullable Future<?> validateTask;
+    private volatile @Nullable PlivoApiClient apiClient;
+    private volatile PlivoAccountConfiguration config = new PlivoAccountConfiguration();
+    private volatile @Nullable Future<?> validateTask;
 
     public PlivoAccountHandler(Bridge bridge, HttpClient httpClient, PlivoCloudWebhookService cloudWebhookService) {
         super(bridge);
@@ -230,7 +230,12 @@ public class PlivoAccountHandler extends BaseBridgeHandler {
             } else {
                 updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, e.getMessage());
             }
-            logger.debug("Failed to validate Plivo account: {}", e.getMessage());
+            logger.warn("Could not validate the Plivo account for {}: {}", getThing().getUID(), e.getMessage());
+        } catch (RuntimeException e) {
+            // This runs on the scheduler, where an unchecked exception would otherwise be swallowed
+            // by the Future and leave the bridge stuck in UNKNOWN with nothing in the log.
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, e.getMessage());
+            logger.warn("Unexpected error validating the Plivo account for {}", getThing().getUID(), e);
         }
     }
 }

--- a/bundles/org.openhab.binding.plivo/src/main/java/org/openhab/binding/plivo/internal/handler/PlivoAccountHandler.java
+++ b/bundles/org.openhab.binding.plivo/src/main/java/org/openhab/binding/plivo/internal/handler/PlivoAccountHandler.java
@@ -1,0 +1,219 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.plivo.internal.handler;
+
+import static org.openhab.binding.plivo.internal.PlivoBindingConstants.SERVLET_PATH;
+import static org.openhab.binding.plivo.internal.PlivoBindingConstants.WEBHOOK_MEDIA;
+
+import java.util.Collection;
+import java.util.Set;
+import java.util.concurrent.Future;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.jetty.client.HttpClient;
+import org.openhab.binding.plivo.internal.api.PlivoApiClient;
+import org.openhab.binding.plivo.internal.api.PlivoApiException;
+import org.openhab.binding.plivo.internal.config.PlivoAccountConfiguration;
+import org.openhab.binding.plivo.internal.discovery.PlivoPhoneDiscoveryService;
+import org.openhab.binding.plivo.internal.service.PlivoCloudWebhookService;
+import org.openhab.core.thing.Bridge;
+import org.openhab.core.thing.ChannelUID;
+import org.openhab.core.thing.ThingStatus;
+import org.openhab.core.thing.ThingStatusDetail;
+import org.openhab.core.thing.binding.BaseBridgeHandler;
+import org.openhab.core.thing.binding.ThingHandlerService;
+import org.openhab.core.types.Command;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link PlivoAccountHandler} is the bridge handler for a Plivo account.
+ * It manages the API client and validates credentials.
+ *
+ * @author Sarvesh Patil - Initial contribution
+ */
+@NonNullByDefault
+public class PlivoAccountHandler extends BaseBridgeHandler {
+
+    private final Logger logger = LoggerFactory.getLogger(PlivoAccountHandler.class);
+
+    private final HttpClient httpClient;
+    private final PlivoCloudWebhookService cloudWebhookService;
+    private @Nullable PlivoApiClient apiClient;
+    private PlivoAccountConfiguration config = new PlivoAccountConfiguration();
+    private @Nullable Future<?> validateTask;
+
+    public PlivoAccountHandler(Bridge bridge, HttpClient httpClient, PlivoCloudWebhookService cloudWebhookService) {
+        super(bridge);
+        this.httpClient = httpClient;
+        this.cloudWebhookService = cloudWebhookService;
+    }
+
+    @Override
+    public void handleCommand(ChannelUID channelUID, Command command) {
+    }
+
+    @Override
+    public void initialize() {
+        config = getConfigAs(PlivoAccountConfiguration.class);
+
+        if (!config.useCloudWebhook) {
+            cloudWebhookService.unregister(getThing().getUID().getAsString());
+        }
+
+        String authId = config.authId;
+        if (authId == null || authId.isBlank()) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
+                    "@text/offline.configuration-error.missing-auth-id");
+            return;
+        }
+
+        String authToken = config.authToken;
+        if (authToken == null || authToken.isBlank()) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
+                    "@text/offline.configuration-error.missing-auth-token");
+            return;
+        }
+
+        apiClient = new PlivoApiClient(httpClient, authId, authToken);
+        updateStatus(ThingStatus.UNKNOWN);
+        validateTask = scheduler.submit(this::asyncValidateAccount);
+    }
+
+    @Override
+    public void dispose() {
+        Future<?> task = validateTask;
+        if (task != null) {
+            task.cancel(true);
+            validateTask = null;
+        }
+        apiClient = null;
+        super.dispose();
+    }
+
+    @Override
+    public void handleRemoval() {
+        cloudWebhookService.unregister(getThing().getUID().getAsString());
+        super.handleRemoval();
+    }
+
+    @Override
+    public Collection<Class<? extends ThingHandlerService>> getServices() {
+        return Set.of(PlivoPhoneDiscoveryService.class);
+    }
+
+    /**
+     * Returns the API client for child things to use.
+     *
+     * @return the {@link PlivoApiClient}, or null if not initialized
+     */
+    public @Nullable PlivoApiClient getApiClient() {
+        return apiClient;
+    }
+
+    /**
+     * Returns the account configuration.
+     *
+     * @return the configuration
+     */
+    public PlivoAccountConfiguration getAccountConfig() {
+        return config;
+    }
+
+    /**
+     * Returns true if cloud webhooks are active (enabled in config and cloud URL is available).
+     */
+    public boolean isUsingCloudWebhooks() {
+        return config.useCloudWebhook && cloudWebhookService.getBaseUrl() != null;
+    }
+
+    /**
+     * Returns the webhook base URL for a phone thing, choosing cloud or publicUrl based on
+     * account configuration. The returned URL can have endpoint path segments appended.
+     *
+     * @param thingUID the phone thing UID as a string
+     * @return the base webhook URL (e.g. {@code https://…/plivo/callback/plivo:phone:…}),
+     *         or {@code null} if no URL source is configured
+     */
+    public @Nullable String getWebhookBaseUrl(String thingUID) {
+        if (config.useCloudWebhook) {
+            String cloudBase = cloudWebhookService.getBaseUrl();
+            if (cloudBase != null) {
+                return cloudBase + "/" + thingUID;
+            }
+        }
+        return getPublicUrlBase(thingUID);
+    }
+
+    /**
+     * Returns the media serving base URL, choosing cloud or publicUrl based on account
+     * configuration. Media UUIDs can be appended as sub-paths.
+     *
+     * @return the media base URL, or {@code null} if no URL source is configured
+     */
+    public @Nullable String getMediaBaseUrl() {
+        if (config.useCloudWebhook) {
+            String cloudBase = cloudWebhookService.getBaseUrl();
+            if (cloudBase != null) {
+                return cloudBase + "/" + WEBHOOK_MEDIA;
+            }
+        }
+        String publicUrl = getNormalizedPublicUrl();
+        return publicUrl != null ? publicUrl + SERVLET_PATH + "/" + WEBHOOK_MEDIA : null;
+    }
+
+    private @Nullable String getPublicUrlBase(String thingUID) {
+        String publicUrl = getNormalizedPublicUrl();
+        return publicUrl != null ? publicUrl + SERVLET_PATH + "/" + thingUID : null;
+    }
+
+    private @Nullable String getNormalizedPublicUrl() {
+        String publicUrl = config.publicUrl;
+        if (publicUrl == null || publicUrl.isBlank()) {
+            return null;
+        }
+        if (publicUrl.endsWith("/")) {
+            publicUrl = publicUrl.substring(0, publicUrl.length() - 1);
+        }
+        return publicUrl;
+    }
+
+    private void asyncValidateAccount() {
+        PlivoApiClient client = apiClient;
+        if (client == null) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
+                    "@text/offline.configuration-error.api-client-not-initialized");
+            return;
+        }
+
+        try {
+            if (client.validateAccount()) {
+                if (config.useCloudWebhook) {
+                    cloudWebhookService.register(getThing().getUID().getAsString());
+                }
+                updateStatus(ThingStatus.ONLINE);
+            } else {
+                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
+                        "@text/offline.configuration-error.account-invalid");
+            }
+        } catch (PlivoApiException e) {
+            if (e.isConfigurationError()) {
+                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, e.getMessage());
+            } else {
+                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, e.getMessage());
+            }
+            logger.debug("Failed to validate Plivo account: {}", e.getMessage());
+        }
+    }
+}

--- a/bundles/org.openhab.binding.plivo/src/main/java/org/openhab/binding/plivo/internal/handler/PlivoAccountHandler.java
+++ b/bundles/org.openhab.binding.plivo/src/main/java/org/openhab/binding/plivo/internal/handler/PlivoAccountHandler.java
@@ -29,6 +29,7 @@ import org.openhab.binding.plivo.internal.discovery.PlivoPhoneDiscoveryService;
 import org.openhab.binding.plivo.internal.service.PlivoCloudWebhookService;
 import org.openhab.core.thing.Bridge;
 import org.openhab.core.thing.ChannelUID;
+import org.openhab.core.thing.Thing;
 import org.openhab.core.thing.ThingStatus;
 import org.openhab.core.thing.ThingStatusDetail;
 import org.openhab.core.thing.binding.BaseBridgeHandler;
@@ -50,6 +51,7 @@ public class PlivoAccountHandler extends BaseBridgeHandler {
 
     private final HttpClient httpClient;
     private final PlivoCloudWebhookService cloudWebhookService;
+    private final Runnable webhookAvailabilityListener = this::onCloudWebhookAvailable;
     private @Nullable PlivoApiClient apiClient;
     private PlivoAccountConfiguration config = new PlivoAccountConfiguration();
     private @Nullable Future<?> validateTask;
@@ -93,6 +95,7 @@ public class PlivoAccountHandler extends BaseBridgeHandler {
 
     @Override
     public void dispose() {
+        cloudWebhookService.removeAvailabilityListener(webhookAvailabilityListener);
         Future<?> task = validateTask;
         if (task != null) {
             task.cancel(true);
@@ -104,6 +107,7 @@ public class PlivoAccountHandler extends BaseBridgeHandler {
 
     @Override
     public void handleRemoval() {
+        cloudWebhookService.removeAvailabilityListener(webhookAvailabilityListener);
         cloudWebhookService.unregister(getThing().getUID().getAsString());
         super.handleRemoval();
     }
@@ -189,6 +193,15 @@ public class PlivoAccountHandler extends BaseBridgeHandler {
         return publicUrl;
     }
 
+    private void onCloudWebhookAvailable() {
+        logger.debug("Cloud webhook URL now available; refreshing phone thing webhook configuration");
+        for (Thing child : getThing().getThings()) {
+            if (child.getHandler() instanceof PlivoPhoneHandler phoneHandler) {
+                phoneHandler.onWebhookUrlAvailable();
+            }
+        }
+    }
+
     private void asyncValidateAccount() {
         PlivoApiClient client = apiClient;
         if (client == null) {
@@ -200,6 +213,10 @@ public class PlivoAccountHandler extends BaseBridgeHandler {
         try {
             if (client.validateAccount()) {
                 if (config.useCloudWebhook) {
+                    // Listen for a deferred cloud webhook URL: if the openHAB Cloud WebhookService
+                    // only binds after the phone Things initialized, the phones need to refresh
+                    // their webhook properties and retry automatic application configuration.
+                    cloudWebhookService.addAvailabilityListener(webhookAvailabilityListener);
                     cloudWebhookService.register(getThing().getUID().getAsString());
                 }
                 updateStatus(ThingStatus.ONLINE);

--- a/bundles/org.openhab.binding.plivo/src/main/java/org/openhab/binding/plivo/internal/handler/PlivoPhoneHandler.java
+++ b/bundles/org.openhab.binding.plivo/src/main/java/org/openhab/binding/plivo/internal/handler/PlivoPhoneHandler.java
@@ -210,7 +210,9 @@ public class PlivoPhoneHandler extends BaseThingHandler {
      */
     public void handleIncomingSms(Map<String, String> params) {
         String from = params.getOrDefault("From", "");
-        String body = params.getOrDefault("Text", "");
+        // Plivo sends SMS text in "Text", while WhatsApp (and MMS body text) use "Body".
+        String bodyParam = params.get("Body");
+        String body = bodyParam != null && !bodyParam.isBlank() ? bodyParam : params.getOrDefault("Text", "");
         String messageUuid = params.getOrDefault("MessageUUID", "");
         String type = params.getOrDefault("Type", "sms");
 

--- a/bundles/org.openhab.binding.plivo/src/main/java/org/openhab/binding/plivo/internal/handler/PlivoPhoneHandler.java
+++ b/bundles/org.openhab.binding.plivo/src/main/java/org/openhab/binding/plivo/internal/handler/PlivoPhoneHandler.java
@@ -63,7 +63,7 @@ public class PlivoPhoneHandler extends BaseThingHandler {
 
     private PlivoPhoneConfiguration config = new PlivoPhoneConfiguration();
     private String phoneNumber = "";
-    private @Nullable Future<?> initializeTask;
+    private volatile @Nullable Future<?> initializeTask;
 
     public PlivoPhoneHandler(Thing thing, PlivoCallbackServlet callbackServlet, ItemRegistry itemRegistry) {
         super(thing);
@@ -93,22 +93,27 @@ public class PlivoPhoneHandler extends BaseThingHandler {
 
     @Override
     public void dispose() {
-        Future<?> initTask = initializeTask;
-        if (initTask != null) {
-            initTask.cancel(true);
-            initializeTask = null;
-        }
+        cancelInitializeTask();
         callbackServlet.unregisterHandler(thing.getUID().getAsString());
         super.dispose();
     }
 
     @Override
     public void bridgeStatusChanged(ThingStatusInfo bridgeStatusInfo) {
+        cancelInitializeTask();
         if (bridgeStatusInfo.getStatus() == ThingStatus.ONLINE) {
             initializeTask = scheduler.submit(this::asyncInitialize);
         } else {
             callbackServlet.unregisterHandler(thing.getUID().getAsString());
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE);
+        }
+    }
+
+    private void cancelInitializeTask() {
+        Future<?> initTask = initializeTask;
+        if (initTask != null) {
+            initTask.cancel(true);
+            initializeTask = null;
         }
     }
 
@@ -370,6 +375,13 @@ public class PlivoPhoneHandler extends BaseThingHandler {
         try {
             configureWebhooksOnPlivo();
         } catch (PlivoApiException e) {
+            if (Thread.currentThread().isInterrupted() || e.getCause() instanceof InterruptedException) {
+                // A newer initialization (bridge status change or webhook availability) cancelled this
+                // one, so leave the status for the superseding run rather than reporting the
+                // interruption as a communication error.
+                logger.debug("Auto-configuration for {} was superseded by a newer initialization", phoneNumber);
+                return;
+            }
             ThingStatusDetail detail = e.isConfigurationError() ? ThingStatusDetail.CONFIGURATION_ERROR
                     : ThingStatusDetail.COMMUNICATION_ERROR;
             updateStatus(ThingStatus.OFFLINE, detail, e.getMessage());
@@ -386,10 +398,7 @@ public class PlivoPhoneHandler extends BaseThingHandler {
      * automatic application configuration is retried against the now-available URL.
      */
     public void onWebhookUrlAvailable() {
-        Future<?> initTask = initializeTask;
-        if (initTask != null) {
-            initTask.cancel(true);
-        }
+        cancelInitializeTask();
         initializeTask = scheduler.submit(this::asyncInitialize);
     }
 
@@ -410,7 +419,11 @@ public class PlivoPhoneHandler extends BaseThingHandler {
         String messageUrl = getWebhookUrl(WEBHOOK_SMS);
         String statusUrl = getWebhookUrl(WEBHOOK_STATUS);
         if (answerUrl == null || messageUrl == null || statusUrl == null) {
-            throw new PlivoApiException("@text/offline.configuration-error.webhook-url-unavailable", true);
+            // No inbound webhook URL is available yet. Outbound SMS, WhatsApp, and calls do not need
+            // one, so this is not an error and the Thing stays ONLINE. If a cloud webhook URL becomes
+            // available later, onWebhookUrlAvailable() retries this configuration.
+            logger.debug("No webhook URL available for {} yet; skipping inbound auto-configuration", phoneNumber);
+            return;
         }
         // Plivo application names accept only alphanumerics, hyphens, and underscores, so the Thing
         // UID (which contains colons) must be sanitized before it can be used as a stable app name.

--- a/bundles/org.openhab.binding.plivo/src/main/java/org/openhab/binding/plivo/internal/handler/PlivoPhoneHandler.java
+++ b/bundles/org.openhab.binding.plivo/src/main/java/org/openhab/binding/plivo/internal/handler/PlivoPhoneHandler.java
@@ -61,8 +61,8 @@ public class PlivoPhoneHandler extends BaseThingHandler {
     private final PlivoCallbackServlet callbackServlet;
     private final ItemRegistry itemRegistry;
 
-    private PlivoPhoneConfiguration config = new PlivoPhoneConfiguration();
-    private String phoneNumber = "";
+    private volatile PlivoPhoneConfiguration config = new PlivoPhoneConfiguration();
+    private volatile String phoneNumber = "";
     private volatile @Nullable Future<?> initializeTask;
 
     public PlivoPhoneHandler(Thing thing, PlivoCallbackServlet callbackServlet, ItemRegistry itemRegistry) {
@@ -387,7 +387,13 @@ public class PlivoPhoneHandler extends BaseThingHandler {
             ThingStatusDetail detail = e.isConfigurationError() ? ThingStatusDetail.CONFIGURATION_ERROR
                     : ThingStatusDetail.COMMUNICATION_ERROR;
             updateStatus(ThingStatus.OFFLINE, detail, e.getMessage());
-            logger.debug("Failed to auto-configure Plivo application for {}: {}", phoneNumber, e.getMessage());
+            logger.warn("Could not auto-configure the Plivo application for {}: {}", phoneNumber, e.getMessage());
+            return;
+        } catch (RuntimeException e) {
+            // Guard the scheduler task: an unchecked exception here would be swallowed by the Future
+            // and leave the Thing stuck in UNKNOWN with nothing in the log.
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, e.getMessage());
+            logger.warn("Unexpected error initializing the Plivo phone Thing for {}", phoneNumber, e);
             return;
         }
 

--- a/bundles/org.openhab.binding.plivo/src/main/java/org/openhab/binding/plivo/internal/handler/PlivoPhoneHandler.java
+++ b/bundles/org.openhab.binding.plivo/src/main/java/org/openhab/binding/plivo/internal/handler/PlivoPhoneHandler.java
@@ -367,12 +367,33 @@ public class PlivoPhoneHandler extends BaseThingHandler {
 
         callbackServlet.registerHandler(thing.getUID().getAsString(), this);
         updateWebhookProperties();
-        configureWebhooksOnPlivo();
+        try {
+            configureWebhooksOnPlivo();
+        } catch (PlivoApiException e) {
+            ThingStatusDetail detail = e.isConfigurationError() ? ThingStatusDetail.CONFIGURATION_ERROR
+                    : ThingStatusDetail.COMMUNICATION_ERROR;
+            updateStatus(ThingStatus.OFFLINE, detail, e.getMessage());
+            logger.debug("Failed to auto-configure Plivo application for {}: {}", phoneNumber, e.getMessage());
+            return;
+        }
 
         updateStatus(ThingStatus.ONLINE);
     }
 
-    private void configureWebhooksOnPlivo() {
+    /**
+     * Called by the account handler when the openHAB Cloud webhook URL becomes available after this
+     * phone thing already initialized. Re-runs initialization so the webhook properties refresh and
+     * automatic application configuration is retried against the now-available URL.
+     */
+    public void onWebhookUrlAvailable() {
+        Future<?> initTask = initializeTask;
+        if (initTask != null) {
+            initTask.cancel(true);
+        }
+        initializeTask = scheduler.submit(this::asyncInitialize);
+    }
+
+    private void configureWebhooksOnPlivo() throws PlivoApiException {
         PlivoAccountHandler accountHandler = getAccountHandler();
         if (accountHandler == null) {
             return;
@@ -388,17 +409,14 @@ public class PlivoPhoneHandler extends BaseThingHandler {
         String answerUrl = getWebhookUrl(WEBHOOK_VOICE);
         String messageUrl = getWebhookUrl(WEBHOOK_SMS);
         String statusUrl = getWebhookUrl(WEBHOOK_STATUS);
-        if (answerUrl != null && messageUrl != null && statusUrl != null) {
-            try {
-                String appName = "openHAB-" + thing.getUID().getAsString();
-                String appId = client.createOrUpdateApplication(appName, answerUrl, messageUrl, statusUrl);
-                client.assignApplicationToNumber(phoneNumber, appId);
-                logger.debug("Auto-configured Plivo application {} for phone number {}", appId, phoneNumber);
-            } catch (PlivoApiException e) {
-                logger.debug("Failed to auto-configure webhooks: {}", e.getMessage());
-            }
-        } else {
-            logger.debug("Cannot auto-configure webhooks: no webhook URLs available");
+        if (answerUrl == null || messageUrl == null || statusUrl == null) {
+            throw new PlivoApiException("@text/offline.configuration-error.webhook-url-unavailable", true);
         }
+        // Plivo application names accept only alphanumerics, hyphens, and underscores, so the Thing
+        // UID (which contains colons) must be sanitized before it can be used as a stable app name.
+        String appName = "openHAB-" + thing.getUID().getAsString().replaceAll("[^A-Za-z0-9_-]", "-");
+        String appId = client.createOrUpdateApplication(appName, answerUrl, messageUrl, statusUrl);
+        client.assignApplicationToNumber(phoneNumber, appId);
+        logger.debug("Auto-configured Plivo application {} ({}) for phone number {}", appId, appName, phoneNumber);
     }
 }

--- a/bundles/org.openhab.binding.plivo/src/main/java/org/openhab/binding/plivo/internal/handler/PlivoPhoneHandler.java
+++ b/bundles/org.openhab.binding.plivo/src/main/java/org/openhab/binding/plivo/internal/handler/PlivoPhoneHandler.java
@@ -1,0 +1,404 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.plivo.internal.handler;
+
+import static org.openhab.binding.plivo.internal.PlivoBindingConstants.*;
+
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Future;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.plivo.internal.action.PlivoActions;
+import org.openhab.binding.plivo.internal.api.PlivoApiClient;
+import org.openhab.binding.plivo.internal.api.PlivoApiException;
+import org.openhab.binding.plivo.internal.config.PlivoAccountConfiguration;
+import org.openhab.binding.plivo.internal.config.PlivoPhoneConfiguration;
+import org.openhab.binding.plivo.internal.servlet.PlivoCallbackServlet;
+import org.openhab.core.items.ItemRegistry;
+import org.openhab.core.library.types.DateTimeType;
+import org.openhab.core.library.types.StringType;
+import org.openhab.core.thing.Bridge;
+import org.openhab.core.thing.ChannelUID;
+import org.openhab.core.thing.Thing;
+import org.openhab.core.thing.ThingStatus;
+import org.openhab.core.thing.ThingStatusDetail;
+import org.openhab.core.thing.ThingStatusInfo;
+import org.openhab.core.thing.binding.BaseThingHandler;
+import org.openhab.core.thing.binding.ThingHandlerService;
+import org.openhab.core.types.Command;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+
+/**
+ * The {@link PlivoPhoneHandler} handles a Plivo phone number thing.
+ * It manages channels for incoming messages/calls and provides actions for sending.
+ *
+ * @author Sarvesh Patil - Initial contribution
+ */
+@NonNullByDefault
+public class PlivoPhoneHandler extends BaseThingHandler {
+
+    private final Logger logger = LoggerFactory.getLogger(PlivoPhoneHandler.class);
+
+    private final PlivoCallbackServlet callbackServlet;
+    private final ItemRegistry itemRegistry;
+
+    private PlivoPhoneConfiguration config = new PlivoPhoneConfiguration();
+    private String phoneNumber = "";
+    private @Nullable Future<?> initializeTask;
+
+    public PlivoPhoneHandler(Thing thing, PlivoCallbackServlet callbackServlet, ItemRegistry itemRegistry) {
+        super(thing);
+        this.callbackServlet = callbackServlet;
+        this.itemRegistry = itemRegistry;
+    }
+
+    @Override
+    public void handleCommand(ChannelUID channelUID, Command command) {
+    }
+
+    @Override
+    public void initialize() {
+        config = getConfigAs(PlivoPhoneConfiguration.class);
+
+        String number = config.phoneNumber;
+        if (number == null || number.isBlank()) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
+                    "@text/offline.configuration-error.missing-phone-number");
+            return;
+        }
+        phoneNumber = number;
+
+        updateStatus(ThingStatus.UNKNOWN);
+        initializeTask = scheduler.submit(this::asyncInitialize);
+    }
+
+    @Override
+    public void dispose() {
+        Future<?> initTask = initializeTask;
+        if (initTask != null) {
+            initTask.cancel(true);
+            initializeTask = null;
+        }
+        callbackServlet.unregisterHandler(thing.getUID().getAsString());
+        super.dispose();
+    }
+
+    @Override
+    public void bridgeStatusChanged(ThingStatusInfo bridgeStatusInfo) {
+        if (bridgeStatusInfo.getStatus() == ThingStatus.ONLINE) {
+            initializeTask = scheduler.submit(this::asyncInitialize);
+        } else {
+            callbackServlet.unregisterHandler(thing.getUID().getAsString());
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE);
+        }
+    }
+
+    @Override
+    public Collection<Class<? extends ThingHandlerService>> getServices() {
+        return Set.of(PlivoActions.class);
+    }
+
+    /**
+     * Returns the bridge handler for this phone thing.
+     *
+     * @return the bridge handler, or null if not available
+     */
+    public @Nullable PlivoAccountHandler getAccountHandler() {
+        if (getBridge() instanceof Bridge bridge && bridge.getHandler() instanceof PlivoAccountHandler handler) {
+            return handler;
+        }
+        return null;
+    }
+
+    /**
+     * Returns the configured phone number.
+     *
+     * @return the phone number in E.164 format
+     */
+    public String getPhoneNumber() {
+        return phoneNumber;
+    }
+
+    /**
+     * Returns the phone configuration.
+     */
+    public PlivoPhoneConfiguration getPhoneConfig() {
+        return config;
+    }
+
+    /**
+     * Returns the item registry for looking up openHAB items.
+     */
+    public ItemRegistry getItemRegistry() {
+        return itemRegistry;
+    }
+
+    /**
+     * Returns the configured response timeout in seconds.
+     */
+    public int getResponseTimeout() {
+        return config.responseTimeout;
+    }
+
+    /**
+     * Returns the webhook URL for a specific endpoint. Checks cloud webhook URLs first,
+     * then falls back to publicUrl-based URLs.
+     *
+     * @param endpoint the webhook endpoint (e.g. "sms", "voice", "gather", "status")
+     * @return the full webhook URL, or null if no public URL is available
+     */
+    public @Nullable String getWebhookUrl(String endpoint) {
+        PlivoAccountHandler accountHandler = getAccountHandler();
+        if (accountHandler == null) {
+            return null;
+        }
+        String baseUrl = accountHandler.getWebhookBaseUrl(thing.getUID().getAsString());
+        return baseUrl != null ? baseUrl + "/" + endpoint : null;
+    }
+
+    /**
+     * Returns true if cloud webhooks are active for this phone's account.
+     */
+    public boolean isUsingCloudWebhooks() {
+        PlivoAccountHandler accountHandler = getAccountHandler();
+        return accountHandler != null && accountHandler.isUsingCloudWebhooks();
+    }
+
+    /**
+     * Returns the media serving base URL. Media UUIDs can be appended as sub-paths.
+     *
+     * @return the media base URL, or null if neither cloud webhook nor publicUrl is available
+     */
+    public @Nullable String getMediaBaseUrl() {
+        PlivoAccountHandler accountHandler = getAccountHandler();
+        return accountHandler != null ? accountHandler.getMediaBaseUrl() : null;
+    }
+
+    /**
+     * Returns a reference to the callback servlet for media and outbound-answer operations.
+     */
+    public PlivoCallbackServlet getCallbackServlet() {
+        return callbackServlet;
+    }
+
+    /**
+     * Called by the servlet when an SMS/MMS/WhatsApp message is received.
+     */
+    public void handleIncomingSms(Map<String, String> params) {
+        String from = params.getOrDefault("From", "");
+        String body = params.getOrDefault("Text", "");
+        String messageUuid = params.getOrDefault("MessageUUID", "");
+        String type = params.getOrDefault("Type", "sms");
+
+        updateState(CHANNEL_LAST_MESSAGE_BODY, new StringType(body));
+        updateState(CHANNEL_LAST_MESSAGE_FROM, new StringType(from));
+        updateState(CHANNEL_LAST_MESSAGE_DATE, new DateTimeType(ZonedDateTime.now(ZoneId.systemDefault())));
+        updateState(CHANNEL_LAST_MESSAGE_UUID, new StringType(messageUuid));
+
+        JsonArray mediaUrlsArray = new JsonArray();
+        for (int i = 0; i < 10; i++) {
+            String media = params.get("Media" + i);
+            if (media == null || media.isBlank()) {
+                break;
+            }
+            mediaUrlsArray.add(media);
+        }
+        String firstMedia = mediaUrlsArray.size() > 0 ? mediaUrlsArray.get(0).getAsString() : "";
+        updateState(CHANNEL_LAST_MESSAGE_MEDIA_URL, new StringType(firstMedia));
+
+        JsonObject payload = new JsonObject();
+        payload.addProperty("from", from);
+        payload.addProperty("to", params.getOrDefault("To", ""));
+        payload.addProperty("body", body);
+        payload.addProperty("messageUuid", messageUuid);
+        payload.addProperty("type", type);
+        payload.add("mediaUrls", mediaUrlsArray);
+
+        if ("whatsapp".equalsIgnoreCase(type)) {
+            triggerChannel(CHANNEL_WHATSAPP_RECEIVED, payload.toString());
+        } else {
+            triggerChannel(CHANNEL_SMS_RECEIVED, payload.toString());
+        }
+
+        logger.debug("Received message from {} with body: {}", from, body);
+    }
+
+    /**
+     * Called by the servlet when an incoming voice call is received.
+     */
+    public void handleIncomingCall(Map<String, String> params) {
+        String from = params.getOrDefault("From", "");
+        String callUuid = params.getOrDefault("CallUUID", "");
+        String callStatus = params.getOrDefault("CallStatus", "");
+
+        updateState(CHANNEL_LAST_CALL_FROM, new StringType(from));
+        updateState(CHANNEL_LAST_CALL_STATUS, new StringType(callStatus));
+        updateState(CHANNEL_LAST_CALL_DATE, new DateTimeType(ZonedDateTime.now(ZoneId.systemDefault())));
+
+        JsonObject payload = new JsonObject();
+        payload.addProperty("from", from);
+        payload.addProperty("to", params.getOrDefault("To", ""));
+        payload.addProperty("callUuid", callUuid);
+        payload.addProperty("callStatus", callStatus);
+
+        triggerChannel(CHANNEL_CALL_RECEIVED, payload.toString());
+        logger.debug("Received call from {}, status: {}", from, callStatus);
+    }
+
+    /**
+     * Called by the servlet when DTMF digits are gathered.
+     */
+    public void handleDtmfInput(Map<String, String> params) {
+        String digits = params.getOrDefault("Digits", "");
+        String callUuid = params.getOrDefault("CallUUID", "");
+        String from = params.getOrDefault("From", "");
+
+        updateState(CHANNEL_LAST_DTMF_DIGITS, new StringType(digits));
+
+        JsonObject payload = new JsonObject();
+        payload.addProperty("digits", digits);
+        payload.addProperty("callUuid", callUuid);
+        payload.addProperty("from", from);
+        payload.addProperty("to", params.getOrDefault("To", ""));
+
+        triggerChannel(CHANNEL_DTMF_RECEIVED, payload.toString());
+        logger.debug("Received DTMF digits: {} from call {}", digits, callUuid);
+    }
+
+    /**
+     * Called by the servlet when a message or call status update is received.
+     */
+    public void handleStatusCallback(Map<String, String> params) {
+        JsonObject payload = new JsonObject();
+
+        String messageUuid = params.get("MessageUUID");
+        String callUuid = params.get("CallUUID");
+
+        if (messageUuid != null) {
+            String messageStatus = params.getOrDefault("Status", "");
+            payload.addProperty("messageUuid", messageUuid);
+            payload.addProperty("messageStatus", messageStatus);
+            payload.addProperty("to", params.getOrDefault("To", ""));
+            triggerChannel(CHANNEL_MESSAGE_STATUS, payload.toString());
+            logger.debug("Message {} status: {}", messageUuid, messageStatus);
+        } else if (callUuid != null) {
+            String callStatus = params.getOrDefault("CallStatus", params.getOrDefault("Status", ""));
+            updateState(CHANNEL_LAST_CALL_STATUS, new StringType(callStatus));
+            payload.addProperty("callUuid", callUuid);
+            payload.addProperty("callStatus", callStatus);
+            payload.addProperty("from", params.getOrDefault("From", ""));
+            payload.addProperty("to", params.getOrDefault("To", ""));
+            triggerChannel(CHANNEL_CALL_STATUS_TRIGGER, payload.toString());
+            logger.debug("Call {} status: {}", callUuid, callStatus);
+        }
+    }
+
+    /**
+     * Returns the Plivo XML for the voice greeting, with placeholders replaced.
+     */
+    public String getVoiceGreetingXml() {
+        return replaceXmlPlaceholders(config.voiceGreeting);
+    }
+
+    /**
+     * Returns the Plivo XML for the gather response.
+     */
+    public String getGatherResponseXml() {
+        return config.gatherResponse;
+    }
+
+    /**
+     * Replaces the {gatherUrl} placeholder in Plivo XML with the actual gather webhook URL.
+     */
+    public String replaceXmlPlaceholders(String xml) {
+        String gatherUrl = getWebhookUrl(WEBHOOK_GATHER);
+        if (gatherUrl != null) {
+            return xml.replace("{gatherUrl}", gatherUrl);
+        }
+        return xml;
+    }
+
+    /**
+     * Returns the status callback URL, or null if not available.
+     */
+    public @Nullable String getStatusCallbackUrl() {
+        return getWebhookUrl(WEBHOOK_STATUS);
+    }
+
+    private void updateWebhookProperties() {
+        updateProperty(PROPERTY_MESSAGE_WEBHOOK_URL, getWebhookUrl(WEBHOOK_SMS));
+        updateProperty(PROPERTY_VOICE_WEBHOOK_URL, getWebhookUrl(WEBHOOK_VOICE));
+        updateProperty(PROPERTY_STATUS_CALLBACK_URL, getWebhookUrl(WEBHOOK_STATUS));
+    }
+
+    private void asyncInitialize() {
+        PlivoAccountHandler accountHandler = getAccountHandler();
+        if (accountHandler == null) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_UNINITIALIZED,
+                    "@text/offline.bridge-uninitialized.bridge-handler-not-available");
+            return;
+        }
+
+        PlivoApiClient client = accountHandler.getApiClient();
+        if (client == null) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_UNINITIALIZED,
+                    "@text/offline.bridge-uninitialized.api-client-not-available");
+            return;
+        }
+
+        callbackServlet.registerHandler(thing.getUID().getAsString(), this);
+        updateWebhookProperties();
+        configureWebhooksOnPlivo();
+
+        updateStatus(ThingStatus.ONLINE);
+    }
+
+    private void configureWebhooksOnPlivo() {
+        PlivoAccountHandler accountHandler = getAccountHandler();
+        if (accountHandler == null) {
+            return;
+        }
+        PlivoAccountConfiguration accountConfig = accountHandler.getAccountConfig();
+        if (!accountConfig.autoConfigureWebhooks) {
+            return;
+        }
+        PlivoApiClient client = accountHandler.getApiClient();
+        if (client == null) {
+            return;
+        }
+        String answerUrl = getWebhookUrl(WEBHOOK_VOICE);
+        String messageUrl = getWebhookUrl(WEBHOOK_SMS);
+        String statusUrl = getWebhookUrl(WEBHOOK_STATUS);
+        if (answerUrl != null && messageUrl != null && statusUrl != null) {
+            try {
+                String appName = "openHAB-" + thing.getUID().getAsString();
+                String appId = client.createOrUpdateApplication(appName, answerUrl, messageUrl, statusUrl);
+                client.assignApplicationToNumber(phoneNumber, appId);
+                logger.debug("Auto-configured Plivo application {} for phone number {}", appId, phoneNumber);
+            } catch (PlivoApiException e) {
+                logger.debug("Failed to auto-configure webhooks: {}", e.getMessage());
+            }
+        } else {
+            logger.debug("Cannot auto-configure webhooks: no webhook URLs available");
+        }
+    }
+}

--- a/bundles/org.openhab.binding.plivo/src/main/java/org/openhab/binding/plivo/internal/service/PlivoCloudWebhookService.java
+++ b/bundles/org.openhab.binding.plivo/src/main/java/org/openhab/binding/plivo/internal/service/PlivoCloudWebhookService.java
@@ -17,6 +17,7 @@ import static org.openhab.binding.plivo.internal.PlivoBindingConstants.SERVLET_P
 
 import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -61,6 +62,7 @@ public class PlivoCloudWebhookService {
             .getScheduledPool(BINDING_ID + "-cloud-webhook");
     private final Object lock = new Object();
     private final Set<String> requestors = new HashSet<>();
+    private final Set<Runnable> availabilityListeners = ConcurrentHashMap.newKeySet();
 
     private volatile @Nullable WebhookService webhookService;
     private @Nullable String baseUrl;
@@ -166,6 +168,26 @@ public class PlivoCloudWebhookService {
         return baseUrl;
     }
 
+    /**
+     * Registers a listener that is notified once the cloud webhook base URL first becomes available.
+     * This lets handlers that already initialized (before the {@link WebhookService} bound) refresh
+     * their webhook configuration.
+     *
+     * @param listener the callback to invoke when the base URL becomes available
+     */
+    public void addAvailabilityListener(Runnable listener) {
+        availabilityListeners.add(listener);
+    }
+
+    /**
+     * Removes a previously registered availability listener.
+     *
+     * @param listener the callback to remove
+     */
+    public void removeAvailabilityListener(Runnable listener) {
+        availabilityListeners.remove(listener);
+    }
+
     private @Nullable String doRegister() {
         synchronized (lock) {
             if (baseUrl != null) {
@@ -180,6 +202,7 @@ public class PlivoCloudWebhookService {
             return null;
         }
         WebhookService orphanedService = null;
+        boolean newlyRegistered = false;
         synchronized (lock) {
             if (baseUrl != null) {
                 return baseUrl;
@@ -188,13 +211,17 @@ public class PlivoCloudWebhookService {
                 orphanedService = webhookService;
             } else {
                 baseUrl = url;
+                newlyRegistered = true;
                 logger.debug("Cloud webhook base URL: {}", url);
                 if (refreshTask == null) {
                     refreshTask = scheduler.scheduleWithFixedDelay(this::refresh, REFRESH_INTERVAL_HOURS,
                             REFRESH_INTERVAL_HOURS, TimeUnit.HOURS);
                 }
-                return url;
             }
+        }
+        if (newlyRegistered) {
+            notifyAvailabilityListeners();
+            return url;
         }
         if (orphanedService != null) {
             try {
@@ -207,6 +234,16 @@ public class PlivoCloudWebhookService {
             }
         }
         return null;
+    }
+
+    private void notifyAvailabilityListeners() {
+        for (Runnable listener : availabilityListeners) {
+            try {
+                listener.run();
+            } catch (RuntimeException e) {
+                logger.debug("Cloud webhook availability listener failed: {}", e.getMessage());
+            }
+        }
     }
 
     private void refresh() {

--- a/bundles/org.openhab.binding.plivo/src/main/java/org/openhab/binding/plivo/internal/service/PlivoCloudWebhookService.java
+++ b/bundles/org.openhab.binding.plivo/src/main/java/org/openhab/binding/plivo/internal/service/PlivoCloudWebhookService.java
@@ -279,7 +279,7 @@ public class PlivoCloudWebhookService {
             Thread.currentThread().interrupt();
             return null;
         } catch (Exception e) {
-            logger.debug("Failed to request cloud webhook for {}: {}", SERVLET_PATH, e.getMessage());
+            logger.warn("Failed to request an openHAB Cloud webhook for {}: {}", SERVLET_PATH, e.getMessage());
             return null;
         }
     }

--- a/bundles/org.openhab.binding.plivo/src/main/java/org/openhab/binding/plivo/internal/service/PlivoCloudWebhookService.java
+++ b/bundles/org.openhab.binding.plivo/src/main/java/org/openhab/binding/plivo/internal/service/PlivoCloudWebhookService.java
@@ -1,0 +1,236 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.plivo.internal.service;
+
+import static org.openhab.binding.plivo.internal.PlivoBindingConstants.BINDING_ID;
+import static org.openhab.binding.plivo.internal.PlivoBindingConstants.SERVLET_PATH;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.core.common.ThreadPoolManager;
+import org.openhab.core.io.rest.Webhook;
+import org.openhab.core.io.rest.WebhookService;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Manages the binding-wide openHAB Cloud webhook registration used for receiving Plivo callbacks.
+ * <p>
+ * All Plivo phone Things share one cloud webhook mapping at
+ * {@link org.openhab.binding.plivo.internal.PlivoBindingConstants#SERVLET_PATH}. Each account
+ * Thing that wants cloud webhooks calls {@link #register(String)}; the first such call contacts
+ * the core {@link WebhookService} and starts a daily refresh task to keep the registration's TTL
+ * from expiring. The webhook is only removed from the cloud when an account explicitly calls
+ * {@link #unregister(String)} (e.g. when the user turns {@code useCloudWebhook} off in the config)
+ * and no other accounts still require it. Bundle stop/restart deliberately does not remove the
+ * webhook, so restarts don't churn the cloud registration.
+ *
+ * @author Sarvesh Patil - Initial contribution
+ */
+@Component(service = PlivoCloudWebhookService.class)
+@NonNullByDefault
+public class PlivoCloudWebhookService {
+
+    private final Logger logger = LoggerFactory.getLogger(PlivoCloudWebhookService.class);
+
+    private static final long REFRESH_INTERVAL_HOURS = 24;
+    private static final int REQUEST_TIMEOUT_SECONDS = 30;
+
+    private final ScheduledExecutorService scheduler = ThreadPoolManager
+            .getScheduledPool(BINDING_ID + "-cloud-webhook");
+    private final Object lock = new Object();
+    private final Set<String> requestors = new HashSet<>();
+
+    private volatile @Nullable WebhookService webhookService;
+    private @Nullable String baseUrl;
+    private @Nullable ScheduledFuture<?> refreshTask;
+
+    @Reference(cardinality = ReferenceCardinality.OPTIONAL, policy = ReferencePolicy.DYNAMIC)
+    void setWebhookService(WebhookService service) {
+        boolean retry;
+        synchronized (lock) {
+            this.webhookService = service;
+            retry = !requestors.isEmpty() && baseUrl == null;
+        }
+        if (retry) {
+            logger.debug("WebhookService now available; attempting deferred webhook registration");
+            scheduler.execute(this::doRegister);
+        }
+    }
+
+    @SuppressWarnings("PMD.CompareObjectsWithEquals")
+    void unsetWebhookService(WebhookService service) {
+        synchronized (lock) {
+            if (this.webhookService == service) {
+                this.webhookService = null;
+                baseUrl = null;
+                ScheduledFuture<?> task = refreshTask;
+                if (task != null) {
+                    task.cancel(false);
+                    refreshTask = null;
+                }
+            }
+        }
+    }
+
+    @Deactivate
+    public void deactivate() {
+        synchronized (lock) {
+            ScheduledFuture<?> task = refreshTask;
+            if (task != null) {
+                task.cancel(true);
+                refreshTask = null;
+            }
+            requestors.clear();
+            baseUrl = null;
+        }
+    }
+
+    /**
+     * Registers the cloud webhook on behalf of the given requestor (typically a Thing UID). If the
+     * {@link WebhookService} is available, this contacts it synchronously and returns the base URL.
+     * If the service is not yet available, the request is remembered and registration will be
+     * retried automatically once the service binds.
+     *
+     * @param requestorId an identifier (typically a Thing UID) so the service can ref-count
+     *            registrations across multiple Things
+     * @return the cloud webhook base URL, or {@code null} if the {@link WebhookService} is not
+     *         (yet) available
+     */
+    public @Nullable String register(String requestorId) {
+        synchronized (lock) {
+            requestors.add(requestorId);
+        }
+        return doRegister();
+    }
+
+    /**
+     * Releases this requestor's interest in the cloud webhook. When the last requestor unregisters,
+     * the webhook is removed from the {@link WebhookService}.
+     *
+     * @param requestorId the same identifier previously passed to {@link #register(String)}
+     */
+    public void unregister(String requestorId) {
+        boolean removeNeeded;
+        WebhookService ws;
+        synchronized (lock) {
+            if (!requestors.remove(requestorId) || !requestors.isEmpty()) {
+                return;
+            }
+            removeNeeded = baseUrl != null;
+            ws = webhookService;
+            baseUrl = null;
+            ScheduledFuture<?> task = refreshTask;
+            if (task != null) {
+                task.cancel(false);
+                refreshTask = null;
+            }
+        }
+        if (removeNeeded && ws != null) {
+            try {
+                ws.removeWebhook(SERVLET_PATH).get(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+                logger.debug("Cloud webhook removed for {}", SERVLET_PATH);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            } catch (Exception e) {
+                logger.debug("Failed to remove cloud webhook for {}: {}", SERVLET_PATH, e.getMessage());
+            }
+        }
+    }
+
+    /**
+     * @return the current cloud webhook base URL, or {@code null} if not yet registered.
+     */
+    public @Nullable String getBaseUrl() {
+        return baseUrl;
+    }
+
+    private @Nullable String doRegister() {
+        synchronized (lock) {
+            if (baseUrl != null) {
+                return baseUrl;
+            }
+            if (webhookService == null || requestors.isEmpty()) {
+                return null;
+            }
+        }
+        String url = fetchWebhookUrl();
+        if (url == null) {
+            return null;
+        }
+        WebhookService orphanedService = null;
+        synchronized (lock) {
+            if (baseUrl != null) {
+                return baseUrl;
+            }
+            if (requestors.isEmpty()) {
+                orphanedService = webhookService;
+            } else {
+                baseUrl = url;
+                logger.debug("Cloud webhook base URL: {}", url);
+                if (refreshTask == null) {
+                    refreshTask = scheduler.scheduleWithFixedDelay(this::refresh, REFRESH_INTERVAL_HOURS,
+                            REFRESH_INTERVAL_HOURS, TimeUnit.HOURS);
+                }
+                return url;
+            }
+        }
+        if (orphanedService != null) {
+            try {
+                orphanedService.removeWebhook(SERVLET_PATH).get(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+                logger.debug("Removed orphaned cloud webhook for {} (no requestors after registration)", SERVLET_PATH);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            } catch (Exception e) {
+                logger.debug("Failed to remove orphaned cloud webhook for {}: {}", SERVLET_PATH, e.getMessage());
+            }
+        }
+        return null;
+    }
+
+    private void refresh() {
+        String url = fetchWebhookUrl();
+        if (url != null) {
+            baseUrl = url;
+            logger.trace("Cloud webhook refreshed: {}", url);
+        }
+    }
+
+    private @Nullable String fetchWebhookUrl() {
+        WebhookService ws = webhookService;
+        if (ws == null) {
+            return null;
+        }
+        try {
+            Webhook hook = ws.requestWebhook(SERVLET_PATH).get(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            return hook.url().toString();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return null;
+        } catch (Exception e) {
+            logger.debug("Failed to request cloud webhook for {}: {}", SERVLET_PATH, e.getMessage());
+            return null;
+        }
+    }
+}

--- a/bundles/org.openhab.binding.plivo/src/main/java/org/openhab/binding/plivo/internal/service/PlivoCloudWebhookService.java
+++ b/bundles/org.openhab.binding.plivo/src/main/java/org/openhab/binding/plivo/internal/service/PlivoCloudWebhookService.java
@@ -150,14 +150,7 @@ public class PlivoCloudWebhookService {
             }
         }
         if (removeNeeded && ws != null) {
-            try {
-                ws.removeWebhook(SERVLET_PATH).get(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
-                logger.debug("Cloud webhook removed for {}", SERVLET_PATH);
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-            } catch (Exception e) {
-                logger.debug("Failed to remove cloud webhook for {}: {}", SERVLET_PATH, e.getMessage());
-            }
+            removeWebhook(ws, "last requestor unregistered");
         }
     }
 
@@ -165,7 +158,9 @@ public class PlivoCloudWebhookService {
      * @return the current cloud webhook base URL, or {@code null} if not yet registered.
      */
     public @Nullable String getBaseUrl() {
-        return baseUrl;
+        synchronized (lock) {
+            return baseUrl;
+        }
     }
 
     /**
@@ -188,28 +183,35 @@ public class PlivoCloudWebhookService {
         availabilityListeners.remove(listener);
     }
 
+    @SuppressWarnings("PMD.CompareObjectsWithEquals")
     private @Nullable String doRegister() {
+        WebhookService requestService;
         synchronized (lock) {
-            if (baseUrl != null) {
-                return baseUrl;
+            String current = baseUrl;
+            if (current != null) {
+                return current;
             }
-            if (webhookService == null || requestors.isEmpty()) {
+            WebhookService ws = webhookService;
+            if (ws == null || requestors.isEmpty()) {
                 return null;
             }
+            // Capture the service this registration is made through, so a replacement that binds
+            // while the request is in flight cannot be mistaken for the one that created the result.
+            requestService = ws;
         }
-        String url = fetchWebhookUrl();
+        String url = fetchWebhookUrl(requestService);
         if (url == null) {
             return null;
         }
-        WebhookService orphanedService = null;
         boolean newlyRegistered = false;
         synchronized (lock) {
-            if (baseUrl != null) {
-                return baseUrl;
+            String current = baseUrl;
+            if (current != null) {
+                // Another thread registered the same path while this request was in flight. Both
+                // asked the service for SERVLET_PATH, so there is nothing orphaned to clean up.
+                return current;
             }
-            if (requestors.isEmpty()) {
-                orphanedService = webhookService;
-            } else {
+            if (webhookService == requestService && !requestors.isEmpty()) {
                 baseUrl = url;
                 newlyRegistered = true;
                 logger.debug("Cloud webhook base URL: {}", url);
@@ -223,16 +225,10 @@ public class PlivoCloudWebhookService {
             notifyAvailabilityListeners();
             return url;
         }
-        if (orphanedService != null) {
-            try {
-                orphanedService.removeWebhook(SERVLET_PATH).get(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
-                logger.debug("Removed orphaned cloud webhook for {} (no requestors after registration)", SERVLET_PATH);
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-            } catch (Exception e) {
-                logger.debug("Failed to remove orphaned cloud webhook for {}: {}", SERVLET_PATH, e.getMessage());
-            }
-        }
+        // The last requestor unregistered, or the service was replaced, while the request was in
+        // flight. Publishing now would resurrect a registration nobody wants, so drop it through the
+        // same service that created it.
+        removeWebhook(requestService, "no longer required after registration");
         return null;
     }
 
@@ -246,21 +242,38 @@ public class PlivoCloudWebhookService {
         }
     }
 
+    @SuppressWarnings("PMD.CompareObjectsWithEquals")
     private void refresh() {
-        String url = fetchWebhookUrl();
-        if (url != null) {
-            baseUrl = url;
-            logger.trace("Cloud webhook refreshed: {}", url);
+        WebhookService requestService;
+        synchronized (lock) {
+            WebhookService ws = webhookService;
+            if (ws == null || requestors.isEmpty() || baseUrl == null) {
+                return;
+            }
+            requestService = ws;
+        }
+        String url = fetchWebhookUrl(requestService);
+        if (url == null) {
+            return;
+        }
+        boolean refreshed = false;
+        synchronized (lock) {
+            // Only keep the refreshed URL while the registration it belongs to is still live;
+            // otherwise an in-flight refresh would restore a URL that unregister() just cleared.
+            if (webhookService == requestService && !requestors.isEmpty() && baseUrl != null) {
+                baseUrl = url;
+                refreshed = true;
+                logger.trace("Cloud webhook refreshed: {}", url);
+            }
+        }
+        if (!refreshed) {
+            removeWebhook(requestService, "registration torn down during refresh");
         }
     }
 
-    private @Nullable String fetchWebhookUrl() {
-        WebhookService ws = webhookService;
-        if (ws == null) {
-            return null;
-        }
+    private @Nullable String fetchWebhookUrl(WebhookService service) {
         try {
-            Webhook hook = ws.requestWebhook(SERVLET_PATH).get(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            Webhook hook = service.requestWebhook(SERVLET_PATH).get(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
             return hook.url().toString();
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
@@ -268,6 +281,17 @@ public class PlivoCloudWebhookService {
         } catch (Exception e) {
             logger.debug("Failed to request cloud webhook for {}: {}", SERVLET_PATH, e.getMessage());
             return null;
+        }
+    }
+
+    private void removeWebhook(WebhookService service, String reason) {
+        try {
+            service.removeWebhook(SERVLET_PATH).get(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            logger.debug("Cloud webhook removed for {} ({})", SERVLET_PATH, reason);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        } catch (Exception e) {
+            logger.debug("Failed to remove cloud webhook for {} ({}): {}", SERVLET_PATH, reason, e.getMessage());
         }
     }
 }

--- a/bundles/org.openhab.binding.plivo/src/main/java/org/openhab/binding/plivo/internal/servlet/PlivoCallbackServlet.java
+++ b/bundles/org.openhab.binding.plivo/src/main/java/org/openhab/binding/plivo/internal/servlet/PlivoCallbackServlet.java
@@ -292,8 +292,11 @@ public class PlivoCallbackServlet extends HttpServlet {
             resp.sendError(HttpServletResponse.SC_FORBIDDEN, "Account not ready");
             return;
         }
+        // The /status endpoint is shared: message-status callbacks carry MessageUUID and use the
+        // messaging signature families, while call-status callbacks carry CallUUID and require V3 like
+        // the other voice callbacks.
         boolean messaging = WEBHOOK_SMS.equals(endpoint) || WEBHOOK_WHATSAPP.equals(endpoint)
-                || WEBHOOK_STATUS.equals(endpoint);
+                || (WEBHOOK_STATUS.equals(endpoint) && params.containsKey("MessageUUID"));
         String requestUrl = getExternalRequestUrl(req, handler, endpoint, false);
         if (!validateSignature(req, extractBodyParameters(req), requestUrl, client.getAuthToken(), messaging)) {
             logger.debug("Invalid Plivo signature for request to {}", requestUrl);
@@ -575,36 +578,15 @@ public class PlivoCallbackServlet extends HttpServlet {
     }
 
     /**
-     * Validates the request signature against the signatures Plivo supplied. Messaging callbacks are
-     * signed with the main-account signature ({@code X-Plivo-Signature-Ma-V3}) and voice callbacks
-     * with the (sub)account signature ({@code X-Plivo-Signature-V3}); the expected header for the
-     * endpoint is preferred but the other is also accepted when Plivo sends both.
+     * Validates the request signature by extracting the Plivo signature headers and delegating to the
+     * callback-aware {@link PlivoSignatureValidator#validateCallback}.
      */
     private boolean validateSignature(HttpServletRequest req, Map<String, String> params, String url, String authToken,
             boolean messaging) {
-        String v3Nonce = req.getHeader(PLIVO_V3_NONCE_HEADER);
-        String v3 = req.getHeader(PLIVO_SIGNATURE_V3_HEADER);
-        String maV3 = req.getHeader(PLIVO_SIGNATURE_MA_V3_HEADER);
-        String v3Combined = messaging ? joinSignatures(maV3, v3) : joinSignatures(v3, maV3);
-        if (PlivoSignatureValidator.validateV3(url, params, v3Combined, v3Nonce, authToken)) {
-            return true;
-        }
-        String v2Nonce = req.getHeader(PLIVO_V2_NONCE_HEADER);
-        String v2Combined = joinSignatures(req.getHeader(PLIVO_SIGNATURE_MA_V2_HEADER),
-                req.getHeader(PLIVO_SIGNATURE_V2_HEADER));
-        return PlivoSignatureValidator.validateV2(url, v2Combined, v2Nonce, authToken);
-    }
-
-    private @Nullable String joinSignatures(@Nullable String primary, @Nullable String secondary) {
-        boolean hasPrimary = primary != null && !primary.isBlank();
-        boolean hasSecondary = secondary != null && !secondary.isBlank();
-        if (hasPrimary && hasSecondary) {
-            return primary + "," + secondary;
-        }
-        if (hasPrimary) {
-            return primary;
-        }
-        return hasSecondary ? secondary : null;
+        return PlivoSignatureValidator.validateCallback(messaging, url, params, authToken,
+                req.getHeader(PLIVO_SIGNATURE_V3_HEADER), req.getHeader(PLIVO_SIGNATURE_MA_V3_HEADER),
+                req.getHeader(PLIVO_V3_NONCE_HEADER), req.getHeader(PLIVO_SIGNATURE_V2_HEADER),
+                req.getHeader(PLIVO_SIGNATURE_MA_V2_HEADER), req.getHeader(PLIVO_V2_NONCE_HEADER));
     }
 
     // --- Media Entry ---

--- a/bundles/org.openhab.binding.plivo/src/main/java/org/openhab/binding/plivo/internal/servlet/PlivoCallbackServlet.java
+++ b/bundles/org.openhab.binding.plivo/src/main/java/org/openhab/binding/plivo/internal/servlet/PlivoCallbackServlet.java
@@ -388,7 +388,10 @@ public class PlivoCallbackServlet extends HttpServlet {
                 }
                 sendXmlResponse((HttpServletResponse) asyncContext.getResponse(), handler, xml, endpoint);
             } finally {
-                pendingResponses.remove(callUuid);
+                // Remove only this request's entry. A retry for the same CallUUID may already have
+                // replaced it, and dropping that newer future would leave respondWithXml unable to
+                // answer the retried request.
+                pendingResponses.remove(callUuid, future);
                 asyncContext.complete();
             }
         });

--- a/bundles/org.openhab.binding.plivo/src/main/java/org/openhab/binding/plivo/internal/servlet/PlivoCallbackServlet.java
+++ b/bundles/org.openhab.binding.plivo/src/main/java/org/openhab/binding/plivo/internal/servlet/PlivoCallbackServlet.java
@@ -295,7 +295,7 @@ public class PlivoCallbackServlet extends HttpServlet {
         // The /status endpoint is shared: message-status callbacks carry MessageUUID and use the
         // messaging signature families, while call-status callbacks carry CallUUID and require V3 like
         // the other voice callbacks.
-        boolean messaging = WEBHOOK_SMS.equals(endpoint) || WEBHOOK_WHATSAPP.equals(endpoint)
+        boolean messaging = WEBHOOK_SMS.equals(endpoint)
                 || (WEBHOOK_STATUS.equals(endpoint) && params.containsKey("MessageUUID"));
         String requestUrl = getExternalRequestUrl(req, handler, endpoint, false);
         if (!validateSignature(req, extractBodyParameters(req), requestUrl, client.getAuthToken(), messaging)) {
@@ -306,7 +306,6 @@ public class PlivoCallbackServlet extends HttpServlet {
 
         switch (endpoint) {
             case WEBHOOK_SMS:
-            case WEBHOOK_WHATSAPP:
                 handler.handleIncomingSms(params);
                 sendXmlResponse(resp, handler, EMPTY_XML_RESPONSE, endpoint);
                 break;

--- a/bundles/org.openhab.binding.plivo/src/main/java/org/openhab/binding/plivo/internal/servlet/PlivoCallbackServlet.java
+++ b/bundles/org.openhab.binding.plivo/src/main/java/org/openhab/binding/plivo/internal/servlet/PlivoCallbackServlet.java
@@ -279,7 +279,7 @@ public class PlivoCallbackServlet extends HttpServlet {
             }
             String answerUrl = getExternalRequestUrl(req, handler, WEBHOOK_ANSWER, true);
             if (!validateSignature(req, extractBodyParameters(req), answerUrl, client.getAuthToken(), false)) {
-                logger.debug("Invalid or missing Plivo signature for answer request to {}", answerUrl);
+                logger.warn("Rejected Plivo answer callback with an invalid or missing signature for {}", answerUrl);
                 resp.sendError(HttpServletResponse.SC_FORBIDDEN, "Invalid signature");
                 return;
             }
@@ -299,7 +299,7 @@ public class PlivoCallbackServlet extends HttpServlet {
                 || (WEBHOOK_STATUS.equals(endpoint) && params.containsKey("MessageUUID"));
         String requestUrl = getExternalRequestUrl(req, handler, endpoint, false);
         if (!validateSignature(req, extractBodyParameters(req), requestUrl, client.getAuthToken(), messaging)) {
-            logger.debug("Invalid Plivo signature for request to {}", requestUrl);
+            logger.warn("Rejected Plivo callback with an invalid signature for {}", requestUrl);
             resp.sendError(HttpServletResponse.SC_FORBIDDEN, "Invalid signature");
             return;
         }

--- a/bundles/org.openhab.binding.plivo/src/main/java/org/openhab/binding/plivo/internal/servlet/PlivoCallbackServlet.java
+++ b/bundles/org.openhab.binding.plivo/src/main/java/org/openhab/binding/plivo/internal/servlet/PlivoCallbackServlet.java
@@ -19,6 +19,8 @@ import java.io.OutputStream;
 import java.io.PrintWriter;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.Enumeration;
 import java.util.HashMap;
@@ -81,13 +83,12 @@ public class PlivoCallbackServlet extends HttpServlet {
 
     private static final long serialVersionUID = 1L;
     private static final String CONTENT_TYPE_XML = "application/xml";
-    // Voice callbacks are signed with the (sub)account signature (V3); messaging callbacks
-    // (SMS/MMS/WhatsApp/status) are signed with the main-account signature (Ma-V3). Both share
-    // the same nonce header and canonical string, so the validator is asked to match against
-    // whichever signatures Plivo supplied for the endpoint.
     private static final String PLIVO_SIGNATURE_V3_HEADER = "X-Plivo-Signature-V3";
     private static final String PLIVO_SIGNATURE_MA_V3_HEADER = "X-Plivo-Signature-Ma-V3";
-    private static final String PLIVO_NONCE_HEADER = "X-Plivo-Signature-V3-Nonce";
+    private static final String PLIVO_V3_NONCE_HEADER = "X-Plivo-Signature-V3-Nonce";
+    private static final String PLIVO_SIGNATURE_V2_HEADER = "X-Plivo-Signature-V2";
+    private static final String PLIVO_SIGNATURE_MA_V2_HEADER = "X-Plivo-Signature-Ma-V2";
+    private static final String PLIVO_V2_NONCE_HEADER = "X-Plivo-Signature-V2-Nonce";
     private static final int PROXY_TIMEOUT_SECONDS = 15;
     private static final int CLEANUP_INTERVAL_SECONDS = 60;
 
@@ -127,7 +128,8 @@ public class PlivoCallbackServlet extends HttpServlet {
         callXmlCache.clear();
         try {
             httpClient.stop();
-        } catch (Exception ignored) {
+        } catch (Exception e) {
+            logger.debug("Error stopping media HttpClient during deactivation: {}", e.getMessage());
         }
     }
 
@@ -267,21 +269,19 @@ public class PlivoCallbackServlet extends HttpServlet {
         PlivoApiClient client = accountHandler != null ? accountHandler.getApiClient() : null;
 
         if (WEBHOOK_ANSWER.equals(endpoint)) {
-            // Plivo fetches the answer XML from a signed URL that carries the one-shot answer token
-            // in its query string. Validate the V3 signature (over that full URL) when Plivo sends
-            // the signature headers.
-            if (hasSignatureHeaders(req)) {
-                if (client == null) {
-                    logger.debug("Rejecting answer callback for {}: account not ready to validate signature", thingUID);
-                    resp.sendError(HttpServletResponse.SC_FORBIDDEN, "Account not ready");
-                    return;
-                }
-                String answerUrl = getExternalRequestUrl(req, handler, WEBHOOK_ANSWER, true);
-                if (!validateSignature(req, params, answerUrl, client.getAuthToken(), false)) {
-                    logger.debug("Invalid Plivo signature for answer request to {}", answerUrl);
-                    resp.sendError(HttpServletResponse.SC_FORBIDDEN, "Invalid signature");
-                    return;
-                }
+            // Plivo signs voice answer callbacks with the V3 signature, so require a valid one
+            // before serving (and before consuming the one-shot token), like the other endpoints.
+            // The token rides in the URL query, so only the POST body params go to the validator.
+            if (client == null) {
+                logger.debug("Rejecting answer callback for {}: account not ready to validate signature", thingUID);
+                resp.sendError(HttpServletResponse.SC_FORBIDDEN, "Account not ready");
+                return;
+            }
+            String answerUrl = getExternalRequestUrl(req, handler, WEBHOOK_ANSWER, true);
+            if (!validateSignature(req, extractBodyParameters(req), answerUrl, client.getAuthToken(), false)) {
+                logger.debug("Invalid or missing Plivo signature for answer request to {}", answerUrl);
+                resp.sendError(HttpServletResponse.SC_FORBIDDEN, "Invalid signature");
+                return;
             }
             serveCallXml(req, resp, handler);
             return;
@@ -295,7 +295,7 @@ public class PlivoCallbackServlet extends HttpServlet {
         boolean messaging = WEBHOOK_SMS.equals(endpoint) || WEBHOOK_WHATSAPP.equals(endpoint)
                 || WEBHOOK_STATUS.equals(endpoint);
         String requestUrl = getExternalRequestUrl(req, handler, endpoint, false);
-        if (!validateSignature(req, params, requestUrl, client.getAuthToken(), messaging)) {
+        if (!validateSignature(req, extractBodyParameters(req), requestUrl, client.getAuthToken(), messaging)) {
             logger.debug("Invalid Plivo signature for request to {}", requestUrl);
             resp.sendError(HttpServletResponse.SC_FORBIDDEN, "Invalid signature");
             return;
@@ -524,6 +524,31 @@ public class PlivoCallbackServlet extends HttpServlet {
     }
 
     /**
+     * Returns only the POST body parameters, excluding any that also appear in the query string. The
+     * servlet merges query-string and body parameters, but the signed string counts query parameters
+     * in the URL portion and body parameters separately, so a parameter present in the query (such as
+     * the {@code /answer} token) must not be counted again as a body parameter.
+     */
+    private Map<String, String> extractBodyParameters(HttpServletRequest req) {
+        Map<String, String> params = extractParameters(req);
+        String query = req.getQueryString();
+        if (query != null && !query.isEmpty()) {
+            for (String pair : query.split("&")) {
+                int eq = pair.indexOf('=');
+                String rawKey = eq >= 0 ? pair.substring(0, eq) : pair;
+                String key;
+                try {
+                    key = URLDecoder.decode(rawKey, StandardCharsets.UTF_8);
+                } catch (IllegalArgumentException e) {
+                    key = rawKey;
+                }
+                params.remove(key);
+            }
+        }
+        return params;
+    }
+
+    /**
      * Returns the externally-visible request URL for signature validation, which must
      * byte-match the URL Plivo signed. That is the webhook URL the binding registered
      * (cloud or publicUrl based), falling back to the raw request URL. When
@@ -550,15 +575,6 @@ public class PlivoCallbackServlet extends HttpServlet {
     }
 
     /**
-     * Returns true if the request carries a V3-family signature header and the nonce header.
-     */
-    private boolean hasSignatureHeaders(HttpServletRequest req) {
-        boolean hasSignature = req.getHeader(PLIVO_SIGNATURE_V3_HEADER) != null
-                || req.getHeader(PLIVO_SIGNATURE_MA_V3_HEADER) != null;
-        return hasSignature && req.getHeader(PLIVO_NONCE_HEADER) != null;
-    }
-
-    /**
      * Validates the request signature against the signatures Plivo supplied. Messaging callbacks are
      * signed with the main-account signature ({@code X-Plivo-Signature-Ma-V3}) and voice callbacks
      * with the (sub)account signature ({@code X-Plivo-Signature-V3}); the expected header for the
@@ -566,11 +582,17 @@ public class PlivoCallbackServlet extends HttpServlet {
      */
     private boolean validateSignature(HttpServletRequest req, Map<String, String> params, String url, String authToken,
             boolean messaging) {
-        String nonce = req.getHeader(PLIVO_NONCE_HEADER);
+        String v3Nonce = req.getHeader(PLIVO_V3_NONCE_HEADER);
         String v3 = req.getHeader(PLIVO_SIGNATURE_V3_HEADER);
         String maV3 = req.getHeader(PLIVO_SIGNATURE_MA_V3_HEADER);
-        String combined = messaging ? joinSignatures(maV3, v3) : joinSignatures(v3, maV3);
-        return PlivoSignatureValidator.validate(url, params, combined, nonce, authToken);
+        String v3Combined = messaging ? joinSignatures(maV3, v3) : joinSignatures(v3, maV3);
+        if (PlivoSignatureValidator.validateV3(url, params, v3Combined, v3Nonce, authToken)) {
+            return true;
+        }
+        String v2Nonce = req.getHeader(PLIVO_V2_NONCE_HEADER);
+        String v2Combined = joinSignatures(req.getHeader(PLIVO_SIGNATURE_MA_V2_HEADER),
+                req.getHeader(PLIVO_SIGNATURE_V2_HEADER));
+        return PlivoSignatureValidator.validateV2(url, v2Combined, v2Nonce, authToken);
     }
 
     private @Nullable String joinSignatures(@Nullable String primary, @Nullable String secondary) {

--- a/bundles/org.openhab.binding.plivo/src/main/java/org/openhab/binding/plivo/internal/servlet/PlivoCallbackServlet.java
+++ b/bundles/org.openhab.binding.plivo/src/main/java/org/openhab/binding/plivo/internal/servlet/PlivoCallbackServlet.java
@@ -1,0 +1,541 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.plivo.internal.servlet;
+
+import static org.openhab.binding.plivo.internal.PlivoBindingConstants.*;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.PrintWriter;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.time.Instant;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import javax.servlet.AsyncContext;
+import javax.servlet.Servlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.api.ContentResponse;
+import org.eclipse.jetty.client.api.Request;
+import org.eclipse.jetty.client.util.FutureResponseListener;
+import org.eclipse.jetty.http.HttpMethod;
+import org.openhab.binding.plivo.internal.api.PlivoApiClient;
+import org.openhab.binding.plivo.internal.api.PlivoSignatureValidator;
+import org.openhab.binding.plivo.internal.handler.PlivoAccountHandler;
+import org.openhab.binding.plivo.internal.handler.PlivoPhoneHandler;
+import org.openhab.core.common.NamedThreadFactory;
+import org.openhab.core.io.net.http.HttpClientFactory;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.http.whiteboard.propertytypes.HttpWhiteboardServletAsyncSupported;
+import org.osgi.service.http.whiteboard.propertytypes.HttpWhiteboardServletName;
+import org.osgi.service.http.whiteboard.propertytypes.HttpWhiteboardServletPattern;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link PlivoCallbackServlet} receives webhook callbacks from Plivo for
+ * incoming SMS, voice calls, DTMF input, and status updates. It serves the
+ * answer XML for outbound calls (Plivo fetches call-flow XML from an answer URL
+ * rather than accepting it inline) and serves media content for MMS and WhatsApp
+ * messages via temporary UUID-keyed URLs.
+ *
+ * @author Sarvesh Patil - Initial contribution
+ */
+@NonNullByDefault
+@HttpWhiteboardServletAsyncSupported
+@HttpWhiteboardServletName(SERVLET_PATH)
+@HttpWhiteboardServletPattern(SERVLET_PATH + "/*")
+@Component(immediate = true, service = { Servlet.class, PlivoCallbackServlet.class })
+public class PlivoCallbackServlet extends HttpServlet {
+
+    private static final long serialVersionUID = 1L;
+    private static final String CONTENT_TYPE_XML = "application/xml";
+    private static final String PLIVO_SIGNATURE_HEADER = "X-Plivo-Signature-V3";
+    private static final String PLIVO_NONCE_HEADER = "X-Plivo-Signature-V3-Nonce";
+    private static final int PROXY_TIMEOUT_SECONDS = 15;
+    private static final int CLEANUP_INTERVAL_SECONDS = 60;
+
+    private final Logger logger = LoggerFactory.getLogger(PlivoCallbackServlet.class);
+
+    private final Map<String, PlivoPhoneHandler> handlers = new ConcurrentHashMap<>();
+    private final Map<String, MediaEntry> mediaCache = new ConcurrentHashMap<>();
+    private final Map<String, CallXmlEntry> callXmlCache = new ConcurrentHashMap<>();
+    private final Map<String, CompletableFuture<String>> pendingResponses = new ConcurrentHashMap<>();
+
+    private final HttpClient httpClient;
+    private final ScheduledExecutorService cleanupScheduler;
+    private @Nullable ScheduledFuture<?> cleanupTask;
+
+    @Activate
+    public PlivoCallbackServlet(final @Reference HttpClientFactory httpClientFactory) {
+        httpClient = httpClientFactory.createHttpClient(BINDING_ID + "-media");
+        try {
+            httpClient.start();
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to start media HttpClient", e);
+        }
+        cleanupScheduler = Executors
+                .newSingleThreadScheduledExecutor(new NamedThreadFactory(BINDING_ID + "-media-cleanup", true));
+        cleanupTask = cleanupScheduler.scheduleWithFixedDelay(this::cleanupExpiredEntries, CLEANUP_INTERVAL_SECONDS,
+                CLEANUP_INTERVAL_SECONDS, TimeUnit.SECONDS);
+    }
+
+    @Deactivate
+    public void deactivate() {
+        ScheduledFuture<?> task = cleanupTask;
+        if (task != null) {
+            task.cancel(true);
+        }
+        cleanupScheduler.shutdownNow();
+        mediaCache.clear();
+        callXmlCache.clear();
+        try {
+            httpClient.stop();
+        } catch (Exception ignored) {
+        }
+    }
+
+    public void registerHandler(String thingUID, PlivoPhoneHandler handler) {
+        handlers.put(thingUID, handler);
+        logger.debug("Registered Plivo callback handler for {}", thingUID);
+    }
+
+    public void unregisterHandler(String thingUID) {
+        handlers.remove(thingUID);
+        logger.debug("Unregistered Plivo callback handler for {}", thingUID);
+    }
+
+    /**
+     * Creates a pending response for a call. The servlet will wait on this future
+     * before returning XML to Plivo.
+     *
+     * @param callUuid the Plivo Call UUID
+     * @return the CompletableFuture that should be completed with Plivo XML
+     */
+    public CompletableFuture<String> createPendingResponse(String callUuid) {
+        CompletableFuture<String> future = new CompletableFuture<>();
+        pendingResponses.put(callUuid, future);
+        return future;
+    }
+
+    /**
+     * Gets the pending response future for a call, so a rule action can complete it.
+     *
+     * @param callUuid the Plivo Call UUID
+     * @return the CompletableFuture, or null if no pending response exists
+     */
+    public @Nullable CompletableFuture<String> getPendingResponse(String callUuid) {
+        return pendingResponses.get(callUuid);
+    }
+
+    /**
+     * Stores answer XML for an outbound call and returns a one-shot token. The token
+     * is placed in the call's answer URL; Plivo fetches it when the call is answered.
+     *
+     * @param xml the answer XML
+     * @return the token identifying the stored XML
+     */
+    public String createCallXmlEntry(String xml) {
+        String token = UUID.randomUUID().toString();
+        Instant expiresAt = Instant.now().plusSeconds(MEDIA_EXPIRY_MINUTES * 60L);
+        callXmlCache.put(token, new CallXmlEntry(xml, expiresAt));
+        logger.debug("Created answer XML entry {} (expires {})", token, expiresAt);
+        return token;
+    }
+
+    /**
+     * Creates a media entry with direct content (bytes + MIME type).
+     *
+     * @param data the media bytes
+     * @param mimeType the MIME type (e.g. "image/jpeg")
+     * @return the UUID key for the entry
+     */
+    public String createMediaEntry(byte[] data, String mimeType) {
+        String uuid = UUID.randomUUID().toString();
+        Instant expiresAt = Instant.now().plusSeconds(MEDIA_EXPIRY_MINUTES * 60L);
+        mediaCache.put(uuid, new MediaEntry(data, mimeType, null, expiresAt));
+        logger.debug("Created media entry {} ({}, {} bytes, expires {})", uuid, mimeType, data.length, expiresAt);
+        return uuid;
+    }
+
+    /**
+     * Creates a media entry that proxies a URL on demand.
+     *
+     * @param proxyUrl the URL to proxy when requested
+     * @return the UUID key for the entry
+     */
+    public String createProxyEntry(String proxyUrl) {
+        String uuid = UUID.randomUUID().toString();
+        Instant expiresAt = Instant.now().plusSeconds(MEDIA_EXPIRY_MINUTES * 60L);
+        mediaCache.put(uuid, new MediaEntry(null, null, proxyUrl, expiresAt));
+        logger.debug("Created proxy media entry {} -> {} (expires {})", uuid, proxyUrl, expiresAt);
+        return uuid;
+    }
+
+    @Override
+    protected void doGet(@Nullable HttpServletRequest req, @Nullable HttpServletResponse resp) throws IOException {
+        if (req == null || resp == null) {
+            return;
+        }
+
+        String pathInfo = req.getPathInfo();
+        logger.trace("GET request: pathInfo={}", pathInfo);
+
+        if (pathInfo == null || pathInfo.isEmpty()) {
+            resp.sendError(HttpServletResponse.SC_NOT_FOUND);
+            return;
+        }
+
+        if (pathInfo.startsWith("/" + WEBHOOK_MEDIA + "/")) {
+            String uuid = pathInfo.substring(("/" + WEBHOOK_MEDIA + "/").length());
+            serveMedia(uuid, resp);
+        } else {
+            resp.sendError(HttpServletResponse.SC_NOT_FOUND);
+        }
+    }
+
+    @Override
+    protected void doPost(@Nullable HttpServletRequest req, @Nullable HttpServletResponse resp) throws IOException {
+        if (req == null || resp == null) {
+            return;
+        }
+
+        String pathInfo = req.getPathInfo();
+        logger.trace("POST request: pathInfo={}", pathInfo);
+
+        if (pathInfo == null || pathInfo.isEmpty()) {
+            resp.sendError(HttpServletResponse.SC_NOT_FOUND, "Missing path");
+            return;
+        }
+
+        int lastSlash = pathInfo.lastIndexOf('/');
+        if (lastSlash <= 0) {
+            resp.sendError(HttpServletResponse.SC_NOT_FOUND, "Invalid path");
+            return;
+        }
+
+        String endpoint = pathInfo.substring(lastSlash + 1);
+        String thingUID = pathInfo.substring(1, lastSlash);
+
+        PlivoPhoneHandler handler = handlers.get(thingUID);
+        if (handler == null) {
+            logger.debug("No handler registered for thingUID: {}", thingUID);
+            resp.sendError(HttpServletResponse.SC_NOT_FOUND, "Unknown thing");
+            return;
+        }
+
+        Map<String, String> params = extractParameters(req);
+        logger.trace("POST {} endpoint={}, params={}", thingUID, endpoint, params);
+
+        if (WEBHOOK_ANSWER.equals(endpoint)) {
+            serveCallXml(req, resp, handler);
+            return;
+        }
+
+        PlivoAccountHandler accountHandler = handler.getAccountHandler();
+        PlivoApiClient client = accountHandler != null ? accountHandler.getApiClient() : null;
+        if (client == null) {
+            logger.debug("Rejecting callback for {}: account not ready to validate signature", thingUID);
+            resp.sendError(HttpServletResponse.SC_FORBIDDEN, "Account not ready");
+            return;
+        }
+        String signature = req.getHeader(PLIVO_SIGNATURE_HEADER);
+        String nonce = req.getHeader(PLIVO_NONCE_HEADER);
+        String requestUrl = getExternalRequestUrl(req, handler, endpoint);
+        if (!PlivoSignatureValidator.validate(requestUrl, params, signature, nonce, client.getAuthToken())) {
+            logger.debug("Invalid Plivo signature for request to {}", requestUrl);
+            resp.sendError(HttpServletResponse.SC_FORBIDDEN, "Invalid signature");
+            return;
+        }
+
+        switch (endpoint) {
+            case WEBHOOK_SMS:
+            case WEBHOOK_WHATSAPP:
+                handler.handleIncomingSms(params);
+                sendXmlResponse(resp, handler, EMPTY_XML_RESPONSE, endpoint);
+                break;
+            case WEBHOOK_VOICE:
+                handleWithPendingResponse(req, resp, params, handler, handler.getVoiceGreetingXml(),
+                        () -> handler.handleIncomingCall(params), endpoint);
+                break;
+            case WEBHOOK_GATHER:
+                handleWithPendingResponse(req, resp, params, handler, handler.getGatherResponseXml(),
+                        () -> handler.handleDtmfInput(params), endpoint);
+                break;
+            case WEBHOOK_STATUS:
+                handler.handleStatusCallback(params);
+                sendXmlResponse(resp, handler, "", endpoint);
+                break;
+            default:
+                resp.sendError(HttpServletResponse.SC_NOT_FOUND, "Unknown endpoint: " + endpoint);
+                return;
+        }
+    }
+
+    // --- Private helpers ---
+
+    private void serveCallXml(HttpServletRequest req, HttpServletResponse resp, PlivoPhoneHandler handler) {
+        String token = req.getParameter(ANSWER_TOKEN_PARAM);
+        String xml = EMPTY_XML_RESPONSE;
+        if (token != null) {
+            CallXmlEntry entry = callXmlCache.remove(token);
+            if (entry != null && !entry.isExpired()) {
+                xml = entry.xml;
+            } else {
+                logger.debug("No valid answer XML for token {}", token);
+            }
+        }
+        sendXmlResponse(resp, handler, xml, WEBHOOK_ANSWER);
+    }
+
+    /**
+     * Handles a voice/gather request using async I/O. Creates a pending response future,
+     * fires the handler (which triggers rules), then completes the HTTP response
+     * asynchronously when a rule calls respondWithXml or the timeout expires.
+     */
+    private void handleWithPendingResponse(HttpServletRequest req, HttpServletResponse resp, Map<String, String> params,
+            PlivoPhoneHandler handler, String defaultXml, Runnable handlerAction, String endpoint) {
+        String callUuid = params.get("CallUUID");
+        if (callUuid == null || callUuid.isBlank()) {
+            handlerAction.run();
+            sendXmlResponse(resp, handler, defaultXml, endpoint);
+            return;
+        }
+
+        int timeout = handler.getResponseTimeout();
+        logger.trace("Creating async pending response for CallUUID={}, timeout={}s", callUuid, timeout);
+
+        AsyncContext asyncContext = req.startAsync(req, resp);
+        asyncContext.setTimeout(0);
+
+        CompletableFuture<String> future = createPendingResponse(callUuid);
+
+        handlerAction.run();
+
+        future.orTimeout(timeout, TimeUnit.SECONDS).whenComplete((result, ex) -> {
+            try {
+                String xml;
+                if (ex != null) {
+                    if (ex instanceof TimeoutException) {
+                        logger.debug("No XML response within timeout for CallUUID {}, using default", callUuid);
+                    } else {
+                        logger.debug("Error waiting for XML for CallUUID {}: {}", callUuid, ex.getMessage());
+                    }
+                    xml = defaultXml;
+                } else {
+                    xml = result;
+                }
+                sendXmlResponse((HttpServletResponse) asyncContext.getResponse(), handler, xml, endpoint);
+            } finally {
+                pendingResponses.remove(callUuid);
+                asyncContext.complete();
+            }
+        });
+    }
+
+    private void sendXmlResponse(HttpServletResponse resp, PlivoPhoneHandler handler, String xmlResponse,
+            String endpoint) {
+        String xml = handler.replaceXmlPlaceholders(xmlResponse);
+        logger.trace("POST response: 200, endpoint={}, xml={}", endpoint, xml);
+        resp.setContentType(CONTENT_TYPE_XML);
+        resp.setStatus(HttpServletResponse.SC_OK);
+        if (!xml.isEmpty()) {
+            try {
+                PrintWriter writer = resp.getWriter();
+                writer.print(xml);
+                writer.flush();
+            } catch (IOException e) {
+                logger.debug("Failed to write XML response: {}", e.getMessage());
+            }
+        }
+    }
+
+    private void serveMedia(String uuid, HttpServletResponse resp) throws IOException {
+        MediaEntry entry = mediaCache.get(uuid);
+        if (entry == null) {
+            resp.sendError(HttpServletResponse.SC_NOT_FOUND, "Media not found");
+            return;
+        }
+
+        if (entry.isExpired()) {
+            mediaCache.remove(uuid);
+            resp.sendError(HttpServletResponse.SC_GONE, "Media expired");
+            return;
+        }
+
+        byte[] data = entry.data;
+        String mimeType = entry.mimeType;
+        String proxyUrl = entry.proxyUrl;
+
+        if (data != null && mimeType != null) {
+            resp.setContentType(mimeType);
+            resp.setContentLength(data.length);
+            OutputStream out = resp.getOutputStream();
+            out.write(data);
+            out.flush();
+        } else if (proxyUrl != null) {
+            proxyMedia(proxyUrl, resp);
+        } else {
+            resp.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, "Invalid media entry");
+        }
+    }
+
+    private void proxyMedia(String sourceUrl, HttpServletResponse resp) throws IOException {
+        try {
+            String scheme = new URI(sourceUrl).getScheme();
+            if (scheme == null || !("http".equalsIgnoreCase(scheme) || "https".equalsIgnoreCase(scheme))) {
+                logger.debug("Rejecting proxy request for non-http(s) URL scheme: {}", scheme);
+                resp.sendError(HttpServletResponse.SC_BAD_GATEWAY, "Unsupported URL scheme");
+                return;
+            }
+        } catch (URISyntaxException e) {
+            logger.debug("Rejecting proxy request for malformed URL {}: {}", sourceUrl, e.getMessage());
+            resp.sendError(HttpServletResponse.SC_BAD_GATEWAY, "Invalid source URL");
+            return;
+        }
+
+        try {
+            Request request = httpClient.newRequest(sourceUrl) //
+                    .method(HttpMethod.GET) //
+                    .timeout(PROXY_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            FutureResponseListener listener = new FutureResponseListener(request, MAX_PROXY_MEDIA_BYTES);
+            request.send(listener);
+            ContentResponse proxyResponse = listener.get(PROXY_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+
+            int status = proxyResponse.getStatus();
+            if (status < 200 || status >= 300) {
+                resp.sendError(HttpServletResponse.SC_BAD_GATEWAY, "Source returned " + status);
+                return;
+            }
+
+            byte[] content = proxyResponse.getContent();
+            String contentType = proxyResponse.getMediaType();
+            if (contentType == null) {
+                contentType = "application/octet-stream";
+            }
+
+            resp.setContentType(contentType);
+            resp.setContentLength(content.length);
+            OutputStream out = resp.getOutputStream();
+            out.write(content);
+            out.flush();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            resp.sendError(HttpServletResponse.SC_BAD_GATEWAY, "Proxy request interrupted");
+        } catch (ExecutionException | TimeoutException e) {
+            logger.debug("Failed to proxy media from {}: {}", sourceUrl, e.getMessage());
+            resp.sendError(HttpServletResponse.SC_BAD_GATEWAY, "Failed to fetch media");
+        }
+    }
+
+    private void cleanupExpiredEntries() {
+        Iterator<Map.Entry<String, MediaEntry>> media = mediaCache.entrySet().iterator();
+        while (media.hasNext()) {
+            Map.Entry<String, MediaEntry> entry = media.next();
+            if (entry.getValue().isExpired()) {
+                media.remove();
+            }
+        }
+        Iterator<Map.Entry<String, CallXmlEntry>> calls = callXmlCache.entrySet().iterator();
+        while (calls.hasNext()) {
+            Map.Entry<String, CallXmlEntry> entry = calls.next();
+            if (entry.getValue().isExpired()) {
+                calls.remove();
+            }
+        }
+    }
+
+    private Map<String, String> extractParameters(HttpServletRequest req) {
+        Map<String, String> params = new HashMap<>();
+        Enumeration<String> paramNames = req.getParameterNames();
+        while (paramNames.hasMoreElements()) {
+            String name = paramNames.nextElement();
+            String value = req.getParameter(name);
+            if (value != null) {
+                params.put(name, value);
+            }
+        }
+        return params;
+    }
+
+    /**
+     * Returns the externally-visible request URL for signature validation, which must
+     * byte-match the URL Plivo signed. That is the webhook URL the binding registered
+     * (cloud or publicUrl based), falling back to the raw request URL.
+     */
+    private String getExternalRequestUrl(HttpServletRequest req, PlivoPhoneHandler handler, String endpoint) {
+        String registeredUrl = handler.getWebhookUrl(endpoint);
+        if (registeredUrl != null) {
+            return registeredUrl;
+        }
+        StringBuffer requestUrl = req.getRequestURL();
+        return requestUrl != null ? requestUrl.toString() : "";
+    }
+
+    // --- Media Entry ---
+
+    private static class MediaEntry {
+        final byte @Nullable [] data;
+        final @Nullable String mimeType;
+        final @Nullable String proxyUrl;
+        final Instant expiresAt;
+
+        MediaEntry(byte @Nullable [] data, @Nullable String mimeType, @Nullable String proxyUrl, Instant expiresAt) {
+            this.data = data;
+            this.mimeType = mimeType;
+            this.proxyUrl = proxyUrl;
+            this.expiresAt = expiresAt;
+        }
+
+        boolean isExpired() {
+            return Instant.now().isAfter(expiresAt);
+        }
+    }
+
+    // --- Call Answer XML Entry ---
+
+    private static class CallXmlEntry {
+        final String xml;
+        final Instant expiresAt;
+
+        CallXmlEntry(String xml, Instant expiresAt) {
+            this.xml = xml;
+            this.expiresAt = expiresAt;
+        }
+
+        boolean isExpired() {
+            return Instant.now().isAfter(expiresAt);
+        }
+    }
+}

--- a/bundles/org.openhab.binding.plivo/src/main/java/org/openhab/binding/plivo/internal/servlet/PlivoCallbackServlet.java
+++ b/bundles/org.openhab.binding.plivo/src/main/java/org/openhab/binding/plivo/internal/servlet/PlivoCallbackServlet.java
@@ -81,7 +81,12 @@ public class PlivoCallbackServlet extends HttpServlet {
 
     private static final long serialVersionUID = 1L;
     private static final String CONTENT_TYPE_XML = "application/xml";
-    private static final String PLIVO_SIGNATURE_HEADER = "X-Plivo-Signature-V3";
+    // Voice callbacks are signed with the (sub)account signature (V3); messaging callbacks
+    // (SMS/MMS/WhatsApp/status) are signed with the main-account signature (Ma-V3). Both share
+    // the same nonce header and canonical string, so the validator is asked to match against
+    // whichever signatures Plivo supplied for the endpoint.
+    private static final String PLIVO_SIGNATURE_V3_HEADER = "X-Plivo-Signature-V3";
+    private static final String PLIVO_SIGNATURE_MA_V3_HEADER = "X-Plivo-Signature-Ma-V3";
     private static final String PLIVO_NONCE_HEADER = "X-Plivo-Signature-V3-Nonce";
     private static final int PROXY_TIMEOUT_SECONDS = 15;
     private static final int CLEANUP_INTERVAL_SECONDS = 60;
@@ -258,22 +263,39 @@ public class PlivoCallbackServlet extends HttpServlet {
         Map<String, String> params = extractParameters(req);
         logger.trace("POST {} endpoint={}, params={}", thingUID, endpoint, params);
 
+        PlivoAccountHandler accountHandler = handler.getAccountHandler();
+        PlivoApiClient client = accountHandler != null ? accountHandler.getApiClient() : null;
+
         if (WEBHOOK_ANSWER.equals(endpoint)) {
+            // Plivo fetches the answer XML from a signed URL that carries the one-shot answer token
+            // in its query string. Validate the V3 signature (over that full URL) when Plivo sends
+            // the signature headers.
+            if (hasSignatureHeaders(req)) {
+                if (client == null) {
+                    logger.debug("Rejecting answer callback for {}: account not ready to validate signature", thingUID);
+                    resp.sendError(HttpServletResponse.SC_FORBIDDEN, "Account not ready");
+                    return;
+                }
+                String answerUrl = getExternalRequestUrl(req, handler, WEBHOOK_ANSWER, true);
+                if (!validateSignature(req, params, answerUrl, client.getAuthToken(), false)) {
+                    logger.debug("Invalid Plivo signature for answer request to {}", answerUrl);
+                    resp.sendError(HttpServletResponse.SC_FORBIDDEN, "Invalid signature");
+                    return;
+                }
+            }
             serveCallXml(req, resp, handler);
             return;
         }
 
-        PlivoAccountHandler accountHandler = handler.getAccountHandler();
-        PlivoApiClient client = accountHandler != null ? accountHandler.getApiClient() : null;
         if (client == null) {
             logger.debug("Rejecting callback for {}: account not ready to validate signature", thingUID);
             resp.sendError(HttpServletResponse.SC_FORBIDDEN, "Account not ready");
             return;
         }
-        String signature = req.getHeader(PLIVO_SIGNATURE_HEADER);
-        String nonce = req.getHeader(PLIVO_NONCE_HEADER);
-        String requestUrl = getExternalRequestUrl(req, handler, endpoint);
-        if (!PlivoSignatureValidator.validate(requestUrl, params, signature, nonce, client.getAuthToken())) {
+        boolean messaging = WEBHOOK_SMS.equals(endpoint) || WEBHOOK_WHATSAPP.equals(endpoint)
+                || WEBHOOK_STATUS.equals(endpoint);
+        String requestUrl = getExternalRequestUrl(req, handler, endpoint, false);
+        if (!validateSignature(req, params, requestUrl, client.getAuthToken(), messaging)) {
             logger.debug("Invalid Plivo signature for request to {}", requestUrl);
             resp.sendError(HttpServletResponse.SC_FORBIDDEN, "Invalid signature");
             return;
@@ -328,7 +350,11 @@ public class PlivoCallbackServlet extends HttpServlet {
             PlivoPhoneHandler handler, String defaultXml, Runnable handlerAction, String endpoint) {
         String callUuid = params.get("CallUUID");
         if (callUuid == null || callUuid.isBlank()) {
-            handlerAction.run();
+            try {
+                handlerAction.run();
+            } catch (RuntimeException e) {
+                logger.debug("Handler action failed for {} callback: {}", endpoint, e.getMessage());
+            }
             sendXmlResponse(resp, handler, defaultXml, endpoint);
             return;
         }
@@ -341,8 +367,9 @@ public class PlivoCallbackServlet extends HttpServlet {
 
         CompletableFuture<String> future = createPendingResponse(callUuid);
 
-        handlerAction.run();
-
+        // Attach the completion handler BEFORE running the handler action so that a failure in the
+        // action (or a timeout) always completes the response and clears the pending entry, rather
+        // than leaving the async request open forever.
         future.orTimeout(timeout, TimeUnit.SECONDS).whenComplete((result, ex) -> {
             try {
                 String xml;
@@ -362,6 +389,13 @@ public class PlivoCallbackServlet extends HttpServlet {
                 asyncContext.complete();
             }
         });
+
+        try {
+            handlerAction.run();
+        } catch (RuntimeException e) {
+            logger.debug("Handler action failed for CallUUID {}: {}", callUuid, e.getMessage());
+            future.complete(defaultXml);
+        }
     }
 
     private void sendXmlResponse(HttpServletResponse resp, PlivoPhoneHandler handler, String xmlResponse,
@@ -492,15 +526,63 @@ public class PlivoCallbackServlet extends HttpServlet {
     /**
      * Returns the externally-visible request URL for signature validation, which must
      * byte-match the URL Plivo signed. That is the webhook URL the binding registered
-     * (cloud or publicUrl based), falling back to the raw request URL.
+     * (cloud or publicUrl based), falling back to the raw request URL. When
+     * {@code includeQuery} is set, the incoming request's query string is appended, which
+     * matters for the {@code /answer} endpoint whose signed URL carries the answer token.
      */
-    private String getExternalRequestUrl(HttpServletRequest req, PlivoPhoneHandler handler, String endpoint) {
+    private String getExternalRequestUrl(HttpServletRequest req, PlivoPhoneHandler handler, String endpoint,
+            boolean includeQuery) {
         String registeredUrl = handler.getWebhookUrl(endpoint);
+        String base;
         if (registeredUrl != null) {
-            return registeredUrl;
+            base = registeredUrl;
+        } else {
+            StringBuffer requestUrl = req.getRequestURL();
+            base = requestUrl != null ? requestUrl.toString() : "";
         }
-        StringBuffer requestUrl = req.getRequestURL();
-        return requestUrl != null ? requestUrl.toString() : "";
+        if (includeQuery) {
+            String query = req.getQueryString();
+            if (query != null && !query.isEmpty()) {
+                return base + "?" + query;
+            }
+        }
+        return base;
+    }
+
+    /**
+     * Returns true if the request carries a V3-family signature header and the nonce header.
+     */
+    private boolean hasSignatureHeaders(HttpServletRequest req) {
+        boolean hasSignature = req.getHeader(PLIVO_SIGNATURE_V3_HEADER) != null
+                || req.getHeader(PLIVO_SIGNATURE_MA_V3_HEADER) != null;
+        return hasSignature && req.getHeader(PLIVO_NONCE_HEADER) != null;
+    }
+
+    /**
+     * Validates the request signature against the signatures Plivo supplied. Messaging callbacks are
+     * signed with the main-account signature ({@code X-Plivo-Signature-Ma-V3}) and voice callbacks
+     * with the (sub)account signature ({@code X-Plivo-Signature-V3}); the expected header for the
+     * endpoint is preferred but the other is also accepted when Plivo sends both.
+     */
+    private boolean validateSignature(HttpServletRequest req, Map<String, String> params, String url, String authToken,
+            boolean messaging) {
+        String nonce = req.getHeader(PLIVO_NONCE_HEADER);
+        String v3 = req.getHeader(PLIVO_SIGNATURE_V3_HEADER);
+        String maV3 = req.getHeader(PLIVO_SIGNATURE_MA_V3_HEADER);
+        String combined = messaging ? joinSignatures(maV3, v3) : joinSignatures(v3, maV3);
+        return PlivoSignatureValidator.validate(url, params, combined, nonce, authToken);
+    }
+
+    private @Nullable String joinSignatures(@Nullable String primary, @Nullable String secondary) {
+        boolean hasPrimary = primary != null && !primary.isBlank();
+        boolean hasSecondary = secondary != null && !secondary.isBlank();
+        if (hasPrimary && hasSecondary) {
+            return primary + "," + secondary;
+        }
+        if (hasPrimary) {
+            return primary;
+        }
+        return hasSecondary ? secondary : null;
     }
 
     // --- Media Entry ---

--- a/bundles/org.openhab.binding.plivo/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.binding.plivo/src/main/resources/OH-INF/addon/addon.xml
@@ -5,8 +5,7 @@
 
 	<type>binding</type>
 	<name>Plivo Binding</name>
-	<description>Integrates with Plivo for sending and receiving SMS, MMS, and WhatsApp messages, as well as making
-		and
+	<description>Integrates with Plivo for sending and receiving SMS, MMS, and WhatsApp messages, as well as making and
 		receiving voice calls with text-to-speech and DTMF input support.</description>
 	<connection>cloud</connection>
 

--- a/bundles/org.openhab.binding.plivo/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.binding.plivo/src/main/resources/OH-INF/addon/addon.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<addon:addon id="plivo" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:addon="https://openhab.org/schemas/addon/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/addon/v1.0.0 https://openhab.org/schemas/addon-1.0.0.xsd">
+
+	<type>binding</type>
+	<name>Plivo Binding</name>
+	<description>Integrates with Plivo for sending and receiving SMS, MMS, and WhatsApp messages, as well as making
+		and
+		receiving voice calls with text-to-speech and DTMF input support.</description>
+	<connection>cloud</connection>
+
+</addon:addon>

--- a/bundles/org.openhab.binding.plivo/src/main/resources/OH-INF/i18n/plivo.properties
+++ b/bundles/org.openhab.binding.plivo/src/main/resources/OH-INF/i18n/plivo.properties
@@ -71,6 +71,5 @@ offline.configuration-error.missing-auth-token = Auth Token is required
 offline.configuration-error.account-invalid = Account credentials are invalid
 offline.configuration-error.api-client-not-initialized = API client not initialized
 offline.configuration-error.missing-phone-number = Phone number is required
-offline.configuration-error.webhook-url-unavailable = No public webhook URL is available to automatically configure the Plivo application. Configure a Public URL or enable openHAB Cloud webhooks.
 offline.bridge-uninitialized.bridge-handler-not-available = Bridge handler not available
 offline.bridge-uninitialized.api-client-not-available = API client not available

--- a/bundles/org.openhab.binding.plivo/src/main/resources/OH-INF/i18n/plivo.properties
+++ b/bundles/org.openhab.binding.plivo/src/main/resources/OH-INF/i18n/plivo.properties
@@ -71,5 +71,6 @@ offline.configuration-error.missing-auth-token = Auth Token is required
 offline.configuration-error.account-invalid = Account credentials are invalid
 offline.configuration-error.api-client-not-initialized = API client not initialized
 offline.configuration-error.missing-phone-number = Phone number is required
+offline.configuration-error.webhook-url-unavailable = No public webhook URL is available to automatically configure the Plivo application. Configure a Public URL or enable openHAB Cloud webhooks.
 offline.bridge-uninitialized.bridge-handler-not-available = Bridge handler not available
 offline.bridge-uninitialized.api-client-not-available = API client not available

--- a/bundles/org.openhab.binding.plivo/src/main/resources/OH-INF/i18n/plivo.properties
+++ b/bundles/org.openhab.binding.plivo/src/main/resources/OH-INF/i18n/plivo.properties
@@ -13,7 +13,7 @@ thing-type.plivo.phone.description = Represents a Plivo phone number for sending
 # thing types config
 
 thing-type.config.plivo.account.authId.label = Auth ID
-thing-type.config.plivo.account.authId.description = Your Plivo Auth ID (starts with MA or SA). Found in the Plivo console dashboard at https://cx.plivo.com.
+thing-type.config.plivo.account.authId.description = Your Plivo Auth ID, found in the Plivo console dashboard at https://cx.plivo.com. Use main account credentials (Auth ID starting with MA): Plivo signs the Ma-V2 and Ma-V3 callback signatures with the main account Auth Token, so a subaccount (SA) can send messages and calls but cannot validate inbound callbacks.
 thing-type.config.plivo.account.authToken.label = Auth Token
 thing-type.config.plivo.account.authToken.description = Your Plivo Auth Token. Found in the Plivo console dashboard at https://cx.plivo.com.
 thing-type.config.plivo.account.autoConfigureWebhooks.label = Auto-Configure Webhooks

--- a/bundles/org.openhab.binding.plivo/src/main/resources/OH-INF/i18n/plivo.properties
+++ b/bundles/org.openhab.binding.plivo/src/main/resources/OH-INF/i18n/plivo.properties
@@ -1,0 +1,75 @@
+# add-on
+
+addon.plivo.name = Plivo Binding
+addon.plivo.description = Integrates with Plivo for sending and receiving SMS, MMS, and WhatsApp messages, as well as making and receiving voice calls with text-to-speech and DTMF input support.
+
+# thing types
+
+thing-type.plivo.account.label = Plivo Account
+thing-type.plivo.account.description = A Plivo account that provides API access for sending SMS, MMS, WhatsApp messages, and making voice calls.
+thing-type.plivo.phone.label = Plivo Phone Number
+thing-type.plivo.phone.description = Represents a Plivo phone number for sending and receiving SMS, MMS, WhatsApp messages, and voice calls.
+
+# thing types config
+
+thing-type.config.plivo.account.authId.label = Auth ID
+thing-type.config.plivo.account.authId.description = Your Plivo Auth ID (starts with MA or SA). Found in the Plivo console dashboard at https://cx.plivo.com.
+thing-type.config.plivo.account.authToken.label = Auth Token
+thing-type.config.plivo.account.authToken.description = Your Plivo Auth Token. Found in the Plivo console dashboard at https://cx.plivo.com.
+thing-type.config.plivo.account.autoConfigureWebhooks.label = Auto-Configure Webhooks
+thing-type.config.plivo.account.autoConfigureWebhooks.description = When enabled, automatically creates a Plivo application with the webhook URLs and assigns it to the phone number via the API. Requires Public URL or Cloud Webhook to be configured.
+thing-type.config.plivo.account.publicUrl.label = Public URL
+thing-type.config.plivo.account.publicUrl.description = Public-facing base URL for webhook callbacks (e.g. https://my.domain.com). Required to receive incoming messages and calls and to make outbound voice calls.
+thing-type.config.plivo.account.useCloudWebhook.label = Use openHAB Cloud Webhooks
+thing-type.config.plivo.account.useCloudWebhook.description = When enabled, uses the openHAB Cloud service to provide publicly-reachable webhook URLs for receiving incoming messages and calls. Requires the openHAB Cloud Connector add-on to be installed and connected. This eliminates the need for port forwarding or a reverse proxy.
+thing-type.config.plivo.phone.gatherResponse.label = Gather Response XML
+thing-type.config.plivo.phone.gatherResponse.description = Plivo XML returned after DTMF digits are gathered from a caller. Used as fallback when no rule responds with respondWithXml.
+thing-type.config.plivo.phone.phoneNumber.label = Phone Number
+thing-type.config.plivo.phone.phoneNumber.description = Your Plivo phone number in E.164 format (e.g. +15551234567).
+thing-type.config.plivo.phone.responseTimeout.label = Response Timeout
+thing-type.config.plivo.phone.responseTimeout.description = Seconds to wait for a rule to respond with XML via respondWithXml before using the default greeting or gather response.
+thing-type.config.plivo.phone.voiceGreeting.label = Voice Greeting XML
+thing-type.config.plivo.phone.voiceGreeting.description = Plivo XML returned when an incoming voice call is received. Use {gatherUrl} as a placeholder for the DTMF callback URL.
+
+# channel types
+
+channel-type.plivo.call-received.label = Call Received
+channel-type.plivo.call-received.description = Triggered when an incoming voice call is received. Payload is a JSON object with from, to, callUuid, and callStatus fields.
+channel-type.plivo.call-status-update.label = Call Status Update
+channel-type.plivo.call-status-update.description = Triggered when a call status changes. Payload is a JSON object with callUuid, callStatus, from, and to fields.
+channel-type.plivo.dtmf-received.label = DTMF Received
+channel-type.plivo.dtmf-received.description = Triggered when DTMF digits are gathered from a caller. Payload is a JSON object with digits, callUuid, from, and to fields.
+channel-type.plivo.last-call-date.label = Last Call Date
+channel-type.plivo.last-call-date.description = Timestamp of the last incoming call.
+channel-type.plivo.last-call-from.label = Last Call From
+channel-type.plivo.last-call-from.description = Phone number of the last incoming caller.
+channel-type.plivo.last-call-status.label = Last Call Status
+channel-type.plivo.last-call-status.description = Status of the last call (e.g. ringing, in-progress, completed).
+channel-type.plivo.last-dtmf-digits.label = Last DTMF Digits
+channel-type.plivo.last-dtmf-digits.description = Last DTMF digits received from a caller during a voice call.
+channel-type.plivo.last-message-body.label = Last Message Body
+channel-type.plivo.last-message-body.description = Body text of the last received SMS or WhatsApp message.
+channel-type.plivo.last-message-date.label = Last Message Date
+channel-type.plivo.last-message-date.description = Timestamp of the last received message.
+channel-type.plivo.last-message-from.label = Last Message From
+channel-type.plivo.last-message-from.description = Phone number of the last message sender.
+channel-type.plivo.last-message-media-url.label = Last Message Media URL
+channel-type.plivo.last-message-media-url.description = URL of the first media attachment from the last received MMS or WhatsApp message.
+channel-type.plivo.last-message-uuid.label = Last Message UUID
+channel-type.plivo.last-message-uuid.description = Plivo Message UUID of the last received message.
+channel-type.plivo.message-status.label = Message Status
+channel-type.plivo.message-status.description = Triggered when a message delivery status changes. Payload is a JSON object with messageUuid, messageStatus, and to fields.
+channel-type.plivo.sms-received.label = SMS Received
+channel-type.plivo.sms-received.description = Triggered when an SMS or MMS message is received. Payload is a JSON object with from, to, body, messageUuid, type, and mediaUrls fields.
+channel-type.plivo.whatsapp-received.label = WhatsApp Received
+channel-type.plivo.whatsapp-received.description = Triggered when a WhatsApp message is received. Payload is a JSON object with from, to, body, messageUuid, type, and mediaUrls fields.
+
+# thing status
+
+offline.configuration-error.missing-auth-id = Auth ID is required
+offline.configuration-error.missing-auth-token = Auth Token is required
+offline.configuration-error.account-invalid = Account credentials are invalid
+offline.configuration-error.api-client-not-initialized = API client not initialized
+offline.configuration-error.missing-phone-number = Phone number is required
+offline.bridge-uninitialized.bridge-handler-not-available = Bridge handler not available
+offline.bridge-uninitialized.api-client-not-available = API client not available

--- a/bundles/org.openhab.binding.plivo/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.plivo/src/main/resources/OH-INF/thing/thing-types.xml
@@ -42,6 +42,7 @@
 					incoming messages and calls. Requires the openHAB Cloud Connector add-on to be installed and connected. This
 					eliminates the need for port forwarding or a reverse proxy.</description>
 				<default>false</default>
+				<advanced>true</advanced>
 			</parameter>
 		</config-description>
 	</bridge-type>

--- a/bundles/org.openhab.binding.plivo/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.plivo/src/main/resources/OH-INF/thing/thing-types.xml
@@ -13,8 +13,9 @@
 		<config-description>
 			<parameter name="authId" type="text" required="true">
 				<label>Auth ID</label>
-				<description>Your Plivo Auth ID (starts with MA or SA). Found in the Plivo console dashboard at
-					https://cx.plivo.com.</description>
+				<description>Your Plivo Auth ID, found in the Plivo console dashboard at https://cx.plivo.com. Use main account
+					credentials (Auth ID starting with MA): Plivo signs the Ma-V2 and Ma-V3 callback signatures with the main account
+					Auth Token, so a subaccount (SA) can send messages and calls but cannot validate inbound callbacks.</description>
 			</parameter>
 			<parameter name="authToken" type="text" required="true">
 				<context>password</context>

--- a/bundles/org.openhab.binding.plivo/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.plivo/src/main/resources/OH-INF/thing/thing-types.xml
@@ -7,8 +7,7 @@
 	<!-- Plivo Account Bridge -->
 	<bridge-type id="account">
 		<label>Plivo Account</label>
-		<description>A Plivo account that provides API access for sending SMS, MMS, WhatsApp messages, and making voice
-			calls.</description>
+		<description>A Plivo account that provides API access for sending SMS, MMS, WhatsApp messages, and making voice calls.</description>
 		<semantic-equipment-tag>WebService</semantic-equipment-tag>
 
 		<config-description>
@@ -31,8 +30,7 @@
 			<parameter name="autoConfigureWebhooks" type="boolean" required="false">
 				<label>Auto-Configure Webhooks</label>
 				<description>When enabled, automatically creates a Plivo application with the webhook URLs and assigns it to the
-					phone
-					number via the API. Requires Public URL or Cloud Webhook to be configured.</description>
+					phone number via the API. Requires Public URL or Cloud Webhook to be configured.</description>
 				<default>true</default>
 				<advanced>true</advanced>
 			</parameter>
@@ -88,8 +86,7 @@
 			<parameter name="voiceGreeting" type="text" required="false">
 				<label>Voice Greeting XML</label>
 				<description>Plivo XML returned when an incoming voice call is received. Use {gatherUrl} as a placeholder for the
-					DTMF
-					callback URL.</description>
+					DTMF callback URL.</description>
 				<advanced>true</advanced>
 			</parameter>
 			<parameter name="gatherResponse" type="text" required="false">

--- a/bundles/org.openhab.binding.plivo/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.plivo/src/main/resources/OH-INF/thing/thing-types.xml
@@ -1,0 +1,259 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="plivo"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
+
+	<!-- Plivo Account Bridge -->
+	<bridge-type id="account">
+		<label>Plivo Account</label>
+		<description>A Plivo account that provides API access for sending SMS, MMS, WhatsApp messages, and making voice
+			calls.</description>
+		<semantic-equipment-tag>WebService</semantic-equipment-tag>
+
+		<config-description>
+			<parameter name="authId" type="text" required="true">
+				<label>Auth ID</label>
+				<description>Your Plivo Auth ID (starts with MA or SA). Found in the Plivo console dashboard at
+					https://cx.plivo.com.</description>
+			</parameter>
+			<parameter name="authToken" type="text" required="true">
+				<context>password</context>
+				<label>Auth Token</label>
+				<description>Your Plivo Auth Token. Found in the Plivo console dashboard at https://cx.plivo.com.</description>
+			</parameter>
+			<parameter name="publicUrl" type="text" required="false">
+				<label>Public URL</label>
+				<description>Public-facing base URL for webhook callbacks (e.g. https://my.domain.com). Required to receive incoming
+					messages and calls and to make outbound voice calls.</description>
+				<advanced>true</advanced>
+			</parameter>
+			<parameter name="autoConfigureWebhooks" type="boolean" required="false">
+				<label>Auto-Configure Webhooks</label>
+				<description>When enabled, automatically creates a Plivo application with the webhook URLs and assigns it to the
+					phone
+					number via the API. Requires Public URL or Cloud Webhook to be configured.</description>
+				<default>true</default>
+				<advanced>true</advanced>
+			</parameter>
+			<parameter name="useCloudWebhook" type="boolean" required="false">
+				<label>Use openHAB Cloud Webhooks</label>
+				<description>When enabled, uses the openHAB Cloud service to provide publicly-reachable webhook URLs for receiving
+					incoming messages and calls. Requires the openHAB Cloud Connector add-on to be installed and connected. This
+					eliminates the need for port forwarding or a reverse proxy.</description>
+				<default>false</default>
+			</parameter>
+		</config-description>
+	</bridge-type>
+
+	<!-- Plivo Phone Number Thing -->
+	<thing-type id="phone">
+		<supported-bridge-type-refs>
+			<bridge-type-ref id="account"/>
+		</supported-bridge-type-refs>
+
+		<label>Plivo Phone Number</label>
+		<description>Represents a Plivo phone number for sending and receiving SMS, MMS, WhatsApp messages, and voice calls.</description>
+		<semantic-equipment-tag>WebService</semantic-equipment-tag>
+
+		<channels>
+			<!-- Message state channels -->
+			<channel id="last-message-body" typeId="last-message-body"/>
+			<channel id="last-message-from" typeId="last-message-from"/>
+			<channel id="last-message-date" typeId="last-message-date"/>
+			<channel id="last-message-media-url" typeId="last-message-media-url"/>
+			<channel id="last-message-uuid" typeId="last-message-uuid"/>
+			<!-- Call state channels -->
+			<channel id="last-call-from" typeId="last-call-from"/>
+			<channel id="last-call-status" typeId="last-call-status"/>
+			<channel id="last-call-date" typeId="last-call-date"/>
+			<channel id="last-dtmf-digits" typeId="last-dtmf-digits"/>
+			<!-- Trigger channels -->
+			<channel id="sms-received" typeId="sms-received"/>
+			<channel id="whatsapp-received" typeId="whatsapp-received"/>
+			<channel id="call-received" typeId="call-received"/>
+			<channel id="dtmf-received" typeId="dtmf-received"/>
+			<channel id="message-status" typeId="message-status"/>
+			<channel id="call-status-update" typeId="call-status-update"/>
+		</channels>
+
+		<representation-property>phoneNumber</representation-property>
+
+		<config-description>
+			<parameter name="phoneNumber" type="text" required="true">
+				<label>Phone Number</label>
+				<description>Your Plivo phone number in E.164 format (e.g. +15551234567).</description>
+			</parameter>
+			<parameter name="voiceGreeting" type="text" required="false">
+				<label>Voice Greeting XML</label>
+				<description>Plivo XML returned when an incoming voice call is received. Use {gatherUrl} as a placeholder for the
+					DTMF
+					callback URL.</description>
+				<advanced>true</advanced>
+			</parameter>
+			<parameter name="gatherResponse" type="text" required="false">
+				<label>Gather Response XML</label>
+				<description>Plivo XML returned after DTMF digits are gathered from a caller. Used as fallback when no rule responds
+					with respondWithXml.</description>
+				<advanced>true</advanced>
+			</parameter>
+			<parameter name="responseTimeout" type="integer" unit="s" min="1" max="14" required="false">
+				<label>Response Timeout</label>
+				<description>Seconds to wait for a rule to respond with XML via respondWithXml before using the default greeting or
+					gather response.</description>
+				<default>10</default>
+				<advanced>true</advanced>
+			</parameter>
+		</config-description>
+	</thing-type>
+
+	<!-- State Channel Types -->
+	<channel-type id="last-message-body">
+		<item-type>String</item-type>
+		<label>Last Message Body</label>
+		<description>Body text of the last received SMS or WhatsApp message.</description>
+		<tags>
+			<tag>Status</tag>
+			<tag>Info</tag>
+		</tags>
+		<state readOnly="true"/>
+	</channel-type>
+
+	<channel-type id="last-message-from">
+		<item-type>String</item-type>
+		<label>Last Message From</label>
+		<description>Phone number of the last message sender.</description>
+		<tags>
+			<tag>Status</tag>
+			<tag>Info</tag>
+		</tags>
+		<state readOnly="true"/>
+	</channel-type>
+
+	<channel-type id="last-message-date">
+		<item-type>DateTime</item-type>
+		<label>Last Message Date</label>
+		<description>Timestamp of the last received message.</description>
+		<tags>
+			<tag>Status</tag>
+			<tag>Timestamp</tag>
+		</tags>
+		<state readOnly="true"/>
+	</channel-type>
+
+	<channel-type id="last-message-media-url">
+		<item-type>String</item-type>
+		<label>Last Message Media URL</label>
+		<description>URL of the first media attachment from the last received MMS or WhatsApp message.</description>
+		<tags>
+			<tag>Status</tag>
+			<tag>Info</tag>
+		</tags>
+		<state readOnly="true"/>
+	</channel-type>
+
+	<channel-type id="last-message-uuid" advanced="true">
+		<item-type>String</item-type>
+		<label>Last Message UUID</label>
+		<description>Plivo Message UUID of the last received message.</description>
+		<tags>
+			<tag>Status</tag>
+			<tag>Info</tag>
+		</tags>
+		<state readOnly="true"/>
+	</channel-type>
+
+	<channel-type id="last-call-from">
+		<item-type>String</item-type>
+		<label>Last Call From</label>
+		<description>Phone number of the last incoming caller.</description>
+		<tags>
+			<tag>Status</tag>
+			<tag>Info</tag>
+		</tags>
+		<state readOnly="true"/>
+	</channel-type>
+
+	<channel-type id="last-call-status">
+		<item-type>String</item-type>
+		<label>Last Call Status</label>
+		<description>Status of the last call (e.g. ringing, in-progress, completed).</description>
+		<tags>
+			<tag>Status</tag>
+			<tag>Info</tag>
+		</tags>
+		<state readOnly="true"/>
+	</channel-type>
+
+	<channel-type id="last-call-date">
+		<item-type>DateTime</item-type>
+		<label>Last Call Date</label>
+		<description>Timestamp of the last incoming call.</description>
+		<tags>
+			<tag>Status</tag>
+			<tag>Timestamp</tag>
+		</tags>
+		<state readOnly="true"/>
+	</channel-type>
+
+	<channel-type id="last-dtmf-digits">
+		<item-type>String</item-type>
+		<label>Last DTMF Digits</label>
+		<description>Last DTMF digits received from a caller during a voice call.</description>
+		<tags>
+			<tag>Status</tag>
+			<tag>Info</tag>
+		</tags>
+		<state readOnly="true"/>
+	</channel-type>
+
+	<!-- Trigger Channel Types -->
+	<channel-type id="sms-received">
+		<kind>trigger</kind>
+		<label>SMS Received</label>
+		<description>Triggered when an SMS or MMS message is received. Payload is a JSON object with from, to, body,
+			messageUuid, type, and mediaUrls fields.</description>
+		<event/>
+	</channel-type>
+
+	<channel-type id="whatsapp-received">
+		<kind>trigger</kind>
+		<label>WhatsApp Received</label>
+		<description>Triggered when a WhatsApp message is received. Payload is a JSON object with from, to, body, messageUuid,
+			type, and mediaUrls fields.</description>
+		<event/>
+	</channel-type>
+
+	<channel-type id="call-received">
+		<kind>trigger</kind>
+		<label>Call Received</label>
+		<description>Triggered when an incoming voice call is received. Payload is a JSON object with from, to, callUuid, and
+			callStatus fields.</description>
+		<event/>
+	</channel-type>
+
+	<channel-type id="dtmf-received">
+		<kind>trigger</kind>
+		<label>DTMF Received</label>
+		<description>Triggered when DTMF digits are gathered from a caller. Payload is a JSON object with digits, callUuid,
+			from, and to fields.</description>
+		<event/>
+	</channel-type>
+
+	<channel-type id="message-status">
+		<kind>trigger</kind>
+		<label>Message Status</label>
+		<description>Triggered when a message delivery status changes. Payload is a JSON object with messageUuid,
+			messageStatus, and to fields.</description>
+		<event/>
+	</channel-type>
+
+	<channel-type id="call-status-update">
+		<kind>trigger</kind>
+		<label>Call Status Update</label>
+		<description>Triggered when a call status changes. Payload is a JSON object with callUuid, callStatus, from, and to
+			fields.</description>
+		<event/>
+	</channel-type>
+
+</thing:thing-descriptions>

--- a/bundles/org.openhab.binding.plivo/src/test/java/org/openhab/binding/plivo/internal/api/PlivoSignatureValidatorTest.java
+++ b/bundles/org.openhab.binding.plivo/src/test/java/org/openhab/binding/plivo/internal/api/PlivoSignatureValidatorTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.plivo.internal.api;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Map;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link PlivoSignatureValidator}.
+ * <p>
+ * The reference signatures below were produced with Plivo's published V3 algorithm (the same
+ * {@code construct_post_url} / {@code get_signature_v3} logic used by the plivo-python SDK):
+ * take the URL without its query string, append {@code ?}, then the sorted query parameters as
+ * {@code key=value} pairs joined by {@code &} plus a {@code .} when a query is present, then the
+ * sorted POST body parameters as a {@code key}+{@code value} concatenation, then {@code .} and the
+ * nonce, and finally {@code Base64(HMAC-SHA256(authToken, ...))}.
+ *
+ * @author Sarvesh Patil - Initial contribution
+ */
+@NonNullByDefault
+public class PlivoSignatureValidatorTest {
+
+    private static final String AUTH_TOKEN = "my_auth_token";
+    private static final String NONCE = "12345";
+    private static final Map<String, String> PARAMS = Map.of("From", "+14156667777", "To", "+14158889999", "CallUUID",
+            "abcd-1234");
+
+    private static final String URL_NO_QUERY = "https://example.com/answer";
+    private static final String URL_WITH_QUERY = "https://example.com/answer?token=xyz";
+
+    // Reference V3 signatures for the values above (canonical strings:
+    // https://example.com/answer?CallUUIDabcd-1234From+14156667777To+14158889999.12345 and
+    // https://example.com/answer?token=xyz.CallUUIDabcd-1234From+14156667777To+14158889999.12345).
+    private static final String SIG_NO_QUERY = "QUFNUHBhaE5m20p3UFtVHCb66PSliiukfx8M6MyiJwk=";
+    private static final String SIG_WITH_QUERY = "IryQ8ucGk4J35wJRxh5K0iVvDCSZpHflFICcZxwx7Cc=";
+
+    @Test
+    public void computeSignatureMatchesPlivoReferenceWithoutQuery() {
+        assertEquals(SIG_NO_QUERY, PlivoSignatureValidator.computeSignature(URL_NO_QUERY, PARAMS, NONCE, AUTH_TOKEN));
+    }
+
+    @Test
+    public void computeSignatureMatchesPlivoReferenceWithQuery() {
+        assertEquals(SIG_WITH_QUERY,
+                PlivoSignatureValidator.computeSignature(URL_WITH_QUERY, PARAMS, NONCE, AUTH_TOKEN));
+    }
+
+    @Test
+    public void validateAcceptsMatchingSignature() {
+        assertTrue(PlivoSignatureValidator.validate(URL_NO_QUERY, PARAMS, SIG_NO_QUERY, NONCE, AUTH_TOKEN));
+        assertTrue(PlivoSignatureValidator.validate(URL_WITH_QUERY, PARAMS, SIG_WITH_QUERY, NONCE, AUTH_TOKEN));
+    }
+
+    @Test
+    public void validateAcceptsSignatureAmongCommaSeparatedList() {
+        String header = "notavalidsignaturevalue==," + SIG_NO_QUERY;
+        assertTrue(PlivoSignatureValidator.validate(URL_NO_QUERY, PARAMS, header, NONCE, AUTH_TOKEN));
+    }
+
+    @Test
+    public void validateRejectsWrongSignature() {
+        assertFalse(PlivoSignatureValidator.validate(URL_NO_QUERY, PARAMS, SIG_WITH_QUERY, NONCE, AUTH_TOKEN));
+    }
+
+    @Test
+    public void validateRejectsWrongAuthToken() {
+        assertFalse(PlivoSignatureValidator.validate(URL_NO_QUERY, PARAMS, SIG_NO_QUERY, NONCE, "wrong_token"));
+    }
+
+    @Test
+    public void validateRejectsMissingSignatureOrNonce() {
+        assertFalse(PlivoSignatureValidator.validate(URL_NO_QUERY, PARAMS, null, NONCE, AUTH_TOKEN));
+        assertFalse(PlivoSignatureValidator.validate(URL_NO_QUERY, PARAMS, SIG_NO_QUERY, null, AUTH_TOKEN));
+        assertFalse(PlivoSignatureValidator.validate(URL_NO_QUERY, PARAMS, "  ", NONCE, AUTH_TOKEN));
+    }
+}

--- a/bundles/org.openhab.binding.plivo/src/test/java/org/openhab/binding/plivo/internal/api/PlivoSignatureValidatorTest.java
+++ b/bundles/org.openhab.binding.plivo/src/test/java/org/openhab/binding/plivo/internal/api/PlivoSignatureValidatorTest.java
@@ -30,6 +30,10 @@ import org.junit.jupiter.api.Test;
  * {@code key=value} pairs joined by {@code &} plus a {@code .} when a query is present, then the
  * sorted POST body parameters as a {@code key}+{@code value} concatenation, then {@code .} and the
  * nonce, and finally {@code Base64(HMAC-SHA256(authToken, ...))}.
+ * <p>
+ * The V2 reference signature was produced with Plivo's V2 algorithm ({@code validate_signature} in
+ * the plivo-python SDK): the URL with its query string removed, followed by the nonce, then
+ * {@code Base64(HMAC-SHA256(authToken, ...))}.
  *
  * @author Sarvesh Patil - Initial contribution
  */
@@ -50,43 +54,67 @@ public class PlivoSignatureValidatorTest {
     private static final String SIG_NO_QUERY = "QUFNUHBhaE5m20p3UFtVHCb66PSliiukfx8M6MyiJwk=";
     private static final String SIG_WITH_QUERY = "IryQ8ucGk4J35wJRxh5K0iVvDCSZpHflFICcZxwx7Cc=";
 
+    // Reference V2 signature (canonical string https://example.com/answer12345). Plivo V2 strips the
+    // query string, so both URLs above produce this same signature.
+    private static final String SIG_V2 = "JTLtnh4xskVxvDEWnLeMYs8IkO4HTZJ8JPdRAmNGgso=";
+
     @Test
     public void computeSignatureMatchesPlivoReferenceWithoutQuery() {
-        assertEquals(SIG_NO_QUERY, PlivoSignatureValidator.computeSignature(URL_NO_QUERY, PARAMS, NONCE, AUTH_TOKEN));
+        assertEquals(SIG_NO_QUERY, PlivoSignatureValidator.computeV3Signature(URL_NO_QUERY, PARAMS, NONCE, AUTH_TOKEN));
     }
 
     @Test
     public void computeSignatureMatchesPlivoReferenceWithQuery() {
         assertEquals(SIG_WITH_QUERY,
-                PlivoSignatureValidator.computeSignature(URL_WITH_QUERY, PARAMS, NONCE, AUTH_TOKEN));
+                PlivoSignatureValidator.computeV3Signature(URL_WITH_QUERY, PARAMS, NONCE, AUTH_TOKEN));
     }
 
     @Test
     public void validateAcceptsMatchingSignature() {
-        assertTrue(PlivoSignatureValidator.validate(URL_NO_QUERY, PARAMS, SIG_NO_QUERY, NONCE, AUTH_TOKEN));
-        assertTrue(PlivoSignatureValidator.validate(URL_WITH_QUERY, PARAMS, SIG_WITH_QUERY, NONCE, AUTH_TOKEN));
+        assertTrue(PlivoSignatureValidator.validateV3(URL_NO_QUERY, PARAMS, SIG_NO_QUERY, NONCE, AUTH_TOKEN));
+        assertTrue(PlivoSignatureValidator.validateV3(URL_WITH_QUERY, PARAMS, SIG_WITH_QUERY, NONCE, AUTH_TOKEN));
     }
 
     @Test
     public void validateAcceptsSignatureAmongCommaSeparatedList() {
         String header = "notavalidsignaturevalue==," + SIG_NO_QUERY;
-        assertTrue(PlivoSignatureValidator.validate(URL_NO_QUERY, PARAMS, header, NONCE, AUTH_TOKEN));
+        assertTrue(PlivoSignatureValidator.validateV3(URL_NO_QUERY, PARAMS, header, NONCE, AUTH_TOKEN));
     }
 
     @Test
     public void validateRejectsWrongSignature() {
-        assertFalse(PlivoSignatureValidator.validate(URL_NO_QUERY, PARAMS, SIG_WITH_QUERY, NONCE, AUTH_TOKEN));
+        assertFalse(PlivoSignatureValidator.validateV3(URL_NO_QUERY, PARAMS, SIG_WITH_QUERY, NONCE, AUTH_TOKEN));
     }
 
     @Test
     public void validateRejectsWrongAuthToken() {
-        assertFalse(PlivoSignatureValidator.validate(URL_NO_QUERY, PARAMS, SIG_NO_QUERY, NONCE, "wrong_token"));
+        assertFalse(PlivoSignatureValidator.validateV3(URL_NO_QUERY, PARAMS, SIG_NO_QUERY, NONCE, "wrong_token"));
     }
 
     @Test
     public void validateRejectsMissingSignatureOrNonce() {
-        assertFalse(PlivoSignatureValidator.validate(URL_NO_QUERY, PARAMS, null, NONCE, AUTH_TOKEN));
-        assertFalse(PlivoSignatureValidator.validate(URL_NO_QUERY, PARAMS, SIG_NO_QUERY, null, AUTH_TOKEN));
-        assertFalse(PlivoSignatureValidator.validate(URL_NO_QUERY, PARAMS, "  ", NONCE, AUTH_TOKEN));
+        assertFalse(PlivoSignatureValidator.validateV3(URL_NO_QUERY, PARAMS, null, NONCE, AUTH_TOKEN));
+        assertFalse(PlivoSignatureValidator.validateV3(URL_NO_QUERY, PARAMS, SIG_NO_QUERY, null, AUTH_TOKEN));
+        assertFalse(PlivoSignatureValidator.validateV3(URL_NO_QUERY, PARAMS, "  ", NONCE, AUTH_TOKEN));
+    }
+
+    @Test
+    public void computeV2SignatureMatchesPlivoReferenceAndIgnoresQuery() {
+        assertEquals(SIG_V2, PlivoSignatureValidator.computeV2Signature(URL_NO_QUERY, NONCE, AUTH_TOKEN));
+        assertEquals(SIG_V2, PlivoSignatureValidator.computeV2Signature(URL_WITH_QUERY, NONCE, AUTH_TOKEN));
+    }
+
+    @Test
+    public void validateV2AcceptsMatchingSignature() {
+        assertTrue(PlivoSignatureValidator.validateV2(URL_NO_QUERY, SIG_V2, NONCE, AUTH_TOKEN));
+        assertTrue(PlivoSignatureValidator.validateV2(URL_WITH_QUERY, SIG_V2, NONCE, AUTH_TOKEN));
+    }
+
+    @Test
+    public void validateV2RejectsWrongSignatureTokenOrMissing() {
+        assertFalse(PlivoSignatureValidator.validateV2(URL_NO_QUERY, "wrongsignature==", NONCE, AUTH_TOKEN));
+        assertFalse(PlivoSignatureValidator.validateV2(URL_NO_QUERY, SIG_V2, NONCE, "wrong_token"));
+        assertFalse(PlivoSignatureValidator.validateV2(URL_NO_QUERY, null, NONCE, AUTH_TOKEN));
+        assertFalse(PlivoSignatureValidator.validateV2(URL_NO_QUERY, SIG_V2, null, AUTH_TOKEN));
     }
 }

--- a/bundles/org.openhab.binding.plivo/src/test/java/org/openhab/binding/plivo/internal/api/PlivoSignatureValidatorTest.java
+++ b/bundles/org.openhab.binding.plivo/src/test/java/org/openhab/binding/plivo/internal/api/PlivoSignatureValidatorTest.java
@@ -26,10 +26,12 @@ import org.junit.jupiter.api.Test;
  * <p>
  * The reference signatures below were produced with Plivo's published V3 algorithm (the same
  * {@code construct_post_url} / {@code get_signature_v3} logic used by the plivo-python SDK):
- * take the URL without its query string, append {@code ?}, then the sorted query parameters as
- * {@code key=value} pairs joined by {@code &} plus a {@code .} when a query is present, then the
- * sorted POST body parameters as a {@code key}+{@code value} concatenation, then {@code .} and the
- * nonce, and finally {@code Base64(HMAC-SHA256(authToken, ...))}.
+ * take the URL without its query string, then the sorted query parameters as {@code key=value}
+ * pairs joined by {@code &}, then the sorted POST body parameters as a {@code key}+{@code value}
+ * concatenation, then {@code .} and the nonce, and finally
+ * {@code Base64(HMAC-SHA256(authToken, ...))}. Separators are only emitted for parts that are
+ * actually present: the {@code ?} is dropped when there is neither a query nor a body parameter,
+ * and the {@code .} between query and body parameters is dropped when the body is empty.
  * <p>
  * The V2 reference signature was produced with Plivo's V2 algorithm ({@code validate_signature} in
  * the plivo-python SDK): the URL with its query string removed, followed by the nonce, then
@@ -57,6 +59,12 @@ public class PlivoSignatureValidatorTest {
     // Reference V2 signature (canonical string https://example.com/answer12345). Plivo V2 strips the
     // query string, so both URLs above produce this same signature.
     private static final String SIG_V2 = "JTLtnh4xskVxvDEWnLeMYs8IkO4HTZJ8JPdRAmNGgso=";
+
+    // Reference V3 signatures for an empty POST body. Plivo only emits a separator for a part that
+    // is present, so the canonical strings are https://example.com/answer.12345 and
+    // https://example.com/answer?token=xyz.12345 -- not answer?.12345 / answer?token=xyz..12345.
+    private static final String SIG_EMPTY_BODY_NO_QUERY = "0yCSTcpk0g5MyH+eKhYi02RUlMZ/VPnJKABuBXoajUc=";
+    private static final String SIG_EMPTY_BODY_WITH_QUERY = "aTkESVixprLGVxJeYf1Uw0FcHSOsZ6SnhyPAXbtGJ0U=";
 
     @Test
     public void computeSignatureMatchesPlivoReferenceWithoutQuery() {
@@ -159,5 +167,40 @@ public class PlivoSignatureValidatorTest {
     public void validateCallbackRejectsWhenNoSignatures() {
         assertFalse(PlivoSignatureValidator.validateCallback(false, URL_NO_QUERY, PARAMS, AUTH_TOKEN, null, null, null,
                 null, null, null));
+    }
+
+    @Test
+    public void computeSignatureWithEmptyBodyAndNoQueryOmitsQuestionMark() {
+        assertEquals(SIG_EMPTY_BODY_NO_QUERY,
+                PlivoSignatureValidator.computeV3Signature(URL_NO_QUERY, Map.of(), NONCE, AUTH_TOKEN));
+    }
+
+    @Test
+    public void computeSignatureWithEmptyBodyAndQueryOmitsExtraSeparator() {
+        assertEquals(SIG_EMPTY_BODY_WITH_QUERY,
+                PlivoSignatureValidator.computeV3Signature(URL_WITH_QUERY, Map.of(), NONCE, AUTH_TOKEN));
+    }
+
+    @Test
+    public void validateAcceptsEmptyBodySignatures() {
+        assertTrue(
+                PlivoSignatureValidator.validateV3(URL_NO_QUERY, Map.of(), SIG_EMPTY_BODY_NO_QUERY, NONCE, AUTH_TOKEN));
+        assertTrue(PlivoSignatureValidator.validateV3(URL_WITH_QUERY, Map.of(), SIG_EMPTY_BODY_WITH_QUERY, NONCE,
+                AUTH_TOKEN));
+    }
+
+    @Test
+    public void emptyBodySignatureDiffersFromPopulatedBodySignature() {
+        // Guards against a canonicalization that collapses the empty-body and populated-body cases.
+        assertFalse(PlivoSignatureValidator.validateV3(URL_NO_QUERY, Map.of(), SIG_NO_QUERY, NONCE, AUTH_TOKEN));
+        assertFalse(
+                PlivoSignatureValidator.validateV3(URL_NO_QUERY, PARAMS, SIG_EMPTY_BODY_NO_QUERY, NONCE, AUTH_TOKEN));
+    }
+
+    @Test
+    public void validateCallbackAcceptsEmptyBodyVoiceCallback() {
+        // A voice/answer callback can legitimately arrive with no POST parameters.
+        assertTrue(PlivoSignatureValidator.validateCallback(false, URL_WITH_QUERY, Map.of(), AUTH_TOKEN,
+                SIG_EMPTY_BODY_WITH_QUERY, null, NONCE, null, null, null));
     }
 }

--- a/bundles/org.openhab.binding.plivo/src/test/java/org/openhab/binding/plivo/internal/api/PlivoSignatureValidatorTest.java
+++ b/bundles/org.openhab.binding.plivo/src/test/java/org/openhab/binding/plivo/internal/api/PlivoSignatureValidatorTest.java
@@ -117,4 +117,47 @@ public class PlivoSignatureValidatorTest {
         assertFalse(PlivoSignatureValidator.validateV2(URL_NO_QUERY, null, NONCE, AUTH_TOKEN));
         assertFalse(PlivoSignatureValidator.validateV2(URL_NO_QUERY, SIG_V2, null, AUTH_TOKEN));
     }
+
+    @Test
+    public void validateCallbackAcceptsV3ForVoice() {
+        // A voice callback (messaging=false) with a valid V3 signature is accepted.
+        assertTrue(PlivoSignatureValidator.validateCallback(false, URL_NO_QUERY, PARAMS, AUTH_TOKEN, SIG_NO_QUERY, null,
+                NONCE, null, null, null));
+    }
+
+    @Test
+    public void validateCallbackRejectsV2ForVoice() {
+        // A voice callback presenting only a V2 signature is rejected. V2 is never accepted for voice,
+        // so there is no downgrade path.
+        assertFalse(PlivoSignatureValidator.validateCallback(false, URL_NO_QUERY, PARAMS, AUTH_TOKEN, null, null, null,
+                SIG_V2, null, NONCE));
+    }
+
+    @Test
+    public void validateCallbackAcceptsV2ForMessaging() {
+        // A messaging callback may use the documented V2 family when no V3 signature is present.
+        assertTrue(PlivoSignatureValidator.validateCallback(true, URL_NO_QUERY, PARAMS, AUTH_TOKEN, null, null, null,
+                SIG_V2, null, NONCE));
+    }
+
+    @Test
+    public void validateCallbackAcceptsMaV3ForMessaging() {
+        // A messaging callback may also use the live-observed Ma-V3 signature.
+        assertTrue(PlivoSignatureValidator.validateCallback(true, URL_NO_QUERY, PARAMS, AUTH_TOKEN, null, SIG_NO_QUERY,
+                NONCE, null, null, null));
+    }
+
+    @Test
+    public void validateCallbackDoesNotDowngradeFailedV3ToV2() {
+        // When a V3-family signature is present but invalid, the request is rejected even if a valid V2
+        // signature is also supplied. A failed V3 must never fall back to V2.
+        assertFalse(PlivoSignatureValidator.validateCallback(true, URL_NO_QUERY, PARAMS, AUTH_TOKEN, "invalidV3==",
+                null, NONCE, SIG_V2, null, NONCE));
+    }
+
+    @Test
+    public void validateCallbackRejectsWhenNoSignatures() {
+        assertFalse(PlivoSignatureValidator.validateCallback(false, URL_NO_QUERY, PARAMS, AUTH_TOKEN, null, null, null,
+                null, null, null));
+    }
 }

--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -362,6 +362,7 @@
     <module>org.openhab.binding.playstation</module>
     <module>org.openhab.binding.plclogo</module>
     <module>org.openhab.binding.plex</module>
+    <module>org.openhab.binding.plivo</module>
     <module>org.openhab.binding.plugwise</module>
     <module>org.openhab.binding.plugwiseha</module>
     <module>org.openhab.binding.powermax</module>


### PR DESCRIPTION
### Description

This is a novel addition. It adds a new binding, `org.openhab.binding.plivo`, for the Plivo cloud communications platform, following the proposal in #21221.

The binding lets openHAB send and receive messages and calls through a Plivo account. It provides an account bridge that authenticates against the Plivo API and a phone thing that represents a Plivo number. Outbound support covers SMS, MMS, WhatsApp, and voice calls with text-to-speech. Inbound support covers SMS and WhatsApp trigger channels together with a synchronous inbound-voice answer flow that includes DTMF gather, delivered either through openHAB Cloud or a configured public URL. Inbound webhook requests are validated using Plivo's X-Plivo-Signature-V3 signature.

Plivo has been requested several times in the community forum, including the thread on making openHAB place a phone call, and there was previously no way to reach it from openHAB. This binding gives users a native Plivo integration for notifications and simple message and call automations.

For the end user the README documents account and phone-thing setup, the available channels and actions, automatic and manual webhook configuration, and example rules. The contribution includes the add-on README, thing-types, full i18n, a discovery service for phone numbers, and the BOM entry.

### Testing

The binding builds cleanly against the current 5.3.0-SNAPSHOT with the full static-analysis gate passing (spotless, checkstyle, PMD, and SpotBugs report no issues). It was loaded into an openHAB 5.3.0-SNAPSHOT runtime, where the account bridge and phone thing came online after a live credential check, and an outbound SMS sent through the binding was delivered successfully.

A built JAR for community testing will be available in the pull-request artifacts folder once CI finishes.

The work is signed off on every commit.
