### PR TITLE
[ddwrt] Discover virtual access point radios

### DIFF
--- a/bundles/org.openhab.binding.ddwrt/src/main/java/org/openhab/binding/ddwrt/internal/DDWRTDiscoveryService.java
+++ b/bundles/org.openhab.binding.ddwrt/src/main/java/org/openhab/binding/ddwrt/internal/DDWRTDiscoveryService.java
@@ -169,9 +169,7 @@ public class DDWRTDiscoveryService extends AbstractThingHandlerDiscoveryService<
             final String hostname = device != null && !device.getHostname().isEmpty() ? device.getHostname()
                     : radio.getParentDeviceMac();
 
-            // ID: deviceMac-interface (e.g., 24f5a2c61659-wlan0)
-            final String id = radio.getParentDeviceMac().replace(":", "-") + "-" + radio.getIfaceName();
-            final ThingUID thingUID = new ThingUID(THING_TYPE_RADIO, bridgeUID, id);
+            final ThingUID thingUID = createRadioThingUID(bridgeUID, radio.getParentDeviceMac(), radio.getIfaceName());
 
             // Label: hostname interface (e.g., "gateway-ap wlan0")
             final String label = hostname + " " + radio.getIfaceName();
@@ -186,6 +184,12 @@ public class DDWRTDiscoveryService extends AbstractThingHandlerDiscoveryService<
 
             thingDiscovered(result);
         });
+    }
+
+    static ThingUID createRadioThingUID(ThingUID bridgeUID, String parentDeviceMac, String ifaceName) {
+        // Thing UID segments cannot contain dots used by virtual interfaces such as wlan0.1.
+        String id = (parentDeviceMac.replace(":", "-") + "-" + ifaceName).replaceAll("[^\\w-]", "-");
+        return new ThingUID(THING_TYPE_RADIO, bridgeUID, id);
     }
 
     private void discoverClients(DDWRTNetwork net) {

--- a/bundles/org.openhab.binding.ddwrt/src/main/java/org/openhab/binding/ddwrt/internal/api/DDWRTBroadcomDevice.java
+++ b/bundles/org.openhab.binding.ddwrt/src/main/java/org/openhab/binding/ddwrt/internal/api/DDWRTBroadcomDevice.java
@@ -15,10 +15,13 @@ package org.openhab.binding.ddwrt.internal.api;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
+import java.util.regex.Pattern;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
@@ -33,11 +36,14 @@ import org.slf4j.Logger;
 @NonNullByDefault
 public class DDWRTBroadcomDevice extends DDWRTBaseDevice {
 
-    // Candidate interfaces to probe on first enumeration
-    private static final String[] BROADCOM_IFACES = { "eth1", "eth2", "wl0", "wl1" };
+    // Candidate physical interfaces to probe on first enumeration
+    private static final List<String> BROADCOM_IFACES = List.of("eth1", "eth2", "eth3", "wl0", "wl1", "wl2");
+    private static final String GET_CONFIGURED_IFACES_COMMAND = "nvram get wl0_ifname; nvram get wl1_ifname; "
+            + "nvram get wl2_ifname; nvram get wl0_vifs; nvram get wl1_vifs; nvram get wl2_vifs";
+    private static final Pattern IFACE_PATTERN = Objects.requireNonNull(Pattern.compile("[\\w.-]+"));
 
-    // After first successful enumeration, only probe these interfaces
-    private volatile String @Nullable [] discoveredIfaces;
+    // Physical interfaces found during previous enumerations
+    private volatile String @Nullable [] discoveredPhysicalIfaces;
 
     // Per-radio noise floor cache (cleared each refresh cycle)
     private final Map<String, Integer> noiseCache = new HashMap<>();
@@ -113,11 +119,20 @@ public class DDWRTBroadcomDevice extends DDWRTBaseDevice {
     @Override
     protected List<DDWRTRadio> enumerateRadios(SshRunner runner) {
         List<DDWRTRadio> radios = new ArrayList<>();
-        // Use cached interfaces if available, otherwise probe all candidates
-        String[] ifaces = discoveredIfaces;
+        Set<String> candidates = new LinkedHashSet<>();
+        String[] ifaces = discoveredPhysicalIfaces;
         if (ifaces == null) {
-            ifaces = BROADCOM_IFACES;
+            candidates.addAll(BROADCOM_IFACES);
+        } else {
+            candidates.addAll(List.of(ifaces));
         }
+        String configuredIfaces = safeTrim(runner.execStdout(GET_CONFIGURED_IFACES_COMMAND));
+        for (String iface : configuredIfaces.split("\\s+")) {
+            if (IFACE_PATTERN.matcher(iface).matches()) {
+                candidates.add(iface);
+            }
+        }
+        ifaces = candidates.toArray(new String[0]);
         List<String> foundIfaces = new ArrayList<>();
         for (String iface : ifaces) {
             String ssid = safeTrim(runner.execStdout("wl -i " + iface + " ssid | awk -F'\"' '{print $2}'"));
@@ -141,10 +156,16 @@ public class DDWRTBroadcomDevice extends DDWRTBaseDevice {
                 logger.debug("Found Broadcom radio: {}", radio);
             }
         }
-        // Cache discovered interfaces to avoid probing non-existent ones on subsequent refreshes
-        if (!foundIfaces.isEmpty() && discoveredIfaces == null) {
-            discoveredIfaces = foundIfaces.toArray(new String[0]);
-            logger.debug("Cached Broadcom interfaces: {}", foundIfaces);
+        // Accumulate known physical interfaces across transient failures while reading configured interfaces each time.
+        Set<String> foundPhysicalIfaces = new LinkedHashSet<>();
+        String[] cachedPhysicalIfaces = discoveredPhysicalIfaces;
+        if (cachedPhysicalIfaces != null) {
+            foundPhysicalIfaces.addAll(List.of(cachedPhysicalIfaces));
+        }
+        foundIfaces.stream().filter(BROADCOM_IFACES::contains).forEach(foundPhysicalIfaces::add);
+        if (!foundPhysicalIfaces.isEmpty()) {
+            discoveredPhysicalIfaces = foundPhysicalIfaces.toArray(new String[0]);
+            logger.debug("Cached Broadcom physical interfaces: {}", foundPhysicalIfaces);
         }
         return radios;
     }

--- a/bundles/org.openhab.binding.ddwrt/src/test/java/org/openhab/binding/ddwrt/internal/DDWRTDiscoveryServiceTest.java
+++ b/bundles/org.openhab.binding.ddwrt/src/test/java/org/openhab/binding/ddwrt/internal/DDWRTDiscoveryServiceTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.ddwrt.internal;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.jupiter.api.Test;
+import org.openhab.binding.ddwrt.internal.api.DDWRTRadio;
+import org.openhab.core.thing.ThingUID;
+
+/**
+ * Tests for {@link DDWRTDiscoveryService}.
+ *
+ * @author Lee Ballard - Initial contribution
+ */
+@NonNullByDefault
+class DDWRTDiscoveryServiceTest {
+
+    @Test
+    void testVirtualRadioInterfaceCreatesValidThingUid() {
+        DDWRTRadio radio = new DDWRTRadio("24:f5:a2:c6:16:59", "wlan0.1");
+        ThingUID bridgeUid = new ThingUID(DDWRTBindingConstants.BRIDGE_TYPE_NETWORK, "test");
+
+        ThingUID thingUid = DDWRTDiscoveryService.createRadioThingUID(bridgeUid, radio.getParentDeviceMac(),
+                radio.getIfaceName());
+
+        assertThat(thingUid.getId(), is("24-f5-a2-c6-16-59-wlan0-1"));
+        assertThat(radio.getInterfaceId(), is("24:f5:a2:c6:16:59:wlan0.1"));
+    }
+}

--- a/bundles/org.openhab.binding.ddwrt/src/test/java/org/openhab/binding/ddwrt/internal/api/DDWRTBroadcomDeviceTest.java
+++ b/bundles/org.openhab.binding.ddwrt/src/test/java/org/openhab/binding/ddwrt/internal/api/DDWRTBroadcomDeviceTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.ddwrt.internal.api;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.jupiter.api.Test;
+import org.openhab.binding.ddwrt.internal.DDWRTDeviceConfiguration;
+import org.slf4j.Logger;
+
+/**
+ * Tests for {@link DDWRTBroadcomDevice}.
+ *
+ * @author Lee Ballard - Initial contribution
+ */
+@NonNullByDefault
+class DDWRTBroadcomDeviceTest {
+
+    @SuppressWarnings("null")
+    @Test
+    void testEnumerateRadiosRefreshesVapsAndRetriesPhysicalInterfaces() {
+        SshRunner runner = mock(SshRunner.class);
+        when(runner.execStdout(anyString())).thenReturn("");
+        when(runner.execStdout("nvram get wl0_ifname; nvram get wl1_ifname; nvram get wl2_ifname; "
+                + "nvram get wl0_vifs; nvram get wl1_vifs; nvram get wl2_vifs"))
+                .thenReturn("eth1 eth2", "eth1 eth2 wl0.1 wl0.2", "eth1 wl0.1 wl0.2");
+        when(runner.execStdout("wl -i eth1 ssid | awk -F'\"' '{print $2}'")).thenReturn("main-24");
+        when(runner.execStdout("wl -i eth2 ssid | awk -F'\"' '{print $2}'")).thenReturn("", "main-5", "", "main-5");
+        when(runner.execStdout("wl -i wl0.1 ssid | awk -F'\"' '{print $2}'")).thenReturn("guest");
+        when(runner.execStdout("wl -i wl0.2 ssid | awk -F'\"' '{print $2}'")).thenReturn("iot");
+
+        DDWRTBroadcomDevice device = new DDWRTBroadcomDevice(new DDWRTDeviceConfiguration(), mock(Logger.class));
+        device.mac = "c0:ff:d4:a5:61:e6";
+
+        List<DDWRTRadio> initialRadios = device.enumerateRadios(runner);
+        List<DDWRTRadio> radiosAfterInitialPhysicalInterfaceRecovers = device.enumerateRadios(runner);
+        List<DDWRTRadio> radiosDuringCachedPhysicalInterfaceFailure = device.enumerateRadios(runner);
+        List<DDWRTRadio> radiosAfterCachedPhysicalInterfaceRecovers = device.enumerateRadios(runner);
+
+        assertThat(initialRadios.stream().map(DDWRTRadio::getIfaceName).toList(), contains("eth1"));
+        assertThat(radiosAfterInitialPhysicalInterfaceRecovers.stream().map(DDWRTRadio::getIfaceName).toList(),
+                contains("eth1", "eth2", "wl0.1", "wl0.2"));
+        assertThat(radiosDuringCachedPhysicalInterfaceFailure.stream().map(DDWRTRadio::getIfaceName).toList(),
+                contains("eth1", "wl0.1", "wl0.2"));
+        assertThat(radiosAfterCachedPhysicalInterfaceRecovers.stream().map(DDWRTRadio::getIfaceName).toList(),
+                contains("eth1", "eth2", "wl0.1", "wl0.2"));
+    }
+}


### PR DESCRIPTION
## Description

This bugfix enables DD-WRT virtual access point (VAP) radios to be discovered correctly.

Virtual interfaces such as `wlan0.1` and `wl0.1` contain a dot, which is not valid in an openHAB Thing UID segment. Discovery therefore failed while constructing the radio Thing UID. Broadcom VAPs also were not enumerated because the binding only probed a fixed set of physical radio interfaces.

The change:

- sanitizes radio interface names when constructing Thing UIDs while preserving the original dotted interface name in the radio's `interfaceId`;
- reads the Broadcom `wl0_vifs`, `wl1_vifs`, and `wl2_vifs` NVRAM values and safely adds their interfaces to radio discovery;
- expands the physical Broadcom candidates to cover a third radio; and
- adds unit tests for dotted Thing UIDs and Broadcom VAP enumeration.

This allows users with guest networks or other VAPs to discover and monitor those radio interfaces.

Fixes #21177

## Testing

- `mvn clean install` completed successfully for the binding (66 tests).
- Verified on a Marvell DD-WRT access point: `wlan0.1` was discovered as a valid radio Thing with SSID `dd-wrt_vap`.
- Verified on a Broadcom DD-WRT access point: `wl0.1` was discovered with SSID `dd-wrt_vap_m`, and associated-client, RSSI, and noise data were read successfully.
- Confirmed the runtime log no longer contains the invalid Thing UID or discovery-scan errors from this issue.
