### PR TITLE
[matter] Use npm ci for builds

### DIFF
--- a/bundles/org.openhab.binding.matter/pom.xml
+++ b/bundles/org.openhab.binding.matter/pom.xml
@@ -49,7 +49,7 @@
             </goals>
             <configuration>
               <workingDirectory>matter-server</workingDirectory>
-              <arguments>install</arguments>
+              <arguments>ci</arguments>
             </configuration>
           </execution>
 
@@ -124,7 +124,7 @@
                 <phase>generate-sources</phase>
                 <configuration>
                   <workingDirectory>code-gen</workingDirectory>
-                  <arguments>install</arguments>
+                  <arguments>ci</arguments>
                 </configuration>
               </execution>
 


### PR DESCRIPTION
Use `npm ci` instead of `npm install` for the Matter server and code generator.
This keeps builds reproducible by consuming the committed lockfiles without modifying them.
It also aligns with the JavaScript Scripting add-on, which already uses `npm ci`.
This avoids lockfile churn after Dependabot updates, such as recalculated `peer` metadata.

See:

* https://github.com/openhab/openhab-addons/pull/21233
* https://github.com/openhab/openhab-addons/pull/21329
