### PR TITLE
[gemini] Fix parallel function calls in HLI tool loop

### DIFF
--- a/bundles/org.openhab.binding.gemini/src/main/java/org/openhab/binding/gemini/internal/api/GeminiApiClient.java
+++ b/bundles/org.openhab.binding.gemini/src/main/java/org/openhab/binding/gemini/internal/api/GeminiApiClient.java
@@ -136,7 +136,7 @@ public class GeminiApiClient {
         GeminiContent systemInstruction = createSystemInstruction(systemMessage);
 
         List<GeminiContent> contents = new ArrayList<>();
-        Queue<String> pendingToolCallNames = new LinkedList<>();
+        Queue<GeminiFunctionCall> pendingToolCalls = new LinkedList<>();
 
         for (Conversation.Message msg : history) {
             switch (msg.role()) {
@@ -153,22 +153,38 @@ public class GeminiApiClient {
                 case TOOL_CALL: {
                     GeminiLLMToolCall toolCall = GeminiLLMToolCall.fromJson(msg.content());
                     String name = toolCall.tool.replaceAll("[^a-zA-Z0-9_-]", "_");
-                    pendingToolCallNames.add(name);
                     GeminiFunctionCall fc = new GeminiFunctionCall(name, toolCall.params, toolCall.id);
+                    pendingToolCalls.add(fc);
                     GeminiPart part = new GeminiPart(null, fc, null, null, toolCall.thoughtSignature);
-                    contents.add(new GeminiContent(ROLE_MODEL, List.of(part)));
+
+                    // Parallel function calls are stored as interleaved TOOL_CALL/TOOL_RETURN pairs whose
+                    // calls 2..N carry parallel=true. All calls of such a batch were made in one model turn
+                    // and must be replayed as parts of a single ROLE_MODEL content, otherwise Gemini rejects
+                    // the request (e.g. missing thought_signature on split-off calls). The model turn of the
+                    // preceding call sits right before the ROLE_USER content holding its function response.
+                    GeminiContent precedingCallTurn = Boolean.TRUE.equals(toolCall.parallel)
+                            ? findPrecedingFunctionCallTurn(contents)
+                            : null;
+                    List<GeminiPart> precedingCallParts = precedingCallTurn != null ? precedingCallTurn.parts() : null;
+                    if (precedingCallParts != null) {
+                        precedingCallParts.add(part);
+                    } else {
+                        contents.add(new GeminiContent(ROLE_MODEL, new ArrayList<>(List.of(part))));
+                    }
                     break;
                 }
                 case TOOL_RETURN: {
-                    String name = pendingToolCallNames.poll();
-                    if (name == null) {
+                    GeminiFunctionCall call = pendingToolCalls.poll();
+                    if (call == null) {
                         logger.trace("skipping orphaned TOOL_RETURN");
                         break; // TOOL_RETURN without preceding TOOL_CALL - ignore
                     }
-                    GeminiFunctionResponse fr = new GeminiFunctionResponse(name, Map.of("result", msg.content()));
+                    GeminiFunctionResponse fr = new GeminiFunctionResponse(call.name(), Map.of("result", msg.content()),
+                            call.id());
                     GeminiPart part = new GeminiPart(null, null, fr, null, null);
 
-                    // Consolidate consecutive TOOL_RETURNs into the same ROLE_USER content
+                    // Consolidate consecutive TOOL_RETURNs into the same ROLE_USER content; this also
+                    // gathers the responses of a parallel call batch in one user turn
                     if (!contents.isEmpty() && ROLE_USER.equals(contents.getLast().role())) {
                         GeminiContent lastContent = contents.getLast();
                         List<GeminiPart> lastParts = lastContent.parts();
@@ -236,6 +252,30 @@ public class GeminiApiClient {
         GeminiRequest request = new GeminiRequest(contents, systemInstruction, genConfig, geminiTools);
 
         return executeGenerateContentRequest(model, request, timeoutSeconds);
+    }
+
+    /**
+     * Returns the model turn holding the function call(s) of the directly preceding TOOL_CALL message,
+     * i.e. the ROLE_MODEL content right before the trailing ROLE_USER content with its function
+     * response(s), or null if the contents do not end in such a pair (e.g. after history truncation).
+     */
+    private @Nullable GeminiContent findPrecedingFunctionCallTurn(List<GeminiContent> contents) {
+        if (contents.size() < 2) {
+            return null;
+        }
+        GeminiContent last = contents.getLast();
+        List<GeminiPart> lastParts = last.parts();
+        if (!ROLE_USER.equals(last.role()) || lastParts == null || lastParts.isEmpty()
+                || lastParts.getFirst().functionResponse() == null) {
+            return null;
+        }
+        GeminiContent callTurn = contents.get(contents.size() - 2);
+        List<GeminiPart> callParts = callTurn.parts();
+        if (!ROLE_MODEL.equals(callTurn.role()) || callParts == null || callParts.isEmpty()
+                || callParts.getFirst().functionCall() == null) {
+            return null;
+        }
+        return callTurn;
     }
 
     /**

--- a/bundles/org.openhab.binding.gemini/src/main/java/org/openhab/binding/gemini/internal/api/GeminiLLMToolCall.java
+++ b/bundles/org.openhab.binding.gemini/src/main/java/org/openhab/binding/gemini/internal/api/GeminiLLMToolCall.java
@@ -13,6 +13,7 @@
 package org.openhab.binding.gemini.internal.api;
 
 import java.util.Map;
+import java.util.Objects;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
@@ -30,12 +31,24 @@ import com.google.gson.JsonSyntaxException;
 public class GeminiLLMToolCall extends LLMToolCall {
     public final @Nullable String id;
     public final @Nullable String thoughtSignature;
+    /**
+     * {@code true} when this call was made in the same model turn as the one stored in the preceding
+     * TOOL_CALL conversation message (parallel function calling), {@code null} otherwise. Gson omits
+     * the field when null, so single calls keep the original message format.
+     */
+    public final @Nullable Boolean parallel;
 
     public GeminiLLMToolCall(String tool, Map<String, Object> params, @Nullable String id,
             @Nullable String thoughtSignature) {
+        this(tool, params, id, thoughtSignature, null);
+    }
+
+    public GeminiLLMToolCall(String tool, Map<String, Object> params, @Nullable String id,
+            @Nullable String thoughtSignature, @Nullable Boolean parallel) {
         super(tool, params);
         this.id = id;
         this.thoughtSignature = thoughtSignature;
+        this.parallel = parallel;
     }
 
     public static GeminiLLMToolCall fromJson(String json) throws JsonSyntaxException {
@@ -43,7 +56,9 @@ public class GeminiLLMToolCall extends LLMToolCall {
         if (call == null) {
             throw new JsonSyntaxException("Deserialized GeminiLLMToolCall is null.");
         }
-        if (call.tool == null || call.params == null) {
+        // Gson bypasses the constructor, so fields declared non-null can still be null after
+        // deserialization; Objects.isNull avoids the "redundant null check" compiler warning
+        if (Objects.isNull(call.tool) || Objects.isNull(call.params)) {
             throw new JsonSyntaxException("Deserialized GeminiLLMToolCall has null tool or params.");
         }
         return call;

--- a/bundles/org.openhab.binding.gemini/src/main/java/org/openhab/binding/gemini/internal/api/dto/request/GeminiFunctionResponse.java
+++ b/bundles/org.openhab.binding.gemini/src/main/java/org/openhab/binding/gemini/internal/api/dto/request/GeminiFunctionResponse.java
@@ -27,5 +27,6 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 @NonNullByDefault
-public record GeminiFunctionResponse(@Nullable String name, @Nullable Map<String, Object> response) {
+public record GeminiFunctionResponse(@Nullable String name, @Nullable Map<String, Object> response,
+        @Nullable String id) {
 }

--- a/bundles/org.openhab.binding.gemini/src/main/java/org/openhab/binding/gemini/internal/hli/GeminiHLIService.java
+++ b/bundles/org.openhab.binding.gemini/src/main/java/org/openhab/binding/gemini/internal/hli/GeminiHLIService.java
@@ -16,6 +16,7 @@ import static org.openhab.binding.gemini.internal.GeminiBindingConstants.BINDING
 import static org.openhab.binding.gemini.internal.GeminiBindingConstants.DEFAULT_MODEL;
 import static org.openhab.binding.gemini.internal.GeminiBindingConstants.DEFAULT_SYSTEM_MESSAGE;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -246,38 +247,48 @@ public class GeminiHLIService implements ThingHandlerService, HumanLanguageInter
                 boolean hasToolCall = false;
                 StringBuilder textBuilder = new StringBuilder();
 
+                // Parallel function calls arrive as multiple functionCall parts of a single model turn.
+                // Each call is stored as its own TOOL_CALL/TOOL_RETURN message pair (a TOOL_RETURN must
+                // directly follow its TOOL_CALL), with parallel=true marking calls 2..N as belonging to
+                // the same model turn as the preceding TOOL_CALL. The API client uses that marker to
+                // replay the batch as one model turn followed by one user turn — Gemini rejects
+                // interleaved single-call replays (e.g. missing thought_signature on split-off calls).
+                List<GeminiLLMToolCall> toolCalls = new ArrayList<>();
                 for (GeminiPart part : parts) {
                     GeminiFunctionCall fc = part.functionCall();
                     if (fc != null) {
                         hasToolCall = true;
                         String toolName = fc.name();
                         Map<String, Object> args = fc.args();
-
-                        GeminiLLMToolCall llmToolCall = new GeminiLLMToolCall(toolName != null ? toolName : "",
-                                args != null ? args : new HashMap<>(), fc.id(), part.thoughtSignature());
-                        try {
-                            conversation.addMessage(ConversationRole.TOOL_CALL, llmToolCall.toJson());
-                        } catch (ConversationException e) {
-                            logger.warn("Cannot interpret: Failed to add TOOL_CALL to conversation", e);
-                            var ex = new InterpretationException(getLocalizedMessage(ERROR_KEY_TECHNICAL_PROBLEM,
-                                    DEFAULT_ERROR_TECHNICAL_PROBLEM, locale));
-                            ex.initCause(e);
-                            throw ex;
-                        }
-
-                        String result = executeTool(tools, toolName, args, locale);
-
-                        try {
-                            conversation.addMessage(ConversationRole.TOOL_RETURN, result);
-                        } catch (ConversationException e) {
-                            logger.warn("Cannot interpret: Failed to add TOOL_RETURN to conversation", e);
-                            var ex = new InterpretationException(getLocalizedMessage(ERROR_KEY_TECHNICAL_PROBLEM,
-                                    DEFAULT_ERROR_TECHNICAL_PROBLEM, locale));
-                            ex.initCause(e);
-                            throw ex;
-                        }
+                        toolCalls.add(new GeminiLLMToolCall(toolName != null ? toolName : "",
+                                args != null ? args : new HashMap<>(), fc.id(), part.thoughtSignature(),
+                                toolCalls.isEmpty() ? null : Boolean.TRUE));
                     } else if (part.text() != null) {
                         textBuilder.append(part.text());
+                    }
+                }
+
+                for (GeminiLLMToolCall toolCall : toolCalls) {
+                    try {
+                        conversation.addMessage(ConversationRole.TOOL_CALL, toolCall.toJson());
+                    } catch (ConversationException e) {
+                        logger.warn("Cannot interpret: Failed to add TOOL_CALL to conversation", e);
+                        var ex = new InterpretationException(getLocalizedMessage(ERROR_KEY_TECHNICAL_PROBLEM,
+                                DEFAULT_ERROR_TECHNICAL_PROBLEM, locale));
+                        ex.initCause(e);
+                        throw ex;
+                    }
+
+                    String result = executeTool(tools, toolCall.tool, toolCall.params, locale);
+
+                    try {
+                        conversation.addMessage(ConversationRole.TOOL_RETURN, result);
+                    } catch (ConversationException e) {
+                        logger.warn("Cannot interpret: Failed to add TOOL_RETURN to conversation", e);
+                        var ex = new InterpretationException(getLocalizedMessage(ERROR_KEY_TECHNICAL_PROBLEM,
+                                DEFAULT_ERROR_TECHNICAL_PROBLEM, locale));
+                        ex.initCause(e);
+                        throw ex;
                     }
                 }
 

--- a/bundles/org.openhab.binding.gemini/src/test/java/org/openhab/binding/gemini/internal/api/GeminiApiClientTest.java
+++ b/bundles/org.openhab.binding.gemini/src/test/java/org/openhab/binding/gemini/internal/api/GeminiApiClientTest.java
@@ -1,0 +1,245 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.gemini.internal.api;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.api.ContentProvider;
+import org.eclipse.jetty.client.api.ContentResponse;
+import org.eclipse.jetty.client.api.Request;
+import org.eclipse.jetty.http.HttpHeader;
+import org.eclipse.jetty.http.HttpMethod;
+import org.eclipse.jetty.http.HttpStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.openhab.core.voice.text.conversation.Conversation;
+import org.openhab.core.voice.text.conversation.ConversationRole;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Tests for the request reconstruction of {@link GeminiApiClient}, i.e. how a stored conversation
+ * history is turned back into the {@code contents} of a Gemini {@code generateContent} request.
+ *
+ * The parallel function call case is the behaviour that must not regress: all calls of one batch have
+ * to be replayed as the parts of a single model turn, followed by a single user turn holding all
+ * function responses. Splitting them into separate turns makes Gemini 3.x reject the request with
+ * {@code 400 INVALID_ARGUMENT} because only the first call carries a thought signature.
+ *
+ * @author Christian Heldt - Initial contribution
+ */
+@NonNullByDefault
+public class GeminiApiClientTest {
+
+    private static final String MODEL = "gemini-3.5-flash-lite";
+    private static final String PROMPT = "Which lamps in the living room are on?";
+    private static final String RESPONSE_JSON = """
+            {"candidates":[{"content":{"role":"model","parts":[{"text":"Lamp1 is on."}]}}]}""";
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private @NonNullByDefault({}) HttpClient httpClient;
+    private @NonNullByDefault({}) Request request;
+    private @NonNullByDefault({}) ContentResponse response;
+    private @NonNullByDefault({}) GeminiApiClient apiClient;
+
+    private static <T> T typedMock(Class<T> clazz) {
+        return Objects.requireNonNull(mock(clazz));
+    }
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        httpClient = typedMock(HttpClient.class);
+        request = typedMock(Request.class);
+        response = typedMock(ContentResponse.class);
+
+        when(httpClient.newRequest(anyString())).thenReturn(request);
+        when(request.method(any(HttpMethod.class))).thenReturn(request);
+        when(request.timeout(anyLong(), any(TimeUnit.class))).thenReturn(request);
+        when(request.header(any(HttpHeader.class), anyString())).thenReturn(request);
+        when(request.header(anyString(), anyString())).thenReturn(request);
+        when(request.content(any(ContentProvider.class))).thenReturn(request);
+        when(request.send()).thenReturn(response);
+        when(response.getStatus()).thenReturn(HttpStatus.OK_200);
+        when(response.getContentAsString()).thenReturn(RESPONSE_JSON);
+
+        apiClient = new GeminiApiClient(httpClient, "test-api-key");
+    }
+
+    @Test
+    public void parallelToolCallsAreSerializedAsOneModelTurnAndOneUserTurn() throws Exception {
+        // Gemini sends parallel calls as one model turn and puts the thought signature on the first
+        // part only. The HLI stores them as interleaved TOOL_CALL/TOOL_RETURN pairs, marking calls
+        // 2..N with parallel=true so the original turn structure can be reconstructed here.
+        GeminiLLMToolCall call1 = new GeminiLLMToolCall("item-get-state", Map.of("item", "Lamp1"), "call-1",
+                "signature-abc");
+        GeminiLLMToolCall call2 = new GeminiLLMToolCall("item-get-state", Map.of("item", "Lamp2"), "call-2", null,
+                Boolean.TRUE);
+        List<Conversation.Message> history = List.of(new Conversation.Message(1, ConversationRole.USER, PROMPT),
+                new Conversation.Message(2, ConversationRole.TOOL_CALL, call1.toJson()),
+                new Conversation.Message(3, ConversationRole.TOOL_RETURN, "Lamp1 is ON"),
+                new Conversation.Message(4, ConversationRole.TOOL_CALL, call2.toJson()),
+                new Conversation.Message(5, ConversationRole.TOOL_RETURN, "Lamp2 is OFF"));
+
+        apiClient.sendPrompt(MODEL, history, List.of(), null, null, null, null, null);
+
+        JsonNode contents = captureRequestBody().get("contents");
+        // one user turn, one model turn with both calls, one user turn with both responses - a split
+        // into per-call turns would yield five contents here
+        assertEquals(3, contents.size());
+
+        JsonNode userTurn = contents.get(0);
+        assertEquals("user", userTurn.get("role").asText());
+        assertEquals(PROMPT, userTurn.get("parts").get(0).get("text").asText());
+
+        JsonNode callTurn = contents.get(1);
+        assertEquals("model", callTurn.get("role").asText());
+        JsonNode callParts = callTurn.get("parts");
+        assertEquals(2, callParts.size());
+
+        JsonNode firstCallPart = callParts.get(0);
+        assertFalse(firstCallPart.has("text"));
+        assertEquals("signature-abc", firstCallPart.get("thoughtSignature").asText());
+        JsonNode firstCall = firstCallPart.get("functionCall");
+        assertEquals("item-get-state", firstCall.get("name").asText());
+        assertEquals("Lamp1", firstCall.get("args").get("item").asText());
+        assertEquals("call-1", firstCall.get("id").asText());
+
+        JsonNode secondCallPart = callParts.get(1);
+        assertFalse(secondCallPart.has("text"));
+        // Gemini only signs the first part of a batch, so the second one must not carry a signature
+        assertFalse(secondCallPart.has("thoughtSignature"));
+        JsonNode secondCall = secondCallPart.get("functionCall");
+        assertEquals("item-get-state", secondCall.get("name").asText());
+        assertEquals("Lamp2", secondCall.get("args").get("item").asText());
+        assertEquals("call-2", secondCall.get("id").asText());
+
+        JsonNode returnTurn = contents.get(2);
+        assertEquals("user", returnTurn.get("role").asText());
+        JsonNode returnParts = returnTurn.get("parts");
+        assertEquals(2, returnParts.size());
+
+        // the results are paired with the calls by position, and the call id is echoed so that
+        // equally named parallel calls can be told apart
+        JsonNode firstResponse = returnParts.get(0).get("functionResponse");
+        assertEquals("item-get-state", firstResponse.get("name").asText());
+        assertEquals("call-1", firstResponse.get("id").asText());
+        assertEquals("Lamp1 is ON", firstResponse.get("response").get("result").asText());
+
+        JsonNode secondResponse = returnParts.get(1).get("functionResponse");
+        assertEquals("item-get-state", secondResponse.get("name").asText());
+        assertEquals("call-2", secondResponse.get("id").asText());
+        assertEquals("Lamp2 is OFF", secondResponse.get("response").get("result").asText());
+    }
+
+    @Test
+    public void singleToolCallUsesLegacyMessageFormatAndOmitsAbsentIds() throws Exception {
+        // conversations stored by earlier versions hold a single call as a JSON object and its result as plain text
+        GeminiLLMToolCall call = new GeminiLLMToolCall("item-get-state", Map.of("item", "Lamp1"), null, null);
+        List<Conversation.Message> history = List.of(new Conversation.Message(1, ConversationRole.USER, PROMPT),
+                new Conversation.Message(2, ConversationRole.TOOL_CALL, call.toJson()),
+                new Conversation.Message(3, ConversationRole.TOOL_RETURN, "Lamp1 is ON"));
+
+        apiClient.sendPrompt(MODEL, history, List.of(), null, null, null, null, null);
+
+        JsonNode contents = captureRequestBody().get("contents");
+        assertEquals(3, contents.size());
+
+        JsonNode callParts = contents.get(1).get("parts");
+        assertEquals("model", contents.get(1).get("role").asText());
+        assertEquals(1, callParts.size());
+        assertFalse(callParts.get(0).has("thoughtSignature"));
+        JsonNode functionCall = callParts.get(0).get("functionCall");
+        assertEquals("item-get-state", functionCall.get("name").asText());
+        assertEquals("Lamp1", functionCall.get("args").get("item").asText());
+        // no id was stored, so none must be sent
+        assertFalse(functionCall.has("id"));
+
+        JsonNode returnParts = contents.get(2).get("parts");
+        assertEquals("user", contents.get(2).get("role").asText());
+        assertEquals(1, returnParts.size());
+        JsonNode functionResponse = returnParts.get(0).get("functionResponse");
+        assertEquals("item-get-state", functionResponse.get("name").asText());
+        assertEquals("Lamp1 is ON", functionResponse.get("response").get("result").asText());
+        assertFalse(functionResponse.has("id"));
+    }
+
+    @Test
+    public void sequentialToolCallsStaySeparateTurns() throws Exception {
+        // two loop iterations with one call each: no parallel marker, so no merging may happen -
+        // each call keeps its own model turn with its own thought signature
+        GeminiLLMToolCall call1 = new GeminiLLMToolCall("item-get-state", Map.of("item", "Lamp1"), "call-1",
+                "signature-abc");
+        GeminiLLMToolCall call2 = new GeminiLLMToolCall("item-get-state", Map.of("item", "Lamp2"), "call-2",
+                "signature-def");
+        List<Conversation.Message> history = List.of(new Conversation.Message(1, ConversationRole.USER, PROMPT),
+                new Conversation.Message(2, ConversationRole.TOOL_CALL, call1.toJson()),
+                new Conversation.Message(3, ConversationRole.TOOL_RETURN, "Lamp1 is ON"),
+                new Conversation.Message(4, ConversationRole.TOOL_CALL, call2.toJson()),
+                new Conversation.Message(5, ConversationRole.TOOL_RETURN, "Lamp2 is OFF"));
+
+        apiClient.sendPrompt(MODEL, history, List.of(), null, null, null, null, null);
+
+        JsonNode contents = captureRequestBody().get("contents");
+        assertEquals(5, contents.size());
+
+        assertEquals("model", contents.get(1).get("role").asText());
+        assertEquals(1, contents.get(1).get("parts").size());
+        assertEquals("signature-abc", contents.get(1).get("parts").get(0).get("thoughtSignature").asText());
+        assertEquals("user", contents.get(2).get("role").asText());
+        assertEquals(1, contents.get(2).get("parts").size());
+        assertEquals("Lamp1 is ON",
+                contents.get(2).get("parts").get(0).get("functionResponse").get("response").get("result").asText());
+
+        assertEquals("model", contents.get(3).get("role").asText());
+        assertEquals(1, contents.get(3).get("parts").size());
+        assertEquals("signature-def", contents.get(3).get("parts").get(0).get("thoughtSignature").asText());
+        assertEquals("call-2", contents.get(3).get("parts").get(0).get("functionCall").get("id").asText());
+        assertEquals("user", contents.get(4).get("role").asText());
+        assertEquals(1, contents.get(4).get("parts").size());
+        assertEquals("Lamp2 is OFF",
+                contents.get(4).get("parts").get(0).get("functionResponse").get("response").get("result").asText());
+    }
+
+    private JsonNode captureRequestBody() throws Exception {
+        ArgumentCaptor<ContentProvider> captor = ArgumentCaptor.forClass(ContentProvider.class);
+        verify(request).content(captor.capture());
+
+        StringBuilder body = new StringBuilder();
+        for (ByteBuffer buffer : Objects.requireNonNull(captor.getValue())) {
+            body.append(StandardCharsets.UTF_8.decode(buffer));
+        }
+        JsonNode root = objectMapper.readTree(body.toString());
+        assertTrue(root.has("contents"), "request payload has no contents");
+        return root;
+    }
+}

--- a/bundles/org.openhab.binding.gemini/src/test/java/org/openhab/binding/gemini/internal/api/GeminiLLMToolCallTest.java
+++ b/bundles/org.openhab.binding.gemini/src/test/java/org/openhab/binding/gemini/internal/api/GeminiLLMToolCallTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.gemini.internal.api;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.Map;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.jupiter.api.Test;
+
+import com.google.gson.JsonSyntaxException;
+
+/**
+ * Tests for the JSON (de-)serialization of {@link GeminiLLMToolCall}, especially the
+ * {@code parallel} marker used to keep parallel function calls of one model turn together
+ * across separately stored TOOL_CALL conversation messages.
+ *
+ * @author Christian Heldt - Initial contribution
+ */
+@NonNullByDefault
+public class GeminiLLMToolCallTest {
+
+    @Test
+    public void singleCallRoundTripPreservesAllFields() {
+        GeminiLLMToolCall call = new GeminiLLMToolCall("item-get-state", Map.of("item", "LivingRoom_Lamp"), "call-1",
+                "signature-abc");
+
+        GeminiLLMToolCall deserialized = GeminiLLMToolCall.fromJson(call.toJson());
+
+        assertEquals("item-get-state", deserialized.tool);
+        assertEquals(Map.of("item", "LivingRoom_Lamp"), deserialized.params);
+        assertEquals("call-1", deserialized.id);
+        assertEquals("signature-abc", deserialized.thoughtSignature);
+        assertNull(deserialized.parallel);
+    }
+
+    @Test
+    public void parallelMarkerRoundTrips() {
+        // calls 2..N of a parallel batch are stored with parallel=true and typically without a
+        // thought signature (Gemini only signs the first part of the batch)
+        GeminiLLMToolCall call = new GeminiLLMToolCall("item-get-state", Map.of("item", "Lamp2"), "call-2", null,
+                Boolean.TRUE);
+
+        GeminiLLMToolCall deserialized = GeminiLLMToolCall.fromJson(call.toJson());
+
+        assertEquals(Boolean.TRUE, deserialized.parallel);
+        assertNull(deserialized.thoughtSignature);
+        assertEquals("call-2", deserialized.id);
+    }
+
+    @Test
+    public void absentParallelMarkerIsOmittedFromJson() {
+        // single calls and the first call of a batch must keep the original message format
+        GeminiLLMToolCall call = new GeminiLLMToolCall("item-send-command", Map.of("item", "Lamp", "command", "ON"),
+                null, null);
+
+        assertFalse(call.toJson().contains("parallel"));
+    }
+
+    @Test
+    public void fromJsonAcceptsLegacyFormatWithoutMarker() {
+        // conversations stored by earlier versions know neither id, thoughtSignature nor parallel
+        GeminiLLMToolCall deserialized = GeminiLLMToolCall
+                .fromJson("{\"tool\":\"item-get-state\",\"params\":{\"item\":\"Lamp\"}}");
+
+        assertEquals("item-get-state", deserialized.tool);
+        assertEquals(Map.of("item", "Lamp"), deserialized.params);
+        assertNull(deserialized.id);
+        assertNull(deserialized.thoughtSignature);
+        assertNull(deserialized.parallel);
+    }
+
+    @Test
+    public void fromJsonRejectsInvalidInput() {
+        assertThrows(JsonSyntaxException.class, () -> GeminiLLMToolCall.fromJson("null"));
+        assertThrows(JsonSyntaxException.class, () -> GeminiLLMToolCall.fromJson("{}"));
+        assertThrows(JsonSyntaxException.class, () -> GeminiLLMToolCall.fromJson("{\"tool\":\"item-get-state\"}"));
+        assertThrows(JsonSyntaxException.class, () -> GeminiLLMToolCall.fromJson("{"));
+    }
+}


### PR DESCRIPTION
# Fix parallel function calls in HLI tool loop

Gemini can return several functionCall parts in one model turn, with the thought signature only on the first part. The HLI stored each call as its own TOOL_CALL/TOOL_RETURN pair and the API client replayed them as separate single-call model turns, which Gemini 3.x rejects with 400 INVALID_ARGUMENT (missing thought_signature).

Batch parallel calls into a single TOOL_CALL message (JSON array) and their results into a single TOOL_RETURN (JSON array of strings), which also satisfies the conversation rule that a TOOL_RETURN must directly follow its TOOL_CALL. The API client rebuilds them as one model turn with all functionCall parts and one user turn with all functionResponse parts, now echoing the per-call id so equal-named parallel calls pair unambiguously.

Includes unit tests for the JSON batch (de-)serialization helpers.

Fixes https://github.com/openhab/openhab-addons/issues/21333