### PR TITLE
Upgrade Node/npm versions used by frontend-maven plugin

### DIFF
--- a/bundles/org.openhab.automation.jsscripting/pom.xml
+++ b/bundles/org.openhab.automation.jsscripting/pom.xml
@@ -15,7 +15,6 @@
   <name>openHAB Add-ons :: Bundles :: Automation :: JavaScript Scripting</name>
 
   <properties>
-    <node.version>v22.17.1</node.version>
     <ohjs.version>v5.21.0</ohjs.version>
   </properties>
 
@@ -78,10 +77,8 @@
       <plugin>
         <groupId>com.github.eirslett</groupId>
         <artifactId>frontend-maven-plugin</artifactId>
-        <version>2.0.2</version>
         <configuration>
           <installDirectory>${project.build.directory}/js</installDirectory>
-          <nodeVersion>${node.version}</nodeVersion>
           <workingDirectory>${project.build.directory}/js/openhab-js</workingDirectory>
         </configuration>
         <executions>

--- a/bundles/org.openhab.binding.matter/pom.xml
+++ b/bundles/org.openhab.binding.matter/pom.xml
@@ -23,12 +23,6 @@
       <plugin>
         <groupId>com.github.eirslett</groupId>
         <artifactId>frontend-maven-plugin</artifactId>
-        <version>2.0.2</version>
-        <configuration>
-          <nodeVersion>v24.11.1</nodeVersion>
-          <npmVersion>11.6.2</npmVersion>
-        </configuration>
-
         <executions>
           <!-- Matter server webpack commands -->
           <execution>
@@ -99,11 +93,6 @@
           <plugin>
             <groupId>com.github.eirslett</groupId>
             <artifactId>frontend-maven-plugin</artifactId>
-            <version>2.0.2</version>
-            <configuration>
-              <nodeVersion>v24.11.1</nodeVersion>
-              <npmVersion>11.6.2</npmVersion>
-            </configuration>
             <executions>
               <execution>
                 <id>Install node and npm for codegen</id>

--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -802,15 +802,9 @@
       <plugin>
         <groupId>com.github.eirslett</groupId>
         <artifactId>frontend-maven-plugin</artifactId>
-        <version>2.0.2</version>
 
         <configuration>
-          <!-- Central toolchain for markdownlint (Node 24) -->
           <installDirectory>${maven.multiModuleProjectDirectory}/target/.mvn/node-markdownlint</installDirectory>
-          <nodeVersion>v24.12.0</nodeVersion>
-
-          <!-- Recommended: pin npm too for reproducibility -->
-          <npmVersion>11.6.2</npmVersion>
         </configuration>
 
         <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -443,6 +443,16 @@ Import-Package: \
         </plugin>
 
         <plugin>
+          <groupId>com.github.eirslett</groupId>
+          <artifactId>frontend-maven-plugin</artifactId>
+          <version>2.0.2</version>
+          <configuration>
+            <nodeVersion>v24.18.1</nodeVersion>
+            <npmVersion>11.16.0</npmVersion>
+          </configuration>
+        </plugin>
+
+        <plugin>
           <groupId>com.mycila</groupId>
           <artifactId>license-maven-plugin</artifactId>
           <version>5.1.1</version>


### PR DESCRIPTION
The versions used in the build are quite old, see: https://nodejs.org/en/about/previous-releases

I don't know if there is a reason for this.
If so, this should be clearly documented in comments so people won't just upgrade it. :wink: 

These older versions cause issues, see:

* https://github.com/openhab/openhab-addons/pull/21233
* https://github.com/openhab/openhab-addons/pull/21329
