### PR TITLE
[hyperion] Send instance-scoped commands one instance at a time

### DIFF
--- a/bundles/org.openhab.binding.hyperion/src/main/java/org/openhab/binding/hyperion/internal/handler/HyperionNgHandler.java
+++ b/bundles/org.openhab.binding.hyperion/src/main/java/org/openhab/binding/hyperion/internal/handler/HyperionNgHandler.java
@@ -476,26 +476,7 @@ public class HyperionNgHandler extends BaseThingHandler {
 
             boolean state = command == OnOffType.ON;
             componentState.setState(state);
-
-            // determine which instances to target: user-configured `instanceIndices` take
-            // precedence; otherwise fall back to available instances reported by server
-            List<Integer> targetInstances = !instanceIndices.isEmpty() ? new ArrayList<>(instanceIndices)
-                    : new ArrayList<>(availableInstanceIndices);
-
-            logger.debug("handleComponentEnabled: instanceIndices={} availableInstanceIndices={} targetInstances={}",
-                    instanceIndices, availableInstanceIndices, targetInstances);
-
-            if (!targetInstances.isEmpty()) {
-                // prefer sending a single batched command with the top-level `instance` array
-                ComponentStateCommand batched = new ComponentStateCommand(componentState);
-                batched.setInstance(targetInstances);
-                logger.debug("handleComponentEnabled: sending batched command for instances={}", targetInstances);
-                sendCommand(batched);
-            } else {
-                ComponentStateCommand stateCommand = new ComponentStateCommand(componentState);
-                logger.debug("handleComponentEnabled: sending global command (no instances)");
-                sendCommand(stateCommand);
-            }
+            sendToInstances(new ComponentStateCommand(componentState));
         } else {
             logger.debug("Channel {} unable to process command {}", channel, command);
         }
@@ -507,23 +488,29 @@ public class HyperionNgHandler extends BaseThingHandler {
             componentState.setComponent(COMPONENTS_ALL);
             boolean state = command == OnOffType.ON;
             componentState.setState(state);
-            // determine which instances to target: user-configured `instanceIndices` take
-            // precedence; otherwise fall back to available instances reported by server
-            List<Integer> targetInstances = !instanceIndices.isEmpty() ? new ArrayList<>(instanceIndices)
-                    : new ArrayList<>(availableInstanceIndices);
-
-            if (!targetInstances.isEmpty()) {
-                ComponentStateCommand batched = new ComponentStateCommand(componentState);
-                // set top-level instance as an array (server expects arrays for `instance`)
-                batched.setInstance(targetInstances);
-                logger.debug("handleHyperionEnabled: sending batched command for instances={}", targetInstances);
-                sendCommand(batched);
-            } else {
-                ComponentStateCommand stateCommand = new ComponentStateCommand(componentState);
-                sendCommand(stateCommand);
-            }
+            sendToInstances(new ComponentStateCommand(componentState));
         } else {
             logger.debug("Channel {} unable to process command {}", CHANNEL_HYPERION_ENABLED, command);
+        }
+    }
+
+    /**
+     * Sends the given command to every targeted instance. Configured instances take precedence over the instances
+     * reported by the server. Hyperion.ng's {@code componentstate} command rejects multiple instances, so one command
+     * is sent per instance with a single-element array. When no instances are known the command is sent as-is for
+     * backwards compatibility.
+     */
+    private void sendToInstances(HyperionCommand command) throws IOException, CommandUnsuccessfulException {
+        List<Integer> targetInstances = !instanceIndices.isEmpty() ? new ArrayList<>(instanceIndices)
+                : new ArrayList<>(availableInstanceIndices);
+        if (targetInstances.isEmpty()) {
+            sendCommand(command);
+            return;
+        }
+        for (int instance : targetInstances) {
+            command.setInstance(List.of(instance));
+            logger.debug("Sending {} command to instance {}", command.getCommand(), instance);
+            sendCommand(command);
         }
     }
 
@@ -535,7 +522,7 @@ public class HyperionNgHandler extends BaseThingHandler {
             adjustment.setBrightness(brightnessValue);
 
             AdjustmentCommand brightnessCommand = new AdjustmentCommand(adjustment);
-            sendCommand(brightnessCommand);
+            sendToInstances(brightnessCommand);
         } else {
             logger.debug("Channel {} unable to process command {}", CHANNEL_BRIGHTNESS, command);
         }
@@ -550,7 +537,7 @@ public class HyperionNgHandler extends BaseThingHandler {
 
             ColorCommand colorCommand = new ColorCommand(r, g, b, priority);
             colorCommand.setOrigin(origin);
-            sendCommand(colorCommand);
+            sendToInstances(colorCommand);
         } else {
             logger.debug("Channel {} unable to process command {}", CHANNEL_COLOR, command);
         }
@@ -565,7 +552,7 @@ public class HyperionNgHandler extends BaseThingHandler {
 
             effectCommand.setOrigin(origin);
 
-            sendCommand(effectCommand);
+            sendToInstances(effectCommand);
         } else {
             logger.debug("Channel {} unable to process command {}", CHANNEL_EFFECT, command);
         }
@@ -576,11 +563,11 @@ public class HyperionNgHandler extends BaseThingHandler {
             String cmd = command.toString();
             if ("ALL".equals(cmd)) {
                 ClearAllCommand clearCommand = new ClearAllCommand();
-                sendCommand(clearCommand);
+                sendToInstances(clearCommand);
             } else {
                 int priority = Integer.parseInt(cmd);
                 ClearCommand clearCommand = new ClearCommand(priority);
-                sendCommand(clearCommand);
+                sendToInstances(clearCommand);
             }
         }
     }

--- a/bundles/org.openhab.binding.hyperion/src/main/java/org/openhab/binding/hyperion/internal/protocol/HyperionCommand.java
+++ b/bundles/org.openhab.binding.hyperion/src/main/java/org/openhab/binding/hyperion/internal/protocol/HyperionCommand.java
@@ -12,6 +12,9 @@
  */
 package org.openhab.binding.hyperion.internal.protocol;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import com.google.gson.annotations.SerializedName;
 
 /**
@@ -24,6 +27,9 @@ public abstract class HyperionCommand {
 
     @SerializedName("command")
     private String command;
+    // Hyperion.ng targets instances via an array of instance indices
+    @SerializedName("instance")
+    private List<Integer> instance;
 
     public HyperionCommand(String command) {
         setCommand(command);
@@ -35,5 +41,21 @@ public abstract class HyperionCommand {
 
     public void setCommand(String command) {
         this.command = command;
+    }
+
+    public void setInstance(List<Integer> instanceList) {
+        if (instanceList == null || instanceList.isEmpty()) {
+            this.instance = null;
+            return;
+        }
+        List<Integer> copy = new ArrayList<>(instanceList.size());
+        for (Integer v : instanceList) {
+            if (v == null || v < 0) {
+                this.instance = null;
+                return;
+            }
+            copy.add(v);
+        }
+        this.instance = copy;
     }
 }

--- a/bundles/org.openhab.binding.hyperion/src/main/java/org/openhab/binding/hyperion/internal/protocol/ng/ComponentStateCommand.java
+++ b/bundles/org.openhab.binding.hyperion/src/main/java/org/openhab/binding/hyperion/internal/protocol/ng/ComponentStateCommand.java
@@ -12,9 +12,6 @@
  */
 package org.openhab.binding.hyperion.internal.protocol.ng;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import org.openhab.binding.hyperion.internal.protocol.HyperionCommand;
 
 import com.google.gson.annotations.SerializedName;
@@ -31,8 +28,6 @@ public class ComponentStateCommand extends HyperionCommand {
 
     @SerializedName("componentstate")
     private ComponentState componentState;
-    @SerializedName("instance")
-    private List<Integer> instance;
 
     public ComponentStateCommand(ComponentState componentState) {
         super(NAME);
@@ -45,21 +40,5 @@ public class ComponentStateCommand extends HyperionCommand {
 
     public void setComponentState(ComponentState componentState) {
         this.componentState = componentState;
-    }
-
-    public void setInstance(List<Integer> instanceList) {
-        if (instanceList == null || instanceList.isEmpty()) {
-            this.instance = null;
-            return;
-        }
-        List<Integer> copy = new ArrayList<>(instanceList.size());
-        for (Integer v : instanceList) {
-            if (v == null || v < 0) {
-                this.instance = null;
-                return;
-            }
-            copy.add(v);
-        }
-        this.instance = copy;
     }
 }


### PR DESCRIPTION
## Follow-up to #19807

Testing the merged multi-instance support (#19807) against real Hyperion.ng hardware with two instances revealed that instance-scoped commands were not applied correctly:

- The `componentstate` command was sent with a top-level `instance` array containing all target instances (e.g. `"instance":[0,1]`). Hyperion.ng rejects this with `success:false` / *"Command does not support multiple instances"*.
- Sending a bare integer (`"instance":0`) is also rejected: the schema requires `instance` to be an **array** (*"array expected"*).
- Brightness/color/effect/clear commands carried no `instance` at all, so they only ever affected instance `0`.

### Fix

- Instance targeting is lifted into the base `HyperionCommand`, so every command type can be scoped to instances.
- A new `sendToInstances(...)` helper sends the command **once per targeted instance** using a single-element array (`"instance":[n]`), which is the form all the relevant Hyperion.ng JSON-RPC schemas accept. When no instances are known it falls back to sending the command as-is.
- Enable/component toggles **and** brightness, color, effect and clear now all apply to every configured (or, if none configured, every available) instance.

Verified on hardware with two instances: Enable and Brightness now take effect on both instances, and the server returns `success:true` for each per-instance command.

Signed-off-by: Ole Morten Rønning <olemr@olemr.com>