### PR TITLE
[discovery] Handle Boolean background discovery configuration

### DIFF
--- a/bundles/org.openhab.binding.androiddebugbridge/src/main/java/org/openhab/binding/androiddebugbridge/internal/discovery/AndroidTVMDNSDiscoveryParticipant.java
+++ b/bundles/org.openhab.binding.androiddebugbridge/src/main/java/org/openhab/binding/androiddebugbridge/internal/discovery/AndroidTVMDNSDiscoveryParticipant.java
@@ -22,6 +22,7 @@ import javax.jmdns.ServiceInfo;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.core.config.core.ConfigParser;
 import org.openhab.core.config.discovery.DiscoveryResult;
 import org.openhab.core.config.discovery.DiscoveryResultBuilder;
 import org.openhab.core.config.discovery.DiscoveryService;
@@ -49,7 +50,7 @@ public class AndroidTVMDNSDiscoveryParticipant implements MDNSDiscoveryParticipa
     private static final String SERVICE_TYPE = "_androidtvremote2._tcp.local.";
     private static final String MDNS_PROPERTY_MAC_ADDRESS = "bt";
 
-    private boolean isAutoDiscoveryEnabled = true;
+    private volatile boolean isAutoDiscoveryEnabled = true;
 
     @Activate
     protected void activate(ComponentContext componentContext) {
@@ -63,11 +64,9 @@ public class AndroidTVMDNSDiscoveryParticipant implements MDNSDiscoveryParticipa
 
     private void activateOrModifyService(ComponentContext componentContext) {
         Dictionary<String, @Nullable Object> properties = componentContext.getProperties();
-        String autoDiscoveryPropertyValue = (String) properties
-                .get(DiscoveryService.CONFIG_PROPERTY_BACKGROUND_DISCOVERY);
-        if (autoDiscoveryPropertyValue != null && !autoDiscoveryPropertyValue.isBlank()) {
-            isAutoDiscoveryEnabled = Boolean.valueOf(autoDiscoveryPropertyValue);
-        }
+        isAutoDiscoveryEnabled = ConfigParser.valueAsOrElse(
+                properties.get(DiscoveryService.CONFIG_PROPERTY_BACKGROUND_DISCOVERY), Boolean.class,
+                isAutoDiscoveryEnabled);
     }
 
     @Override

--- a/bundles/org.openhab.binding.androiddebugbridge/src/main/java/org/openhab/binding/androiddebugbridge/internal/discovery/FireTVStickMDNSDiscoveryParticipant.java
+++ b/bundles/org.openhab.binding.androiddebugbridge/src/main/java/org/openhab/binding/androiddebugbridge/internal/discovery/FireTVStickMDNSDiscoveryParticipant.java
@@ -22,6 +22,7 @@ import javax.jmdns.ServiceInfo;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.core.config.core.ConfigParser;
 import org.openhab.core.config.discovery.DiscoveryResult;
 import org.openhab.core.config.discovery.DiscoveryResultBuilder;
 import org.openhab.core.config.discovery.DiscoveryService;
@@ -49,7 +50,7 @@ public class FireTVStickMDNSDiscoveryParticipant implements MDNSDiscoveryPartici
     private static final String MDNS_PROPERTY_NAME = "n";
     private static final String MDNS_PROPERTY_MAC_ADDRESS = "c";
 
-    private boolean isAutoDiscoveryEnabled = true;
+    private volatile boolean isAutoDiscoveryEnabled = true;
 
     @Activate
     protected void activate(ComponentContext componentContext) {
@@ -63,11 +64,9 @@ public class FireTVStickMDNSDiscoveryParticipant implements MDNSDiscoveryPartici
 
     private void activateOrModifyService(ComponentContext componentContext) {
         Dictionary<String, @Nullable Object> properties = componentContext.getProperties();
-        String autoDiscoveryPropertyValue = (String) properties
-                .get(DiscoveryService.CONFIG_PROPERTY_BACKGROUND_DISCOVERY);
-        if (autoDiscoveryPropertyValue != null && !autoDiscoveryPropertyValue.isBlank()) {
-            isAutoDiscoveryEnabled = Boolean.valueOf(autoDiscoveryPropertyValue);
-        }
+        isAutoDiscoveryEnabled = ConfigParser.valueAsOrElse(
+                properties.get(DiscoveryService.CONFIG_PROPERTY_BACKGROUND_DISCOVERY), Boolean.class,
+                isAutoDiscoveryEnabled);
     }
 
     @Override

--- a/bundles/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/discovery/AVMFritzUpnpDiscoveryParticipant.java
+++ b/bundles/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/discovery/AVMFritzUpnpDiscoveryParticipant.java
@@ -24,8 +24,10 @@ import org.eclipse.jdt.annotation.Nullable;
 import org.jupnp.model.meta.DeviceDetails;
 import org.jupnp.model.meta.ModelDetails;
 import org.jupnp.model.meta.RemoteDevice;
+import org.openhab.core.config.core.ConfigParser;
 import org.openhab.core.config.discovery.DiscoveryResult;
 import org.openhab.core.config.discovery.DiscoveryResultBuilder;
+import org.openhab.core.config.discovery.DiscoveryService;
 import org.openhab.core.config.discovery.upnp.UpnpDiscoveryParticipant;
 import org.openhab.core.config.discovery.upnp.internal.UpnpDiscoveryService;
 import org.openhab.core.thing.ThingTypeUID;
@@ -51,7 +53,7 @@ public class AVMFritzUpnpDiscoveryParticipant implements UpnpDiscoveryParticipan
 
     private final Logger logger = LoggerFactory.getLogger(AVMFritzUpnpDiscoveryParticipant.class);
 
-    private boolean isAutoDiscoveryEnabled = true;
+    private volatile boolean isAutoDiscoveryEnabled = true;
 
     @Activate
     protected void activate(ComponentContext componentContext) {
@@ -65,10 +67,9 @@ public class AVMFritzUpnpDiscoveryParticipant implements UpnpDiscoveryParticipan
 
     private void activateOrModifyService(ComponentContext componentContext) {
         Dictionary<String, @Nullable Object> properties = componentContext.getProperties();
-        String autoDiscoveryPropertyValue = (String) properties.get("background");
-        if (autoDiscoveryPropertyValue != null && autoDiscoveryPropertyValue.length() != 0) {
-            isAutoDiscoveryEnabled = Boolean.valueOf(autoDiscoveryPropertyValue);
-        }
+        isAutoDiscoveryEnabled = ConfigParser.valueAsOrElse(
+                properties.get(DiscoveryService.CONFIG_PROPERTY_BACKGROUND_DISCOVERY), Boolean.class,
+                isAutoDiscoveryEnabled);
     }
 
     @Override

--- a/bundles/org.openhab.binding.froniuswattpilot/src/main/java/org/openhab/binding/froniuswattpilot/internal/FroniusWattpilotMDNSDiscoveryServiceParticipant.java
+++ b/bundles/org.openhab.binding.froniuswattpilot/src/main/java/org/openhab/binding/froniuswattpilot/internal/FroniusWattpilotMDNSDiscoveryServiceParticipant.java
@@ -23,6 +23,7 @@ import javax.jmdns.ServiceInfo;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.core.config.core.ConfigParser;
 import org.openhab.core.config.discovery.DiscoveryResult;
 import org.openhab.core.config.discovery.DiscoveryResultBuilder;
 import org.openhab.core.config.discovery.DiscoveryService;
@@ -47,7 +48,7 @@ public class FroniusWattpilotMDNSDiscoveryServiceParticipant implements MDNSDisc
 
     private static final String SERVICE_TYPE = "_Fronius-SE-Wattpilot._tcp.local.";
 
-    private boolean isAutoDiscoveryEnabled = true;
+    private volatile boolean isAutoDiscoveryEnabled = true;
 
     @Activate
     protected void activate(ComponentContext componentContext) {
@@ -61,11 +62,9 @@ public class FroniusWattpilotMDNSDiscoveryServiceParticipant implements MDNSDisc
 
     private void activateOrModifyService(ComponentContext componentContext) {
         Dictionary<String, @Nullable Object> properties = componentContext.getProperties();
-        String autoDiscoveryPropertyValue = (String) properties
-                .get(DiscoveryService.CONFIG_PROPERTY_BACKGROUND_DISCOVERY);
-        if (autoDiscoveryPropertyValue != null && !autoDiscoveryPropertyValue.isBlank()) {
-            isAutoDiscoveryEnabled = Boolean.valueOf(autoDiscoveryPropertyValue);
-        }
+        isAutoDiscoveryEnabled = ConfigParser.valueAsOrElse(
+                properties.get(DiscoveryService.CONFIG_PROPERTY_BACKGROUND_DISCOVERY), Boolean.class,
+                isAutoDiscoveryEnabled);
     }
 
     @Override

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/discovery/HueBridgeMDNSDiscoveryParticipant.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/discovery/HueBridgeMDNSDiscoveryParticipant.java
@@ -26,6 +26,7 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.hue.internal.HueBridgeModel;
 import org.openhab.binding.hue.internal.connection.Clip2Bridge;
+import org.openhab.core.config.core.ConfigParser;
 import org.openhab.core.config.discovery.DiscoveryResult;
 import org.openhab.core.config.discovery.DiscoveryResultBuilder;
 import org.openhab.core.config.discovery.DiscoveryService;
@@ -63,7 +64,7 @@ public class HueBridgeMDNSDiscoveryParticipant implements MDNSDiscoveryParticipa
     protected final ThingRegistry thingRegistry;
 
     private long removalGracePeriod = 0L;
-    private boolean isAutoDiscoveryEnabled = true;
+    private volatile boolean isAutoDiscoveryEnabled = true;
 
     @Activate
     public HueBridgeMDNSDiscoveryParticipant(final @Reference ThingRegistry thingRegistry) {
@@ -82,11 +83,9 @@ public class HueBridgeMDNSDiscoveryParticipant implements MDNSDiscoveryParticipa
 
     private void activateOrModifyService(ComponentContext componentContext) {
         Dictionary<String, @Nullable Object> properties = componentContext.getProperties();
-        String autoDiscoveryPropertyValue = (String) properties
-                .get(DiscoveryService.CONFIG_PROPERTY_BACKGROUND_DISCOVERY);
-        if (autoDiscoveryPropertyValue != null && !autoDiscoveryPropertyValue.isBlank()) {
-            isAutoDiscoveryEnabled = Boolean.valueOf(autoDiscoveryPropertyValue);
-        }
+        isAutoDiscoveryEnabled = ConfigParser.valueAsOrElse(
+                properties.get(DiscoveryService.CONFIG_PROPERTY_BACKGROUND_DISCOVERY), Boolean.class,
+                isAutoDiscoveryEnabled);
         String removalGracePeriodPropertyValue = (String) properties.get(REMOVAL_GRACE_PERIOD);
         if (removalGracePeriodPropertyValue != null && !removalGracePeriodPropertyValue.isBlank()) {
             try {

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/discovery/HueBridgeUPNPDiscoveryParticipant.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/discovery/HueBridgeUPNPDiscoveryParticipant.java
@@ -28,6 +28,7 @@ import org.jupnp.model.meta.DeviceDetails;
 import org.jupnp.model.meta.ModelDetails;
 import org.jupnp.model.meta.RemoteDevice;
 import org.openhab.binding.hue.internal.handler.HueBridgeHandler;
+import org.openhab.core.config.core.ConfigParser;
 import org.openhab.core.config.discovery.DiscoveryResult;
 import org.openhab.core.config.discovery.DiscoveryResultBuilder;
 import org.openhab.core.config.discovery.DiscoveryService;
@@ -62,7 +63,7 @@ public class HueBridgeUPNPDiscoveryParticipant implements UpnpDiscoveryParticipa
 
     private long removalGracePeriod = 50L;
 
-    private boolean isAutoDiscoveryEnabled = true;
+    private volatile boolean isAutoDiscoveryEnabled = true;
 
     @Activate
     protected void activate(ComponentContext componentContext) {
@@ -76,11 +77,9 @@ public class HueBridgeUPNPDiscoveryParticipant implements UpnpDiscoveryParticipa
 
     private void activateOrModifyService(ComponentContext componentContext) {
         Dictionary<String, @Nullable Object> properties = componentContext.getProperties();
-        String autoDiscoveryPropertyValue = (String) properties
-                .get(DiscoveryService.CONFIG_PROPERTY_BACKGROUND_DISCOVERY);
-        if (autoDiscoveryPropertyValue != null && !autoDiscoveryPropertyValue.isBlank()) {
-            isAutoDiscoveryEnabled = Boolean.valueOf(autoDiscoveryPropertyValue);
-        }
+        isAutoDiscoveryEnabled = ConfigParser.valueAsOrElse(
+                properties.get(DiscoveryService.CONFIG_PROPERTY_BACKGROUND_DISCOVERY), Boolean.class,
+                isAutoDiscoveryEnabled);
         String removalGracePeriodPropertyValue = (String) properties.get(REMOVAL_GRACE_PERIOD);
         if (removalGracePeriodPropertyValue != null && !removalGracePeriodPropertyValue.isBlank()) {
             try {

--- a/bundles/org.openhab.binding.huesync/src/main/java/org/openhab/binding/huesync/internal/discovery/HueSyncDiscoveryParticipant.java
+++ b/bundles/org.openhab.binding.huesync/src/main/java/org/openhab/binding/huesync/internal/discovery/HueSyncDiscoveryParticipant.java
@@ -22,6 +22,7 @@ import javax.jmdns.ServiceInfo;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.huesync.internal.HueSyncConstants;
+import org.openhab.core.config.core.ConfigParser;
 import org.openhab.core.config.discovery.DiscoveryResult;
 import org.openhab.core.config.discovery.DiscoveryResultBuilder;
 import org.openhab.core.config.discovery.DiscoveryService;
@@ -59,7 +60,7 @@ public class HueSyncDiscoveryParticipant implements MDNSDiscoveryParticipant {
      */
     private static final String SERVICE_TYPE = "_huesync._tcp.local.";
 
-    private boolean autoDiscoveryEnabled = true;
+    private volatile boolean autoDiscoveryEnabled = true;
 
     protected final ThingRegistry thingRegistry;
 
@@ -128,16 +129,13 @@ public class HueSyncDiscoveryParticipant implements MDNSDiscoveryParticipant {
     }
 
     private void updateService(ComponentContext componentContext) {
-        String autoDiscoveryPropertyValue = (String) componentContext.getProperties()
+        Object autoDiscoveryPropertyValue = componentContext.getProperties()
                 .get(DiscoveryService.CONFIG_PROPERTY_BACKGROUND_DISCOVERY);
-
-        if (autoDiscoveryPropertyValue != null && !autoDiscoveryPropertyValue.isBlank()) {
-            boolean value = Boolean.parseBoolean(autoDiscoveryPropertyValue);
-            if (value != this.autoDiscoveryEnabled) {
-                logger.debug("{} update: {} - {}", DiscoveryService.CONFIG_PROPERTY_BACKGROUND_DISCOVERY,
-                        autoDiscoveryPropertyValue, value);
-                this.autoDiscoveryEnabled = value;
-            }
+        boolean value = ConfigParser.valueAsOrElse(autoDiscoveryPropertyValue, Boolean.class, autoDiscoveryEnabled);
+        if (value != autoDiscoveryEnabled) {
+            logger.debug("{} update: {} - {}", DiscoveryService.CONFIG_PROPERTY_BACKGROUND_DISCOVERY,
+                    autoDiscoveryPropertyValue, value);
+            autoDiscoveryEnabled = value;
         }
     }
 }

--- a/bundles/org.openhab.binding.kodi/src/main/java/org/openhab/binding/kodi/internal/discovery/KodiUpnpDiscoveryParticipant.java
+++ b/bundles/org.openhab.binding.kodi/src/main/java/org/openhab/binding/kodi/internal/discovery/KodiUpnpDiscoveryParticipant.java
@@ -22,8 +22,10 @@ import java.util.Set;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.jupnp.model.meta.RemoteDevice;
+import org.openhab.core.config.core.ConfigParser;
 import org.openhab.core.config.discovery.DiscoveryResult;
 import org.openhab.core.config.discovery.DiscoveryResultBuilder;
+import org.openhab.core.config.discovery.DiscoveryService;
 import org.openhab.core.config.discovery.upnp.UpnpDiscoveryParticipant;
 import org.openhab.core.thing.ThingTypeUID;
 import org.openhab.core.thing.ThingUID;
@@ -46,7 +48,7 @@ public class KodiUpnpDiscoveryParticipant implements UpnpDiscoveryParticipant {
 
     private Logger logger = LoggerFactory.getLogger(KodiUpnpDiscoveryParticipant.class);
 
-    private boolean isAutoDiscoveryEnabled = true;
+    private volatile boolean isAutoDiscoveryEnabled = true;
 
     @Activate
     protected void activate(ComponentContext componentContext) {
@@ -60,10 +62,9 @@ public class KodiUpnpDiscoveryParticipant implements UpnpDiscoveryParticipant {
 
     private void activateOrModifyService(ComponentContext componentContext) {
         Dictionary<String, @Nullable Object> properties = componentContext.getProperties();
-        String autoDiscoveryPropertyValue = (String) properties.get("background");
-        if (autoDiscoveryPropertyValue != null && !autoDiscoveryPropertyValue.isEmpty()) {
-            isAutoDiscoveryEnabled = Boolean.valueOf(autoDiscoveryPropertyValue);
-        }
+        isAutoDiscoveryEnabled = ConfigParser.valueAsOrElse(
+                properties.get(DiscoveryService.CONFIG_PROPERTY_BACKGROUND_DISCOVERY), Boolean.class,
+                isAutoDiscoveryEnabled);
     }
 
     @Override


### PR DESCRIPTION
## The problem

PR #21324 fixed the Chromecast discovery participant because the `background` discovery property can be a `Boolean` when updated through the REST API. Several other discovery participants still cast the value to `String`, so updating their background discovery setting can throw `ClassCastException` from `@Modified` and leave the previous runtime value active.

## The change

Update the remaining affected discovery participants to parse the setting with `ConfigParser.valueAsOrElse(..., Boolean.class, currentValue)`, matching `AbstractDiscoveryService` and the Chromecast fix.

The flags updated by `@Modified` are also made `volatile` because they are read from discovery callback threads.

Affected add-ons:

- androiddebugbridge
- avmfritz
- froniuswattpilot
- hue
- huesync
- kodi

Fixes #21353.