### PR TITLE
[loqed] initial contribution for Loqed smart locks

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -222,6 +222,7 @@
 /bundles/org.openhab.binding.lirc/ @kabili207
 /bundles/org.openhab.binding.livisismarthome/ @Novanic
 /bundles/org.openhab.binding.logreader/ @paulianttila
+/bundles/org.openhab.binding.loqed/ @octa22
 /bundles/org.openhab.binding.loxone/ @ppieczul
 /bundles/org.openhab.binding.lutron/ @actong @bobadair
 /bundles/org.openhab.binding.luxom/ @jesperskriasoft

--- a/bom/openhab-addons/pom.xml
+++ b/bom/openhab-addons/pom.xml
@@ -1098,6 +1098,11 @@
     </dependency>
     <dependency>
       <groupId>org.openhab.addons.bundles</groupId>
+      <artifactId>org.openhab.binding.loqed</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.openhab.addons.bundles</groupId>
       <artifactId>org.openhab.binding.loxone</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/bundles/org.openhab.binding.loqed/NOTICE
+++ b/bundles/org.openhab.binding.loqed/NOTICE
@@ -1,0 +1,13 @@
+This content is produced and maintained by the openHAB project.
+
+* Project home: https://www.openhab.org
+
+== Declared Project Licenses
+
+This program and the accompanying materials are made available under the terms
+of the Eclipse Public License 2.0 which is available at
+https://www.eclipse.org/legal/epl-2.0/.
+
+== Source Code
+
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.loqed/README.md
+++ b/bundles/org.openhab.binding.loqed/README.md
@@ -1,0 +1,117 @@
+# LOQED Binding
+
+The LOQED binding controls LOQED Touch and LOQED Pure smart locks either through the cloud Integrations API or directly through a LOQED Bridge on the local network.
+
+## Supported Things
+
+- `account`: Bridge representing a LOQED account and its personal access token.
+- `local-bridge`: Direct local connection using signed commands and signed outgoing webhooks.
+- `lock`: A LOQED smart lock connected through either bridge type.
+
+## Discovery
+
+Discovery is supported by the `account` bridge only.
+After the bridge is online, start a discovery scan to add all locks available to the Inbox.
+Each discovered lock is linked to the account bridge and is uniquely identified by its LOQED lock ID.
+Locks connected through a `local-bridge` must be configured manually.
+
+## `account` Configuration
+
+Create a personal access token at [LOQED Personal Access Tokens](https://integrations.loqed.com/personal-access-tokens).
+The account used to create the token must have administrator access to the locks.
+
+| Name            | Type    | Description                                | Default | Required | Advanced |
+|-----------------|---------|--------------------------------------------|---------|----------|----------|
+| apiToken        | text    | LOQED personal access token.               | N/A     | yes      | no       |
+| refreshInterval | integer | Interval between API refreshes in seconds. | 60      | no       | yes      |
+
+The refresh interval cannot be shorter than 30 seconds.
+
+## `local-bridge` Configuration
+
+Create an incoming API key and obtain the outgoing-webhook authentication key at [LOQED API Configuration](https://app.loqed.com/API-Config).
+The bridge authentication key is required for local operation, but a cloud personal access token is not.
+
+| Name            | Type    | Description                                                       | Default | Required |
+|-----------------|---------|-------------------------------------------------------------------|---------|----------|
+| host            | text    | IP address, hostname, or base URL of the LOQED Bridge.            | N/A     | yes      |
+| bridgeKey       | text    | Base64 bridge authentication key for webhook management/signing.  | N/A     | yes      |
+| callbackBaseUrl | text    | Optional override for the automatically detected openHAB URL.     | Auto    | no       |
+| refreshInterval | integer | Fallback status refresh interval in seconds.                      | 60      | no       |
+
+The binding registers its callback below `/loqed/webhook` and verifies the `TIMESTAMP` and `HASH` headers before accepting an event.
+The binding obtains the primary IPv4 address and HTTP port from the openHAB runtime.
+Set the advanced callback base URL only when automatic detection returns an address that the bridge cannot reach, for example with multiple network interfaces, VLANs, or some Docker network modes.
+State changes are delivered instantly by the webhook; the status endpoint is used initially, once daily while the
+webhook is active, and at the configured interval in fallback mode.
+When the lock reports that it is offline, the binding polls the status endpoint every 60 seconds until the lock is
+online again.
+After a command, the binding also refreshes the status if the matching webhook update does not arrive within 10 seconds.
+
+## Lock Configuration
+
+Cloud lock Things are normally created through discovery.
+Local lock Things are configured manually because their signing credentials belong to the lock and cannot be discovered from the bridge.
+Use the lock ID and local API key shown on the LOQED API configuration page.
+
+| Name       | Type    | Description                                                    | Required            |
+|------------|---------|----------------------------------------------------------------|---------------------|
+| lockId     | text    | Unique lock identifier from LOQED.                             | yes                 |
+| keySecret  | text    | Base64 secret used to sign commands.                           | with `local-bridge` |
+| localKeyId | integer | Numeric local key ID belonging to `keySecret`, from 0 to 250.  | with `local-bridge` |
+
+## Channels
+
+| Channel          | Type                 | Read/Write | Description                                                                                                     |
+|------------------|----------------------|------------|-----------------------------------------------------------------------------------------------------------------|
+| lock             | Switch               | RW         | `ON` sets night lock; `OFF` sets day lock.                                                                      |
+| bolt-state       | String               | RW         | Current bolt state. `OPEN` retracts the latch; on doors with an outside handle LOQED treats it like `DAY_LOCK`. |
+| battery-level    | Number:Dimensionless | R          | Remaining battery level in percent.                                                                             |
+| battery-type     | String               | R          | Configured battery chemistry.                                                                                   |
+| party-mode       | Switch               | R          | Whether Open House (party) mode is enabled.                                                                     |
+| guest-access     | Switch               | R          | Whether guest access mode is enabled.                                                                           |
+| twist-assist     | Switch               | R          | Whether twist assist is enabled.                                                                                |
+| touch-to-connect | Switch               | R          | Whether the 500 m geofence restriction for Touch to Open is removed.                                            |
+
+## Full Example
+
+### Thing Configuration
+
+```java
+Bridge loqed:account:home "LOQED Account" [ apiToken="YOUR_PERSONAL_ACCESS_TOKEN", refreshInterval=60 ] {
+    Thing lock frontdoor "Front Door" [ lockId="Yq1gK4oeE9KWe0ByxjX2" ]
+}
+```
+
+Local alternative:
+
+```java
+Bridge loqed:local-bridge:home "LOQED Local Bridge" [
+    host="192.168.1.20",
+    bridgeKey="YOUR_BASE64_BRIDGE_AUTHENTICATION_KEY"
+] {
+    Thing lock frontdoor "Front Door" [
+        lockId="Yq1gK4oeE9KWe0ByxjX2",
+        keySecret="YOUR_BASE64_LOCAL_KEY_SECRET",
+        localKeyId=3
+    ]
+}
+```
+
+### Item Configuration
+
+```java
+Switch FrontDoor_Lock "Front Door Lock" { channel="loqed:lock:home:frontdoor:lock", autoupdate="false" }
+String FrontDoor_BoltState "Front Door [%s]" { channel="loqed:lock:home:frontdoor:bolt-state" }
+Number:Dimensionless FrontDoor_Battery "Front Door Battery [%d %%]" { channel="loqed:lock:home:frontdoor:battery-level" }
+```
+
+Disabling autoupdate on the lock Item prevents openHAB from displaying an optimistic state before the binding receives
+confirmation from a webhook or status refresh.
+
+To retract the latch from a rule, send the `OPEN` command to `FrontDoor_BoltState`.
+
+## Security
+
+The personal access token and local API keys grant control over the lock.
+Store them as secrets, revoke unused credentials on the LOQED website, and do not include them in logs or support bundles.

--- a/bundles/org.openhab.binding.loqed/pom.xml
+++ b/bundles/org.openhab.binding.loqed/pom.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.openhab.addons.bundles</groupId>
+    <artifactId>org.openhab.addons.reactor.bundles</artifactId>
+    <version>5.3.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>org.openhab.binding.loqed</artifactId>
+
+  <name>openHAB Add-ons :: Bundles :: Loqed Binding</name>
+
+</project>

--- a/bundles/org.openhab.binding.loqed/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.loqed/src/main/feature/feature.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<features name="org.openhab.binding.loqed-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.6.0">
+	<repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
+
+	<feature name="openhab-binding-loqed" description="Loqed Binding" version="${project.version}">
+		<feature>openhab-runtime-base</feature>
+		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.loqed/${project.version}</bundle>
+	</feature>
+</features>

--- a/bundles/org.openhab.binding.loqed/src/main/java/org/openhab/binding/loqed/internal/LoqedBindingConstants.java
+++ b/bundles/org.openhab.binding.loqed/src/main/java/org/openhab/binding/loqed/internal/LoqedBindingConstants.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.loqed.internal;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.core.thing.ThingTypeUID;
+
+/**
+ * The {@link LoqedBindingConstants} class defines common constants, which are
+ * used across the whole binding.
+ *
+ * @author Ondrej Pecta - Initial contribution
+ */
+@NonNullByDefault
+public class LoqedBindingConstants {
+
+    public static final String BINDING_ID = "loqed";
+
+    public static final ThingTypeUID BRIDGE_TYPE_ACCOUNT = new ThingTypeUID(BINDING_ID, "account");
+    public static final ThingTypeUID BRIDGE_TYPE_LOCAL = new ThingTypeUID(BINDING_ID, "local-bridge");
+    public static final ThingTypeUID THING_TYPE_LOCK = new ThingTypeUID(BINDING_ID, "lock");
+
+    public static final String WEBHOOK_PATH = "/loqed/webhook";
+
+    public static final String CHANNEL_BATTERY_LEVEL = "battery-level";
+    public static final String CHANNEL_BATTERY_TYPE = "battery-type";
+    public static final String CHANNEL_BOLT_STATE = "bolt-state";
+    public static final String CHANNEL_GUEST_ACCESS = "guest-access";
+    public static final String CHANNEL_LOCK = "lock";
+    public static final String CHANNEL_PARTY_MODE = "party-mode";
+    public static final String CHANNEL_TOUCH_TO_CONNECT = "touch-to-connect";
+    public static final String CHANNEL_TWIST_ASSIST = "twist-assist";
+
+    public static final String PROPERTY_LOCK_ID = "lockId";
+    public static final String PROPERTY_MODEL = "model";
+}

--- a/bundles/org.openhab.binding.loqed/src/main/java/org/openhab/binding/loqed/internal/LoqedBridge.java
+++ b/bundles/org.openhab.binding.loqed/src/main/java/org/openhab/binding/loqed/internal/LoqedBridge.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.loqed.internal;
+
+import java.util.List;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.binding.loqed.internal.api.BoltState;
+import org.openhab.binding.loqed.internal.api.LoqedApiException;
+import org.openhab.binding.loqed.internal.api.LoqedLockData;
+
+/**
+ * Common operations provided by cloud and local LOQED bridges.
+ *
+ * @author Ondrej Pecta - Initial contribution
+ */
+@NonNullByDefault
+public interface LoqedBridge {
+    /**
+     * Refreshes all locks and returns the latest snapshot.
+     *
+     * @return immutable snapshot of the locks available through this bridge
+     */
+    List<LoqedLockData> refreshAndGetLocks();
+
+    /** Refreshes all locks and updates their handlers. */
+    void refresh();
+
+    /**
+     * Changes the bolt state of a lock.
+     *
+     * @param lockId LOQED lock identifier
+     * @param keySecret local API key secret, ignored by cloud bridges
+     * @param localKeyId local API key identifier, ignored by cloud bridges
+     * @param boltState requested bolt state
+     * @throws LoqedApiException if the command cannot be sent
+     */
+    void setBoltState(String lockId, String keySecret, int localKeyId, BoltState boltState) throws LoqedApiException;
+
+    /**
+     * Returns whether state updates normally arrive asynchronously.
+     *
+     * @return {@code true} if the bridge uses push updates
+     */
+    default boolean usesPushUpdates() {
+        return false;
+    }
+
+    /**
+     * Returns the sequence number of the latest matching state update received asynchronously.
+     *
+     * @param boltState state whose updates are tracked
+     * @return matching state update sequence number
+     */
+    default long getStateUpdateSequence(BoltState boltState) {
+        return 0;
+    }
+
+    /**
+     * Returns whether the child lock needs local API credentials.
+     *
+     * @return {@code true} if local credentials are required
+     */
+    default boolean requiresLocalCredentials() {
+        return false;
+    }
+}

--- a/bundles/org.openhab.binding.loqed/src/main/java/org/openhab/binding/loqed/internal/LoqedBridgeHandler.java
+++ b/bundles/org.openhab.binding.loqed/src/main/java/org/openhab/binding/loqed/internal/LoqedBridgeHandler.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.loqed.internal;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.jetty.client.HttpClient;
+import org.openhab.binding.loqed.internal.api.BoltState;
+import org.openhab.binding.loqed.internal.api.LoqedApiClient;
+import org.openhab.binding.loqed.internal.api.LoqedApiException;
+import org.openhab.binding.loqed.internal.api.LoqedAuthenticationException;
+import org.openhab.binding.loqed.internal.api.LoqedCommunicationException;
+import org.openhab.binding.loqed.internal.api.LoqedLockData;
+import org.openhab.binding.loqed.internal.discovery.LoqedDiscoveryService;
+import org.openhab.core.thing.Bridge;
+import org.openhab.core.thing.ChannelUID;
+import org.openhab.core.thing.ThingStatus;
+import org.openhab.core.thing.ThingStatusDetail;
+import org.openhab.core.thing.binding.BaseBridgeHandler;
+import org.openhab.core.thing.binding.ThingHandlerService;
+import org.openhab.core.types.Command;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Handles authentication and polling for all locks belonging to one LOQED account.
+ *
+ * @author Ondrej Pecta - Initial contribution
+ */
+@NonNullByDefault
+public class LoqedBridgeHandler extends BaseBridgeHandler implements LoqedBridge {
+    private final Logger logger = LoggerFactory.getLogger(LoqedBridgeHandler.class);
+    private final HttpClient httpClient;
+    private final Object lifecycleLock = new Object();
+
+    private volatile List<LoqedLockData> locks = List.of();
+    private volatile @Nullable LoqedApiClient apiClient;
+    private @Nullable ScheduledFuture<?> pollingJob;
+
+    public LoqedBridgeHandler(Bridge bridge, HttpClient httpClient) {
+        super(bridge);
+        this.httpClient = httpClient;
+    }
+
+    @Override
+    public void initialize() {
+        LoqedConfiguration config = getConfigAs(LoqedConfiguration.class);
+        if (config.apiToken.isBlank()) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
+                    "@text/thing-status.loqed.account.token-empty");
+            return;
+        }
+
+        synchronized (lifecycleLock) {
+            apiClient = new LoqedApiClient(httpClient, config.apiToken);
+        }
+        updateStatus(ThingStatus.UNKNOWN);
+        pollingJob = scheduler.scheduleWithFixedDelay(this::refresh, 0, Math.max(30, config.refreshInterval),
+                TimeUnit.SECONDS);
+    }
+
+    @Override
+    public void dispose() {
+        ScheduledFuture<?> job = pollingJob;
+        if (job != null) {
+            job.cancel(true);
+            pollingJob = null;
+        }
+        synchronized (lifecycleLock) {
+            apiClient = null;
+            locks = List.of();
+        }
+    }
+
+    @Override
+    public void handleCommand(ChannelUID channelUID, Command command) {
+        // The account bridge has no channels.
+    }
+
+    public synchronized List<LoqedLockData> refreshAndGetLocks() {
+        refresh();
+        return locks;
+    }
+
+    public void refresh() {
+        LoqedApiClient client = apiClient;
+        if (client == null) {
+            return;
+        }
+
+        try {
+            List<LoqedLockData> refreshedLocks = client.getLocks();
+            synchronized (lifecycleLock) {
+                if (!client.equals(apiClient)) {
+                    return;
+                }
+                locks = refreshedLocks;
+            }
+            if (!client.equals(apiClient)) {
+                return;
+            }
+            updateStatus(ThingStatus.ONLINE);
+            if (!client.equals(apiClient)) {
+                return;
+            }
+            getThing().getThings().stream().map(thing -> thing.getHandler()).filter(LoqedLockHandler.class::isInstance)
+                    .map(LoqedLockHandler.class::cast).forEach(handler -> handler.updateFromBridge(refreshedLocks));
+        } catch (LoqedAuthenticationException e) {
+            if (client.equals(apiClient)) {
+                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
+                        "@text/thing-status.loqed.account.token-rejected");
+                logger.debug("LOQED rejected the personal access token", e);
+            }
+        } catch (LoqedApiException e) {
+            if (client.equals(apiClient)) {
+                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
+                        "@text/thing-status.loqed.account.communication-error");
+                logger.debug("Could not refresh LOQED locks", e);
+            }
+        }
+    }
+
+    public void setBoltState(String lockId, String keySecret, int localKeyId, BoltState boltState)
+            throws LoqedApiException {
+        LoqedApiClient client = apiClient;
+        if (client == null) {
+            throw new LoqedCommunicationException("The LOQED account bridge is not initialized",
+                    new IllegalStateException());
+        }
+        client.setBoltState(lockId, boltState);
+    }
+
+    @Override
+    public Collection<Class<? extends ThingHandlerService>> getServices() {
+        return Set.of(LoqedDiscoveryService.class);
+    }
+}

--- a/bundles/org.openhab.binding.loqed/src/main/java/org/openhab/binding/loqed/internal/LoqedConfiguration.java
+++ b/bundles/org.openhab.binding.loqed/src/main/java/org/openhab/binding/loqed/internal/LoqedConfiguration.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.loqed.internal;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * The {@link LoqedConfiguration} class contains fields mapping thing configuration parameters.
+ *
+ * @author Ondrej Pecta - Initial contribution
+ */
+@NonNullByDefault
+public class LoqedConfiguration {
+    public String apiToken = "";
+    public int refreshInterval = 60;
+    public String lockId = "";
+    public String keySecret = "";
+    public int localKeyId = -1;
+}

--- a/bundles/org.openhab.binding.loqed/src/main/java/org/openhab/binding/loqed/internal/LoqedHandlerFactory.java
+++ b/bundles/org.openhab.binding.loqed/src/main/java/org/openhab/binding/loqed/internal/LoqedHandlerFactory.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.loqed.internal;
+
+import static org.openhab.binding.loqed.internal.LoqedBindingConstants.*;
+
+import java.util.Set;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.core.id.InstanceUUID;
+import org.openhab.core.io.net.http.HttpClientFactory;
+import org.openhab.core.net.HttpServiceUtil;
+import org.openhab.core.net.NetworkAddressService;
+import org.openhab.core.thing.Bridge;
+import org.openhab.core.thing.Thing;
+import org.openhab.core.thing.ThingTypeUID;
+import org.openhab.core.thing.binding.BaseThingHandlerFactory;
+import org.openhab.core.thing.binding.ThingHandler;
+import org.openhab.core.thing.binding.ThingHandlerFactory;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link LoqedHandlerFactory} is responsible for creating things and thing
+ * handlers.
+ *
+ * @author Ondrej Pecta - Initial contribution
+ */
+@NonNullByDefault
+@Component(configurationPid = "binding.loqed", service = ThingHandlerFactory.class)
+public class LoqedHandlerFactory extends BaseThingHandlerFactory {
+
+    private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Set.of(BRIDGE_TYPE_ACCOUNT, BRIDGE_TYPE_LOCAL,
+            THING_TYPE_LOCK);
+    private final Logger logger = LoggerFactory.getLogger(LoqedHandlerFactory.class);
+    private final HttpClientFactory httpClientFactory;
+    private final NetworkAddressService networkAddressService;
+    private final LoqedWebhookServlet webhookServlet;
+
+    @Activate
+    public LoqedHandlerFactory(@Reference HttpClientFactory httpClientFactory,
+            @Reference NetworkAddressService networkAddressService, @Reference LoqedWebhookServlet webhookServlet) {
+        this.httpClientFactory = httpClientFactory;
+        this.networkAddressService = networkAddressService;
+        this.webhookServlet = webhookServlet;
+    }
+
+    @Override
+    public boolean supportsThingType(ThingTypeUID thingTypeUID) {
+        return SUPPORTED_THING_TYPES_UIDS.contains(thingTypeUID);
+    }
+
+    @Override
+    protected @Nullable ThingHandler createHandler(Thing thing) {
+        ThingTypeUID thingTypeUID = thing.getThingTypeUID();
+
+        if (BRIDGE_TYPE_ACCOUNT.equals(thingTypeUID)) {
+            return new LoqedBridgeHandler((Bridge) thing, httpClientFactory.getCommonHttpClient());
+        } else if (BRIDGE_TYPE_LOCAL.equals(thingTypeUID)) {
+            String routeId = InstanceUUID.get() + "_" + thing.getUID().toString().replace(':', '_');
+            LoqedLocalBridgeHandler handler = new LoqedLocalBridgeHandler((Bridge) thing,
+                    httpClientFactory.getCommonHttpClient(), routeId, createCallbackBaseUrl());
+            webhookServlet.addHandler(routeId, handler);
+            return handler;
+        } else if (THING_TYPE_LOCK.equals(thingTypeUID)) {
+            return new LoqedLockHandler(thing);
+        }
+
+        return null;
+    }
+
+    private @Nullable String createCallbackBaseUrl() {
+        String ipAddress = networkAddressService.getPrimaryIpv4HostAddress();
+        if (ipAddress == null) {
+            logger.warn("No primary IPv4 network interface could be found for the LOQED webhook");
+            return null;
+        }
+
+        // HTTP avoids certificate validation problems on local-network bridges.
+        int port = HttpServiceUtil.getHttpServicePort(bundleContext);
+        if (port == -1) {
+            logger.warn("Could not determine the openHAB HTTP port for the LOQED webhook");
+            return null;
+        }
+        return "http://" + ipAddress + ":" + port;
+    }
+
+    @Override
+    protected void removeHandler(ThingHandler thingHandler) {
+        if (thingHandler instanceof LoqedLocalBridgeHandler localHandler) {
+            webhookServlet.removeHandler(localHandler);
+        }
+        super.removeHandler(thingHandler);
+    }
+}

--- a/bundles/org.openhab.binding.loqed/src/main/java/org/openhab/binding/loqed/internal/LoqedLocalBridgeHandler.java
+++ b/bundles/org.openhab.binding.loqed/src/main/java/org/openhab/binding/loqed/internal/LoqedLocalBridgeHandler.java
@@ -1,0 +1,506 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.loqed.internal;
+
+import static org.openhab.binding.loqed.internal.LoqedBindingConstants.PROPERTY_LOCK_ID;
+import static org.openhab.binding.loqed.internal.LoqedBindingConstants.WEBHOOK_PATH;
+
+import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.jetty.client.HttpClient;
+import org.openhab.binding.loqed.internal.api.BoltState;
+import org.openhab.binding.loqed.internal.api.LoqedApiException;
+import org.openhab.binding.loqed.internal.api.LoqedAuthenticationException;
+import org.openhab.binding.loqed.internal.api.LoqedCommunicationException;
+import org.openhab.binding.loqed.internal.api.LoqedConfigurationException;
+import org.openhab.binding.loqed.internal.api.LoqedLocalApiClient;
+import org.openhab.binding.loqed.internal.api.LoqedLockData;
+import org.openhab.binding.loqed.internal.api.LoqedResponseException;
+import org.openhab.core.thing.Bridge;
+import org.openhab.core.thing.ChannelUID;
+import org.openhab.core.thing.ThingStatus;
+import org.openhab.core.thing.ThingStatusDetail;
+import org.openhab.core.thing.binding.BaseBridgeHandler;
+import org.openhab.core.types.Command;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+
+/**
+ * Handles one bridge through the LOQED Local Bridge API and outgoing webhooks.
+ *
+ * @author Ondrej Pecta - Initial contribution
+ */
+@NonNullByDefault
+public class LoqedLocalBridgeHandler extends BaseBridgeHandler implements LoqedBridge {
+    private static final int MAX_INITIALIZATION_RETRIES = 3;
+    private static final int INITIALIZATION_RETRY_DELAY_SECONDS = 30;
+    private static final int RECOVERY_REFRESH_INTERVAL_SECONDS = 60;
+    private static final int WEBHOOK_REFRESH_INTERVAL_SECONDS = 86400;
+    private static final Gson GSON = new Gson();
+
+    private final Logger logger = LoggerFactory.getLogger(LoqedLocalBridgeHandler.class);
+    private final HttpClient httpClient;
+    private final String routeId;
+    private final @Nullable String detectedCallbackBaseUrl;
+    private final Object connectionLock = new Object();
+    private final Object lifecycleLock = new Object();
+    private final EnumMap<BoltState, Long> stateUpdateSequences = new EnumMap<>(BoltState.class);
+
+    private volatile List<LoqedLockData> locks = List.of();
+    private @Nullable LoqedLockData status;
+    private volatile @Nullable LoqedLocalApiClient apiClient;
+    private @Nullable ScheduledFuture<?> initializationJob;
+    private @Nullable ScheduledFuture<?> pollingJob;
+    private @Nullable ScheduledFuture<?> recoveryJob;
+    private long lifecycleGeneration;
+    private long webhookId = -1;
+    private boolean webhookActive;
+
+    public LoqedLocalBridgeHandler(Bridge bridge, HttpClient httpClient, String routeId,
+            @Nullable String detectedCallbackBaseUrl) {
+        super(bridge);
+        this.httpClient = httpClient;
+        this.routeId = routeId;
+        this.detectedCallbackBaseUrl = detectedCallbackBaseUrl;
+    }
+
+    @Override
+    public void initialize() {
+        resetConnection();
+        locks = List.of();
+        status = null;
+
+        LoqedLocalConfiguration config = getConfigAs(LoqedLocalConfiguration.class);
+        String error = config.validate();
+        if (!error.isEmpty()) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
+                    "@text/thing-status.loqed.local-bridge.configuration-invalid");
+            return;
+        }
+
+        try {
+            LoqedLocalApiClient client = new LoqedLocalApiClient(httpClient, config);
+            String callbackBaseUrl = config.callbackBaseUrl.isBlank() ? detectedCallbackBaseUrl
+                    : config.callbackBaseUrl;
+            if (callbackBaseUrl == null) {
+                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
+                        "@text/thing-status.loqed.local-bridge.callback-unavailable");
+                return;
+            }
+            String callbackUrl = stripTrailingSlash(callbackBaseUrl) + WEBHOOK_PATH + "/" + routeId;
+            int refreshInterval = Math.max(60, config.refreshInterval);
+            long generation;
+            synchronized (lifecycleLock) {
+                generation = ++lifecycleGeneration;
+                apiClient = client;
+                webhookActive = false;
+                stateUpdateSequences.clear();
+            }
+            updateStatus(ThingStatus.UNKNOWN);
+            scheduleInitialization(client, callbackUrl, refreshInterval, generation, 0, 0);
+        } catch (LoqedConfigurationException e) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
+                    "@text/thing-status.loqed.local-bridge.configuration-invalid");
+            logger.debug("Invalid LOQED local bridge configuration", e);
+        }
+    }
+
+    private void scheduleInitialization(LoqedLocalApiClient client, String callbackUrl, int refreshInterval,
+            long generation, int retry, long delaySeconds) {
+        synchronized (lifecycleLock) {
+            if (isCurrentConnection(client, generation)) {
+                initializationJob = scheduler.schedule(
+                        () -> initializeConnection(client, callbackUrl, refreshInterval, generation, retry),
+                        delaySeconds, TimeUnit.SECONDS);
+            }
+        }
+    }
+
+    private void initializeConnection(LoqedLocalApiClient client, String callbackUrl, int refreshInterval,
+            long generation, int retry) {
+        boolean retryInitialization = false;
+        try {
+            long registeredWebhookId;
+            boolean active;
+            synchronized (connectionLock) {
+                registeredWebhookId = client.ensureWebhook(callbackUrl);
+                synchronized (lifecycleLock) {
+                    active = isCurrentConnection(client, generation);
+                    if (active) {
+                        webhookId = registeredWebhookId;
+                        webhookActive = true;
+                        pollingJob = scheduler.scheduleWithFixedDelay(this::refresh, 0,
+                                WEBHOOK_REFRESH_INTERVAL_SECONDS, TimeUnit.SECONDS);
+                    }
+                }
+            }
+            if (!active) {
+                scheduleWebhookRemoval(client, registeredWebhookId);
+            }
+        } catch (LoqedAuthenticationException e) {
+            if (isCurrentConnection(client, generation)) {
+                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
+                        "@text/thing-status.loqed.local-bridge.authentication-error");
+                logger.debug("Could not authenticate with the LOQED local bridge", e);
+            }
+        } catch (LoqedConfigurationException e) {
+            if (isCurrentConnection(client, generation)) {
+                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
+                        "@text/thing-status.loqed.local-bridge.configuration-invalid");
+                logger.debug("Invalid LOQED local bridge configuration", e);
+            }
+        } catch (LoqedCommunicationException | LoqedResponseException e) {
+            if (isCurrentConnection(client, generation)) {
+                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
+                        "@text/thing-status.loqed.local-bridge.communication-error");
+                if (retry < MAX_INITIALIZATION_RETRIES) {
+                    retryInitialization = true;
+                    logger.debug("Could not initialize LOQED local bridge, retrying ({}/{})", retry + 1,
+                            MAX_INITIALIZATION_RETRIES, e);
+                } else {
+                    startPolling(client, refreshInterval, generation);
+                    logger.debug("Could not initialize LOQED webhook after {} retries, using fallback polling",
+                            MAX_INITIALIZATION_RETRIES, e);
+                }
+            }
+        } catch (LoqedApiException e) {
+            if (isCurrentConnection(client, generation)) {
+                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
+                        "@text/thing-status.loqed.local-bridge.communication-error");
+                logger.debug("Could not initialize LOQED local bridge", e);
+            }
+        } finally {
+            synchronized (lifecycleLock) {
+                if (isCurrentConnection(client, generation)) {
+                    initializationJob = null;
+                }
+            }
+        }
+        if (retryInitialization) {
+            scheduleInitialization(client, callbackUrl, refreshInterval, generation, retry + 1,
+                    INITIALIZATION_RETRY_DELAY_SECONDS);
+        }
+    }
+
+    private void startPolling(LoqedLocalApiClient client, int refreshInterval, long generation) {
+        synchronized (lifecycleLock) {
+            if (isCurrentConnection(client, generation) && pollingJob == null) {
+                pollingJob = scheduler.scheduleWithFixedDelay(this::refresh, 0, refreshInterval, TimeUnit.SECONDS);
+            }
+        }
+    }
+
+    @Override
+    public void dispose() {
+        resetConnection();
+        locks = List.of();
+        status = null;
+    }
+
+    @Override
+    public void handleCommand(ChannelUID channelUID, Command command) {
+        // The local bridge has no channels.
+    }
+
+    @Override
+    public synchronized List<LoqedLockData> refreshAndGetLocks() {
+        refresh();
+        return locks;
+    }
+
+    @Override
+    public synchronized void refresh() {
+        LoqedLocalApiClient client = apiClient;
+        if (client == null) {
+            return;
+        }
+        try {
+            LoqedLockData currentStatus = client.getStatus();
+            List<LoqedLockData> refreshedLocks = createLocks(currentStatus);
+            synchronized (lifecycleLock) {
+                if (!client.equals(apiClient)) {
+                    return;
+                }
+                status = currentStatus;
+                locks = refreshedLocks;
+            }
+            if (!client.equals(apiClient)) {
+                return;
+            }
+            updateStatus(ThingStatus.ONLINE);
+            updateRecoveryPolling(client, currentStatus.online);
+            if (!client.equals(apiClient)) {
+                return;
+            }
+            updateChildren(refreshedLocks);
+        } catch (LoqedAuthenticationException e) {
+            if (client.equals(apiClient)) {
+                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
+                        "@text/thing-status.loqed.local-bridge.authentication-error");
+                logger.debug("Could not authenticate with the LOQED local bridge", e);
+            }
+        } catch (LoqedConfigurationException e) {
+            if (client.equals(apiClient)) {
+                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
+                        "@text/thing-status.loqed.local-bridge.configuration-invalid");
+                logger.debug("Invalid LOQED local bridge configuration", e);
+            }
+        } catch (LoqedApiException e) {
+            if (client.equals(apiClient)) {
+                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
+                        "@text/thing-status.loqed.local-bridge.communication-error");
+                logger.debug("Could not refresh LOQED local bridge", e);
+            }
+        }
+    }
+
+    @Override
+    public void setBoltState(String lockId, String keySecret, int localKeyId, BoltState boltState)
+            throws LoqedApiException {
+        LoqedLocalApiClient client = apiClient;
+        if (client == null) {
+            throw new LoqedCommunicationException("The LOQED local bridge is not initialized",
+                    new IllegalStateException());
+        }
+        boolean configured = getThing().getThings().stream()
+                .map(thing -> thing.getConfiguration().get(PROPERTY_LOCK_ID)).anyMatch(lockId::equals);
+        if (!configured) {
+            throw new LoqedConfigurationException("The lock does not belong to this LOQED local bridge");
+        }
+        client.setBoltState(keySecret, localKeyId, boltState);
+    }
+
+    @Override
+    public boolean usesPushUpdates() {
+        synchronized (lifecycleLock) {
+            return webhookActive;
+        }
+    }
+
+    @Override
+    public long getStateUpdateSequence(BoltState boltState) {
+        synchronized (lifecycleLock) {
+            return stateUpdateSequences.getOrDefault(boltState, 0L);
+        }
+    }
+
+    @Override
+    public boolean requiresLocalCredentials() {
+        return true;
+    }
+
+    public boolean handleWebhook(byte[] body, String timestamp, String hash) {
+        @Nullable
+        LoqedLocalApiClient client;
+        long generation;
+        synchronized (lifecycleLock) {
+            client = apiClient;
+            generation = lifecycleGeneration;
+        }
+        if (client == null || !client.verifyWebhook(body, timestamp, hash)) {
+            return false;
+        }
+
+        @Nullable
+        JsonElement parsed;
+        try {
+            parsed = GSON.fromJson(new String(body, java.nio.charset.StandardCharsets.UTF_8), JsonElement.class);
+        } catch (JsonParseException e) {
+            return false;
+        }
+        if (parsed == null || !parsed.isJsonObject()) {
+            return false;
+        }
+        return applyWebhook(client, generation, parsed.getAsJsonObject());
+    }
+
+    private synchronized boolean applyWebhook(LoqedLocalApiClient client, long generation, JsonObject event) {
+        @Nullable
+        LoqedLockData currentStatus;
+        boolean refreshRequired = false;
+        synchronized (lifecycleLock) {
+            if (!isCurrentConnection(client, generation)) {
+                return false;
+            }
+            JsonElement requestedState = event.get("requested_state");
+            if (requestedState != null && requestedState.isJsonPrimitive()) {
+                BoltState.fromApiValue(requestedState.getAsString())
+                        .ifPresent(state -> stateUpdateSequences.merge(state, 1L, Long::sum));
+            }
+            currentStatus = status;
+            if (currentStatus != null) {
+                refreshRequired = LoqedLocalApiClient.applyWebhook(currentStatus, event);
+            }
+        }
+        if (currentStatus == null || refreshRequired) {
+            scheduler.execute(this::refresh);
+            return true;
+        }
+
+        List<LoqedLockData> refreshedLocks = createLocks(currentStatus);
+        synchronized (lifecycleLock) {
+            if (!isCurrentConnection(client, generation)) {
+                return false;
+            }
+            locks = refreshedLocks;
+        }
+        if (!isCurrentConnection(client, generation)) {
+            return false;
+        }
+        updateStatus(ThingStatus.ONLINE);
+        if (!isCurrentConnection(client, generation)) {
+            return false;
+        }
+        updateChildren(refreshedLocks);
+        updateRecoveryPolling(client, currentStatus.online);
+        return true;
+    }
+
+    private void updateRecoveryPolling(LoqedLocalApiClient client, boolean lockOnline) {
+        synchronized (lifecycleLock) {
+            if (!client.equals(apiClient)) {
+                return;
+            }
+            ScheduledFuture<?> job = recoveryJob;
+            if (lockOnline) {
+                if (job != null) {
+                    job.cancel(false);
+                    recoveryJob = null;
+                    logger.debug("LOQED lock is online, stopping recovery polling");
+                }
+            } else if (job == null) {
+                recoveryJob = scheduler.scheduleWithFixedDelay(this::refresh, RECOVERY_REFRESH_INTERVAL_SECONDS,
+                        RECOVERY_REFRESH_INTERVAL_SECONDS, TimeUnit.SECONDS);
+                logger.debug("LOQED lock is offline, starting recovery polling every {} seconds",
+                        RECOVERY_REFRESH_INTERVAL_SECONDS);
+            }
+        }
+    }
+
+    private void updateChildren(List<LoqedLockData> lockSnapshot) {
+        getThing().getThings().stream().map(thing -> thing.getHandler()).filter(LoqedLockHandler.class::isInstance)
+                .map(LoqedLockHandler.class::cast).forEach(handler -> handler.updateFromBridge(lockSnapshot));
+    }
+
+    private List<LoqedLockData> createLocks(LoqedLockData currentStatus) {
+        List<LoqedLockData> result = new ArrayList<>();
+        getThing().getThings().forEach(thing -> {
+            LoqedConfiguration config = thing.getConfiguration().as(LoqedConfiguration.class);
+            if (!config.lockId.isBlank()) {
+                LoqedLockData lock = new LoqedLockData();
+                lock.id = config.lockId;
+                lock.name = Objects.requireNonNullElse(thing.getLabel(), "LOQED Smart Lock");
+                lock.modelName = currentStatus.modelName;
+                lock.online = currentStatus.online;
+                lock.batteryPercentage = currentStatus.batteryPercentage;
+                lock.batteryType = currentStatus.batteryType;
+                lock.boltState = currentStatus.boltState;
+                lock.partyMode = currentStatus.partyMode;
+                lock.guestAccessMode = currentStatus.guestAccessMode;
+                lock.twistAssist = currentStatus.twistAssist;
+                lock.touchToConnect = currentStatus.touchToConnect;
+                result.add(lock);
+            }
+        });
+        return List.copyOf(result);
+    }
+
+    private static String stripTrailingSlash(String value) {
+        String result = value.strip();
+        while (result.endsWith("/")) {
+            result = result.substring(0, result.length() - 1);
+        }
+        return result;
+    }
+
+    private void resetConnection() {
+        @Nullable
+        LoqedLocalApiClient client;
+        long registeredWebhookId;
+        synchronized (lifecycleLock) {
+            lifecycleGeneration++;
+            ScheduledFuture<?> job = initializationJob;
+            if (job != null) {
+                job.cancel(true);
+                initializationJob = null;
+            }
+            job = pollingJob;
+            if (job != null) {
+                job.cancel(true);
+                pollingJob = null;
+            }
+            job = recoveryJob;
+            if (job != null) {
+                job.cancel(true);
+                recoveryJob = null;
+            }
+            client = apiClient;
+            registeredWebhookId = webhookId;
+            apiClient = null;
+            webhookId = -1;
+            webhookActive = false;
+            stateUpdateSequences.clear();
+        }
+        if (client != null && registeredWebhookId >= 0) {
+            scheduleWebhookRemoval(client, registeredWebhookId);
+        }
+    }
+
+    private void scheduleWebhookRemoval(LoqedLocalApiClient client, long registeredWebhookId) {
+        try {
+            scheduler.execute(() -> removeWebhookUnlessInUse(client, registeredWebhookId));
+        } catch (RejectedExecutionException e) {
+            logger.debug("Could not schedule removal of LOQED webhook {}", registeredWebhookId, e);
+        }
+    }
+
+    private void removeWebhookUnlessInUse(LoqedLocalApiClient client, long registeredWebhookId) {
+        synchronized (connectionLock) {
+            synchronized (lifecycleLock) {
+                LoqedLocalApiClient currentClient = apiClient;
+                if (currentClient != null && currentClient.connectsToSameBridge(client)
+                        && webhookId == registeredWebhookId) {
+                    return;
+                }
+            }
+            removeWebhook(client, registeredWebhookId);
+        }
+    }
+
+    private void removeWebhook(LoqedLocalApiClient client, long registeredWebhookId) {
+        try {
+            client.removeWebhook(registeredWebhookId);
+        } catch (LoqedApiException e) {
+            logger.debug("Could not remove LOQED webhook {}", registeredWebhookId, e);
+        }
+    }
+
+    private boolean isCurrentConnection(LoqedLocalApiClient client, long generation) {
+        synchronized (lifecycleLock) {
+            return client.equals(apiClient) && lifecycleGeneration == generation;
+        }
+    }
+}

--- a/bundles/org.openhab.binding.loqed/src/main/java/org/openhab/binding/loqed/internal/LoqedLocalConfiguration.java
+++ b/bundles/org.openhab.binding.loqed/src/main/java/org/openhab/binding/loqed/internal/LoqedLocalConfiguration.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.loqed.internal;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * Configuration of a LOQED Local Bridge API connection.
+ *
+ * @author Ondrej Pecta - Initial contribution
+ */
+@NonNullByDefault
+public class LoqedLocalConfiguration {
+    public String host = "";
+    public String bridgeKey = "";
+    public String callbackBaseUrl = "";
+    public int refreshInterval = 60;
+
+    /**
+     * Validates the required local bridge configuration.
+     *
+     * @return an error message, or an empty string if the configuration is valid
+     */
+    public String validate() {
+        return host.isBlank() || bridgeKey.isBlank() ? "Host and bridge key are required" : "";
+    }
+}

--- a/bundles/org.openhab.binding.loqed/src/main/java/org/openhab/binding/loqed/internal/LoqedLockHandler.java
+++ b/bundles/org.openhab.binding.loqed/src/main/java/org/openhab/binding/loqed/internal/LoqedLockHandler.java
@@ -1,0 +1,276 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.loqed.internal;
+
+import static org.openhab.binding.loqed.internal.LoqedBindingConstants.*;
+
+import java.util.List;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.loqed.internal.api.BoltState;
+import org.openhab.binding.loqed.internal.api.LoqedApiException;
+import org.openhab.binding.loqed.internal.api.LoqedAuthenticationException;
+import org.openhab.binding.loqed.internal.api.LoqedConfigurationException;
+import org.openhab.binding.loqed.internal.api.LoqedLockData;
+import org.openhab.core.library.types.DecimalType;
+import org.openhab.core.library.types.OnOffType;
+import org.openhab.core.library.types.StringType;
+import org.openhab.core.thing.Bridge;
+import org.openhab.core.thing.ChannelUID;
+import org.openhab.core.thing.Thing;
+import org.openhab.core.thing.ThingStatus;
+import org.openhab.core.thing.ThingStatusDetail;
+import org.openhab.core.thing.binding.BaseThingHandler;
+import org.openhab.core.types.Command;
+import org.openhab.core.types.RefreshType;
+import org.openhab.core.types.UnDefType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Handles a single LOQED lock.
+ *
+ * @author Ondrej Pecta - Initial contribution
+ */
+@NonNullByDefault
+public class LoqedLockHandler extends BaseThingHandler {
+    private final Logger logger = LoggerFactory.getLogger(LoqedLockHandler.class);
+    private final Object lifecycleLock = new Object();
+    private String lockId = "";
+    private String keySecret = "";
+    private int localKeyId = -1;
+    private @Nullable ScheduledFuture<?> initializationJob;
+    private long lifecycleGeneration;
+
+    public LoqedLockHandler(Thing thing) {
+        super(thing);
+    }
+
+    @Override
+    public void initialize() {
+        long generation;
+        synchronized (lifecycleLock) {
+            lifecycleGeneration++;
+            cancelInitializationJob();
+            generation = lifecycleGeneration;
+        }
+        LoqedConfiguration config = getConfigAs(LoqedConfiguration.class);
+        String configuredLockId = config.lockId;
+        String configuredKeySecret = config.keySecret;
+        int configuredLocalKeyId = config.localKeyId;
+        synchronized (lifecycleLock) {
+            if (generation != lifecycleGeneration) {
+                return;
+            }
+            lockId = configuredLockId;
+            keySecret = configuredKeySecret;
+            localKeyId = configuredLocalKeyId;
+        }
+        if (configuredLockId.isBlank()) {
+            updateInitializationStatus(generation, ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
+                    "@text/thing-status.loqed.lock.id-empty");
+            return;
+        }
+        synchronized (lifecycleLock) {
+            if (generation == lifecycleGeneration) {
+                updateStatus(ThingStatus.UNKNOWN);
+                initializationJob = scheduler.schedule(
+                        () -> initializeConnection(generation, configuredKeySecret, configuredLocalKeyId), 0,
+                        TimeUnit.SECONDS);
+            }
+        }
+    }
+
+    private void initializeConnection(long generation, String configuredKeySecret, int configuredLocalKeyId) {
+        try {
+            LoqedBridge bridgeHandler = getBridgeHandler();
+            if (bridgeHandler == null) {
+                updateInitializationStatus(generation, ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE,
+                        "@text/thing-status.loqed.lock.bridge-unavailable");
+            } else if (bridgeHandler.requiresLocalCredentials()
+                    && (configuredKeySecret.isBlank() || configuredLocalKeyId < 0 || configuredLocalKeyId > 250)) {
+                updateInitializationStatus(generation, ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
+                        "@text/thing-status.loqed.lock.local-credentials-invalid");
+            } else {
+                List<LoqedLockData> refreshedLocks = bridgeHandler.refreshAndGetLocks();
+                synchronized (lifecycleLock) {
+                    if (generation == lifecycleGeneration) {
+                        updateFromBridge(refreshedLocks);
+                    }
+                }
+            }
+        } finally {
+            synchronized (lifecycleLock) {
+                if (generation == lifecycleGeneration) {
+                    initializationJob = null;
+                }
+            }
+        }
+    }
+
+    private void updateInitializationStatus(long generation, ThingStatus status, ThingStatusDetail statusDetail,
+            String description) {
+        synchronized (lifecycleLock) {
+            if (generation == lifecycleGeneration) {
+                updateStatus(status, statusDetail, description);
+            }
+        }
+    }
+
+    @Override
+    public void dispose() {
+        synchronized (lifecycleLock) {
+            lifecycleGeneration++;
+            cancelInitializationJob();
+        }
+    }
+
+    private void cancelInitializationJob() {
+        ScheduledFuture<?> job = initializationJob;
+        if (job != null) {
+            job.cancel(true);
+            initializationJob = null;
+        }
+    }
+
+    @Override
+    public void handleCommand(ChannelUID channelUID, Command command) {
+        if (command instanceof RefreshType) {
+            LoqedBridge bridgeHandler = getBridgeHandler();
+            if (bridgeHandler != null) {
+                scheduler.execute(bridgeHandler::refresh);
+            }
+            return;
+        }
+
+        @Nullable
+        BoltState boltState = null;
+        if (CHANNEL_LOCK.equals(channelUID.getId()) && command instanceof OnOffType onOffCommand) {
+            boltState = onOffCommand == OnOffType.ON ? BoltState.NIGHT_LOCK : BoltState.DAY_LOCK;
+        } else if (CHANNEL_BOLT_STATE.equals(channelUID.getId()) && command instanceof StringType stringCommand) {
+            boltState = BoltState.fromApiValue(stringCommand.toString()).filter(state -> state != BoltState.UNKNOWN)
+                    .orElse(null);
+        }
+
+        if (boltState != null) {
+            long generation;
+            String commandLockId;
+            String commandKeySecret;
+            int commandLocalKeyId;
+            @Nullable
+            LoqedBridge bridgeHandler;
+            synchronized (lifecycleLock) {
+                generation = lifecycleGeneration;
+                commandLockId = lockId;
+                commandKeySecret = keySecret;
+                commandLocalKeyId = localKeyId;
+                bridgeHandler = getBridgeHandler();
+            }
+            BoltState requestedState = boltState;
+            scheduler.execute(() -> setBoltState(generation, bridgeHandler, commandLockId, commandKeySecret,
+                    commandLocalKeyId, requestedState));
+        }
+    }
+
+    private void setBoltState(long generation, @Nullable LoqedBridge bridgeHandler, String commandLockId,
+            String commandKeySecret, int commandLocalKeyId, BoltState boltState) {
+        if (!isCurrentGeneration(generation)) {
+            return;
+        }
+        if (bridgeHandler == null) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE,
+                    "@text/thing-status.loqed.lock.bridge-unavailable");
+            return;
+        }
+        try {
+            long stateUpdateSequence = bridgeHandler.getStateUpdateSequence(boltState);
+            bridgeHandler.setBoltState(commandLockId, commandKeySecret, commandLocalKeyId, boltState);
+            if (isCurrentGeneration(generation)) {
+                scheduler.schedule(() -> refreshAfterCommand(generation, bridgeHandler, boltState, stateUpdateSequence),
+                        10, TimeUnit.SECONDS);
+            }
+        } catch (LoqedAuthenticationException | LoqedConfigurationException e) {
+            logger.debug("Could not set LOQED lock {} to {}", commandLockId, boltState, e);
+            if (isCurrentGeneration(generation)) {
+                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
+                        "@text/thing-status.loqed.lock.command-configuration-error");
+            }
+        } catch (LoqedApiException e) {
+            logger.debug("Could not set LOQED lock {} to {}", commandLockId, boltState, e);
+            if (isCurrentGeneration(generation)) {
+                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
+                        "@text/thing-status.loqed.lock.command-communication-error");
+            }
+        }
+    }
+
+    private void refreshAfterCommand(long generation, LoqedBridge bridgeHandler, BoltState boltState,
+            long stateUpdateSequence) {
+        if (isCurrentGeneration(generation) && (!bridgeHandler.usesPushUpdates()
+                || bridgeHandler.getStateUpdateSequence(boltState) == stateUpdateSequence)) {
+            logger.debug("No LOQED state update received after command, refreshing lock status");
+            bridgeHandler.refresh();
+        }
+    }
+
+    private boolean isCurrentGeneration(long generation) {
+        synchronized (lifecycleLock) {
+            return generation == lifecycleGeneration;
+        }
+    }
+
+    public void updateFromBridge(List<LoqedLockData> locks) {
+        locks.stream().filter(lock -> lockId.equals(lock.id)).findFirst().ifPresentOrElse(this::updateChannels, () -> {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
+                    "@text/thing-status.loqed.lock.unavailable");
+            getThing().getChannels().forEach(channel -> updateState(channel.getUID(), UnDefType.UNDEF));
+        });
+    }
+
+    private void updateChannels(LoqedLockData lock) {
+        if (!lock.online) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
+                    "@text/thing-status.loqed.lock.disconnected");
+            updateState(CHANNEL_BOLT_STATE, UnDefType.UNDEF);
+            updateState(CHANNEL_LOCK, UnDefType.UNDEF);
+            updateState(CHANNEL_BATTERY_LEVEL, UnDefType.UNDEF);
+            return;
+        }
+        updateStatus(ThingStatus.ONLINE);
+        updateState(CHANNEL_BOLT_STATE, new StringType(lock.boltState.name()));
+        updateState(CHANNEL_LOCK, lock.boltState == BoltState.UNKNOWN ? UnDefType.UNDEF
+                : OnOffType.from(lock.boltState == BoltState.NIGHT_LOCK));
+        if (lock.batteryPercentage >= 0) {
+            updateState(CHANNEL_BATTERY_LEVEL, new DecimalType(lock.batteryPercentage));
+        } else {
+            updateState(CHANNEL_BATTERY_LEVEL, UnDefType.UNDEF);
+        }
+        updateState(CHANNEL_BATTERY_TYPE, new StringType(lock.batteryType));
+        updateOptionalState(CHANNEL_PARTY_MODE, lock.partyMode);
+        updateOptionalState(CHANNEL_GUEST_ACCESS, lock.guestAccessMode);
+        updateOptionalState(CHANNEL_TWIST_ASSIST, lock.twistAssist);
+        updateOptionalState(CHANNEL_TOUCH_TO_CONNECT, lock.touchToConnect);
+    }
+
+    private void updateOptionalState(String channelId, @Nullable Boolean value) {
+        updateState(channelId, value == null ? UnDefType.UNDEF : OnOffType.from(value));
+    }
+
+    private @Nullable LoqedBridge getBridgeHandler() {
+        Bridge bridge = getBridge();
+        return bridge != null && bridge.getHandler() instanceof LoqedBridge handler ? handler : null;
+    }
+}

--- a/bundles/org.openhab.binding.loqed/src/main/java/org/openhab/binding/loqed/internal/LoqedWebhookServlet.java
+++ b/bundles/org.openhab.binding.loqed/src/main/java/org/openhab/binding/loqed/internal/LoqedWebhookServlet.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.loqed.internal;
+
+import static org.openhab.binding.loqed.internal.LoqedBindingConstants.WEBHOOK_PATH;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import javax.servlet.Servlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.http.whiteboard.HttpWhiteboardConstants;
+
+/**
+ * Receives signed outgoing webhook calls from local LOQED bridges.
+ *
+ * @author Ondrej Pecta - Initial contribution
+ */
+@NonNullByDefault
+@Component(immediate = true, service = { Servlet.class, LoqedWebhookServlet.class }, property = {
+        HttpWhiteboardConstants.HTTP_WHITEBOARD_SERVLET_PATTERN + "=" + WEBHOOK_PATH + "/*",
+        HttpWhiteboardConstants.HTTP_WHITEBOARD_SERVLET_NAME + "=loqed-webhook" })
+public class LoqedWebhookServlet extends HttpServlet {
+    private static final long serialVersionUID = 1L;
+    private static final int MAX_BODY_SIZE = 65536;
+
+    private final Map<String, LoqedLocalBridgeHandler> handlers = new ConcurrentHashMap<>();
+
+    public void addHandler(String routeId, LoqedLocalBridgeHandler handler) {
+        handlers.put(routeId, handler);
+    }
+
+    public void removeHandler(LoqedLocalBridgeHandler handler) {
+        handlers.values().removeIf(value -> value.equals(handler));
+    }
+
+    @Override
+    protected void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        String routeId = request.getPathInfo();
+        if (routeId == null || routeId.length() < 2) {
+            response.sendError(HttpServletResponse.SC_NOT_FOUND);
+            return;
+        }
+        LoqedLocalBridgeHandler handler = handlers.get(routeId.substring(1));
+        if (handler == null) {
+            response.sendError(HttpServletResponse.SC_NOT_FOUND);
+            return;
+        }
+        if (request.getContentLengthLong() > MAX_BODY_SIZE) {
+            response.sendError(HttpServletResponse.SC_REQUEST_ENTITY_TOO_LARGE);
+            return;
+        }
+        byte[] body = request.getInputStream().readNBytes(MAX_BODY_SIZE + 1);
+        if (body.length > MAX_BODY_SIZE) {
+            response.sendError(HttpServletResponse.SC_REQUEST_ENTITY_TOO_LARGE);
+            return;
+        }
+        @Nullable
+        String timestamp = request.getHeader("TIMESTAMP");
+        @Nullable
+        String hash = request.getHeader("HASH");
+        if (timestamp == null || hash == null || !handler.handleWebhook(body, timestamp, hash)) {
+            response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+            return;
+        }
+        response.setStatus(HttpServletResponse.SC_OK);
+    }
+}

--- a/bundles/org.openhab.binding.loqed/src/main/java/org/openhab/binding/loqed/internal/api/BoltState.java
+++ b/bundles/org.openhab.binding.loqed/src/main/java/org/openhab/binding/loqed/internal/api/BoltState.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.loqed.internal.api;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * Bolt states supported by the LOQED APIs.
+ *
+ * @author Ondrej Pecta - Initial contribution
+ */
+@NonNullByDefault
+public enum BoltState {
+    @SerializedName("unknown")
+    UNKNOWN("unknown", 0),
+    @SerializedName("open")
+    OPEN("open", 1),
+    @SerializedName("day_lock")
+    DAY_LOCK("day_lock", 2),
+    @SerializedName("night_lock")
+    NIGHT_LOCK("night_lock", 3);
+
+    private final String apiValue;
+    private final int localAction;
+
+    BoltState(String apiValue, int localAction) {
+        this.apiValue = apiValue;
+        this.localAction = localAction;
+    }
+
+    /** Returns the value used by the LOQED APIs. */
+    public String apiValue() {
+        return apiValue;
+    }
+
+    /** Returns the numeric action used by signed local commands. */
+    public int localAction() {
+        return localAction;
+    }
+
+    /** Returns the state matching an API value, ignoring case. */
+    public static Optional<BoltState> fromApiValue(String value) {
+        if ("latch".equalsIgnoreCase(value)) {
+            return Optional.of(DAY_LOCK);
+        }
+        return Arrays.stream(values()).filter(state -> state.apiValue.equalsIgnoreCase(value)).findFirst();
+    }
+
+    /** Returns the state matching an API value, or {@link #UNKNOWN} if the value is not recognized. */
+    public static BoltState fromApiValueOrUnknown(String value) {
+        if ("latch".equalsIgnoreCase(value)) {
+            return DAY_LOCK;
+        }
+        for (BoltState state : values()) {
+            if (state.apiValue.equalsIgnoreCase(value)) {
+                return state;
+            }
+        }
+        return UNKNOWN;
+    }
+}

--- a/bundles/org.openhab.binding.loqed/src/main/java/org/openhab/binding/loqed/internal/api/LoqedApiClient.java
+++ b/bundles/org.openhab.binding.loqed/src/main/java/org/openhab/binding/loqed/internal/api/LoqedApiClient.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.loqed.internal.api;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.api.ContentResponse;
+import org.eclipse.jetty.http.HttpHeader;
+import org.eclipse.jetty.http.HttpMethod;
+import org.eclipse.jetty.http.HttpStatus;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonParser;
+
+/**
+ * Minimal client for the LOQED Integrations API.
+ *
+ * @author Ondrej Pecta - Initial contribution
+ */
+@NonNullByDefault
+public class LoqedApiClient {
+    private static final String API_BASE_URL = "https://integrations.production.loqed.com/api/locks";
+    private static final int TIMEOUT_SECONDS = 15;
+    private static final Gson GSON = new Gson();
+
+    private final HttpClient httpClient;
+    private final String apiToken;
+
+    public LoqedApiClient(HttpClient httpClient, String apiToken) {
+        this.httpClient = httpClient;
+        this.apiToken = apiToken;
+    }
+
+    public List<LoqedLockData> getLocks() throws LoqedApiException {
+        ContentResponse response = send(API_BASE_URL + "/");
+        return parseLocks(response.getContentAsString());
+    }
+
+    public void setBoltState(String lockId, BoltState boltState) throws LoqedApiException {
+        send(API_BASE_URL + "/" + lockId + "/bolt_state/" + boltState.apiValue());
+    }
+
+    private ContentResponse send(String url) throws LoqedApiException {
+        try {
+            ContentResponse response = httpClient.newRequest(url).method(HttpMethod.GET)
+                    .header(HttpHeader.AUTHORIZATION, "Bearer " + apiToken).timeout(TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                    .send();
+            if (!HttpStatus.isSuccess(response.getStatus())) {
+                throw responseException(response);
+            }
+            return response;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new LoqedCommunicationException("Communication with the LOQED API was interrupted", e);
+        } catch (ExecutionException | TimeoutException e) {
+            throw new LoqedCommunicationException("Could not communicate with the LOQED API", e);
+        }
+    }
+
+    private static LoqedApiException responseException(ContentResponse response) {
+        int statusCode = response.getStatus();
+        if (statusCode == HttpStatus.UNAUTHORIZED_401 || statusCode == HttpStatus.FORBIDDEN_403) {
+            return new LoqedAuthenticationException(statusCode);
+        }
+        return new LoqedResponseException(statusCode, response.getContentAsString());
+    }
+
+    static List<LoqedLockData> parseLocks(String json) throws LoqedResponseException {
+        try {
+            @Nullable
+            JsonElement response = JsonParser.parseString(json);
+            if (!response.isJsonObject()) {
+                throw new LoqedResponseException("The LOQED API returned an invalid response");
+            }
+            JsonElement data = response.getAsJsonObject().get("data");
+            if (data == null || !data.isJsonArray()) {
+                throw new LoqedResponseException("The LOQED API response does not contain a lock list");
+            }
+
+            List<LoqedLockData> locks = new ArrayList<>();
+            for (JsonElement element : data.getAsJsonArray()) {
+                if (!element.isJsonObject()) {
+                    throw new LoqedResponseException("The LOQED API returned invalid lock data");
+                }
+                @Nullable
+                LoqedLockData lock = GSON.fromJson(element, LoqedLockData.class);
+                if (lock == null) {
+                    throw new LoqedResponseException("The LOQED API returned invalid lock data");
+                }
+                lock.boltState = Objects.requireNonNullElse(lock.boltState, BoltState.UNKNOWN);
+                locks.add(lock);
+            }
+            return List.copyOf(locks);
+        } catch (JsonParseException | IllegalStateException e) {
+            throw new LoqedResponseException("The LOQED API returned invalid JSON", e);
+        }
+    }
+}

--- a/bundles/org.openhab.binding.loqed/src/main/java/org/openhab/binding/loqed/internal/api/LoqedApiException.java
+++ b/bundles/org.openhab.binding.loqed/src/main/java/org/openhab/binding/loqed/internal/api/LoqedApiException.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.loqed.internal.api;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * Base class for errors reported by the LOQED APIs.
+ *
+ * @author Ondrej Pecta - Initial contribution
+ */
+@NonNullByDefault
+public class LoqedApiException extends Exception {
+    private static final long serialVersionUID = 1L;
+
+    public LoqedApiException(String message) {
+        super(message);
+    }
+
+    public LoqedApiException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/bundles/org.openhab.binding.loqed/src/main/java/org/openhab/binding/loqed/internal/api/LoqedAuthenticationException.java
+++ b/bundles/org.openhab.binding.loqed/src/main/java/org/openhab/binding/loqed/internal/api/LoqedAuthenticationException.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.loqed.internal.api;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * Indicates that LOQED rejected the supplied authentication credentials.
+ *
+ * @author Ondrej Pecta - Initial contribution
+ */
+@NonNullByDefault
+public class LoqedAuthenticationException extends LoqedApiException {
+    private static final long serialVersionUID = 1L;
+
+    public LoqedAuthenticationException(int statusCode) {
+        super("LOQED rejected the supplied credentials with HTTP " + statusCode);
+    }
+}

--- a/bundles/org.openhab.binding.loqed/src/main/java/org/openhab/binding/loqed/internal/api/LoqedCommunicationException.java
+++ b/bundles/org.openhab.binding.loqed/src/main/java/org/openhab/binding/loqed/internal/api/LoqedCommunicationException.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.loqed.internal.api;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * Indicates a transport error while communicating with LOQED.
+ *
+ * @author Ondrej Pecta - Initial contribution
+ */
+@NonNullByDefault
+public class LoqedCommunicationException extends LoqedApiException {
+    private static final long serialVersionUID = 1L;
+
+    public LoqedCommunicationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/bundles/org.openhab.binding.loqed/src/main/java/org/openhab/binding/loqed/internal/api/LoqedConfigurationException.java
+++ b/bundles/org.openhab.binding.loqed/src/main/java/org/openhab/binding/loqed/internal/api/LoqedConfigurationException.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.loqed.internal.api;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * Indicates invalid LOQED binding configuration.
+ *
+ * @author Ondrej Pecta - Initial contribution
+ */
+@NonNullByDefault
+public class LoqedConfigurationException extends LoqedApiException {
+    private static final long serialVersionUID = 1L;
+
+    public LoqedConfigurationException(String message) {
+        super(message);
+    }
+
+    public LoqedConfigurationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/bundles/org.openhab.binding.loqed/src/main/java/org/openhab/binding/loqed/internal/api/LoqedLocalApiClient.java
+++ b/bundles/org.openhab.binding.loqed/src/main/java/org/openhab/binding/loqed/internal/api/LoqedLocalApiClient.java
@@ -1,0 +1,395 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.loqed.internal.api;
+
+import java.net.URI;
+import java.net.URLEncoder;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.security.InvalidKeyException;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Instant;
+import java.util.Base64;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.api.ContentResponse;
+import org.eclipse.jetty.client.util.StringContentProvider;
+import org.eclipse.jetty.http.HttpHeader;
+import org.eclipse.jetty.http.HttpMethod;
+import org.eclipse.jetty.http.HttpStatus;
+import org.openhab.binding.loqed.internal.LoqedLocalConfiguration;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+
+/**
+ * Client for the API exposed by a LOQED bridge on the local network.
+ *
+ * @author Ondrej Pecta - Initial contribution
+ */
+@NonNullByDefault
+public class LoqedLocalApiClient {
+    private static final String CONTENT_TYPE_JSON = "application/json";
+    private static final int TIMEOUT_SECONDS = 15;
+    private static final int WEBHOOK_FLAGS = 0x18F;
+    private static final Gson GSON = new Gson();
+
+    private final HttpClient httpClient;
+    private final String baseUrl;
+    private final byte[] bridgeKey;
+
+    public LoqedLocalApiClient(HttpClient httpClient, LoqedLocalConfiguration config)
+            throws LoqedConfigurationException {
+        this.httpClient = httpClient;
+        baseUrl = normalizeHost(config.host);
+        try {
+            bridgeKey = Base64.getDecoder().decode(config.bridgeKey);
+        } catch (IllegalArgumentException e) {
+            throw new LoqedConfigurationException("The LOQED bridge key is not valid Base64", e);
+        }
+    }
+
+    public LoqedLockData getStatus() throws LoqedApiException {
+        return parseStatus(send(baseUrl + "/status", HttpMethod.GET, null).getContentAsString());
+    }
+
+    public void setBoltState(String keySecret, int localKeyId, BoltState boltState) throws LoqedApiException {
+        if (boltState == BoltState.UNKNOWN) {
+            throw new LoqedConfigurationException("Unsupported LOQED bolt state: " + boltState);
+        }
+        long timestamp = Instant.now().getEpochSecond();
+        byte[] command = createSignedCommand(keySecret, localKeyId, boltState.localAction(), timestamp);
+        String encoded = URLEncoder.encode(Base64.getEncoder().encodeToString(command), StandardCharsets.UTF_8);
+        send(baseUrl + "/to_lock?command_signed_base64=" + encoded, HttpMethod.GET, null);
+    }
+
+    /**
+     * Ensures that exactly one webhook exists for the callback route and returns its bridge-assigned identifier.
+     *
+     * @param callbackUrl complete callback URL
+     * @return webhook identifier assigned by the bridge
+     * @throws LoqedApiException if the webhook cannot be listed, created, or reconciled
+     */
+    public long ensureWebhook(String callbackUrl) throws LoqedApiException {
+        List<Webhook> webhooks = listWebhooks();
+        @Nullable
+        Webhook currentWebhook = null;
+        for (Webhook webhook : webhooks) {
+            if (callbackUrl.equals(webhook.url)) {
+                if (currentWebhook == null) {
+                    currentWebhook = webhook;
+                } else {
+                    removeWebhook(webhook.id);
+                }
+            } else if (hasSameCallbackPath(webhook.url, callbackUrl)) {
+                removeWebhook(webhook.id);
+            }
+        }
+        if (currentWebhook != null) {
+            return currentWebhook.id;
+        }
+
+        createWebhook(callbackUrl);
+        return listWebhooks().stream().filter(webhook -> callbackUrl.equals(webhook.url)).mapToLong(Webhook::id)
+                .findFirst()
+                .orElseThrow(() -> new LoqedResponseException("The LOQED local bridge did not return the new webhook"));
+    }
+
+    /**
+     * Removes a webhook from the local bridge.
+     *
+     * @param webhookId bridge-assigned webhook identifier
+     * @throws LoqedApiException if the webhook cannot be removed
+     */
+    public void removeWebhook(long webhookId) throws LoqedApiException {
+        long timestamp = Instant.now().getEpochSecond();
+        String deleteHash = createWebhookDeleteHash(webhookId, timestamp);
+        sendWebhookRequest(HttpMethod.DELETE, baseUrl + "/webhooks/" + webhookId, null, timestamp, deleteHash);
+    }
+
+    /** Returns whether another client communicates with the same local bridge endpoint. */
+    public boolean connectsToSameBridge(LoqedLocalApiClient other) {
+        return baseUrl.equals(other.baseUrl);
+    }
+
+    /**
+     * Applies a local webhook payload to the latest known lock status.
+     *
+     * @param currentStatus latest known lock status
+     * @param event webhook payload
+     * @return {@code true} when the lock transitioned from offline to online and requires a full status refresh
+     */
+    public static boolean applyWebhook(LoqedLockData currentStatus, JsonObject event) {
+        boolean wasOnline = currentStatus.online;
+        String requestedState = getString(event, "requested_state", "");
+        if (!requestedState.isEmpty()) {
+            BoltState.fromApiValue(requestedState).ifPresent(state -> currentStatus.boltState = state);
+        }
+
+        JsonElement batteryPercentage = event.get("battery_percentage");
+        if (batteryPercentage != null && batteryPercentage.isJsonPrimitive()) {
+            currentStatus.batteryPercentage = batteryPercentage.getAsInt();
+        }
+        JsonElement batteryType = event.get("battery_type");
+        if (batteryType != null) {
+            currentStatus.batteryType = batteryType(batteryType);
+        }
+        JsonElement bleStrength = event.get("ble_strength");
+        if (bleStrength != null && bleStrength.isJsonPrimitive()) {
+            currentStatus.online = bleStrength.getAsInt() != -1;
+        }
+        boolean becameOnline = !wasOnline && currentStatus.online;
+        if (becameOnline) {
+            currentStatus.boltState = BoltState.UNKNOWN;
+            currentStatus.batteryPercentage = -1;
+        }
+        return becameOnline;
+    }
+
+    private List<Webhook> listWebhooks() throws LoqedApiException {
+        long timestamp = Instant.now().getEpochSecond();
+        String listHash = sha256Hex(longBytes(timestamp), bridgeKey);
+        ContentResponse response = sendWebhookRequest(HttpMethod.GET, baseUrl + "/webhooks", null, timestamp, listHash);
+        try {
+            JsonElement responseBody = GSON.fromJson(response.getContentAsString(), JsonElement.class);
+            if (responseBody == null || !responseBody.isJsonArray()) {
+                throw new LoqedResponseException("The LOQED local bridge returned an invalid webhook list");
+            }
+            return responseBody.getAsJsonArray().asList().stream().filter(JsonElement::isJsonObject)
+                    .map(JsonElement::getAsJsonObject)
+                    .map(webhook -> new Webhook(getLong(webhook, "id", -1), getString(webhook, "url", "")))
+                    .filter(webhook -> webhook.id >= 0 && !webhook.url.isEmpty()).toList();
+        } catch (JsonParseException | IllegalStateException | NumberFormatException e) {
+            throw new LoqedResponseException("The LOQED local bridge returned an invalid webhook list", e);
+        }
+    }
+
+    private void createWebhook(String callbackUrl) throws LoqedApiException {
+        JsonObject body = new JsonObject();
+        body.addProperty("url", callbackUrl);
+        body.addProperty("trigger_state_changed_open", 1);
+        body.addProperty("trigger_state_changed_latch", 1);
+        body.addProperty("trigger_state_changed_night_lock", 1);
+        body.addProperty("trigger_state_changed_unknown", 1);
+        body.addProperty("trigger_state_goto_open", 0);
+        body.addProperty("trigger_state_goto_latch", 0);
+        body.addProperty("trigger_state_goto_night_lock", 0);
+        body.addProperty("trigger_battery", 1);
+        body.addProperty("trigger_online_status", 1);
+
+        long timestamp = Instant.now().getEpochSecond();
+        String createHash = sha256Hex(callbackUrl.getBytes(StandardCharsets.UTF_8), intBytes(WEBHOOK_FLAGS),
+                longBytes(timestamp), bridgeKey);
+        sendWebhookRequest(HttpMethod.POST, baseUrl + "/webhooks", GSON.toJson(body), timestamp, createHash);
+    }
+
+    public boolean verifyWebhook(byte[] body, String timestampHeader, String hashHeader) {
+        try {
+            long timestamp = Long.parseLong(timestampHeader);
+            if (Math.abs(Instant.now().getEpochSecond() - timestamp) > 10) {
+                return false;
+            }
+            byte[] expected = HexFormat.of().parseHex(sha256Hex(body, longBytes(timestamp), bridgeKey));
+            byte[] supplied = HexFormat.of().parseHex(hashHeader);
+            return MessageDigest.isEqual(expected, supplied);
+        } catch (IllegalArgumentException | LoqedApiException e) {
+            return false;
+        }
+    }
+
+    byte[] createSignedCommand(String keySecret, int localKeyId, int action, long timestamp) throws LoqedApiException {
+        byte[] payload = ByteBuffer.allocate(13).put((byte) 2).put((byte) 7).putLong(timestamp).put((byte) localKeyId)
+                .put((byte) 1).put((byte) action).array();
+        try {
+            Mac mac = Mac.getInstance("HmacSHA256");
+            mac.init(new SecretKeySpec(Base64.getDecoder().decode(keySecret), "HmacSHA256"));
+            byte[] signature = mac.doFinal(payload);
+            return ByteBuffer.allocate(53).putLong(0).put((byte) 2).put((byte) 7).putLong(timestamp).put(signature)
+                    .put((byte) localKeyId).put((byte) 1).put((byte) action).array();
+        } catch (InvalidKeyException | NoSuchAlgorithmException | IllegalArgumentException e) {
+            throw new LoqedConfigurationException("Could not sign the LOQED local command", e);
+        }
+    }
+
+    String createWebhookDeleteHash(long webhookId, long timestamp) throws LoqedApiException {
+        return sha256Hex(longBytes(webhookId), longBytes(timestamp), bridgeKey);
+    }
+
+    private ContentResponse sendWebhookRequest(HttpMethod method, String url, @Nullable String body, long timestamp,
+            String hash) throws LoqedApiException {
+        try {
+            var request = httpClient.newRequest(url).method(method).header("TIMESTAMP", Long.toString(timestamp))
+                    .header("HASH", hash).timeout(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            if (body != null) {
+                request.header(HttpHeader.CONTENT_TYPE, CONTENT_TYPE_JSON)
+                        .content(new StringContentProvider(body, StandardCharsets.UTF_8));
+            }
+            ContentResponse response = request.send();
+            if (!HttpStatus.isSuccess(response.getStatus())) {
+                throw responseException(response);
+            }
+            return response;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new LoqedCommunicationException("Communication with the LOQED local bridge was interrupted", e);
+        } catch (ExecutionException | TimeoutException e) {
+            throw new LoqedCommunicationException("Could not communicate with the LOQED local bridge", e);
+        }
+    }
+
+    private ContentResponse send(String url, HttpMethod method, @Nullable String body) throws LoqedApiException {
+        try {
+            var request = httpClient.newRequest(url).method(method).timeout(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            if (body != null) {
+                request.content(new StringContentProvider(body, StandardCharsets.UTF_8));
+            }
+            ContentResponse response = request.send();
+            if (!HttpStatus.isSuccess(response.getStatus())) {
+                throw responseException(response);
+            }
+            return response;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new LoqedCommunicationException("Communication with the LOQED local bridge was interrupted", e);
+        } catch (ExecutionException | TimeoutException e) {
+            throw new LoqedCommunicationException("Could not communicate with the LOQED local bridge", e);
+        }
+    }
+
+    private static LoqedApiException responseException(ContentResponse response) {
+        int statusCode = response.getStatus();
+        if (statusCode == HttpStatus.UNAUTHORIZED_401 || statusCode == HttpStatus.FORBIDDEN_403) {
+            return new LoqedAuthenticationException(statusCode);
+        }
+        return new LoqedResponseException(statusCode, response.getContentAsString());
+    }
+
+    static LoqedLockData parseStatus(String json) throws LoqedResponseException {
+        try {
+            @Nullable
+            JsonElement element = GSON.fromJson(json, JsonElement.class);
+            if (element == null || !element.isJsonObject()) {
+                throw new LoqedResponseException("The LOQED local bridge returned an invalid response");
+            }
+            JsonObject status = element.getAsJsonObject();
+            LoqedLockData lock = new LoqedLockData();
+            lock.modelName = "LOQED Smart Lock";
+            lock.batteryPercentage = getInt(status, "battery_percentage", -1);
+            lock.batteryType = batteryType(status.get("battery_type"));
+            lock.boltState = BoltState.fromApiValueOrUnknown(getString(status, "bolt_state", "unknown"));
+            lock.online = getBoolean(status, "lock_online");
+            lock.partyMode = getOptionalBoolean(status, "party_mode");
+            lock.guestAccessMode = getOptionalBoolean(status, "guest_access_mode");
+            lock.twistAssist = getOptionalBoolean(status, "twist_assist");
+            lock.touchToConnect = getOptionalBoolean(status, "touch_to_connect");
+            return lock;
+        } catch (JsonParseException | IllegalStateException | NumberFormatException e) {
+            throw new LoqedResponseException("The LOQED local bridge returned invalid JSON", e);
+        }
+    }
+
+    private static int getInt(JsonObject object, String name, int defaultValue) {
+        JsonElement value = object.get(name);
+        return value != null && value.isJsonPrimitive() ? value.getAsInt() : defaultValue;
+    }
+
+    private static long getLong(JsonObject object, String name, long defaultValue) {
+        JsonElement value = object.get(name);
+        return value != null && value.isJsonPrimitive() ? value.getAsLong() : defaultValue;
+    }
+
+    private static boolean getBoolean(JsonObject object, String name) {
+        return getInt(object, name, 0) != 0;
+    }
+
+    private static @Nullable Boolean getOptionalBoolean(JsonObject object, String name) {
+        JsonElement value = object.get(name);
+        return value != null && value.isJsonPrimitive() ? value.getAsInt() != 0 : null;
+    }
+
+    private static String getString(JsonObject object, String name, String defaultValue) {
+        JsonElement value = object.get(name);
+        return value != null && value.isJsonPrimitive() ? value.getAsString() : defaultValue;
+    }
+
+    private static String batteryType(@Nullable JsonElement value) {
+        if (value == null || !value.isJsonPrimitive()) {
+            return "unknown";
+        }
+        if (value.getAsJsonPrimitive().isNumber()) {
+            return switch (value.getAsInt()) {
+                case 0 -> "alkaline";
+                case 1 -> "nimh";
+                case 2 -> "lithium";
+                default -> "unknown";
+            };
+        }
+        return value.getAsString();
+    }
+
+    private static String normalizeHost(String host) {
+        String result = host.strip();
+        if (!result.startsWith("http://") && !result.startsWith("https://")) {
+            result = "http://" + result;
+        }
+        while (result.endsWith("/")) {
+            result = result.substring(0, result.length() - 1);
+        }
+        return result;
+    }
+
+    static boolean hasSameCallbackPath(String registeredUrl, String callbackUrl) {
+        try {
+            return Objects.equals(URI.create(registeredUrl).getPath(), URI.create(callbackUrl).getPath());
+        } catch (IllegalArgumentException e) {
+            return false;
+        }
+    }
+
+    private static byte[] intBytes(int value) {
+        return ByteBuffer.allocate(Integer.BYTES).putInt(value).array();
+    }
+
+    private static byte[] longBytes(long value) {
+        return ByteBuffer.allocate(Long.BYTES).putLong(value).array();
+    }
+
+    private static String sha256Hex(byte[]... parts) throws LoqedApiException {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            for (byte[] part : parts) {
+                digest.update(part);
+            }
+            return HexFormat.of().formatHex(digest.digest());
+        } catch (NoSuchAlgorithmException e) {
+            throw new LoqedConfigurationException("Could not calculate the LOQED authentication hash", e);
+        }
+    }
+
+    private record Webhook(long id, String url) {
+    }
+}

--- a/bundles/org.openhab.binding.loqed/src/main/java/org/openhab/binding/loqed/internal/api/LoqedLockData.java
+++ b/bundles/org.openhab.binding.loqed/src/main/java/org/openhab/binding/loqed/internal/api/LoqedLockData.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.loqed.internal.api;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * Data returned for one lock by the LOQED Integrations API.
+ *
+ * @author Ondrej Pecta - Initial contribution
+ */
+@NonNullByDefault
+public class LoqedLockData {
+    public boolean online = true;
+    public String id = "";
+    public String name = "";
+    @SerializedName("model_name")
+    public String modelName = "";
+    @SerializedName("battery_percentage")
+    public int batteryPercentage = -1;
+    @SerializedName("battery_type")
+    public String batteryType = "unknown";
+    @SerializedName("bolt_state")
+    public BoltState boltState = BoltState.UNKNOWN;
+    @SerializedName("party_mode")
+    public @Nullable Boolean partyMode;
+    @SerializedName("guest_access_mode")
+    public @Nullable Boolean guestAccessMode;
+    @SerializedName("twist_assist")
+    public @Nullable Boolean twistAssist;
+    @SerializedName("touch_to_connect")
+    public @Nullable Boolean touchToConnect;
+}

--- a/bundles/org.openhab.binding.loqed/src/main/java/org/openhab/binding/loqed/internal/api/LoqedResponseException.java
+++ b/bundles/org.openhab.binding.loqed/src/main/java/org/openhab/binding/loqed/internal/api/LoqedResponseException.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.loqed.internal.api;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * Indicates that LOQED returned an unsuccessful or invalid response.
+ *
+ * @author Ondrej Pecta - Initial contribution
+ */
+@NonNullByDefault
+public class LoqedResponseException extends LoqedApiException {
+    private static final long serialVersionUID = 1L;
+
+    public LoqedResponseException(String message) {
+        super(message);
+    }
+
+    public LoqedResponseException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public LoqedResponseException(int statusCode, String responseBody) {
+        super("LOQED API returned HTTP " + statusCode + (responseBody.isBlank() ? "" : ": " + responseBody));
+    }
+}

--- a/bundles/org.openhab.binding.loqed/src/main/java/org/openhab/binding/loqed/internal/discovery/LoqedDiscoveryService.java
+++ b/bundles/org.openhab.binding.loqed/src/main/java/org/openhab/binding/loqed/internal/discovery/LoqedDiscoveryService.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.loqed.internal.discovery;
+
+import static org.openhab.binding.loqed.internal.LoqedBindingConstants.*;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+import java.util.Map;
+import java.util.Set;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.binding.loqed.internal.LoqedBridgeHandler;
+import org.openhab.binding.loqed.internal.api.LoqedLockData;
+import org.openhab.core.config.discovery.AbstractThingHandlerDiscoveryService;
+import org.openhab.core.config.discovery.DiscoveryResultBuilder;
+import org.openhab.core.thing.ThingTypeUID;
+import org.openhab.core.thing.ThingUID;
+import org.openhab.core.thing.binding.ThingHandlerService;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ServiceScope;
+
+/**
+ * Discovers all locks returned by a configured LOQED account.
+ *
+ * @author Ondrej Pecta - Initial contribution
+ */
+@NonNullByDefault
+@Component(scope = ServiceScope.PROTOTYPE, service = LoqedDiscoveryService.class)
+public class LoqedDiscoveryService extends AbstractThingHandlerDiscoveryService<LoqedBridgeHandler>
+        implements ThingHandlerService {
+    private static final int DISCOVERY_TIMEOUT_SECONDS = 20;
+    private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES = Set.of(THING_TYPE_LOCK);
+
+    @Activate
+    public LoqedDiscoveryService() {
+        super(LoqedBridgeHandler.class, SUPPORTED_THING_TYPES, DISCOVERY_TIMEOUT_SECONDS, false);
+    }
+
+    @Override
+    protected void startScan() {
+        ThingUID bridgeUID = thingHandler.getThing().getUID();
+        for (LoqedLockData lock : thingHandler.refreshAndGetLocks()) {
+            ThingUID thingUID = new ThingUID(THING_TYPE_LOCK, bridgeUID, uidSegment(lock.id));
+            thingDiscovered(DiscoveryResultBuilder.create(thingUID).withBridge(bridgeUID).withLabel(lock.name)
+                    .withProperties(Map.of(PROPERTY_LOCK_ID, lock.id, PROPERTY_MODEL, lock.modelName))
+                    .withRepresentationProperty(PROPERTY_LOCK_ID).build());
+        }
+    }
+
+    private String uidSegment(String lockId) {
+        try {
+            byte[] digest = MessageDigest.getInstance("SHA-256").digest(lockId.getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(digest, 0, 8);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 is not available", e);
+        }
+    }
+}

--- a/bundles/org.openhab.binding.loqed/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.binding.loqed/src/main/resources/OH-INF/addon/addon.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<addon:addon id="loqed" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:addon="https://openhab.org/schemas/addon/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/addon/v1.0.0 https://openhab.org/schemas/addon-1.0.0.xsd">
+
+	<type>binding</type>
+	<name>LOQED Binding</name>
+	<description>Controls LOQED Touch and LOQED Pure smart locks.</description>
+	<connection>hybrid</connection>
+
+	<discovery-methods>
+		<discovery-method>
+			<service-type>mdns</service-type>
+			<discovery-parameters>
+				<discovery-parameter>
+					<name>mdnsServiceType</name>
+					<value>_http._tcp.local.</value>
+				</discovery-parameter>
+			</discovery-parameters>
+			<match-properties>
+				<match-property>
+					<name>name</name>
+					<regex>LOQED-.*</regex>
+				</match-property>
+			</match-properties>
+		</discovery-method>
+	</discovery-methods>
+
+</addon:addon>

--- a/bundles/org.openhab.binding.loqed/src/main/resources/OH-INF/i18n/loqed.properties
+++ b/bundles/org.openhab.binding.loqed/src/main/resources/OH-INF/i18n/loqed.properties
@@ -1,0 +1,72 @@
+# add-on
+
+addon.loqed.name = LOQED Binding
+addon.loqed.description = Controls LOQED Touch and LOQED Pure smart locks.
+
+# thing types
+
+thing-type.loqed.account.label = LOQED Account
+thing-type.loqed.account.description = Connects to the LOQED Integrations API and discovers the account's locks.
+thing-type.loqed.local-bridge.label = LOQED Local Bridge
+thing-type.loqed.local-bridge.description = Connects directly to a LOQED Bridge on the local network and receives signed webhook updates.
+thing-type.loqed.lock.label = LOQED Smart Lock
+thing-type.loqed.lock.description = A LOQED Touch or LOQED Pure smart lock.
+
+# thing types config
+
+thing-type.config.loqed.account.apiToken.label = Personal Access Token
+thing-type.config.loqed.account.apiToken.description = Personal access token created on the LOQED integrations website.
+thing-type.config.loqed.account.refreshInterval.label = Refresh Interval
+thing-type.config.loqed.account.refreshInterval.description = Interval in seconds at which lock data is refreshed.
+thing-type.config.loqed.local-bridge.bridgeKey.label = Authentication Key
+thing-type.config.loqed.local-bridge.bridgeKey.description = Base64 authentication key used to manage and verify bridge webhooks.
+thing-type.config.loqed.local-bridge.callbackBaseUrl.label = openHAB Callback Base URL
+thing-type.config.loqed.local-bridge.callbackBaseUrl.description = Optional override for the automatically detected openHAB URL, for example http://192.168.1.10:8080.
+thing-type.config.loqed.local-bridge.host.label = Host
+thing-type.config.loqed.local-bridge.host.description = IP address, hostname, or base URL of the LOQED Bridge.
+thing-type.config.loqed.local-bridge.refreshInterval.label = Status Refresh Interval
+thing-type.config.loqed.local-bridge.refreshInterval.description = Fallback status refresh interval. Normal state updates are delivered by webhook.
+thing-type.config.loqed.lock.keySecret.label = API Key Secret
+thing-type.config.loqed.lock.keySecret.description = Base64 key secret used to sign local commands. Required with a local bridge.
+thing-type.config.loqed.lock.localKeyId.label = Local API Key ID
+thing-type.config.loqed.lock.localKeyId.description = Numeric ID belonging to the local API key. Required with a local bridge.
+thing-type.config.loqed.lock.lockId.label = Lock ID
+thing-type.config.loqed.lock.lockId.description = Unique lock identifier assigned by LOQED.
+
+# channel types
+
+channel-type.loqed.battery-type.label = Battery Type
+channel-type.loqed.battery-type.description = Configured battery chemistry.
+channel-type.loqed.bolt-state.label = Bolt State
+channel-type.loqed.bolt-state.description = Current bolt state. Send OPEN, DAY_LOCK, or NIGHT_LOCK to operate the lock.
+channel-type.loqed.bolt-state.state.option.OPEN = Open
+channel-type.loqed.bolt-state.state.option.DAY_LOCK = Day Lock
+channel-type.loqed.bolt-state.state.option.NIGHT_LOCK = Night Lock
+channel-type.loqed.bolt-state.state.option.UNKNOWN = Unknown
+channel-type.loqed.guest-access.label = Guest Access
+channel-type.loqed.guest-access.description = Indicates whether guest access mode is enabled.
+channel-type.loqed.lock.label = Lock
+channel-type.loqed.lock.description = Locks the door with ON and unlocks it to day lock with OFF.
+channel-type.loqed.party-mode.label = Open House Mode
+channel-type.loqed.party-mode.description = Indicates whether Open House (party) mode is enabled.
+channel-type.loqed.touch-to-connect.label = Touch to Connect
+channel-type.loqed.touch-to-connect.description = Indicates whether the 500 m geofence restriction for Touch to Open is removed.
+channel-type.loqed.twist-assist.label = Twist Assist
+channel-type.loqed.twist-assist.description = Indicates whether twist assist is enabled.
+
+# thing status descriptions
+
+thing-status.loqed.account.communication-error = Could not communicate with the LOQED Integrations API
+thing-status.loqed.account.token-empty = The personal access token must not be empty
+thing-status.loqed.account.token-rejected = The LOQED personal access token was rejected
+thing-status.loqed.local-bridge.authentication-error = The LOQED local bridge authentication failed
+thing-status.loqed.local-bridge.callback-unavailable = The callback URL could not be detected; configure the callback base URL manually
+thing-status.loqed.local-bridge.communication-error = Could not communicate with the LOQED local bridge
+thing-status.loqed.local-bridge.configuration-invalid = The local bridge configuration is invalid
+thing-status.loqed.lock.bridge-unavailable = The LOQED bridge is not available
+thing-status.loqed.lock.command-communication-error = Could not send the command to the LOQED lock
+thing-status.loqed.lock.command-configuration-error = The lock command configuration is invalid
+thing-status.loqed.lock.disconnected = The lock is not connected to the LOQED bridge
+thing-status.loqed.lock.id-empty = The lock ID must not be empty
+thing-status.loqed.lock.local-credentials-invalid = The local key secret and a local key ID between 0 and 250 are required
+thing-status.loqed.lock.unavailable = The lock is not available through this LOQED bridge

--- a/bundles/org.openhab.binding.loqed/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.loqed/src/main/resources/OH-INF/thing/thing-types.xml
@@ -1,0 +1,182 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="loqed"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
+
+	<bridge-type id="account">
+		<label>LOQED Account</label>
+		<description>Connects to the LOQED Integrations API and discovers the account's locks.</description>
+		<config-description>
+			<parameter name="apiToken" type="text" required="true">
+				<context>password</context>
+				<label>Personal Access Token</label>
+				<description>Personal access token created on the LOQED integrations website.</description>
+			</parameter>
+			<parameter name="refreshInterval" type="integer" unit="s" min="30">
+				<label>Refresh Interval</label>
+				<description>Interval in seconds at which lock data is refreshed.</description>
+				<default>60</default>
+				<advanced>true</advanced>
+			</parameter>
+		</config-description>
+	</bridge-type>
+
+	<bridge-type id="local-bridge">
+		<label>LOQED Local Bridge</label>
+		<description>Connects directly to a LOQED Bridge on the local network and receives signed webhook updates.</description>
+		<config-description>
+			<parameter name="host" type="text" required="true">
+				<label>Host</label>
+				<description>IP address, hostname, or base URL of the LOQED Bridge.</description>
+			</parameter>
+			<parameter name="bridgeKey" type="text" required="true">
+				<context>password</context>
+				<label>Authentication Key</label>
+				<description>Base64 authentication key used to manage and verify bridge webhooks.</description>
+			</parameter>
+			<parameter name="callbackBaseUrl" type="text">
+				<label>openHAB Callback Base URL</label>
+				<description>Optional override for the automatically detected openHAB URL, for example http://192.168.1.10:8080.</description>
+				<advanced>true</advanced>
+			</parameter>
+			<parameter name="refreshInterval" type="integer" unit="s" min="60">
+				<label>Status Refresh Interval</label>
+				<description>Fallback status refresh interval. Normal state updates are delivered by webhook.</description>
+				<default>60</default>
+				<advanced>true</advanced>
+			</parameter>
+		</config-description>
+	</bridge-type>
+
+	<thing-type id="lock">
+		<supported-bridge-type-refs>
+			<bridge-type-ref id="account"/>
+			<bridge-type-ref id="local-bridge"/>
+		</supported-bridge-type-refs>
+		<label>LOQED Smart Lock</label>
+		<description>A LOQED Touch or LOQED Pure smart lock.</description>
+		<channels>
+			<channel id="lock" typeId="lock"/>
+			<channel id="bolt-state" typeId="bolt-state"/>
+			<channel id="battery-level" typeId="system.battery-level"/>
+			<channel id="battery-type" typeId="battery-type"/>
+			<channel id="party-mode" typeId="party-mode"/>
+			<channel id="guest-access" typeId="guest-access"/>
+			<channel id="twist-assist" typeId="twist-assist"/>
+			<channel id="touch-to-connect" typeId="touch-to-connect"/>
+		</channels>
+		<properties>
+			<property name="model"/>
+		</properties>
+		<representation-property>lockId</representation-property>
+		<config-description>
+			<parameter name="lockId" type="text" required="true">
+				<label>Lock ID</label>
+				<description>Unique lock identifier assigned by LOQED.</description>
+			</parameter>
+			<parameter name="keySecret" type="text">
+				<context>password</context>
+				<label>API Key Secret</label>
+				<description>Base64 key secret used to sign local commands. Required with a local bridge.</description>
+			</parameter>
+			<parameter name="localKeyId" type="integer" min="0" max="250">
+				<label>Local API Key ID</label>
+				<description>Numeric ID belonging to the local API key. Required with a local bridge.</description>
+			</parameter>
+		</config-description>
+	</thing-type>
+
+	<channel-type id="lock">
+		<item-type>Switch</item-type>
+		<label>Lock</label>
+		<description>Locks the door with ON and unlocks it to day lock with OFF.</description>
+		<category>Door</category>
+		<tags>
+			<tag>Switch</tag>
+			<tag>LockState</tag>
+		</tags>
+	</channel-type>
+
+	<channel-type id="bolt-state">
+		<item-type>String</item-type>
+		<label>Bolt State</label>
+		<description>Current bolt state. Send OPEN, DAY_LOCK, or NIGHT_LOCK to operate the lock.</description>
+		<category>Door</category>
+		<tags>
+			<tag>Control</tag>
+			<tag>LockState</tag>
+		</tags>
+		<state>
+			<options>
+				<option value="OPEN">Open</option>
+				<option value="DAY_LOCK">Day Lock</option>
+				<option value="NIGHT_LOCK">Night Lock</option>
+				<option value="UNKNOWN">Unknown</option>
+			</options>
+		</state>
+		<command>
+			<options>
+				<option value="OPEN">Open</option>
+				<option value="DAY_LOCK">Day Lock</option>
+				<option value="NIGHT_LOCK">Night Lock</option>
+			</options>
+		</command>
+	</channel-type>
+
+	<channel-type id="battery-type">
+		<item-type>String</item-type>
+		<label>Battery Type</label>
+		<description>Configured battery chemistry.</description>
+		<category>Battery</category>
+		<state readOnly="true"/>
+	</channel-type>
+
+	<channel-type id="party-mode">
+		<item-type>Switch</item-type>
+		<label>Open House Mode</label>
+		<description>Indicates whether Open House (party) mode is enabled.</description>
+		<category>Door</category>
+		<tags>
+			<tag>Status</tag>
+			<tag>Enabled</tag>
+		</tags>
+		<state readOnly="true"/>
+	</channel-type>
+
+	<channel-type id="guest-access">
+		<item-type>Switch</item-type>
+		<label>Guest Access</label>
+		<description>Indicates whether guest access mode is enabled.</description>
+		<category>Door</category>
+		<tags>
+			<tag>Status</tag>
+			<tag>Enabled</tag>
+		</tags>
+		<state readOnly="true"/>
+	</channel-type>
+
+	<channel-type id="twist-assist">
+		<item-type>Switch</item-type>
+		<label>Twist Assist</label>
+		<description>Indicates whether twist assist is enabled.</description>
+		<category>Door</category>
+		<tags>
+			<tag>Status</tag>
+			<tag>Enabled</tag>
+		</tags>
+		<state readOnly="true"/>
+	</channel-type>
+
+	<channel-type id="touch-to-connect">
+		<item-type>Switch</item-type>
+		<label>Touch to Connect</label>
+		<description>Indicates whether the 500 m geofence restriction for Touch to Open is removed.</description>
+		<category>Door</category>
+		<tags>
+			<tag>Status</tag>
+			<tag>Enabled</tag>
+		</tags>
+		<state readOnly="true"/>
+	</channel-type>
+</thing:thing-descriptions>

--- a/bundles/org.openhab.binding.loqed/src/test/java/org/openhab/binding/loqed/internal/api/BoltStateTest.java
+++ b/bundles/org.openhab.binding.loqed/src/test/java/org/openhab/binding/loqed/internal/api/BoltStateTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.loqed.internal.api;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Objects;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.jupiter.api.Test;
+
+import com.google.gson.Gson;
+
+/**
+ * Tests conversion between LOQED API values and typed bolt states.
+ *
+ * @author Ondrej Pecta - Initial contribution
+ */
+@NonNullByDefault
+public class BoltStateTest {
+    @Test
+    public void convertsApiValues() {
+        assertEquals(BoltState.OPEN, BoltState.fromApiValueOrUnknown("open"));
+        assertEquals(BoltState.DAY_LOCK, BoltState.fromApiValueOrUnknown("DAY_LOCK"));
+        assertEquals(BoltState.NIGHT_LOCK, BoltState.fromApiValueOrUnknown("night_lock"));
+        assertEquals(BoltState.UNKNOWN, BoltState.fromApiValueOrUnknown("invalid"));
+    }
+
+    @Test
+    public void convertsLocalLatchAlias() {
+        assertEquals(BoltState.DAY_LOCK, BoltState.fromApiValueOrUnknown("latch"));
+        assertTrue(BoltState.fromApiValue("latch").filter(state -> state == BoltState.DAY_LOCK).isPresent());
+    }
+
+    @Test
+    public void deserializesCloudApiValue() {
+        LoqedLockData lockData = Objects
+                .requireNonNull(new Gson().fromJson("{\"bolt_state\":\"night_lock\"}", LoqedLockData.class));
+
+        assertEquals(BoltState.NIGHT_LOCK, lockData.boltState);
+    }
+}

--- a/bundles/org.openhab.binding.loqed/src/test/java/org/openhab/binding/loqed/internal/api/LoqedApiClientTest.java
+++ b/bundles/org.openhab.binding.loqed/src/test/java/org/openhab/binding/loqed/internal/api/LoqedApiClientTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.loqed.internal.api;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.List;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests parsing responses from the LOQED Integrations API.
+ *
+ * @author Ondrej Pecta - Initial contribution
+ */
+@NonNullByDefault
+public class LoqedApiClientTest {
+    @Test
+    public void rejectsMalformedResponse() {
+        assertThrows(LoqedResponseException.class, () -> LoqedApiClient.parseLocks("{"));
+    }
+
+    @Test
+    public void rejectsMissingOrNullData() {
+        assertThrows(LoqedResponseException.class, () -> LoqedApiClient.parseLocks("{}"));
+        assertThrows(LoqedResponseException.class, () -> LoqedApiClient.parseLocks("{\"data\":null}"));
+    }
+
+    @Test
+    public void convertsUnknownBoltStateToUnknown() throws Exception {
+        List<LoqedLockData> locks = LoqedApiClient
+                .parseLocks("{\"data\":[{\"id\":\"lock-id\",\"bolt_state\":\"future_state\"}]}");
+
+        assertEquals(1, locks.size());
+        assertEquals(BoltState.UNKNOWN, locks.getFirst().boltState);
+    }
+}

--- a/bundles/org.openhab.binding.loqed/src/test/java/org/openhab/binding/loqed/internal/api/LoqedLocalApiClientTest.java
+++ b/bundles/org.openhab.binding.loqed/src/test/java/org/openhab/binding/loqed/internal/api/LoqedLocalApiClientTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.loqed.internal.api;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+import java.util.Base64;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jetty.client.HttpClient;
+import org.junit.jupiter.api.Test;
+import org.openhab.binding.loqed.internal.LoqedLocalConfiguration;
+
+import com.google.gson.JsonObject;
+
+/**
+ * Tests LOQED's binary local command signature format.
+ *
+ * @author Ondrej Pecta - Initial contribution
+ */
+@NonNullByDefault
+public class LoqedLocalApiClientTest {
+    @Test
+    public void signedCommandMatchesKnownVector() throws Exception {
+        LoqedLocalApiClient client = createClient();
+
+        byte[] expected = Base64.getDecoder()
+                .decode("AAAAAAAAAAACBwAAAABlU/EABlSJLsSkSa0yBnGxx9fOAPnFCh4lK3HsM0ZNan2LPvYDAQI=");
+
+        assertArrayEquals(expected,
+                client.createSignedCommand("MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=", 3, 2, 1700000000L));
+    }
+
+    @Test
+    public void webhookDeleteHashMatchesKnownVector() throws Exception {
+        LoqedLocalApiClient client = createClient();
+
+        assertEquals("19c993eb3fb1804186484e5a3d81a200d4abbe5b09a02383a4f6a6cc62737852",
+                client.createWebhookDeleteHash(123, 1700000000L));
+    }
+
+    @Test
+    public void identifiesStaleCallbackForSameRoute() {
+        assertTrue(LoqedLocalApiClient.hasSameCallbackPath("http://192.0.2.10:8080/loqed/webhook/instance-a_localhome",
+                "https://openhab.example/loqed/webhook/instance-a_localhome"));
+        assertFalse(LoqedLocalApiClient.hasSameCallbackPath("http://192.0.2.10:8080/loqed/webhook/instance-b_localhome",
+                "https://openhab.example/loqed/webhook/instance-a_localhome"));
+    }
+
+    @Test
+    public void appliesLocalWebhookStatus() {
+        LoqedLockData status = new LoqedLockData();
+        status.online = true;
+        JsonObject event = new JsonObject();
+        event.addProperty("event_type", "STATE_CHANGED_NIGHT_LOCK");
+        event.addProperty("requested_state", "NIGHT_LOCK");
+        event.addProperty("battery_percentage", 74);
+        event.addProperty("battery_type", 1);
+        event.addProperty("ble_strength", -1);
+
+        assertFalse(LoqedLocalApiClient.applyWebhook(status, event));
+
+        assertEquals(BoltState.NIGHT_LOCK, status.boltState);
+        assertEquals(74, status.batteryPercentage);
+        assertEquals("nimh", status.batteryType);
+        assertFalse(status.online);
+
+        event = new JsonObject();
+        event.addProperty("ble_strength", 42);
+        assertTrue(LoqedLocalApiClient.applyWebhook(status, event));
+        assertTrue(status.online);
+        assertEquals(BoltState.UNKNOWN, status.boltState);
+        assertEquals(-1, status.batteryPercentage);
+    }
+
+    @Test
+    public void appliesMotorStallReachedState() {
+        LoqedLockData status = new LoqedLockData();
+        status.boltState = BoltState.NIGHT_LOCK;
+        JsonObject event = new JsonObject();
+        event.addProperty("event_type", "MOTOR_STALL");
+        event.addProperty("requested_state", "UNKNOWN");
+
+        LoqedLocalApiClient.applyWebhook(status, event);
+
+        assertEquals(BoltState.UNKNOWN, status.boltState);
+    }
+
+    @Test
+    public void appliesTouchToLockReachedState() {
+        LoqedLockData status = new LoqedLockData();
+        status.boltState = BoltState.DAY_LOCK;
+        JsonObject event = new JsonObject();
+        event.addProperty("event_type", "GO_TO_STATE_TOUCH_TO_LOCK");
+        event.addProperty("requested_state", "NIGHT_LOCK");
+
+        LoqedLocalApiClient.applyWebhook(status, event);
+
+        assertEquals(BoltState.NIGHT_LOCK, status.boltState);
+    }
+
+    @Test
+    public void rejectsMalformedStatusJson() {
+        assertThrows(LoqedResponseException.class, () -> LoqedLocalApiClient.parseStatus("{"));
+    }
+
+    @Test
+    public void leavesUnsupportedLocalStatusValuesUnknown() throws Exception {
+        LoqedLockData status = LoqedLocalApiClient
+                .parseStatus("{\"battery_percentage\":75,\"bolt_state\":\"night_lock\",\"lock_online\":1}");
+
+        assertNull(status.partyMode);
+        assertNull(status.guestAccessMode);
+        assertNull(status.twistAssist);
+        assertNull(status.touchToConnect);
+    }
+
+    private static LoqedLocalApiClient createClient() throws Exception {
+        LoqedLocalConfiguration config = new LoqedLocalConfiguration();
+        config.host = "192.0.2.1";
+        config.bridgeKey = "YWJjZGVmMDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODk=";
+        return new LoqedLocalApiClient(mock(HttpClient.class), config);
+    }
+}

--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -260,6 +260,7 @@
     <module>org.openhab.binding.lirc</module>
     <module>org.openhab.binding.livisismarthome</module>
     <module>org.openhab.binding.logreader</module>
+    <module>org.openhab.binding.loqed</module>
     <module>org.openhab.binding.loxone</module>
     <module>org.openhab.binding.lutron</module>
     <module>org.openhab.binding.luxom</module>


### PR DESCRIPTION
## Description

This PR adds a new binding for LOQED Touch and LOQED Pure smart locks.

The binding supports two connection modes:

- Cloud access through the LOQED Integrations API using a personal access token.
- Direct local access through a LOQED Bridge using signed commands and signed outgoing webhooks.

Cloud-connected locks can be discovered automatically. Local locks are configured manually with credentials obtained from the LOQED API configuration page.

The binding provides channels for:

- Lock control
- Bolt state and latch opening
- Battery level and battery type
- Open House (party) mode
- Guest access
- Twist assist
- Touch-to-Open configuration

For local connections, openHAB automatically determines the webhook callback address. A manual callback URL can be configured for installations with multiple network interfaces, VLANs, or container networking.

The README documents both connection modes, configuration parameters, channels, security considerations, and textual configuration examples.

## Testing

The binding was tested with a physical LOQED lock using local bridge communication.

The following functionality was verified:

- Signed local lock commands
- Initial lock state retrieval
- Signed webhook registration and state updates
- Lock, unlock, and latch-open commands
- Battery and configuration channel updates
- Automatic callback URL detection

A complete local build was executed with Java 21:

```text
./mvnw clean install