### PR TITLE
[mqtt.ruuvigateway] Fix flaky itest and NPE on thing disposal (test teardown)

### DIFF
--- a/bundles/org.openhab.binding.mqtt.ruuvigateway/src/main/java/org/openhab/binding/mqtt/ruuvigateway/internal/handler/RuuviHandler.java
+++ b/bundles/org.openhab.binding.mqtt.ruuvigateway/src/main/java/org/openhab/binding/mqtt/ruuvigateway/internal/handler/RuuviHandler.java
@@ -232,7 +232,8 @@ public class RuuviHandler extends AbstractMQTTThingHandler implements MqttMessag
         MqttBrokerConnection localConnection = connection;
         String localTopic = topic;
         if (localConnection != null && localTopic != null) {
-            return localConnection.unsubscribe(localTopic, this).thenCompose(unsubscribeSuccessful -> null);
+            return localConnection.unsubscribe(localTopic, this).thenAccept(unsubscribeSuccessful -> {
+            });
         } else {
             return CompletableFuture.completedFuture(null);
         }

--- a/itests/org.openhab.binding.mqtt.ruuvigateway.tests/src/main/java/org/openhab/binding/mqtt/ruuvigateway/RuuviGatewayTest.java
+++ b/itests/org.openhab.binding.mqtt.ruuvigateway.tests/src/main/java/org/openhab/binding/mqtt/ruuvigateway/RuuviGatewayTest.java
@@ -38,6 +38,7 @@ import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import javax.measure.quantity.Acceleration;
@@ -170,9 +171,14 @@ public class RuuviGatewayTest extends MqttOSGiTest {
         Bridge bridge = BridgeBuilder.create(new ThingTypeUID("mqtt", "broker"), "mybroker").withLabel("MQTT Broker")
                 .withConfiguration(configuration).build();
         thingProvider.add(bridge);
+        things.add(bridge);
         waitForAssert(() -> assertNotNull(bridge.getHandler()));
         assertNotNull(bridge.getConfiguration());
-        things.add(bridge);
+        // Wait until the broker bridge is really connected before any Ruuvi things are created. A Ruuvi thing that
+        // is initialized while the bridge is not ONLINE immediately reports OFFLINE (BRIDGE_OFFLINE) or
+        // OFFLINE (COMMUNICATION_ERROR), which would show up as an extra, unexpected thing status update in the
+        // assertions of the tests.
+        waitForAssert(() -> assertEquals(ThingStatus.ONLINE, bridge.getStatus(), bridge.getStatusInfo().toString()));
         return bridge;
     }
 
@@ -201,9 +207,9 @@ public class RuuviGatewayTest extends MqttOSGiTest {
 
         Thing thing = thingBuilder.build();
         thingProvider.add(thing);
+        things.add(thing);
         waitForAssert(() -> assertNotNull(thing.getHandler()));
         assertNotNull(thing.getConfiguration());
-        things.add(thing);
         return thing;
     }
 
@@ -284,17 +290,33 @@ public class RuuviGatewayTest extends MqttOSGiTest {
     @Override
     @AfterEach
     public void afterEach() throws Exception {
+        unregisterService(statusSubscriber);
+        removeThings();
         if (mqttConnection != null) {
             mqttConnection.removeConnectionObserver(failIfChange);
             mqttConnection.stop().get(5, TimeUnit.SECONDS);
         }
-        things.stream().map(thing -> thingProvider.remove(thing.getUID()));
-        unregisterService(statusSubscriber);
 
         if (scheduler != null) {
             scheduler.shutdownNow();
         }
         super.afterEach();
+    }
+
+    /**
+     * Remove the things created by the test and wait until their handlers have been disposed.
+     *
+     * This is done while the MQTT broker is still running. Without the explicit removal the things are removed only
+     * later on, when {@link org.openhab.core.test.java.JavaOSGiTest} unregisters the volatile storage service, i.e.
+     * after the broker has already been stopped. The broker connection of such a late disposed bridge handler keeps
+     * on reconnecting in the background and leaks into the next test.
+     */
+    private void removeThings() {
+        // Remove the ruuvi things first, so that their handlers are disposed before the bridge handler
+        things.stream().filter(thing -> !(thing instanceof Bridge)).map(Thing::getUID).forEach(thingProvider::remove);
+        things.stream().filter(Bridge.class::isInstance).map(Thing::getUID).forEach(thingProvider::remove);
+        waitForAssert(() -> things.forEach(thing -> assertNull(thing.getHandler(), thing.getUID().getAsString())));
+        things.clear();
     }
 
     @Test
@@ -305,25 +327,34 @@ public class RuuviGatewayTest extends MqttOSGiTest {
                 "Connection " + mqttConnection.getClientId() + " not retrieving all topics ");
     }
 
+    /**
+     * Describe all status updates received so far. Since the tests assert the status updates by their index, the
+     * whole sequence is needed to make sense of a failed assertion. For example an unexpected
+     * OFFLINE (BRIDGE_OFFLINE) update in the sequence tells that the MQTT broker connection of the bridge was
+     * disturbed during the test.
+     */
+    private Supplier<@Nullable String> describeStatusUpdates(List<ThingStatusInfo> statusUpdates, int index) {
+        return () -> String.format("Unexpected thing status update at index %d. Status updates received: %s", index,
+                statusUpdates.stream().map(ThingStatusInfo::toString).collect(Collectors.joining(", ", "[", "]")));
+    }
+
     private void assertThingStatus(List<ThingStatusInfo> statusUpdates, int index, ThingStatus status,
             @Nullable ThingStatusDetail detail, @Nullable String description) {
-        assertTrue(statusUpdates.size() > index,
-                String.format("Not enough status updates. Expected %d, but only had %d. Status updates received: %s",
-                        index + 1, statusUpdates.size(),
-                        statusUpdates.stream().map(ThingStatusInfo::getStatus).collect(Collectors.toList())));
-        assertEquals(status, statusUpdates.get(index).getStatus(), statusUpdates.get(index).toString());
-        assertEquals(detail, statusUpdates.get(index).getStatusDetail(), statusUpdates.get(index).toString());
-        assertEquals(description, statusUpdates.get(index).getDescription(), statusUpdates.get(index).toString());
+        Supplier<@Nullable String> message = describeStatusUpdates(statusUpdates, index);
+        assertTrue(statusUpdates.size() > index, message);
+        assertEquals(status, statusUpdates.get(index).getStatus(), message);
+        assertEquals(detail, statusUpdates.get(index).getStatusDetail(), message);
+        assertEquals(description, statusUpdates.get(index).getDescription(), message);
     }
 
     @SuppressWarnings("null")
     private void assertThingStatusWithDescriptionPattern(List<ThingStatusInfo> statusUpdates, int index,
             ThingStatus status, ThingStatusDetail detail, String descriptionPattern) {
-        assertTrue(statusUpdates.size() > index, "assert " + statusUpdates.size() + " > " + index + " failed");
-        assertEquals(status, statusUpdates.get(index).getStatus(), statusUpdates.get(index).toString());
-        assertEquals(detail, statusUpdates.get(index).getStatusDetail(), statusUpdates.get(index).toString());
-        assertTrue(statusUpdates.get(index).getDescription().matches(descriptionPattern),
-                statusUpdates.get(index).toString());
+        Supplier<@Nullable String> message = describeStatusUpdates(statusUpdates, index);
+        assertTrue(statusUpdates.size() > index, message);
+        assertEquals(status, statusUpdates.get(index).getStatus(), message);
+        assertEquals(detail, statusUpdates.get(index).getStatusDetail(), message);
+        assertTrue(statusUpdates.get(index).getDescription().matches(descriptionPattern), message);
     }
 
     private void assertThingStatus(List<ThingStatusInfo> statusUpdates, int index, ThingStatus status) {

--- a/itests/org.openhab.binding.mqtt.ruuvigateway.tests/src/main/java/org/openhab/binding/mqtt/ruuvigateway/RuuviGatewayTest.java
+++ b/itests/org.openhab.binding.mqtt.ruuvigateway.tests/src/main/java/org/openhab/binding/mqtt/ruuvigateway/RuuviGatewayTest.java
@@ -20,6 +20,7 @@ import static org.mockito.Mockito.when;
 import static org.openhab.binding.mqtt.ruuvigateway.internal.RuuviGatewayBindingConstants.*;
 import static org.openhab.core.library.unit.MetricPrefix.HECTO;
 
+import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.math.BigDecimal;
@@ -290,17 +291,25 @@ public class RuuviGatewayTest extends MqttOSGiTest {
     @Override
     @AfterEach
     public void afterEach() throws Exception {
-        unregisterService(statusSubscriber);
-        removeThings();
-        if (mqttConnection != null) {
-            mqttConnection.removeConnectionObserver(failIfChange);
-            mqttConnection.stop().get(5, TimeUnit.SECONDS);
+        try {
+            unregisterService(statusSubscriber);
+            removeThings();
+        } finally {
+            try {
+                if (mqttConnection != null) {
+                    mqttConnection.removeConnectionObserver(failIfChange);
+                    mqttConnection.stop().get(5, TimeUnit.SECONDS);
+                }
+            } finally {
+                try {
+                    if (scheduler != null) {
+                        scheduler.shutdownNow();
+                    }
+                } finally {
+                    super.afterEach();
+                }
+            }
         }
-
-        if (scheduler != null) {
-            scheduler.shutdownNow();
-        }
-        super.afterEach();
     }
 
     /**
@@ -325,6 +334,30 @@ public class RuuviGatewayTest extends MqttOSGiTest {
         mqttConnection.subscribe(BASE_TOPIC_RUUVI + "/#", (topic, payload) -> c.countDown()).get(5, TimeUnit.SECONDS);
         assertTrue(c.await(5, TimeUnit.SECONDS),
                 "Connection " + mqttConnection.getClientId() + " not retrieving all topics ");
+    }
+
+    @Test
+    public void unsubscribeAllCompletesNormally() throws Exception {
+        String topic = BASE_TOPIC_RUUVI + "/mygwid/DE:AD:BE:EF:AA:01";
+        Thing ruuviThing = createRuuviThing("mygwid", topic, null);
+        waitForAssert(() -> assertEquals(ThingStatus.ONLINE, ruuviThing.getStatus()));
+
+        RuuviHandler handler = assertInstanceOf(RuuviHandler.class, ruuviThing.getHandler());
+        MqttBrokerConnection connection = Objects.requireNonNull(handler.getConnection());
+        assertTrue(hasSubscription(connection, topic));
+
+        handler.unsubscribeAll().get(5, TimeUnit.SECONDS);
+
+        assertFalse(hasSubscription(connection, topic));
+    }
+
+    @SuppressWarnings("unchecked")
+    private boolean hasSubscription(MqttBrokerConnection connection, String topic)
+            throws NoSuchFieldException, SecurityException, IllegalArgumentException, IllegalAccessException {
+        Field subscribersField = MqttBrokerConnection.class.getDeclaredField("subscribers");
+        subscribersField.setAccessible(true);
+        Map<String, ?> subscribers = Objects.requireNonNull((Map<String, ?>) subscribersField.get(connection));
+        return subscribers.containsKey(topic);
     }
 
     /**


### PR DESCRIPTION
Fix attempt for https://github.com/openhab/openhab-addons/issues/21349

The `RuuviGatewayTest#testHappyFlow` itest fails intermittently on CI with

    OFFLINE (BRIDGE_OFFLINE) ==> expected: <UNKNOWN> but was: <OFFLINE>

The tests assert the Ruuvi thing's status updates by absolute index, expecting
`INITIALIZING, UNKNOWN, ONLINE("Waiting for initial data")`. That sequence only
holds if the MQTT broker bridge is ONLINE when the Ruuvi thing is initialized:
`AbstractMQTTThingHandler.initialize()` calls `bridgeStatusChanged(getBridgeStatus())`,
which reports `OFFLINE (BRIDGE_OFFLINE)` straight away when the bridge is OFFLINE.
That extra update shifts every following index, and the bridge's default reconnect
delay (10 s, then 60 s) is longer than the `waitForAssert` budget, so the test can
never recover.

Two things in the test made it unable to cope:

* `createMqttBrokerBridge()` only waited for the bridge *handler* to exist, never
  for the bridge to reach ONLINE, so Ruuvi things could be created against a bridge
  that was still connecting or had just dropped.
* `afterEach()`'s cleanup was a no-op: `things.stream().map(thing -> thingProvider.remove(...))`
  has no terminal operation. Things were therefore disposed only later, when
  `JavaOSGiTest` unregisters the volatile storage service — after the Moquette broker
  had already been stopped — leaving bridge handlers whose connections keep
  reconnecting in the background and leak into the next test.

Changes:

* Wait for the broker bridge to reach ONLINE before creating Ruuvi things.
* Actually remove the things in `afterEach`, while the broker is still running, and
  wait for the handlers to be disposed.
* Report the whole captured status update sequence when a status assertion fails,
  so this class of failure is diagnosable from the build log.
* `RuuviHandler.unsubscribeAll()` used `thenCompose(unsubscribeSuccessful -> null)`,
  which returns a null `CompletionStage`, so every disposal of a Ruuvi thing logged
  `unsubscription on disposal failed ... NullPointerException` from
  `AbstractMQTTThingHandler.dispose()`. Changed to `thenAccept`.

Developed with AI assistance.
