### PR TITLE
[rrd4j] Improve unstable RRD4jPersistenceServiceTest

### DIFF
--- a/bundles/org.openhab.persistence.rrd4j/src/test/java/org/openhab/persistence/rrd4j/internal/RRD4jPersistenceServiceTest.java
+++ b/bundles/org.openhab.persistence.rrd4j/src/test/java/org/openhab/persistence/rrd4j/internal/RRD4jPersistenceServiceTest.java
@@ -51,24 +51,19 @@ import org.slf4j.LoggerFactory;
  */
 @ExtendWith(MockitoExtension.class)
 class RRD4jPersistenceServiceTest {
-    private static final long STORAGE_TIMEOUT_MS = 20000; // 20 seconds for CI
+    private static final long STORAGE_TIMEOUT_MS = 20_000; // 20 seconds for CI
     private static final long POLL_INTERVAL_MS = 250; // Check every 250ms
 
     private final Logger logger = LoggerFactory.getLogger(RRD4jPersistenceServiceTest.class);
 
-    @Mock
-    private ItemRegistry itemRegistry;
-
-    @Mock
-    private NumberItem numberItem;
-
-    @Mock
-    private SwitchItem switchItem;
+    private @Mock ItemRegistry itemRegistry;
+    private @Mock NumberItem numberItem;
+    private @Mock SwitchItem switchItem;
 
     private RRD4jPersistenceService service;
 
     @BeforeEach
-    void setUp() throws Exception {
+    void setUp() {
         // Create service with empty config
         service = new RRD4jPersistenceService(itemRegistry, Map.of());
     }
@@ -77,27 +72,23 @@ class RRD4jPersistenceServiceTest {
      * Waits for data to be persisted by polling the database.
      * This is more robust than Thread.sleep() in CI environments with resource contention.
      *
-     * @param itemName the name of the item to check
-     * @param timeoutMs maximum time to wait in milliseconds
+     * @param criteria the query criteria to use to check for persisted data
      * @throws InterruptedException if interrupted while waiting
      */
-    private void waitForStorage(String itemName, long timeoutMs) throws InterruptedException {
+    private Iterable<HistoricItem> waitForStorage(FilterCriteria criteria) throws InterruptedException {
         long startTime = System.currentTimeMillis();
         int attempts = 0;
 
-        while (System.currentTimeMillis() - startTime < timeoutMs) {
+        while (System.currentTimeMillis() - startTime < STORAGE_TIMEOUT_MS) {
             attempts++;
-
-            FilterCriteria criteria = new FilterCriteria();
-            criteria.setItemName(itemName);
-            criteria.setPageSize(1);
 
             try {
                 Iterable<HistoricItem> results = service.query(criteria);
                 if (results.iterator().hasNext()) {
                     long elapsed = System.currentTimeMillis() - startTime;
-                    logger.info("Storage completed for '{}' after {}ms ({} attempts)", itemName, elapsed, attempts);
-                    return; // Success!
+                    logger.info("Storage completed for '{}' after {}ms ({} attempts)", criteria.getItemName(), elapsed,
+                            attempts);
+                    return results;
                 }
             } catch (Exception e) {
                 // Query might fail if data not ready yet, continue polling
@@ -108,8 +99,8 @@ class RRD4jPersistenceServiceTest {
         }
 
         long elapsed = System.currentTimeMillis() - startTime;
-        fail(String.format("Data for item '%s' was not persisted within %dms (%d polling attempts).", itemName, elapsed,
-                attempts));
+        return fail(String.format("Data for item '%s' was not persisted within %dms (%d polling attempts).",
+                criteria.getItemName(), elapsed, attempts));
     }
 
     private void configureNumberItem(String suffix) throws Exception {
@@ -155,17 +146,14 @@ class RRD4jPersistenceServiceTest {
             service = new RRD4jPersistenceService(itemRegistry, Map.of());
         }
 
-        // Wait for background storage to complete
-        waitForStorage(numberItem.getName(), STORAGE_TIMEOUT_MS);
-
-        // Query the value back
         FilterCriteria criteria = new FilterCriteria();
         criteria.setItemName(numberItem.getName());
         criteria.setOrdering(FilterCriteria.Ordering.DESCENDING);
         criteria.setPageSize(1);
         criteria.setPageNumber(0);
 
-        Iterable<HistoricItem> results = service.query(criteria);
+        // Wait for background storage to complete
+        Iterable<HistoricItem> results = waitForStorage(criteria);
         assertNotNull(results);
 
         // Verify the retrieved value
@@ -189,17 +177,14 @@ class RRD4jPersistenceServiceTest {
             service = new RRD4jPersistenceService(itemRegistry, Map.of());
         }
 
-        // Wait for background storage to complete
-        waitForStorage(switchItem.getName(), STORAGE_TIMEOUT_MS);
-
-        // Query the value back
         FilterCriteria criteria = new FilterCriteria();
         criteria.setItemName(switchItem.getName());
         criteria.setOrdering(FilterCriteria.Ordering.DESCENDING);
         criteria.setPageSize(1);
         criteria.setPageNumber(0);
 
-        Iterable<HistoricItem> results = service.query(criteria);
+        // Wait for background storage to complete
+        Iterable<HistoricItem> results = waitForStorage(criteria);
         assertNotNull(results);
 
         // Verify the retrieved value (converted back to OnOffType by toStateMapper)
@@ -228,17 +213,14 @@ class RRD4jPersistenceServiceTest {
             service = new RRD4jPersistenceService(itemRegistry, Map.of());
         }
 
-        // Wait for background storage to complete
-        waitForStorage(numberItem.getName(), STORAGE_TIMEOUT_MS);
-
-        // Query with time range
         FilterCriteria criteria = new FilterCriteria();
         criteria.setItemName(numberItem.getName());
         criteria.setBeginDate(ZonedDateTime.now(ZoneId.systemDefault()).minusHours(1));
         criteria.setEndDate(ZonedDateTime.now(ZoneId.systemDefault()).plusHours(1));
         criteria.setOrdering(FilterCriteria.Ordering.ASCENDING);
 
-        Iterable<HistoricItem> results = service.query(criteria);
+        // Wait for background storage to complete
+        Iterable<HistoricItem> results = waitForStorage(criteria);
         assertNotNull(results);
 
         // Verify we got at least one result
@@ -282,10 +264,6 @@ class RRD4jPersistenceServiceTest {
             service = new RRD4jPersistenceService(itemRegistry, Map.of("something.invalid", "invalid/path/to/db"));
         }
 
-        // Wait for background storage to complete
-        waitForStorage(numberItem.getName(), STORAGE_TIMEOUT_MS);
-
-        // Query the value back
         FilterCriteria criteria = new FilterCriteria();
         criteria.setItemName(numberItem.getName());
         criteria.setOrdering(FilterCriteria.Ordering.ASCENDING);
@@ -293,7 +271,8 @@ class RRD4jPersistenceServiceTest {
         criteria.setPageNumber(0);
         criteria.setBeginDate(ZonedDateTime.now(ZoneId.systemDefault()).minusHours(1));
 
-        Iterable<HistoricItem> results = service.query(criteria);
+        // Wait for background storage to complete
+        Iterable<HistoricItem> results = waitForStorage(criteria);
         assertNotNull(results);
 
         // Verify the retrieved value


### PR DESCRIPTION
This fixes a race condition in `RRD4jPersistenceServiceTest`.

#20181 replaced fixed sleeps with adaptive polling to make the RRD4j persistence tests more reliable under CI load. However, the polling helper introduced there uses a different query from the one subsequently used by some tests.

In particular, the polling query can use RRD4j's latest-value fast path, while the actual test query uses a time range and fetches archived values. This means `waitForStorage` can report that data is available before it is available through the query that the test is about to execute.

An example failure occurred in this build:

https://github.com/openhab/openhab-addons/actions/runs/31481653611/job/93747743452

```text
[ERROR] Tests run: 11, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 10.25 s <<< FAILURE! -- in org.openhab.persistence.rrd4j.internal.RRD4jPersistenceServiceTest
[ERROR] org.openhab.persistence.rrd4j.internal.RRD4jPersistenceServiceTest.storeAndRetrieveWithInvalidDBConfig(boolean)[2] -- Time elapsed: 1.105 s <<< ERROR!
java.util.NoSuchElementException
	at java.base/java.util.ArrayList$Itr.next(ArrayList.java:1052)
	at org.openhab.persistence.rrd4j.internal.RRD4jPersistenceServiceTest.storeAndRetrieveWithInvalidDBConfig(RRD4jPersistenceServiceTest.java:300)
...
```

This changes the tests to:

* poll using the same `FilterCriteria` as the actual test query;
* return the successful query result directly;
* avoid issuing a second query after storage readiness has been established.

This keeps the adaptive polling introduced in #20181 while ensuring it waits for the condition each test actually depends on.
