### PR TITLE
Suppress npm update notifier

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -449,6 +449,9 @@ Import-Package: \
           <configuration>
             <nodeVersion>v24.18.1</nodeVersion>
             <npmVersion>11.16.0</npmVersion>
+            <environmentVariables>
+              <NPM_CONFIG_UPDATE_NOTIFIER>false</NPM_CONFIG_UPDATE_NOTIFIER>
+            </environmentVariables>
           </configuration>
         </plugin>
 


### PR DESCRIPTION
## Description

Suppress the npm update notifier by setting `NPM_CONFIG_UPDATE_NOTIFIER=false` for `frontend-maven-plugin` executions.

Without this, npm can periodically print its update notification to stderr, which Maven reports as errors:

```text
[ERROR] npm notice
[ERROR] npm notice New major version of npm available! 11.16.0 -> 12.0.2
[ERROR] npm notice Changelog: https://github.com/npm/cli/releases/tag/v12.0.2
[ERROR] npm notice To update run: npm install -g npm@12.0.2
[ERROR] npm notice
```

These messages do not indicate a build failure but make the build output unnecessarily look like it contains errors.

## Testing

Remove npm's update-notifier timestamp to force it to check for updates again:

```bash
rm ~/.npm/_update-notifier-last-checked
```

Then run a new build.

The npm update notice should no longer be shown. The `_update-notifier-last-checked` file should also remain absent, confirming that the update notifier was disabled rather than merely suppressed because npm had recently checked for updates.
