### PR TITLE
[avmfritz] Improve AVMFritzDeviceListModelTest stability

### DIFF
--- a/bundles/org.openhab.binding.avmfritz/src/test/java/org/openhab/binding/avmfritz/internal/dto/AVMFritzDeviceListModelTest.java
+++ b/bundles/org.openhab.binding.avmfritz/src/test/java/org/openhab/binding/avmfritz/internal/dto/AVMFritzDeviceListModelTest.java
@@ -52,6 +52,8 @@ import org.openhab.core.thing.ThingUID;
 @NonNullByDefault
 public class AVMFritzDeviceListModelTest {
 
+    private static final int CALLBACK_TIMEOUT_MS = 3_000;
+
     private @NonNullByDefault({}) DeviceListModel devices;
 
     @SuppressWarnings("null")
@@ -1119,10 +1121,11 @@ public class AVMFritzDeviceListModelTest {
 
         bridgeHandler.onDeviceListAdded(devices.getDevicelist());
 
-        verify(thingHandler0, times(1)).onDeviceUpdated(any(), any());
-        verify(thingHandler1, times(1)).onDeviceUpdated(any(), any());
-        verify(thingHandler2, times(1)).onDeviceUpdated(any(), any());
+        verify(thingHandler0, timeout(CALLBACK_TIMEOUT_MS).times(1)).onDeviceUpdated(any(), any());
+        verify(thingHandler1, timeout(CALLBACK_TIMEOUT_MS).times(1)).onDeviceUpdated(any(), any());
+        verify(thingHandler2, timeout(CALLBACK_TIMEOUT_MS).times(1)).onDeviceUpdated(any(), any());
 
-        verify(discoveryService, times(devices.getDevicelist().size() - 3)).onDeviceAdded(any());
+        verify(discoveryService, timeout(CALLBACK_TIMEOUT_MS).times(devices.getDevicelist().size() - 3))
+                .onDeviceAdded(any());
     }
 }


### PR DESCRIPTION
## Description

Fix the unstable `AVMFritzDeviceListModelTest.testCallbacks` test by using Mockito timeouts when verifying asynchronously scheduled callbacks.

`AVMFritzBaseBridgeHandler.onDeviceListAdded()` submits the device update and discovery callbacks to the thing handler scheduler. The test previously verified the invocations immediately after calling this method, so it could fail when the scheduled callbacks had not all completed yet.

This was observed in CI where 17 discovery callbacks were expected, but only 16 had completed when Mockito performed the verification:

```text
org.mockito.exceptions.verification.TooFewActualInvocations:

aVMFritzDiscoveryService.onDeviceAdded(
    <any>
);
Wanted 17 times:
But was 16 times:
```

Build: https://github.com/openhab/openhab-addons/actions/runs/31413369281

The test now uses a 3-second Mockito timeout for the asynchronous callback verifications. The timeout is only an upper bound: verification completes as soon as the expected callbacks have occurred, while providing sufficient headroom for slower or congested CI runners.
