### PR TITLE
Transform bindings to getConfigAs

### DIFF
--- a/bundles/org.openhab.binding.airq/src/main/java/org/openhab/binding/airq/internal/AirqHandler.java
+++ b/bundles/org.openhab.binding.airq/src/main/java/org/openhab/binding/airq/internal/AirqHandler.java
@@ -312,7 +312,7 @@ public class AirqHandler extends BaseThingHandler {
 
     @Override
     public void initialize() {
-        config = getThing().getConfiguration().as(AirqConfiguration.class);
+        config = getConfigAs(AirqConfiguration.class);
         updateStatus(ThingStatus.UNKNOWN);
 
         pollingJob = scheduler.scheduleWithFixedDelay(this::pollData, 0, POLLING_PERIOD_DATA_MSEC,

--- a/bundles/org.openhab.binding.atlona/src/main/java/org/openhab/binding/atlona/internal/pro3/AtlonaPro3Handler.java
+++ b/bundles/org.openhab.binding.atlona/src/main/java/org/openhab/binding/atlona/internal/pro3/AtlonaPro3Handler.java
@@ -594,7 +594,7 @@ public class AtlonaPro3Handler extends AtlonaHandler<AtlonaPro3Capabilities> {
      * @return {@link AtlonaPro3Config}
      */
     private AtlonaPro3Config getAtlonaConfig() {
-        return getThing().getConfiguration().as(AtlonaPro3Config.class);
+        return getConfigAs(AtlonaPro3Config.class);
     }
 
     /**

--- a/bundles/org.openhab.binding.cm11a/src/main/java/org/openhab/binding/cm11a/internal/handler/Cm11aBridgeHandler.java
+++ b/bundles/org.openhab.binding.cm11a/src/main/java/org/openhab/binding/cm11a/internal/handler/Cm11aBridgeHandler.java
@@ -68,7 +68,7 @@ public class Cm11aBridgeHandler extends BaseBridgeHandler implements ReceivedDat
     @Override
     public void initialize() {
         // Get serial port number from config
-        cm11aConfig = getThing().getConfiguration().as(Cm11aConfig.class);
+        cm11aConfig = getConfigAs(Cm11aConfig.class);
         logger.trace("********* cm11a initialize started *********");
 
         // Verify the configuration is valid

--- a/bundles/org.openhab.binding.deutschebahn/src/main/java/org/openhab/binding/deutschebahn/internal/DeutscheBahnTimetableHandler.java
+++ b/bundles/org.openhab.binding.deutschebahn/src/main/java/org/openhab/binding/deutschebahn/internal/DeutscheBahnTimetableHandler.java
@@ -72,7 +72,8 @@ public class DeutscheBahnTimetableHandler extends BaseBridgeHandler {
 
         public void addThing(Thing thing) {
             if (isTrain(thing)) {
-                int position = thing.getConfiguration().as(DeutscheBahnTrainConfiguration.class).position;
+                int position = DeutscheBahnTimetableHandler.getThingConfig(thing,
+                        DeutscheBahnTrainConfiguration.class).position;
                 this.maxPosition = Math.max(this.maxPosition, position);
                 List<Thing> thingsAtPosition = this.thingsPerPosition.get(position);
                 if (thingsAtPosition == null) {
@@ -106,6 +107,14 @@ public class DeutscheBahnTimetableHandler extends BaseBridgeHandler {
 
     private final Logger logger = LoggerFactory.getLogger(DeutscheBahnTimetableHandler.class);
     private @Nullable TimetableLoader loader;
+
+    private static <T> T getThingConfig(Thing thing, Class<T> configurationClass) {
+        ThingHandler handler = thing.getHandler();
+        if (handler instanceof DeutscheBahnTrainHandler trainHandler) {
+            return trainHandler.getConfigAs(configurationClass);
+        }
+        return thing.getConfiguration().as(configurationClass);
+    }
 
     private final TimetablesV1ApiFactory timetablesV1ApiFactory;
 

--- a/bundles/org.openhab.binding.deutschebahn/src/main/java/org/openhab/binding/deutschebahn/internal/DeutscheBahnTrainHandler.java
+++ b/bundles/org.openhab.binding.deutschebahn/src/main/java/org/openhab/binding/deutschebahn/internal/DeutscheBahnTrainHandler.java
@@ -95,6 +95,11 @@ public class DeutscheBahnTrainHandler extends BaseThingHandler {
     }
 
     @Override
+    public <T> T getConfigAs(Class<T> configurationClass) {
+        return super.getConfigAs(configurationClass);
+    }
+
+    @Override
     public void initialize() {
         this.updateStatus(ThingStatus.UNKNOWN);
 

--- a/bundles/org.openhab.binding.deutschebahn/src/test/java/org/openhab/binding/deutschebahn/internal/DeutscheBahnTimetableHandlerTest.java
+++ b/bundles/org.openhab.binding.deutschebahn/src/test/java/org/openhab/binding/deutschebahn/internal/DeutscheBahnTimetableHandlerTest.java
@@ -63,6 +63,12 @@ public class DeutscheBahnTimetableHandlerTest implements TimetablesV1ImplTestHel
         return config;
     }
 
+    private static DeutscheBahnTrainConfiguration createTrainConfig(int position) {
+        final DeutscheBahnTrainConfiguration trainConfig = new DeutscheBahnTrainConfiguration();
+        trainConfig.position = position;
+        return trainConfig;
+    }
+
     private static Bridge mockBridge(String trainFilter) {
         final Bridge bridge = mock(Bridge.class);
         when(bridge.getUID()).thenReturn(new ThingUID(DeutscheBahnBindingConstants.TIMETABLE_TYPE, "timetable"));
@@ -72,9 +78,18 @@ public class DeutscheBahnTimetableHandlerTest implements TimetablesV1ImplTestHel
         things.add(DeutscheBahnTrainHandlerTest.mockThing(1));
         things.add(DeutscheBahnTrainHandlerTest.mockThing(2));
         things.add(DeutscheBahnTrainHandlerTest.mockThing(3));
-        when(things.get(0).getHandler()).thenReturn(mock(DeutscheBahnTrainHandler.class));
-        when(things.get(1).getHandler()).thenReturn(mock(DeutscheBahnTrainHandler.class));
-        when(things.get(2).getHandler()).thenReturn(mock(DeutscheBahnTrainHandler.class));
+
+        DeutscheBahnTrainHandler trainHandler1 = mock(DeutscheBahnTrainHandler.class);
+        DeutscheBahnTrainHandler trainHandler2 = mock(DeutscheBahnTrainHandler.class);
+        DeutscheBahnTrainHandler trainHandler3 = mock(DeutscheBahnTrainHandler.class);
+
+        when(things.get(0).getHandler()).thenReturn(trainHandler1);
+        when(things.get(1).getHandler()).thenReturn(trainHandler2);
+        when(things.get(2).getHandler()).thenReturn(trainHandler3);
+
+        when(trainHandler1.getConfigAs(DeutscheBahnTrainConfiguration.class)).thenReturn(createTrainConfig(1));
+        when(trainHandler2.getConfigAs(DeutscheBahnTrainConfiguration.class)).thenReturn(createTrainConfig(2));
+        when(trainHandler3.getConfigAs(DeutscheBahnTrainConfiguration.class)).thenReturn(createTrainConfig(3));
 
         when(bridge.getThings()).thenReturn(things);
 

--- a/bundles/org.openhab.binding.enocean/src/main/java/org/openhab/binding/enocean/internal/handler/EnOceanBridgeHandler.java
+++ b/bundles/org.openhab.binding.enocean/src/main/java/org/openhab/binding/enocean/internal/handler/EnOceanBridgeHandler.java
@@ -177,7 +177,7 @@ public class EnOceanBridgeHandler extends ConfigStatusBridgeHandler implements T
 
     private synchronized void initTransceiver() {
         try {
-            EnOceanBridgeConfig c = getThing().getConfiguration().as(EnOceanBridgeConfig.class);
+            EnOceanBridgeConfig c = getConfigAs(EnOceanBridgeConfig.class);
             EnOceanTransceiver localTransceiver = transceiver;
             if (localTransceiver != null) {
                 localTransceiver.shutDown();
@@ -320,7 +320,7 @@ public class EnOceanBridgeHandler extends ConfigStatusBridgeHandler implements T
         Collection<ConfigStatusMessage> configStatusMessages = new LinkedList<>();
 
         // The serial port must be provided
-        String path = getThing().getConfiguration().as(EnOceanBridgeConfig.class).path;
+        String path = getConfigAs(EnOceanBridgeConfig.class).path;
         if (path.isEmpty()) {
             ConfigStatusMessage statusMessage = ConfigStatusMessage.Builder.error(PATH)
                     .withMessageKeySuffix(EnOceanConfigStatusMessage.PORT_MISSING.getMessageKey()).withArguments(PATH)

--- a/bundles/org.openhab.binding.fineoffsetweatherstation/src/main/java/org/openhab/binding/fineoffsetweatherstation/internal/handler/FineOffsetGatewayHandler.java
+++ b/bundles/org.openhab.binding.fineoffsetweatherstation/src/main/java/org/openhab/binding/fineoffsetweatherstation/internal/handler/FineOffsetGatewayHandler.java
@@ -267,7 +267,7 @@ public class FineOffsetGatewayHandler extends BaseBridgeHandler {
     private void startDiscoverJob() {
         ScheduledFuture<?> job = discoverJob;
         if (job == null || job.isCancelled()) {
-            int discoverInterval = thing.getConfiguration().as(FineOffsetGatewayConfiguration.class).discoverInterval;
+            int discoverInterval = getConfigAs(FineOffsetGatewayConfiguration.class).discoverInterval;
             discoverJob = scheduler.scheduleWithFixedDelay(this::fetchAndUpdateSensors, 0, discoverInterval,
                     TimeUnit.SECONDS);
         }
@@ -284,7 +284,7 @@ public class FineOffsetGatewayHandler extends BaseBridgeHandler {
     private void startPollingJob() {
         ScheduledFuture<?> job = pollingJob;
         if (job == null || job.isCancelled()) {
-            int pollingInterval = thing.getConfiguration().as(FineOffsetGatewayConfiguration.class).pollingInterval;
+            int pollingInterval = getConfigAs(FineOffsetGatewayConfiguration.class).pollingInterval;
             pollingJob = scheduler.scheduleWithFixedDelay(this::updateLiveData, 5, pollingInterval, TimeUnit.SECONDS);
         }
     }

--- a/bundles/org.openhab.binding.fineoffsetweatherstation/src/main/java/org/openhab/binding/fineoffsetweatherstation/internal/handler/FineOffsetSensorHandler.java
+++ b/bundles/org.openhab.binding.fineoffsetweatherstation/src/main/java/org/openhab/binding/fineoffsetweatherstation/internal/handler/FineOffsetSensorHandler.java
@@ -46,6 +46,11 @@ public class FineOffsetSensorHandler extends BaseThingHandler {
     }
 
     @Override
+    public <T> T getConfigAs(Class<T> configurationClass) {
+        return super.getConfigAs(configurationClass);
+    }
+
+    @Override
     public void handleCommand(ChannelUID channelUID, Command command) {
     }
 

--- a/bundles/org.openhab.binding.gardena/src/main/java/org/openhab/binding/gardena/internal/handler/GardenaAccountHandler.java
+++ b/bundles/org.openhab.binding.gardena/src/main/java/org/openhab/binding/gardena/internal/handler/GardenaAccountHandler.java
@@ -170,9 +170,9 @@ public class GardenaAccountHandler extends BaseBridgeHandler implements GardenaS
      */
     private synchronized void initializeGardena() {
         try {
-GardenaConfig gardenaConfig = getConfigAs(GardenaConfig.class);
-logger.debug("Loaded Gardena config (timeout={}, apiKeySet={})", gardenaConfig.getConnectionTimeout(),
-        gardenaConfig.getApiKey() != null && !gardenaConfig.getApiKey().isBlank());
+            GardenaConfig gardenaConfig = getConfigAs(GardenaConfig.class);
+            logger.debug("Loaded Gardena config (timeout={}, apiKeySet={})", gardenaConfig.getConnectionTimeout(),
+                    gardenaConfig.getApiKey() != null && !gardenaConfig.getApiKey().isBlank());
             gardenaSmart = new GardenaSmartImpl(getThing().getUID(), gardenaConfig, this, scheduler, httpClientFactory,
                     webSocketFactory);
             final GardenaDeviceDiscoveryService discoveryService = this.discoveryService;

--- a/bundles/org.openhab.binding.gardena/src/main/java/org/openhab/binding/gardena/internal/handler/GardenaAccountHandler.java
+++ b/bundles/org.openhab.binding.gardena/src/main/java/org/openhab/binding/gardena/internal/handler/GardenaAccountHandler.java
@@ -170,7 +170,7 @@ public class GardenaAccountHandler extends BaseBridgeHandler implements GardenaS
      */
     private synchronized void initializeGardena() {
         try {
-            GardenaConfig gardenaConfig = getThing().getConfiguration().as(GardenaConfig.class);
+            GardenaConfig gardenaConfig = getConfigAs(GardenaConfig.class);
             logger.debug("{}", gardenaConfig);
 
             gardenaSmart = new GardenaSmartImpl(getThing().getUID(), gardenaConfig, this, scheduler, httpClientFactory,

--- a/bundles/org.openhab.binding.gardena/src/main/java/org/openhab/binding/gardena/internal/handler/GardenaAccountHandler.java
+++ b/bundles/org.openhab.binding.gardena/src/main/java/org/openhab/binding/gardena/internal/handler/GardenaAccountHandler.java
@@ -170,9 +170,9 @@ public class GardenaAccountHandler extends BaseBridgeHandler implements GardenaS
      */
     private synchronized void initializeGardena() {
         try {
-            GardenaConfig gardenaConfig = getConfigAs(GardenaConfig.class);
-            logger.debug("{}", gardenaConfig);
-
+GardenaConfig gardenaConfig = getConfigAs(GardenaConfig.class);
+logger.debug("Loaded Gardena config (timeout={}, apiKeySet={})", gardenaConfig.getConnectionTimeout(),
+        gardenaConfig.getApiKey() != null && !gardenaConfig.getApiKey().isBlank());
             gardenaSmart = new GardenaSmartImpl(getThing().getUID(), gardenaConfig, this, scheduler, httpClientFactory,
                     webSocketFactory);
             final GardenaDeviceDiscoveryService discoveryService = this.discoveryService;

--- a/bundles/org.openhab.binding.heos/src/main/java/org/openhab/binding/heos/internal/handler/HeosBridgeHandler.java
+++ b/bundles/org.openhab.binding.heos/src/main/java/org/openhab/binding/heos/internal/handler/HeosBridgeHandler.java
@@ -148,7 +148,7 @@ public class HeosBridgeHandler extends BaseBridgeHandler implements HeosEventLis
 
     @Override
     public synchronized void initialize() {
-        configuration = thing.getConfiguration().as(BridgeConfiguration.class);
+        configuration = getConfigAs(BridgeConfiguration.class);
         cancel(startupFuture);
         startupFuture = scheduler.submit(this::delayedInitialize);
     }

--- a/bundles/org.openhab.binding.heos/src/main/java/org/openhab/binding/heos/internal/handler/HeosGroupHandler.java
+++ b/bundles/org.openhab.binding.heos/src/main/java/org/openhab/binding/heos/internal/handler/HeosGroupHandler.java
@@ -106,7 +106,7 @@ public class HeosGroupHandler extends HeosThingBaseHandler {
     public synchronized void initialize() {
         super.initialize();
 
-        configuration = thing.getConfiguration().as(GroupConfiguration.class);
+        configuration = getConfigAs(GroupConfiguration.class);
 
         // Prevents that initialize() is called multiple times if group goes online
         blockInitialization = true;

--- a/bundles/org.openhab.binding.heos/src/main/java/org/openhab/binding/heos/internal/handler/HeosPlayerHandler.java
+++ b/bundles/org.openhab.binding.heos/src/main/java/org/openhab/binding/heos/internal/handler/HeosPlayerHandler.java
@@ -76,7 +76,7 @@ public class HeosPlayerHandler extends HeosThingBaseHandler {
     public void initialize() {
         super.initialize();
 
-        PlayerConfiguration configuration = thing.getConfiguration().as(PlayerConfiguration.class);
+        PlayerConfiguration configuration = getConfigAs(PlayerConfiguration.class);
         pid = configuration.pid;
 
         cancel(scheduledFuture);

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/discovery/HomematicDeviceDiscoveryService.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/discovery/HomematicDeviceDiscoveryService.java
@@ -21,7 +21,6 @@ import java.util.concurrent.ScheduledExecutorService;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
-import org.openhab.binding.homematic.internal.common.HomematicConfig;
 import org.openhab.binding.homematic.internal.communicator.HomematicGateway;
 import org.openhab.binding.homematic.internal.handler.HomematicBridgeHandler;
 import org.openhab.binding.homematic.internal.model.HmDevice;
@@ -104,7 +103,7 @@ public class HomematicDeviceDiscoveryService extends AbstractThingHandlerDiscove
     }
 
     private int getInstallModeDuration() {
-        return thingHandler.getThing().getConfiguration().as(HomematicConfig.class).getInstallModeDuration();
+        return thingHandler.getBindingConfig().getInstallModeDuration();
     }
 
     @Override
@@ -222,7 +221,7 @@ public class HomematicDeviceDiscoveryService extends AbstractThingHandlerDiscove
         ThingTypeUID typeUid = UidUtils.generateThingTypeUID(device);
         ThingUID thingUID = new ThingUID(typeUid, bridgeUID, device.getAddress());
         String label = device.getName().isEmpty() ? device.getAddress() : device.getName();
-        long timeToLive = thingHandler.getThing().getConfiguration().as(HomematicConfig.class).getDiscoveryTimeToLive();
+        long timeToLive = thingHandler.getBindingConfig().getDiscoveryTimeToLive();
 
         DiscoveryResult discoveryResult = DiscoveryResultBuilder.create(thingUID).withBridge(bridgeUID).withLabel(label)
                 .withProperty(Thing.PROPERTY_SERIAL_NUMBER, device.getAddress())

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/discovery/HomematicDeviceDiscoveryService.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/discovery/HomematicDeviceDiscoveryService.java
@@ -103,7 +103,7 @@ public class HomematicDeviceDiscoveryService extends AbstractThingHandlerDiscove
     }
 
     private int getInstallModeDuration() {
-        return thingHandler.getBindingConfig().getInstallModeDuration();
+        return thingHandler.getHomematicConfig().getInstallModeDuration();
     }
 
     @Override
@@ -221,7 +221,7 @@ public class HomematicDeviceDiscoveryService extends AbstractThingHandlerDiscove
         ThingTypeUID typeUid = UidUtils.generateThingTypeUID(device);
         ThingUID thingUID = new ThingUID(typeUid, bridgeUID, device.getAddress());
         String label = device.getName().isEmpty() ? device.getAddress() : device.getName();
-        long timeToLive = thingHandler.getBindingConfig().getDiscoveryTimeToLive();
+        long timeToLive = thingHandler.getHomematicConfig().getDiscoveryTimeToLive();
 
         DiscoveryResult discoveryResult = DiscoveryResultBuilder.create(thingUID).withBridge(bridgeUID).withLabel(label)
                 .withProperty(Thing.PROPERTY_SERIAL_NUMBER, device.getAddress())

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/handler/HomematicBridgeHandler.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/handler/HomematicBridgeHandler.java
@@ -241,7 +241,7 @@ public class HomematicBridgeHandler extends BaseBridgeHandler implements Homemat
      * Creates the configuration for the HomematicGateway.
      */
     private HomematicConfig createHomematicConfig() {
-        HomematicConfig homematicConfig = getThing().getConfiguration().as(HomematicConfig.class);
+        HomematicConfig homematicConfig = getBindingConfig();
         if (homematicConfig.getCallbackHost() == null) {
             homematicConfig.setCallbackHost(this.ipv4Address);
         }
@@ -257,6 +257,10 @@ public class HomematicBridgeHandler extends BaseBridgeHandler implements Homemat
         }
         logger.debug("{}", homematicConfig);
         return homematicConfig;
+    }
+
+    public HomematicConfig getBindingConfig() {
+        return getConfigAs(HomematicConfig.class);
     }
 
     @Override

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/handler/HomematicBridgeHandler.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/handler/HomematicBridgeHandler.java
@@ -241,7 +241,7 @@ public class HomematicBridgeHandler extends BaseBridgeHandler implements Homemat
      * Creates the configuration for the HomematicGateway.
      */
     private HomematicConfig createHomematicConfig() {
-        HomematicConfig homematicConfig = getBindingConfig();
+        HomematicConfig homematicConfig = getHomematicConfig();
         if (homematicConfig.getCallbackHost() == null) {
             homematicConfig.setCallbackHost(this.ipv4Address);
         }
@@ -259,7 +259,7 @@ public class HomematicBridgeHandler extends BaseBridgeHandler implements Homemat
         return homematicConfig;
     }
 
-    public HomematicConfig getBindingConfig() {
+    public HomematicConfig getHomematicConfig() {
         return getConfigAs(HomematicConfig.class);
     }
 

--- a/bundles/org.openhab.binding.homematic/src/test/java/org/openhab/binding/homematic/internal/discovery/HomematicDeviceDiscoveryServiceTest.java
+++ b/bundles/org.openhab.binding.homematic/src/test/java/org/openhab/binding/homematic/internal/discovery/HomematicDeviceDiscoveryServiceTest.java
@@ -77,7 +77,7 @@ public class HomematicDeviceDiscoveryServiceTest extends JavaTest {
         when(homematicBridgeHandler.getThing()).thenReturn(bridge);
         when(homematicBridgeHandler.getGateway()).thenReturn(homematicGateway);
         when(homematicBridgeHandler.getTypeGenerator()).thenReturn(homematicTypeGenerator);
-        when(homematicBridgeHandler.getBindingConfig()).thenReturn(new HomematicConfig());
+        when(homematicBridgeHandler.getHomematicConfig()).thenReturn(new HomematicConfig());
 
         return homematicBridgeHandler;
     }

--- a/bundles/org.openhab.binding.homematic/src/test/java/org/openhab/binding/homematic/internal/discovery/HomematicDeviceDiscoveryServiceTest.java
+++ b/bundles/org.openhab.binding.homematic/src/test/java/org/openhab/binding/homematic/internal/discovery/HomematicDeviceDiscoveryServiceTest.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.openhab.binding.homematic.internal.common.HomematicConfig;
 import org.openhab.binding.homematic.internal.communicator.HomematicGateway;
 import org.openhab.binding.homematic.internal.handler.HomematicBridgeHandler;
 import org.openhab.binding.homematic.internal.model.HmDevice;
@@ -76,6 +77,7 @@ public class HomematicDeviceDiscoveryServiceTest extends JavaTest {
         when(homematicBridgeHandler.getThing()).thenReturn(bridge);
         when(homematicBridgeHandler.getGateway()).thenReturn(homematicGateway);
         when(homematicBridgeHandler.getTypeGenerator()).thenReturn(homematicTypeGenerator);
+        when(homematicBridgeHandler.getBindingConfig()).thenReturn(new HomematicConfig());
 
         return homematicBridgeHandler;
     }

--- a/bundles/org.openhab.binding.jellyfin/src/main/java/org/openhab/binding/jellyfin/internal/discovery/ClientDiscoveryService.java
+++ b/bundles/org.openhab.binding.jellyfin/src/main/java/org/openhab/binding/jellyfin/internal/discovery/ClientDiscoveryService.java
@@ -198,7 +198,7 @@ public class ClientDiscoveryService extends AbstractThingHandlerDiscoveryService
         }
 
         // Second pass: publish discovery results for deduplicated clients
-        Configuration config = thingHandler.getBindingConfig();
+        Configuration config = thingHandler.getBridgeConfig();
         for (Map.Entry<String, SessionInfoDto> entry : deduped.entrySet()) {
             SessionInfoDto session = entry.getValue();
             String deviceId = entry.getKey();

--- a/bundles/org.openhab.binding.jellyfin/src/main/java/org/openhab/binding/jellyfin/internal/discovery/ClientDiscoveryService.java
+++ b/bundles/org.openhab.binding.jellyfin/src/main/java/org/openhab/binding/jellyfin/internal/discovery/ClientDiscoveryService.java
@@ -198,7 +198,7 @@ public class ClientDiscoveryService extends AbstractThingHandlerDiscoveryService
         }
 
         // Second pass: publish discovery results for deduplicated clients
-        Configuration config = thingHandler.getThing().getConfiguration().as(Configuration.class);
+        Configuration config = thingHandler.getBindingConfig();
         for (Map.Entry<String, SessionInfoDto> entry : deduped.entrySet()) {
             SessionInfoDto session = entry.getValue();
             String deviceId = entry.getKey();

--- a/bundles/org.openhab.binding.jellyfin/src/main/java/org/openhab/binding/jellyfin/internal/handler/ServerHandler.java
+++ b/bundles/org.openhab.binding.jellyfin/src/main/java/org/openhab/binding/jellyfin/internal/handler/ServerHandler.java
@@ -673,6 +673,10 @@ public class ServerHandler extends BaseBridgeHandler implements ErrorEventListen
         }
     }
 
+    public Configuration getBindingConfig() {
+        return getConfigAs(Configuration.class);
+    }
+
     /**
      * Removes deprecated configuration keys that are no longer used by the
      * binding. This migration runs once on handler initialization and cleans up

--- a/bundles/org.openhab.binding.jellyfin/src/main/java/org/openhab/binding/jellyfin/internal/handler/ServerHandler.java
+++ b/bundles/org.openhab.binding.jellyfin/src/main/java/org/openhab/binding/jellyfin/internal/handler/ServerHandler.java
@@ -673,7 +673,7 @@ public class ServerHandler extends BaseBridgeHandler implements ErrorEventListen
         }
     }
 
-    public Configuration getBindingConfig() {
+    public Configuration getBridgeConfig() {
         return getConfigAs(Configuration.class);
     }
 

--- a/bundles/org.openhab.binding.jellyfin/src/test/java/org/openhab/binding/jellyfin/internal/handler/ClientDiscoveryServiceTest.java
+++ b/bundles/org.openhab.binding.jellyfin/src/test/java/org/openhab/binding/jellyfin/internal/handler/ClientDiscoveryServiceTest.java
@@ -71,7 +71,7 @@ class ClientDiscoveryServiceTest {
         when(serverHandler.getThing()).thenReturn(bridge);
 
         // All categories enabled by default so existing tests are unaffected
-        when(serverHandler.getBindingConfig()).thenReturn(allCategoriesEnabled());
+        when(serverHandler.getBridgeConfig()).thenReturn(allCategoriesEnabled());
 
         // Return empty collection by default so existing tests are unaffected
         when(thingRegistry.getAll()).thenReturn(Collections.emptyList());
@@ -394,7 +394,7 @@ class ClientDiscoveryServiceTest {
 
     @Test
     void testWebClientSkippedWhenDiscoverWebClientsIsFalse() {
-        when(serverHandler.getBindingConfig()).thenReturn(buildConfig(false, true, true, true, true, true, true));
+        when(serverHandler.getBridgeConfig()).thenReturn(buildConfig(false, true, true, true, true, true, true));
         when(serverHandler.getClients()).thenReturn(Map.of("s1", sessionWith("web-1", "Jellyfin Web")));
 
         DiscoveryListener listener = mock(DiscoveryListener.class);
@@ -406,7 +406,7 @@ class ClientDiscoveryServiceTest {
 
     @Test
     void testWebClientDiscoveredWhenDiscoverWebClientsIsTrue() {
-        when(serverHandler.getBindingConfig()).thenReturn(buildConfig(true, true, true, true, true, true, true));
+        when(serverHandler.getBridgeConfig()).thenReturn(buildConfig(true, true, true, true, true, true, true));
         when(serverHandler.getClients()).thenReturn(Map.of("s1", sessionWith("web-1", "Jellyfin Web")));
 
         DiscoveryListener listener = mock(DiscoveryListener.class);
@@ -418,7 +418,7 @@ class ClientDiscoveryServiceTest {
 
     @Test
     void testAndroidClientSkippedWhenDiscoverAndroidClientsIsFalse() {
-        when(serverHandler.getBindingConfig()).thenReturn(buildConfig(true, false, true, true, true, true, true));
+        when(serverHandler.getBridgeConfig()).thenReturn(buildConfig(true, false, true, true, true, true, true));
         when(serverHandler.getClients()).thenReturn(Map.of("s1", sessionWith("android-1", "Jellyfin for Android")));
 
         DiscoveryListener listener = mock(DiscoveryListener.class);
@@ -431,7 +431,7 @@ class ClientDiscoveryServiceTest {
     @Test
     void testAndroidTvClientSkippedWhenDiscoverAndroidTvClientsIsFalse() {
         // Android TV disabled, plain Android enabled — TV client must be skipped
-        when(serverHandler.getBindingConfig()).thenReturn(buildConfig(true, true, false, true, true, true, true));
+        when(serverHandler.getBridgeConfig()).thenReturn(buildConfig(true, true, false, true, true, true, true));
         when(serverHandler.getClients()).thenReturn(Map.of("s1", sessionWith("atv-1", "Jellyfin for Android TV")));
 
         DiscoveryListener listener = mock(DiscoveryListener.class);
@@ -444,7 +444,7 @@ class ClientDiscoveryServiceTest {
     @Test
     void testAndroidTvClientNotMatchedByAndroidFilter() {
         // Android TV enabled, plain Android disabled — TV client must still be discovered
-        when(serverHandler.getBindingConfig()).thenReturn(buildConfig(true, false, true, true, true, true, true));
+        when(serverHandler.getBridgeConfig()).thenReturn(buildConfig(true, false, true, true, true, true, true));
         when(serverHandler.getClients()).thenReturn(Map.of("s1", sessionWith("atv-1", "Jellyfin for Android TV")));
 
         DiscoveryListener listener = mock(DiscoveryListener.class);
@@ -456,7 +456,7 @@ class ClientDiscoveryServiceTest {
 
     @Test
     void testIosClientSkippedWhenDiscoverIosClientsIsFalse() {
-        when(serverHandler.getBindingConfig()).thenReturn(buildConfig(true, true, true, false, true, true, true));
+        when(serverHandler.getBridgeConfig()).thenReturn(buildConfig(true, true, true, false, true, true, true));
         when(serverHandler.getClients()).thenReturn(Map.of("s1", sessionWith("ios-1", "Jellyfin iOS")));
 
         DiscoveryListener listener = mock(DiscoveryListener.class);
@@ -468,7 +468,7 @@ class ClientDiscoveryServiceTest {
 
     @Test
     void testSwiftfinMatchedAsIosCategory() {
-        when(serverHandler.getBindingConfig()).thenReturn(buildConfig(true, true, true, false, true, true, true));
+        when(serverHandler.getBridgeConfig()).thenReturn(buildConfig(true, true, true, false, true, true, true));
         when(serverHandler.getClients()).thenReturn(Map.of("s1", sessionWith("swiftfin-1", "Swiftfin")));
 
         DiscoveryListener listener = mock(DiscoveryListener.class);
@@ -480,7 +480,7 @@ class ClientDiscoveryServiceTest {
 
     @Test
     void testInfuseMatchedAsIosCategory() {
-        when(serverHandler.getBindingConfig()).thenReturn(buildConfig(true, true, true, false, true, true, true));
+        when(serverHandler.getBridgeConfig()).thenReturn(buildConfig(true, true, true, false, true, true, true));
         when(serverHandler.getClients()).thenReturn(Map.of("s1", sessionWith("infuse-1", "Infuse")));
 
         DiscoveryListener listener = mock(DiscoveryListener.class);
@@ -492,7 +492,7 @@ class ClientDiscoveryServiceTest {
 
     @Test
     void testKodiClientSkippedWhenDiscoverKodiClientsIsFalse() {
-        when(serverHandler.getBindingConfig()).thenReturn(buildConfig(true, true, true, true, false, true, true));
+        when(serverHandler.getBridgeConfig()).thenReturn(buildConfig(true, true, true, true, false, true, true));
         when(serverHandler.getClients()).thenReturn(Map.of("s1", sessionWith("kodi-1", "JellyCon")));
 
         DiscoveryListener listener = mock(DiscoveryListener.class);
@@ -504,7 +504,7 @@ class ClientDiscoveryServiceTest {
 
     @Test
     void testRokuClientSkippedWhenDiscoverRokuClientsIsFalse() {
-        when(serverHandler.getBindingConfig()).thenReturn(buildConfig(true, true, true, true, true, false, true));
+        when(serverHandler.getBridgeConfig()).thenReturn(buildConfig(true, true, true, true, true, false, true));
         when(serverHandler.getClients()).thenReturn(Map.of("s1", sessionWith("roku-1", "Jellyfin for Roku")));
 
         DiscoveryListener listener = mock(DiscoveryListener.class);
@@ -516,7 +516,7 @@ class ClientDiscoveryServiceTest {
 
     @Test
     void testUnknownClientSkippedWhenDiscoverOtherClientsIsFalse() {
-        when(serverHandler.getBindingConfig()).thenReturn(buildConfig(true, true, true, true, true, true, false));
+        when(serverHandler.getBridgeConfig()).thenReturn(buildConfig(true, true, true, true, true, true, false));
         when(serverHandler.getClients()).thenReturn(Map.of("s1", sessionWith("other-1", "Some Unknown App")));
 
         DiscoveryListener listener = mock(DiscoveryListener.class);
@@ -528,7 +528,7 @@ class ClientDiscoveryServiceTest {
 
     @Test
     void testNullClientNameFallsIntoOtherCategory() {
-        when(serverHandler.getBindingConfig()).thenReturn(buildConfig(true, true, true, true, true, true, false));
+        when(serverHandler.getBridgeConfig()).thenReturn(buildConfig(true, true, true, true, true, true, false));
         SessionInfoDto session = new SessionInfoDto();
         session.setDeviceId("null-client-1");
         session.setDeviceName("Unknown Device");
@@ -544,7 +544,7 @@ class ClientDiscoveryServiceTest {
 
     @Test
     void testAllFiltersDisabledResultsInNoDiscovery() {
-        when(serverHandler.getBindingConfig()).thenReturn(buildConfig(false, false, false, false, false, false, false));
+        when(serverHandler.getBridgeConfig()).thenReturn(buildConfig(false, false, false, false, false, false, false));
 
         Map<String, SessionInfoDto> clients = new HashMap<>();
         clients.put("s1", sessionWith("web-1", "Jellyfin Web"));

--- a/bundles/org.openhab.binding.jellyfin/src/test/java/org/openhab/binding/jellyfin/internal/handler/ClientDiscoveryServiceTest.java
+++ b/bundles/org.openhab.binding.jellyfin/src/test/java/org/openhab/binding/jellyfin/internal/handler/ClientDiscoveryServiceTest.java
@@ -28,11 +28,11 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.openhab.binding.jellyfin.internal.Configuration;
 import org.openhab.binding.jellyfin.internal.Constants;
 import org.openhab.binding.jellyfin.internal.discovery.ClientDiscoveryService;
 import org.openhab.binding.jellyfin.internal.gen.current.model.SessionInfoDto;
 import org.openhab.binding.jellyfin.internal.util.discovery.DeviceIdSanitizer;
-import org.openhab.core.config.core.Configuration;
 import org.openhab.core.config.discovery.DiscoveryListener;
 import org.openhab.core.config.discovery.DiscoveryResult;
 import org.openhab.core.thing.Bridge;
@@ -71,7 +71,7 @@ class ClientDiscoveryServiceTest {
         when(serverHandler.getThing()).thenReturn(bridge);
 
         // All categories enabled by default so existing tests are unaffected
-        when(bridge.getConfiguration()).thenReturn(allCategoriesEnabled());
+        when(serverHandler.getBindingConfig()).thenReturn(allCategoriesEnabled());
 
         // Return empty collection by default so existing tests are unaffected
         when(thingRegistry.getAll()).thenReturn(Collections.emptyList());
@@ -91,13 +91,13 @@ class ClientDiscoveryServiceTest {
     private Configuration buildConfig(boolean web, boolean android, boolean androidTv, boolean ios, boolean kodi,
             boolean roku, boolean other) {
         Configuration config = new Configuration();
-        config.put("discoverWebClients", web);
-        config.put("discoverAndroidClients", android);
-        config.put("discoverAndroidTvClients", androidTv);
-        config.put("discoverIosClients", ios);
-        config.put("discoverKodiClients", kodi);
-        config.put("discoverRokuClients", roku);
-        config.put("discoverOtherClients", other);
+        config.discoverWebClients = web;
+        config.discoverAndroidClients = android;
+        config.discoverAndroidTvClients = androidTv;
+        config.discoverIosClients = ios;
+        config.discoverKodiClients = kodi;
+        config.discoverRokuClients = roku;
+        config.discoverOtherClients = other;
         return config;
     }
 
@@ -394,7 +394,7 @@ class ClientDiscoveryServiceTest {
 
     @Test
     void testWebClientSkippedWhenDiscoverWebClientsIsFalse() {
-        when(bridge.getConfiguration()).thenReturn(buildConfig(false, true, true, true, true, true, true));
+        when(serverHandler.getBindingConfig()).thenReturn(buildConfig(false, true, true, true, true, true, true));
         when(serverHandler.getClients()).thenReturn(Map.of("s1", sessionWith("web-1", "Jellyfin Web")));
 
         DiscoveryListener listener = mock(DiscoveryListener.class);
@@ -406,7 +406,7 @@ class ClientDiscoveryServiceTest {
 
     @Test
     void testWebClientDiscoveredWhenDiscoverWebClientsIsTrue() {
-        when(bridge.getConfiguration()).thenReturn(buildConfig(true, true, true, true, true, true, true));
+        when(serverHandler.getBindingConfig()).thenReturn(buildConfig(true, true, true, true, true, true, true));
         when(serverHandler.getClients()).thenReturn(Map.of("s1", sessionWith("web-1", "Jellyfin Web")));
 
         DiscoveryListener listener = mock(DiscoveryListener.class);
@@ -418,7 +418,7 @@ class ClientDiscoveryServiceTest {
 
     @Test
     void testAndroidClientSkippedWhenDiscoverAndroidClientsIsFalse() {
-        when(bridge.getConfiguration()).thenReturn(buildConfig(true, false, true, true, true, true, true));
+        when(serverHandler.getBindingConfig()).thenReturn(buildConfig(true, false, true, true, true, true, true));
         when(serverHandler.getClients()).thenReturn(Map.of("s1", sessionWith("android-1", "Jellyfin for Android")));
 
         DiscoveryListener listener = mock(DiscoveryListener.class);
@@ -431,7 +431,7 @@ class ClientDiscoveryServiceTest {
     @Test
     void testAndroidTvClientSkippedWhenDiscoverAndroidTvClientsIsFalse() {
         // Android TV disabled, plain Android enabled — TV client must be skipped
-        when(bridge.getConfiguration()).thenReturn(buildConfig(true, true, false, true, true, true, true));
+        when(serverHandler.getBindingConfig()).thenReturn(buildConfig(true, true, false, true, true, true, true));
         when(serverHandler.getClients()).thenReturn(Map.of("s1", sessionWith("atv-1", "Jellyfin for Android TV")));
 
         DiscoveryListener listener = mock(DiscoveryListener.class);
@@ -444,7 +444,7 @@ class ClientDiscoveryServiceTest {
     @Test
     void testAndroidTvClientNotMatchedByAndroidFilter() {
         // Android TV enabled, plain Android disabled — TV client must still be discovered
-        when(bridge.getConfiguration()).thenReturn(buildConfig(true, false, true, true, true, true, true));
+        when(serverHandler.getBindingConfig()).thenReturn(buildConfig(true, false, true, true, true, true, true));
         when(serverHandler.getClients()).thenReturn(Map.of("s1", sessionWith("atv-1", "Jellyfin for Android TV")));
 
         DiscoveryListener listener = mock(DiscoveryListener.class);
@@ -456,7 +456,7 @@ class ClientDiscoveryServiceTest {
 
     @Test
     void testIosClientSkippedWhenDiscoverIosClientsIsFalse() {
-        when(bridge.getConfiguration()).thenReturn(buildConfig(true, true, true, false, true, true, true));
+        when(serverHandler.getBindingConfig()).thenReturn(buildConfig(true, true, true, false, true, true, true));
         when(serverHandler.getClients()).thenReturn(Map.of("s1", sessionWith("ios-1", "Jellyfin iOS")));
 
         DiscoveryListener listener = mock(DiscoveryListener.class);
@@ -468,7 +468,7 @@ class ClientDiscoveryServiceTest {
 
     @Test
     void testSwiftfinMatchedAsIosCategory() {
-        when(bridge.getConfiguration()).thenReturn(buildConfig(true, true, true, false, true, true, true));
+        when(serverHandler.getBindingConfig()).thenReturn(buildConfig(true, true, true, false, true, true, true));
         when(serverHandler.getClients()).thenReturn(Map.of("s1", sessionWith("swiftfin-1", "Swiftfin")));
 
         DiscoveryListener listener = mock(DiscoveryListener.class);
@@ -480,7 +480,7 @@ class ClientDiscoveryServiceTest {
 
     @Test
     void testInfuseMatchedAsIosCategory() {
-        when(bridge.getConfiguration()).thenReturn(buildConfig(true, true, true, false, true, true, true));
+        when(serverHandler.getBindingConfig()).thenReturn(buildConfig(true, true, true, false, true, true, true));
         when(serverHandler.getClients()).thenReturn(Map.of("s1", sessionWith("infuse-1", "Infuse")));
 
         DiscoveryListener listener = mock(DiscoveryListener.class);
@@ -492,7 +492,7 @@ class ClientDiscoveryServiceTest {
 
     @Test
     void testKodiClientSkippedWhenDiscoverKodiClientsIsFalse() {
-        when(bridge.getConfiguration()).thenReturn(buildConfig(true, true, true, true, false, true, true));
+        when(serverHandler.getBindingConfig()).thenReturn(buildConfig(true, true, true, true, false, true, true));
         when(serverHandler.getClients()).thenReturn(Map.of("s1", sessionWith("kodi-1", "JellyCon")));
 
         DiscoveryListener listener = mock(DiscoveryListener.class);
@@ -504,7 +504,7 @@ class ClientDiscoveryServiceTest {
 
     @Test
     void testRokuClientSkippedWhenDiscoverRokuClientsIsFalse() {
-        when(bridge.getConfiguration()).thenReturn(buildConfig(true, true, true, true, true, false, true));
+        when(serverHandler.getBindingConfig()).thenReturn(buildConfig(true, true, true, true, true, false, true));
         when(serverHandler.getClients()).thenReturn(Map.of("s1", sessionWith("roku-1", "Jellyfin for Roku")));
 
         DiscoveryListener listener = mock(DiscoveryListener.class);
@@ -516,7 +516,7 @@ class ClientDiscoveryServiceTest {
 
     @Test
     void testUnknownClientSkippedWhenDiscoverOtherClientsIsFalse() {
-        when(bridge.getConfiguration()).thenReturn(buildConfig(true, true, true, true, true, true, false));
+        when(serverHandler.getBindingConfig()).thenReturn(buildConfig(true, true, true, true, true, true, false));
         when(serverHandler.getClients()).thenReturn(Map.of("s1", sessionWith("other-1", "Some Unknown App")));
 
         DiscoveryListener listener = mock(DiscoveryListener.class);
@@ -528,7 +528,7 @@ class ClientDiscoveryServiceTest {
 
     @Test
     void testNullClientNameFallsIntoOtherCategory() {
-        when(bridge.getConfiguration()).thenReturn(buildConfig(true, true, true, true, true, true, false));
+        when(serverHandler.getBindingConfig()).thenReturn(buildConfig(true, true, true, true, true, true, false));
         SessionInfoDto session = new SessionInfoDto();
         session.setDeviceId("null-client-1");
         session.setDeviceName("Unknown Device");
@@ -544,7 +544,7 @@ class ClientDiscoveryServiceTest {
 
     @Test
     void testAllFiltersDisabledResultsInNoDiscovery() {
-        when(bridge.getConfiguration()).thenReturn(buildConfig(false, false, false, false, false, false, false));
+        when(serverHandler.getBindingConfig()).thenReturn(buildConfig(false, false, false, false, false, false, false));
 
         Map<String, SessionInfoDto> clients = new HashMap<>();
         clients.put("s1", sessionWith("web-1", "Jellyfin Web"));
@@ -572,7 +572,7 @@ class ClientDiscoveryServiceTest {
         when(thing.getThingTypeUID()).thenReturn(Constants.THING_TYPE_JELLYFIN_CLIENT);
         when(thing.getBridgeUID()).thenReturn(bridgeUID);
 
-        Configuration config = new Configuration();
+        org.openhab.core.config.core.Configuration config = new org.openhab.core.config.core.Configuration();
         config.put("serialNumber", serialNumber);
         when(thing.getConfiguration()).thenReturn(config);
 
@@ -628,7 +628,7 @@ class ClientDiscoveryServiceTest {
         when(legacyThing.getUID()).thenReturn(existingThingUID);
         when(legacyThing.getThingTypeUID()).thenReturn(Constants.THING_TYPE_JELLYFIN_CLIENT);
         when(legacyThing.getBridgeUID()).thenReturn(bridgeUID);
-        when(legacyThing.getConfiguration()).thenReturn(new Configuration());
+        when(legacyThing.getConfiguration()).thenReturn(new org.openhab.core.config.core.Configuration());
         when(legacyThing.getProperties()).thenReturn(Map.of()); // no deviceName property
 
         when(thingRegistry.getAll()).thenReturn(List.of(legacyThing));

--- a/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/grxprg/GrafikEyeHandler.java
+++ b/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/grxprg/GrafikEyeHandler.java
@@ -262,7 +262,7 @@ public class GrafikEyeHandler extends BaseThingHandler {
      * starts a status refresh job
      */
     private void internalInitialize() {
-        config = getThing().getConfiguration().as(GrafikEyeConfig.class);
+        config = getConfigAs(GrafikEyeConfig.class);
 
         if (config == null) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, "Configuration file missing");

--- a/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/grxprg/PrgBridgeHandler.java
+++ b/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/grxprg/PrgBridgeHandler.java
@@ -323,7 +323,7 @@ public class PrgBridgeHandler extends BaseBridgeHandler {
      * @return a possible null {@link PrgBridgeConfig}
      */
     private PrgBridgeConfig getPrgBridgeConfig() {
-        final PrgBridgeConfig config = getThing().getConfiguration().as(PrgBridgeConfig.class);
+        final PrgBridgeConfig config = getConfigAs(PrgBridgeConfig.class);
 
         if (config == null) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, "Configuration file missing");

--- a/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/handler/BlindHandler.java
+++ b/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/handler/BlindHandler.java
@@ -61,7 +61,7 @@ public class BlindHandler extends LutronHandler {
 
     @Override
     public void initialize() {
-        config = getThing().getConfiguration().as(BlindConfig.class);
+        config = getConfigAs(BlindConfig.class);
         if (config.integrationId <= 0) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, "No integrationId configured");
             return;

--- a/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/handler/DimmerHandler.java
+++ b/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/handler/DimmerHandler.java
@@ -70,7 +70,7 @@ public class DimmerHandler extends LutronHandler {
 
     @Override
     public void initialize() {
-        config = getThing().getConfiguration().as(DimmerConfig.class);
+        config = getConfigAs(DimmerConfig.class);
         if (config.integrationId <= 0) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, "No integrationId configured");
             return;

--- a/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/handler/IPBridgeHandler.java
+++ b/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/handler/IPBridgeHandler.java
@@ -479,6 +479,7 @@ public class IPBridgeHandler extends LutronBridgeHandler {
 
     @Override
     public void thingUpdated(Thing thing) {
+        this.thing = thing;
         IPBridgeConfig newConfig = getConfigAs(IPBridgeConfig.class);
         boolean validConfig = validConfiguration(newConfig);
         boolean needsReconnect = validConfig && !this.config.sameConnectionParameters(newConfig);
@@ -487,7 +488,6 @@ public class IPBridgeHandler extends LutronBridgeHandler {
             dispose();
         }
 
-        this.thing = thing;
         this.config = newConfig;
 
         if (needsReconnect) {

--- a/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/handler/IPBridgeHandler.java
+++ b/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/handler/IPBridgeHandler.java
@@ -35,7 +35,6 @@ import org.openhab.binding.lutron.internal.protocol.lip.LutronCommandType;
 import org.openhab.binding.lutron.internal.protocol.lip.LutronOperation;
 import org.openhab.binding.lutron.internal.protocol.lip.Monitoring;
 import org.openhab.binding.lutron.internal.protocol.lip.TargetType;
-import org.openhab.core.config.core.ConfigUtil;
 import org.openhab.core.thing.Bridge;
 import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.Thing;
@@ -80,7 +79,6 @@ public class IPBridgeHandler extends LutronBridgeHandler {
     private int reconnectInterval;
     private int heartbeatInterval;
     private int sendDelay;
-    private boolean preserveConnectionOnUpdate;
 
     private TelnetSession session;
     private BlockingQueue<LutronCommandNew> sendQueue = new LinkedBlockingQueue<>();
@@ -140,10 +138,6 @@ public class IPBridgeHandler extends LutronBridgeHandler {
             reconnectInterval = (config.reconnect > 0) ? config.reconnect : DEFAULT_RECONNECT_MINUTES;
             heartbeatInterval = (config.heartbeat > 0) ? config.heartbeat : DEFAULT_HEARTBEAT_MINUTES;
             sendDelay = (config.delay < 0) ? 0 : config.delay;
-
-            if (preserveConnectionOnUpdate) {
-                return;
-            }
 
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.NONE, "Connecting");
             scheduler.submit(this::connect); // start the async connect task
@@ -484,28 +478,25 @@ public class IPBridgeHandler extends LutronBridgeHandler {
     }
 
     @Override
-    public synchronized void thingUpdated(Thing thing) {
-        boolean preserveConnection = false;
-        try {
-            IPBridgeConfig newConfig = ConfigUtil.resolveVariables(thing.getConfiguration()).as(IPBridgeConfig.class);
-            preserveConnection = config != null && newConfig.ipAddress != null && !newConfig.ipAddress.isEmpty()
-                    && config.sameConnectionParameters(newConfig);
-        } catch (IllegalArgumentException e) {
-            // BaseThingHandler logs the resolution failure and applies the unresolved configuration.
+    public void thingUpdated(Thing thing) {
+        setThing(thing);
+        IPBridgeConfig newConfig = getConfigAs(IPBridgeConfig.class);
+        boolean validConfig = validConfiguration(newConfig);
+        boolean needsReconnect = validConfig && !this.config.sameConnectionParameters(newConfig);
+
+        if (!validConfig || needsReconnect) {
+            dispose();
         }
 
-        preserveConnectionOnUpdate = preserveConnection;
-        try {
-            super.thingUpdated(thing);
-        } finally {
-            preserveConnectionOnUpdate = false;
+        this.config = newConfig;
+
+        if (needsReconnect) {
+            initialize();
         }
     }
 
     @Override
-    public synchronized void dispose() {
-        if (!preserveConnectionOnUpdate) {
-            disconnect();
-        }
+    public void dispose() {
+        disconnect();
     }
 }

--- a/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/handler/IPBridgeHandler.java
+++ b/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/handler/IPBridgeHandler.java
@@ -132,7 +132,7 @@ public class IPBridgeHandler extends LutronBridgeHandler {
 
     @Override
     public void initialize() {
-        this.config = getThing().getConfiguration().as(IPBridgeConfig.class);
+        this.config = getConfigAs(IPBridgeConfig.class);
 
         if (validConfiguration(this.config)) {
             reconnectInterval = (config.reconnect > 0) ? config.reconnect : DEFAULT_RECONNECT_MINUTES;
@@ -479,7 +479,7 @@ public class IPBridgeHandler extends LutronBridgeHandler {
 
     @Override
     public void thingUpdated(Thing thing) {
-        IPBridgeConfig newConfig = thing.getConfiguration().as(IPBridgeConfig.class);
+        IPBridgeConfig newConfig = getConfigAs(IPBridgeConfig.class);
         boolean validConfig = validConfiguration(newConfig);
         boolean needsReconnect = validConfig && !this.config.sameConnectionParameters(newConfig);
 

--- a/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/handler/IPBridgeHandler.java
+++ b/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/handler/IPBridgeHandler.java
@@ -131,7 +131,7 @@ public class IPBridgeHandler extends LutronBridgeHandler {
     }
 
     @Override
-    public synchronized void initialize() {
+    public void initialize() {
         this.config = getConfigAs(IPBridgeConfig.class);
 
         if (validConfiguration(this.config)) {

--- a/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/handler/IPBridgeHandler.java
+++ b/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/handler/IPBridgeHandler.java
@@ -35,6 +35,7 @@ import org.openhab.binding.lutron.internal.protocol.lip.LutronCommandType;
 import org.openhab.binding.lutron.internal.protocol.lip.LutronOperation;
 import org.openhab.binding.lutron.internal.protocol.lip.Monitoring;
 import org.openhab.binding.lutron.internal.protocol.lip.TargetType;
+import org.openhab.core.config.core.ConfigUtil;
 import org.openhab.core.thing.Bridge;
 import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.Thing;
@@ -79,6 +80,7 @@ public class IPBridgeHandler extends LutronBridgeHandler {
     private int reconnectInterval;
     private int heartbeatInterval;
     private int sendDelay;
+    private boolean preserveConnectionOnUpdate;
 
     private TelnetSession session;
     private BlockingQueue<LutronCommandNew> sendQueue = new LinkedBlockingQueue<>();
@@ -131,13 +133,17 @@ public class IPBridgeHandler extends LutronBridgeHandler {
     }
 
     @Override
-    public void initialize() {
+    public synchronized void initialize() {
         this.config = getConfigAs(IPBridgeConfig.class);
 
         if (validConfiguration(this.config)) {
             reconnectInterval = (config.reconnect > 0) ? config.reconnect : DEFAULT_RECONNECT_MINUTES;
             heartbeatInterval = (config.heartbeat > 0) ? config.heartbeat : DEFAULT_HEARTBEAT_MINUTES;
             sendDelay = (config.delay < 0) ? 0 : config.delay;
+
+            if (preserveConnectionOnUpdate) {
+                return;
+            }
 
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.NONE, "Connecting");
             scheduler.submit(this::connect); // start the async connect task
@@ -478,25 +484,28 @@ public class IPBridgeHandler extends LutronBridgeHandler {
     }
 
     @Override
-    public void thingUpdated(Thing thing) {
-        this.thing = thing;
-        IPBridgeConfig newConfig = getConfigAs(IPBridgeConfig.class);
-        boolean validConfig = validConfiguration(newConfig);
-        boolean needsReconnect = validConfig && !this.config.sameConnectionParameters(newConfig);
-
-        if (!validConfig || needsReconnect) {
-            dispose();
+    public synchronized void thingUpdated(Thing thing) {
+        boolean preserveConnection = false;
+        try {
+            IPBridgeConfig newConfig = ConfigUtil.resolveVariables(thing.getConfiguration()).as(IPBridgeConfig.class);
+            preserveConnection = config != null && newConfig.ipAddress != null && !newConfig.ipAddress.isEmpty()
+                    && config.sameConnectionParameters(newConfig);
+        } catch (IllegalArgumentException e) {
+            // BaseThingHandler logs the resolution failure and applies the unresolved configuration.
         }
 
-        this.config = newConfig;
-
-        if (needsReconnect) {
-            initialize();
+        preserveConnectionOnUpdate = preserveConnection;
+        try {
+            super.thingUpdated(thing);
+        } finally {
+            preserveConnectionOnUpdate = false;
         }
     }
 
     @Override
-    public void dispose() {
-        disconnect();
+    public synchronized void dispose() {
+        if (!preserveConnectionOnUpdate) {
+            disconnect();
+        }
     }
 }

--- a/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/handler/SysvarHandler.java
+++ b/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/handler/SysvarHandler.java
@@ -60,7 +60,7 @@ public class SysvarHandler extends LutronHandler {
 
     @Override
     public void initialize() {
-        SysvarConfig config = getThing().getConfiguration().as(SysvarConfig.class);
+        SysvarConfig config = getConfigAs(SysvarConfig.class);
         this.config = config;
         if (config.integrationId <= 0) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, "No integrationId configured");

--- a/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/hw/HwDimmerHandler.java
+++ b/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/hw/HwDimmerHandler.java
@@ -41,7 +41,7 @@ public class HwDimmerHandler extends BaseThingHandler {
 
     @Override
     public void initialize() {
-        HwDimmerConfig config = getThing().getConfiguration().as(HwDimmerConfig.class);
+        HwDimmerConfig config = getConfigAs(HwDimmerConfig.class);
 
         address = config.getAddress();
         if (address == null || address.isEmpty()) {

--- a/bundles/org.openhab.binding.luxom/src/main/java/org/openhab/binding/luxom/internal/handler/LuxomBridgeHandler.java
+++ b/bundles/org.openhab.binding.luxom/src/main/java/org/openhab/binding/luxom/internal/handler/LuxomBridgeHandler.java
@@ -253,7 +253,7 @@ public class LuxomBridgeHandler extends BaseBridgeHandler {
 
     @Override
     public void thingUpdated(Thing thing) {
-        this.thing = thing;
+        setThing(thing);
         LuxomBridgeConfig newConfig = getConfigAs(LuxomBridgeConfig.class);
         boolean validConfig = validConfiguration(newConfig);
         boolean needsReconnect = validConfig && config != null && !config.sameConnectionParameters(newConfig);

--- a/bundles/org.openhab.binding.luxom/src/main/java/org/openhab/binding/luxom/internal/handler/LuxomBridgeHandler.java
+++ b/bundles/org.openhab.binding.luxom/src/main/java/org/openhab/binding/luxom/internal/handler/LuxomBridgeHandler.java
@@ -253,6 +253,7 @@ public class LuxomBridgeHandler extends BaseBridgeHandler {
 
     @Override
     public void thingUpdated(Thing thing) {
+        this.thing = thing;
         LuxomBridgeConfig newConfig = getConfigAs(LuxomBridgeConfig.class);
         boolean validConfig = validConfiguration(newConfig);
         boolean needsReconnect = validConfig && config != null && !config.sameConnectionParameters(newConfig);
@@ -261,7 +262,6 @@ public class LuxomBridgeHandler extends BaseBridgeHandler {
             dispose();
         }
 
-        this.thing = thing;
         this.config = newConfig;
 
         if (needsReconnect) {

--- a/bundles/org.openhab.binding.luxom/src/main/java/org/openhab/binding/luxom/internal/handler/LuxomBridgeHandler.java
+++ b/bundles/org.openhab.binding.luxom/src/main/java/org/openhab/binding/luxom/internal/handler/LuxomBridgeHandler.java
@@ -253,7 +253,7 @@ public class LuxomBridgeHandler extends BaseBridgeHandler {
 
     @Override
     public void thingUpdated(Thing thing) {
-        LuxomBridgeConfig newConfig = thing.getConfiguration().as(LuxomBridgeConfig.class);
+        LuxomBridgeConfig newConfig = getConfigAs(LuxomBridgeConfig.class);
         boolean validConfig = validConfiguration(newConfig);
         boolean needsReconnect = validConfig && config != null && !config.sameConnectionParameters(newConfig);
 

--- a/bundles/org.openhab.binding.luxtronikheatpump/src/main/java/org/openhab/binding/luxtronikheatpump/internal/ChannelUpdaterJob.java
+++ b/bundles/org.openhab.binding.luxtronikheatpump/src/main/java/org/openhab/binding/luxtronikheatpump/internal/ChannelUpdaterJob.java
@@ -59,7 +59,7 @@ public class ChannelUpdaterJob implements SchedulerRunnable, Runnable {
         this.translationProvider = translationProvider;
         this.handler = handler;
         this.thing = handler.getThing();
-        this.config = this.thing.getConfiguration().as(LuxtronikHeatpumpConfiguration.class);
+        this.config = handler.getConfigAs(LuxtronikHeatpumpConfiguration.class);
     }
 
     public Thing getThing() {

--- a/bundles/org.openhab.binding.luxtronikheatpump/src/main/java/org/openhab/binding/luxtronikheatpump/internal/LuxtronikHeatpumpHandler.java
+++ b/bundles/org.openhab.binding.luxtronikheatpump/src/main/java/org/openhab/binding/luxtronikheatpump/internal/LuxtronikHeatpumpHandler.java
@@ -71,6 +71,11 @@ public class LuxtronikHeatpumpHandler extends BaseThingHandler {
     }
 
     @Override
+    public <T> T getConfigAs(Class<T> configurationClass) {
+        return super.getConfigAs(configurationClass);
+    }
+
+    @Override
     public void updateState(String channelID, State state) {
         super.updateState(channelID, state);
     }

--- a/bundles/org.openhab.binding.minecraft/src/main/java/org/openhab/binding/minecraft/internal/handler/MinecraftPlayerHandler.java
+++ b/bundles/org.openhab.binding.minecraft/src/main/java/org/openhab/binding/minecraft/internal/handler/MinecraftPlayerHandler.java
@@ -62,7 +62,7 @@ public class MinecraftPlayerHandler extends BaseThingHandler {
     @Override
     public void initialize() {
         this.bridgeHandler = getBridgeHandler();
-        this.config = getThing().getConfiguration().as(PlayerConfig.class);
+        this.config = getConfigAs(PlayerConfig.class);
 
         if (bridgeHandler == null || getThing().getBridgeUID() == null) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, "No bridge configured");

--- a/bundles/org.openhab.binding.minecraft/src/main/java/org/openhab/binding/minecraft/internal/handler/MinecraftSignHandler.java
+++ b/bundles/org.openhab.binding.minecraft/src/main/java/org/openhab/binding/minecraft/internal/handler/MinecraftSignHandler.java
@@ -60,7 +60,7 @@ public class MinecraftSignHandler extends BaseThingHandler {
     @Override
     public void initialize() {
         this.bridgeHandler = getBridgeHandler();
-        this.config = getThing().getConfiguration().as(SignConfig.class);
+        this.config = getConfigAs(SignConfig.class);
 
         if (getThing().getBridgeUID() == null) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, "No bridge configured");

--- a/bundles/org.openhab.binding.neato/src/main/java/org/openhab/binding/neato/internal/config/NeatoRobotConfig.java
+++ b/bundles/org.openhab.binding.neato/src/main/java/org/openhab/binding/neato/internal/config/NeatoRobotConfig.java
@@ -50,6 +50,7 @@ public class NeatoRobotConfig {
 
     @Override
     public String toString() {
-        return "NeatoRobotConfig [refresh=" + refresh + ", secret=" + secret + ", serial=" + serial + "]";
+        return "NeatoRobotConfig [refresh=" + refresh + ", secret=" + (secret != null && !secret.isBlank())
+                + ", serial=" + serial + "]";
     }
 }

--- a/bundles/org.openhab.binding.neato/src/main/java/org/openhab/binding/neato/internal/handler/NeatoHandler.java
+++ b/bundles/org.openhab.binding.neato/src/main/java/org/openhab/binding/neato/internal/handler/NeatoHandler.java
@@ -94,7 +94,7 @@ public class NeatoHandler extends BaseThingHandler {
         updateStatus(ThingStatus.UNKNOWN);
         logger.debug("Will boot up Neato Vacuum Cleaner binding!");
 
-        NeatoRobotConfig config = getThing().getConfiguration().as(NeatoRobotConfig.class);
+        NeatoRobotConfig config = getConfigAs(NeatoRobotConfig.class);
 
         logger.debug("Neato Robot Config: {}", config);
 

--- a/bundles/org.openhab.binding.neeo/src/main/java/org/openhab/binding/neeo/internal/handler/NeeoDeviceHandler.java
+++ b/bundles/org.openhab.binding.neeo/src/main/java/org/openhab/binding/neeo/internal/handler/NeeoDeviceHandler.java
@@ -307,7 +307,7 @@ public class NeeoDeviceHandler extends BaseThingHandler {
     private String getRoomKey() {
         final Bridge bridge = getBridge();
         if (bridge != null && bridge.getHandler() instanceof NeeoRoomHandler neeoRoomHandler) {
-            return neeoRoomHandler.getBridgeHandler().getRoomKey();
+            return neeoRoomHandler.getBridgeConfig().getRoomKey();
         }
         return null;
     }

--- a/bundles/org.openhab.binding.neeo/src/main/java/org/openhab/binding/neeo/internal/handler/NeeoDeviceHandler.java
+++ b/bundles/org.openhab.binding.neeo/src/main/java/org/openhab/binding/neeo/internal/handler/NeeoDeviceHandler.java
@@ -30,7 +30,6 @@ import org.openhab.binding.neeo.internal.NeeoConstants;
 import org.openhab.binding.neeo.internal.NeeoDeviceConfig;
 import org.openhab.binding.neeo.internal.NeeoDeviceProtocol;
 import org.openhab.binding.neeo.internal.NeeoHandlerCallback;
-import org.openhab.binding.neeo.internal.NeeoRoomConfig;
 import org.openhab.binding.neeo.internal.NeeoUtil;
 import org.openhab.binding.neeo.internal.UidUtils;
 import org.openhab.binding.neeo.internal.models.NeeoDevice;
@@ -308,9 +307,8 @@ public class NeeoDeviceHandler extends BaseThingHandler {
     private String getRoomKey() {
         final Bridge bridge = getBridge();
         if (bridge != null) {
-            final BridgeHandler handler = bridge.getHandler();
-            if (handler instanceof NeeoRoomHandler) {
-                return handler.getThing().getConfiguration().as(NeeoRoomConfig.class).getRoomKey();
+            if (bridge.getHandler() instanceof NeeoRoomHandler neeoRoomHandler) {
+                return neeoRoomHandler.getBindingConfig().getRoomKey();
             }
         }
         return null;

--- a/bundles/org.openhab.binding.neeo/src/main/java/org/openhab/binding/neeo/internal/handler/NeeoDeviceHandler.java
+++ b/bundles/org.openhab.binding.neeo/src/main/java/org/openhab/binding/neeo/internal/handler/NeeoDeviceHandler.java
@@ -306,10 +306,8 @@ public class NeeoDeviceHandler extends BaseThingHandler {
     @Nullable
     private String getRoomKey() {
         final Bridge bridge = getBridge();
-        if (bridge != null) {
-            if (bridge.getHandler() instanceof NeeoRoomHandler neeoRoomHandler) {
-                return neeoRoomHandler.getBindingConfig().getRoomKey();
-            }
+        if (bridge != null && bridge.getHandler() instanceof NeeoRoomHandler neeoRoomHandler) {
+            return neeoRoomHandler.getBridgeConfig().getRoomKey();
         }
         return null;
     }

--- a/bundles/org.openhab.binding.neeo/src/main/java/org/openhab/binding/neeo/internal/handler/NeeoDeviceHandler.java
+++ b/bundles/org.openhab.binding.neeo/src/main/java/org/openhab/binding/neeo/internal/handler/NeeoDeviceHandler.java
@@ -307,7 +307,7 @@ public class NeeoDeviceHandler extends BaseThingHandler {
     private String getRoomKey() {
         final Bridge bridge = getBridge();
         if (bridge != null && bridge.getHandler() instanceof NeeoRoomHandler neeoRoomHandler) {
-            return neeoRoomHandler.getBridgeConfig().getRoomKey();
+            return neeoRoomHandler.getBridgeHandler().getRoomKey();
         }
         return null;
     }

--- a/bundles/org.openhab.binding.neeo/src/main/java/org/openhab/binding/neeo/internal/handler/NeeoRoomHandler.java
+++ b/bundles/org.openhab.binding.neeo/src/main/java/org/openhab/binding/neeo/internal/handler/NeeoRoomHandler.java
@@ -132,7 +132,7 @@ public class NeeoRoomHandler extends BaseBridgeHandler {
         }
     }
 
-    public NeeoRoomConfig getBridgeHandler() {
+    public NeeoRoomConfig getBridgeConfig() {
         return getConfigAs(NeeoRoomConfig.class);
     }
 

--- a/bundles/org.openhab.binding.neeo/src/main/java/org/openhab/binding/neeo/internal/handler/NeeoRoomHandler.java
+++ b/bundles/org.openhab.binding.neeo/src/main/java/org/openhab/binding/neeo/internal/handler/NeeoRoomHandler.java
@@ -132,6 +132,10 @@ public class NeeoRoomHandler extends BaseBridgeHandler {
         }
     }
 
+    public NeeoRoomConfig getBindingConfig() {
+        return getConfigAs(NeeoRoomConfig.class);
+    }
+
     /**
      * Refresh the specified channel section, key and id using the specified protocol
      *

--- a/bundles/org.openhab.binding.neeo/src/main/java/org/openhab/binding/neeo/internal/handler/NeeoRoomHandler.java
+++ b/bundles/org.openhab.binding.neeo/src/main/java/org/openhab/binding/neeo/internal/handler/NeeoRoomHandler.java
@@ -132,7 +132,7 @@ public class NeeoRoomHandler extends BaseBridgeHandler {
         }
     }
 
-    public NeeoRoomConfig getBindingConfig() {
+    public NeeoRoomConfig getBridgeHandler() {
         return getConfigAs(NeeoRoomConfig.class);
     }
 

--- a/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/handler/CommonInterface.java
+++ b/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/handler/CommonInterface.java
@@ -122,9 +122,7 @@ public interface CommonInterface {
         return getThingConfigAs(NAThingConfiguration.class).getId();
     }
 
-    default <T> T getThingConfigAs(Class<T> configurationClass) {
-        return getThing().getConfiguration().as(configurationClass);
-    }
+    <T> T getThingConfigAs(Class<T> configurationClass);
 
     default Stream<Channel> getActiveChannels() {
         return getThing().getChannels().stream()

--- a/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/handler/DeviceHandler.java
+++ b/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/handler/DeviceHandler.java
@@ -118,4 +118,9 @@ public class DeviceHandler extends BaseBridgeHandler implements CommonInterface 
     public ScheduledExecutorService getScheduler() {
         return scheduler;
     }
+
+    @Override
+    public <T> T getThingConfigAs(Class<T> configurationClass) {
+        return getConfigAs(configurationClass);
+    }
 }

--- a/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/handler/ModuleHandler.java
+++ b/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/handler/ModuleHandler.java
@@ -129,4 +129,9 @@ public class ModuleHandler extends BaseThingHandler implements CommonInterface {
     public ScheduledExecutorService getScheduler() {
         return scheduler;
     }
+
+    @Override
+    public <T> T getThingConfigAs(Class<T> configurationClass) {
+        return getConfigAs(configurationClass);
+    }
 }

--- a/bundles/org.openhab.binding.russound/src/main/java/org/openhab/binding/russound/internal/rio/controller/RioControllerHandler.java
+++ b/bundles/org.openhab.binding.russound/src/main/java/org/openhab/binding/russound/internal/rio/controller/RioControllerHandler.java
@@ -154,7 +154,7 @@ public class RioControllerHandler extends AbstractBridgeHandler<RioControllerPro
             return;
         }
 
-        final RioControllerConfig config = getThing().getConfiguration().as(RioControllerConfig.class);
+        final RioControllerConfig config = getConfigAs(RioControllerConfig.class);
         if (config == null) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, "Configuration file missing");
             return;

--- a/bundles/org.openhab.binding.russound/src/main/java/org/openhab/binding/russound/internal/rio/source/RioSourceHandler.java
+++ b/bundles/org.openhab.binding.russound/src/main/java/org/openhab/binding/russound/internal/rio/source/RioSourceHandler.java
@@ -229,7 +229,7 @@ public class RioSourceHandler extends AbstractThingHandler<RioSourceProtocol> im
             return;
         }
 
-        final RioSourceConfig config = getThing().getConfiguration().as(RioSourceConfig.class);
+        final RioSourceConfig config = getConfigAs(RioSourceConfig.class);
         if (config == null) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, "Configuration file missing");
             return;

--- a/bundles/org.openhab.binding.russound/src/main/java/org/openhab/binding/russound/internal/rio/system/RioSystemHandler.java
+++ b/bundles/org.openhab.binding.russound/src/main/java/org/openhab/binding/russound/internal/rio/system/RioSystemHandler.java
@@ -420,7 +420,7 @@ public class RioSystemHandler extends AbstractBridgeHandler<RioSystemProtocol> {
     public RioSystemConfig getRioConfig() {
         configLock.lock();
         try {
-            final RioSystemConfig sysConfig = getThing().getConfiguration().as(RioSystemConfig.class);
+            final RioSystemConfig sysConfig = getConfigAs(RioSystemConfig.class);
 
             if (sysConfig == null) {
                 updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, "Configuration file missing");

--- a/bundles/org.openhab.binding.russound/src/main/java/org/openhab/binding/russound/internal/rio/zone/RioZoneHandler.java
+++ b/bundles/org.openhab.binding.russound/src/main/java/org/openhab/binding/russound/internal/rio/zone/RioZoneHandler.java
@@ -426,7 +426,7 @@ public class RioZoneHandler extends AbstractThingHandler<RioZoneProtocol>
             return;
         }
 
-        final RioZoneConfig config = getThing().getConfiguration().as(RioZoneConfig.class);
+        final RioZoneConfig config = getConfigAs(RioZoneConfig.class);
         if (config == null) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, "Configuration file missing");
             return;

--- a/bundles/org.openhab.binding.sbus/src/main/java/org/openhab/binding/sbus/internal/handler/AbstractSbusHandler.java
+++ b/bundles/org.openhab.binding.sbus/src/main/java/org/openhab/binding/sbus/internal/handler/AbstractSbusHandler.java
@@ -54,6 +54,11 @@ public abstract class AbstractSbusHandler extends BaseThingHandler implements Sb
     }
 
     @Override
+    public <T> T getConfigAs(Class<T> configurationClass) {
+        return super.getConfigAs(configurationClass);
+    }
+
+    @Override
     public final void initialize() {
         logger.debug("Initializing Sbus handler for thing {}", getThing().getUID());
 

--- a/bundles/org.openhab.binding.sbus/src/main/java/org/openhab/binding/sbus/internal/handler/AbstractSbusHandler.java
+++ b/bundles/org.openhab.binding.sbus/src/main/java/org/openhab/binding/sbus/internal/handler/AbstractSbusHandler.java
@@ -54,11 +54,6 @@ public abstract class AbstractSbusHandler extends BaseThingHandler implements Sb
     }
 
     @Override
-    public <T> T getConfigAs(Class<T> configurationClass) {
-        return super.getConfigAs(configurationClass);
-    }
-
-    @Override
     public final void initialize() {
         logger.debug("Initializing Sbus handler for thing {}", getThing().getUID());
 

--- a/bundles/org.openhab.binding.sbus/src/main/java/org/openhab/binding/sbus/internal/handler/SbusHandlerFactory.java
+++ b/bundles/org.openhab.binding.sbus/src/main/java/org/openhab/binding/sbus/internal/handler/SbusHandlerFactory.java
@@ -50,6 +50,17 @@ public class SbusHandlerFactory extends BaseThingHandlerFactory {
         return SUPPORTED_THING_TYPES_UIDS.contains(thingTypeUID);
     }
 
+    private static <T> T getThingConfig(Thing thing, Class<T> configurationClass) {
+        ThingHandler handler = thing.getHandler();
+        if (handler instanceof SbusContactHandler contactHandler) {
+            return contactHandler.getConfigAs(configurationClass);
+        }
+        if (handler instanceof Sbus9in1ContactHandler nineInOneContactHandler) {
+            return nineInOneContactHandler.getConfigAs(configurationClass);
+        }
+        return thing.getConfiguration().as(configurationClass);
+    }
+
     @Override
     protected @Nullable ThingHandler createHandler(Thing thing) {
         ThingTypeUID thingTypeUID = thing.getThingTypeUID();
@@ -70,7 +81,7 @@ public class SbusHandlerFactory extends BaseThingHandlerFactory {
             return new SbusRgbwHandler(thing);
         } else if (thingTypeUID.equals(THING_TYPE_CONTACT_SENSOR)) {
             // Determine which contact handler to create based on sensor type configuration
-            SbusContactConfig config = thing.getConfiguration().as(SbusContactConfig.class);
+            SbusContactConfig config = getThingConfig(thing, SbusContactConfig.class);
             ContactSensorType sensorType = config.getSensorType();
 
             if (sensorType == ContactSensorType.MULTI_SENSOR_02CA) {

--- a/bundles/org.openhab.binding.sbus/src/main/java/org/openhab/binding/sbus/internal/handler/SbusHandlerFactory.java
+++ b/bundles/org.openhab.binding.sbus/src/main/java/org/openhab/binding/sbus/internal/handler/SbusHandlerFactory.java
@@ -50,17 +50,6 @@ public class SbusHandlerFactory extends BaseThingHandlerFactory {
         return SUPPORTED_THING_TYPES_UIDS.contains(thingTypeUID);
     }
 
-    private static <T> T getThingConfig(Thing thing, Class<T> configurationClass) {
-        ThingHandler handler = thing.getHandler();
-        if (handler instanceof SbusContactHandler contactHandler) {
-            return contactHandler.getConfigAs(configurationClass);
-        }
-        if (handler instanceof Sbus9in1ContactHandler nineInOneContactHandler) {
-            return nineInOneContactHandler.getConfigAs(configurationClass);
-        }
-        return thing.getConfiguration().as(configurationClass);
-    }
-
     @Override
     protected @Nullable ThingHandler createHandler(Thing thing) {
         ThingTypeUID thingTypeUID = thing.getThingTypeUID();
@@ -81,7 +70,7 @@ public class SbusHandlerFactory extends BaseThingHandlerFactory {
             return new SbusRgbwHandler(thing);
         } else if (thingTypeUID.equals(THING_TYPE_CONTACT_SENSOR)) {
             // Determine which contact handler to create based on sensor type configuration
-            SbusContactConfig config = getThingConfig(thing, SbusContactConfig.class);
+            SbusContactConfig config = thing.getConfiguration().as(SbusContactConfig.class);
             ContactSensorType sensorType = config.getSensorType();
 
             if (sensorType == ContactSensorType.MULTI_SENSOR_02CA) {

--- a/bundles/org.openhab.binding.smartthings/src/main/java/org/openhab/binding/smartthings/internal/converter/SmartthingsColor100Converter.java
+++ b/bundles/org.openhab.binding.smartthings/src/main/java/org/openhab/binding/smartthings/internal/converter/SmartthingsColor100Converter.java
@@ -18,10 +18,10 @@ import java.util.regex.Pattern;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.smartthings.internal.dto.SmartthingsStateData;
+import org.openhab.binding.smartthings.internal.handler.SmartthingsThingConfig;
 import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.library.types.HSBType;
 import org.openhab.core.thing.ChannelUID;
-import org.openhab.core.thing.Thing;
 import org.openhab.core.types.Command;
 import org.openhab.core.types.State;
 import org.openhab.core.types.UnDefType;
@@ -43,8 +43,8 @@ public class SmartthingsColor100Converter extends SmartthingsConverter {
 
     private final Logger logger = LoggerFactory.getLogger(SmartthingsColor100Converter.class);
 
-    public SmartthingsColor100Converter(Thing thing) {
-        super(thing);
+    public SmartthingsColor100Converter(SmartthingsThingConfig config, String thingTypeId) {
+        super(config, thingTypeId);
     }
 
     @Override

--- a/bundles/org.openhab.binding.smartthings/src/main/java/org/openhab/binding/smartthings/internal/converter/SmartthingsColorConverter.java
+++ b/bundles/org.openhab.binding.smartthings/src/main/java/org/openhab/binding/smartthings/internal/converter/SmartthingsColorConverter.java
@@ -18,9 +18,9 @@ import java.util.regex.Pattern;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.smartthings.internal.dto.SmartthingsStateData;
+import org.openhab.binding.smartthings.internal.handler.SmartthingsThingConfig;
 import org.openhab.core.library.types.HSBType;
 import org.openhab.core.thing.ChannelUID;
-import org.openhab.core.thing.Thing;
 import org.openhab.core.types.Command;
 import org.openhab.core.types.State;
 import org.openhab.core.types.UnDefType;
@@ -41,8 +41,8 @@ public class SmartthingsColorConverter extends SmartthingsConverter {
 
     private final Logger logger = LoggerFactory.getLogger(SmartthingsColorConverter.class);
 
-    public SmartthingsColorConverter(Thing thing) {
-        super(thing);
+    public SmartthingsColorConverter(SmartthingsThingConfig config, String thingTypeId) {
+        super(config, thingTypeId);
     }
 
     @Override

--- a/bundles/org.openhab.binding.smartthings/src/main/java/org/openhab/binding/smartthings/internal/converter/SmartthingsConverter.java
+++ b/bundles/org.openhab.binding.smartthings/src/main/java/org/openhab/binding/smartthings/internal/converter/SmartthingsConverter.java
@@ -34,7 +34,6 @@ import org.openhab.core.library.types.StringListType;
 import org.openhab.core.library.types.StringType;
 import org.openhab.core.library.types.UpDownType;
 import org.openhab.core.thing.ChannelUID;
-import org.openhab.core.thing.Thing;
 import org.openhab.core.types.Command;
 import org.openhab.core.types.RefreshType;
 import org.openhab.core.types.State;
@@ -57,9 +56,9 @@ public abstract class SmartthingsConverter {
     protected String smartthingsName;
     protected String thingTypeId;
 
-    SmartthingsConverter(Thing thing) {
-        smartthingsName = thing.getConfiguration().as(SmartthingsThingConfig.class).smartthingsName;
-        thingTypeId = thing.getThingTypeUID().getId();
+    SmartthingsConverter(SmartthingsThingConfig config, String thingTypeId) {
+        smartthingsName = config.smartthingsName;
+        this.thingTypeId = thingTypeId;
     }
 
     public abstract String convertToSmartthings(ChannelUID channelUid, Command command);

--- a/bundles/org.openhab.binding.smartthings/src/main/java/org/openhab/binding/smartthings/internal/converter/SmartthingsDefaultConverter.java
+++ b/bundles/org.openhab.binding.smartthings/src/main/java/org/openhab/binding/smartthings/internal/converter/SmartthingsDefaultConverter.java
@@ -15,8 +15,8 @@ package org.openhab.binding.smartthings.internal.converter;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.smartthings.internal.dto.SmartthingsStateData;
+import org.openhab.binding.smartthings.internal.handler.SmartthingsThingConfig;
 import org.openhab.core.thing.ChannelUID;
-import org.openhab.core.thing.Thing;
 import org.openhab.core.types.Command;
 import org.openhab.core.types.State;
 
@@ -35,8 +35,8 @@ import org.openhab.core.types.State;
 @NonNullByDefault
 public class SmartthingsDefaultConverter extends SmartthingsConverter {
 
-    public SmartthingsDefaultConverter(Thing thing) {
-        super(thing);
+    public SmartthingsDefaultConverter(SmartthingsThingConfig config, String thingTypeId) {
+        super(config, thingTypeId);
     }
 
     @Override

--- a/bundles/org.openhab.binding.smartthings/src/main/java/org/openhab/binding/smartthings/internal/converter/SmartthingsHue100Converter.java
+++ b/bundles/org.openhab.binding.smartthings/src/main/java/org/openhab/binding/smartthings/internal/converter/SmartthingsHue100Converter.java
@@ -17,10 +17,10 @@ import java.math.BigDecimal;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.smartthings.internal.dto.SmartthingsStateData;
+import org.openhab.binding.smartthings.internal.handler.SmartthingsThingConfig;
 import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.library.types.HSBType;
 import org.openhab.core.thing.ChannelUID;
-import org.openhab.core.thing.Thing;
 import org.openhab.core.types.Command;
 import org.openhab.core.types.State;
 import org.openhab.core.types.UnDefType;
@@ -39,8 +39,8 @@ public class SmartthingsHue100Converter extends SmartthingsConverter {
 
     private final Logger logger = LoggerFactory.getLogger(SmartthingsHue100Converter.class);
 
-    public SmartthingsHue100Converter(Thing thing) {
-        super(thing);
+    public SmartthingsHue100Converter(SmartthingsThingConfig config, String thingTypeId) {
+        super(config, thingTypeId);
     }
 
     @Override

--- a/bundles/org.openhab.binding.smartthings/src/main/java/org/openhab/binding/smartthings/internal/converter/SmartthingsOpenCloseControlConverter.java
+++ b/bundles/org.openhab.binding.smartthings/src/main/java/org/openhab/binding/smartthings/internal/converter/SmartthingsOpenCloseControlConverter.java
@@ -15,8 +15,8 @@ package org.openhab.binding.smartthings.internal.converter;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.smartthings.internal.dto.SmartthingsStateData;
+import org.openhab.binding.smartthings.internal.handler.SmartthingsThingConfig;
 import org.openhab.core.thing.ChannelUID;
-import org.openhab.core.thing.Thing;
 import org.openhab.core.types.Command;
 import org.openhab.core.types.State;
 
@@ -31,8 +31,8 @@ import org.openhab.core.types.State;
 @NonNullByDefault
 public class SmartthingsOpenCloseControlConverter extends SmartthingsConverter {
 
-    public SmartthingsOpenCloseControlConverter(Thing thing) {
-        super(thing);
+    public SmartthingsOpenCloseControlConverter(SmartthingsThingConfig config, String thingTypeId) {
+        super(config, thingTypeId);
     }
 
     @Override

--- a/bundles/org.openhab.binding.smartthings/src/main/java/org/openhab/binding/smartthings/internal/handler/SmartthingsBridgeHandler.java
+++ b/bundles/org.openhab.binding.smartthings/src/main/java/org/openhab/binding/smartthings/internal/handler/SmartthingsBridgeHandler.java
@@ -49,7 +49,7 @@ public class SmartthingsBridgeHandler extends ConfigStatusBridgeHandler {
         super(bridge);
         this.smartthingsHandlerFactory = smartthingsHandlerFactory;
         this.bundleContext = bundleContext;
-        config = getThing().getConfiguration().as(SmartthingsBridgeConfig.class);
+        config = getConfigAs(SmartthingsBridgeConfig.class);
     }
 
     @Override

--- a/bundles/org.openhab.binding.smartthings/src/main/java/org/openhab/binding/smartthings/internal/handler/SmartthingsThingHandler.java
+++ b/bundles/org.openhab.binding.smartthings/src/main/java/org/openhab/binding/smartthings/internal/handler/SmartthingsThingHandler.java
@@ -166,7 +166,7 @@ public class SmartthingsThingHandler extends ConfigStatusThingHandler {
 
     @Override
     public void initialize() {
-        config = getThing().getConfiguration().as(SmartthingsThingConfig.class);
+        config = getConfigAs(SmartthingsThingConfig.class);
         if (!validateConfig(config)) {
             return;
         }
@@ -208,9 +208,10 @@ public class SmartthingsThingHandler extends ConfigStatusThingHandler {
         converterClassName.append(converterName.substring(1));
         converterClassName.append("Converter");
         try {
-            Constructor<?> constr = Class.forName(converterClassName.toString()).getDeclaredConstructor(Thing.class);
+            Constructor<?> constr = Class.forName(converterClassName.toString())
+                    .getDeclaredConstructor(SmartthingsThingConfig.class, String.class);
             constr.setAccessible(true);
-            return (SmartthingsConverter) constr.newInstance(thing);
+            return (SmartthingsConverter) constr.newInstance(config, thing.getThingTypeUID().getId());
         } catch (ClassNotFoundException e) {
             // Most of the time there is no channel specific converter, the default converter is all that is needed.
             logger.trace("No Custom converter exists for {} ({})", converterName, converterClassName);

--- a/bundles/org.openhab.binding.somfymylink/src/main/java/org/openhab/binding/somfymylink/internal/handler/SomfyMyLinkBridgeHandler.java
+++ b/bundles/org.openhab.binding.somfymylink/src/main/java/org/openhab/binding/somfymylink/internal/handler/SomfyMyLinkBridgeHandler.java
@@ -367,7 +367,7 @@ public class SomfyMyLinkBridgeHandler extends BaseBridgeHandler {
 
     @Override
     public void thingUpdated(Thing thing) {
-        this.thing = thing;
+        setThing(thing);
         SomfyMyLinkConfiguration newConfig = getConfigAs(SomfyMyLinkConfiguration.class);
         config = newConfig;
     }

--- a/bundles/org.openhab.binding.somfymylink/src/main/java/org/openhab/binding/somfymylink/internal/handler/SomfyMyLinkBridgeHandler.java
+++ b/bundles/org.openhab.binding.somfymylink/src/main/java/org/openhab/binding/somfymylink/internal/handler/SomfyMyLinkBridgeHandler.java
@@ -129,7 +129,7 @@ public class SomfyMyLinkBridgeHandler extends BaseBridgeHandler {
     @Override
     public void initialize() {
         logger.info("Initializing mylink");
-        config = getThing().getConfiguration().as(SomfyMyLinkConfiguration.class);
+        config = getConfigAs(SomfyMyLinkConfiguration.class);
 
         commandExecutor = Executors.newSingleThreadExecutor(new NamedThreadFactory(thing.getUID().getAsString(), true));
 
@@ -367,7 +367,7 @@ public class SomfyMyLinkBridgeHandler extends BaseBridgeHandler {
 
     @Override
     public void thingUpdated(Thing thing) {
-        SomfyMyLinkConfiguration newConfig = thing.getConfiguration().as(SomfyMyLinkConfiguration.class);
+        SomfyMyLinkConfiguration newConfig = getConfigAs(SomfyMyLinkConfiguration.class);
         config = newConfig;
     }
 

--- a/bundles/org.openhab.binding.somfymylink/src/main/java/org/openhab/binding/somfymylink/internal/handler/SomfyMyLinkBridgeHandler.java
+++ b/bundles/org.openhab.binding.somfymylink/src/main/java/org/openhab/binding/somfymylink/internal/handler/SomfyMyLinkBridgeHandler.java
@@ -367,6 +367,7 @@ public class SomfyMyLinkBridgeHandler extends BaseBridgeHandler {
 
     @Override
     public void thingUpdated(Thing thing) {
+        this.thing = thing;
         SomfyMyLinkConfiguration newConfig = getConfigAs(SomfyMyLinkConfiguration.class);
         config = newConfig;
     }

--- a/bundles/org.openhab.binding.sunsynk/src/main/java/org/openhab/binding/sunsynk/internal/handler/SunSynkInverterHandler.java
+++ b/bundles/org.openhab.binding.sunsynk/src/main/java/org/openhab/binding/sunsynk/internal/handler/SunSynkInverterHandler.java
@@ -247,7 +247,7 @@ public class SunSynkInverterHandler extends BaseThingHandler {
     @Override
     public void initialize() {
         updateStatus(ThingStatus.UNKNOWN);
-        config = getThing().getConfiguration().as(SunSynkInverterConfig.class);
+        config = getConfigAs(SunSynkInverterConfig.class);
         logger.debug("Inverter Config: {}", config);
         if (config.getRefresh() < 60) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,

--- a/bundles/org.openhab.binding.tr064/src/main/java/org/openhab/binding/tr064/internal/Tr064RootHandler.java
+++ b/bundles/org.openhab.binding.tr064/src/main/java/org/openhab/binding/tr064/internal/Tr064RootHandler.java
@@ -117,6 +117,11 @@ public class Tr064RootHandler extends BaseBridgeHandler implements PhonebookProv
     }
 
     @Override
+    public <T> T getConfigAs(Class<T> configurationClass) {
+        return super.getConfigAs(configurationClass);
+    }
+
+    @Override
     public void handleCommand(ChannelUID channelUID, Command command) {
         if (!communicationEstablished) {
             logger.debug("Tried to process command, but thing is not yet ready: {} to {}", channelUID, command);

--- a/bundles/org.openhab.binding.tr064/src/main/java/org/openhab/binding/tr064/internal/Tr064SubHandler.java
+++ b/bundles/org.openhab.binding.tr064/src/main/java/org/openhab/binding/tr064/internal/Tr064SubHandler.java
@@ -78,6 +78,11 @@ public class Tr064SubHandler extends BaseThingHandler {
     }
 
     @Override
+    public <T> T getConfigAs(Class<T> configurationClass) {
+        return super.getConfigAs(configurationClass);
+    }
+
+    @Override
     public void handleCommand(ChannelUID channelUID, Command command) {
         Tr064ChannelConfig channelConfig = channels.get(channelUID);
         if (channelConfig == null) {

--- a/bundles/org.openhab.binding.tr064/src/main/java/org/openhab/binding/tr064/internal/util/Util.java
+++ b/bundles/org.openhab.binding.tr064/src/main/java/org/openhab/binding/tr064/internal/util/Util.java
@@ -48,6 +48,7 @@ import org.eclipse.jetty.client.api.ContentResponse;
 import org.eclipse.jetty.http.HttpMethod;
 import org.openhab.binding.tr064.internal.ChannelConfigException;
 import org.openhab.binding.tr064.internal.Tr064RootHandler;
+import org.openhab.binding.tr064.internal.Tr064SubHandler;
 import org.openhab.binding.tr064.internal.config.Tr064BaseThingConfiguration;
 import org.openhab.binding.tr064.internal.config.Tr064ChannelConfig;
 import org.openhab.binding.tr064.internal.config.Tr064RootConfiguration;
@@ -66,6 +67,7 @@ import org.openhab.core.cache.ExpiringCacheMap;
 import org.openhab.core.thing.Channel;
 import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.Thing;
+import org.openhab.core.thing.binding.ThingHandler;
 import org.openhab.core.thing.binding.ThingHandlerCallback;
 import org.openhab.core.thing.binding.builder.ThingBuilder;
 import org.openhab.core.thing.type.ChannelTypeUID;
@@ -170,9 +172,15 @@ public class Util {
      */
     public static void checkAvailableChannels(Thing thing, ThingHandlerCallback callback, ThingBuilder thingBuilder,
             SCPDUtil scpdUtil, String deviceId, String deviceType, Map<ChannelUID, Tr064ChannelConfig> channels) {
-        Tr064BaseThingConfiguration thingConfig = Tr064RootHandler.SUPPORTED_THING_TYPES
-                .contains(thing.getThingTypeUID()) ? thing.getConfiguration().as(Tr064RootConfiguration.class)
-                        : thing.getConfiguration().as(Tr064SubConfiguration.class);
+        ThingHandler handler = thing.getHandler();
+        Tr064BaseThingConfiguration thingConfig;
+        if (handler instanceof Tr064RootHandler rootHandler) {
+            thingConfig = rootHandler.getConfigAs(Tr064RootConfiguration.class);
+        } else if (handler instanceof Tr064SubHandler subHandler) {
+            thingConfig = subHandler.getConfigAs(Tr064SubConfiguration.class);
+        } else {
+            throw new IllegalStateException("Unable to resolve tr064 configuration without a handler");
+        }
         channels.clear();
         CHANNEL_TYPES.stream().filter(channel -> deviceType.equals(channel.getService().getDeviceType()))
                 .forEach(channelTypeDescription -> {


### PR DESCRIPTION
Fixes: https://github.com/openhab/openhab-addons/issues/21356

There might still be as few cases left, but i could not find them or changing them would outweight the benefit. For instance when only an id or refreshinterval is retrieved. Probably nobody will consider consider to use environment variables for those, as they mainly target credentials, api keys and those type of secrets.

The underlying issue is that bindings should not use:

- `getThing().getConfiguration().as(MyConfiguration.class)`

to obtain their runtime configuration in the first place.

For a BaseThingHandler, the intended API is:

- `getConfigAs(MyConfiguration.class)`

or `getConfig()` when the untyped configuration is needed. These methods provide the effective runtime configuration and include the central variable resolution.

`Thing.getConfiguration()` serves a different purpose: it exposes the configuration stored on the Thing model. That configuration should remain the raw configuration, e.g. `${ENV:PASSWORD}`, rather than the resolved runtime value.

`Configuration.as(...)` is also a generic configuration API and is not specific to Thing handlers. Changing its semantics to implicitly resolve environment variables would therefore affect callers outside the binding-handler use case and would mix two separate responsibilities:

 - `Configuration.as(...)`, map a configuration to a typed object.
 - `BaseThingHandler.getConfig()` / `getConfigAs(...)`, obtain the effective runtime configuration for a binding, including variable resolution.

So I think fixing `Configuration.as(...)` would address the symptom at the wrong abstraction level.

Instead, bindings currently using:

`getThing().getConfiguration().as(...)`

should be changed to use:

`getConfigAs(...)`

Besides the above, the PR can also be considered as a clean up to align bindings and make a more consistent use of available core API’s

_summary and PR is AI assisted, while i reviewed every single line myself._