### PR TITLE
[astro] Fix timezone regression in moon phase calculation

### DIFF
--- a/bundles/org.openhab.binding.astro/src/main/java/org/openhab/binding/astro/internal/calc/MoonPhaseCalc.java
+++ b/bundles/org.openhab.binding.astro/src/main/java/org/openhab/binding/astro/internal/calc/MoonPhaseCalc.java
@@ -16,6 +16,7 @@ import static org.openhab.binding.astro.internal.util.MathUtils.*;
 
 import java.time.InstantSource;
 import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -37,7 +38,9 @@ public class MoonPhaseCalc {
         final MoonPhaseSet result;
 
         if (previousMP.needsRecalc(julianDate)) {
-            double julianDateMidnight = Math.floor(julianDate + 0.5) - 0.5;
+            ZoneOffset offset = zone instanceof ZoneOffset zo ? zo : zone.getRules().getOffset(instantSource.instant());
+            double offsetDays = offset.getTotalSeconds() / 86400.0;
+            double julianDateMidnight = Math.floor(julianDate + offsetDays + 0.5) - 0.5 - offsetDays;
             double parentNewMoon = getPhase(julianDateMidnight, MoonPhase.NEW, false);
 
             Map<MoonPhase, Double> comingPhases = MoonPhase.remarkables().stream()


### PR DESCRIPTION
When the moon phase calculations were "modernized" in https://github.com/openhab/openhab-addons/pull/20104, timezone was ignored when finding midnight, which led to inaccuracies that are dragged into further calculations.

This fixes the ignored timezone and takes that into account when finding "midnight". I can't quite explain how it can account for such a [large error](https://github.com/openhab/openhab-addons/issues/20586#issuecomment-5273928723), but I haven't seen the exception logged since I corrected the midnight calculation. This can be because the earth and moon have moved while I figured it out, but it didn't take that long, so chances are that this actually fixes #20586.