### PR TITLE
[homeconnectdirect] Avoid Thing status flapping when appliance is unreachable

### DIFF
--- a/bundles/org.openhab.binding.homeconnectdirect/src/main/java/org/openhab/binding/homeconnectdirect/internal/handler/BaseHomeConnectDirectHandler.java
+++ b/bundles/org.openhab.binding.homeconnectdirect/src/main/java/org/openhab/binding/homeconnectdirect/internal/handler/BaseHomeConnectDirectHandler.java
@@ -201,7 +201,11 @@ public class BaseHomeConnectDirectHandler extends BaseThingHandler implements We
             return;
         }
 
-        updateStatus(ThingStatus.UNKNOWN);
+        // keep the Thing OFFLINE while reconnecting, otherwise the status would toggle between OFFLINE and UNKNOWN on
+        // every retry (e.g. appliances that power down their WiFi module when switched off)
+        if (!ThingStatus.OFFLINE.equals(thing.getStatus())) {
+            updateStatus(ThingStatus.UNKNOWN);
+        }
 
         scheduler.execute(() -> {
             // initialize deviceDescription and featureMapping service
@@ -246,7 +250,8 @@ public class BaseHomeConnectDirectHandler extends BaseThingHandler implements We
                     }
                 }
             } catch (WebSocketClientServiceException e) {
-                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, e.getMessage());
+                logger.debug("Could not connect to appliance! error={} thingUID={}", e.getMessage(), thing.getUID());
+                updateStatus(ThingStatus.OFFLINE);
                 scheduleReconnect();
                 stopUpdateAllValuesFuture();
             }
@@ -531,10 +536,9 @@ public class BaseHomeConnectDirectHandler extends BaseThingHandler implements We
 
         var connectionError = this.connectionError;
         if (connectionError != null) {
-            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, connectionError);
-        } else {
-            updateStatus(ThingStatus.OFFLINE);
+            logger.debug("Connection error: {} (thingUID={})", connectionError, thing.getUID());
         }
+        updateStatus(ThingStatus.OFFLINE);
 
         // dispose websocket
         var webSocketClientService = this.webSocketClientService;


### PR DESCRIPTION
Fixes #21195

Some appliances, mostly washing machines and dryers, completely power down their WiFi
module when switched off. While they are off, the Thing status cycled endlessly:

```
OFFLINE (COMMUNICATION_ERROR): Could not connect to ws://192.168.69.49:80/homeconnect
UNKNOWN
OFFLINE (COMMUNICATION_ERROR): No route to host
OFFLINE (COMMUNICATION_ERROR): Could not connect to ws://192.168.69.49:80/homeconnect
...
```

Three status change events per retry, because a single failed handshake was reported twice:
Jetty's error callback reported the low level cause (`No route to host`), and the exception
returned by `connect()` reported the same failure again with a different description. On top
of that, `initialize()` unconditionally set `UNKNOWN` on every reconnect attempt.

This PR reports every connection failure as plain `OFFLINE` and logs the actual cause on
debug level instead, and keeps the Thing `OFFLINE` while reconnecting. Consecutive failed
attempts now produce an identical `ThingStatusInfo`, so the core emits no further
`ThingStatusInfoChangedEvent`. `events.log` stays quiet while the appliance is off, with one
event when it goes offline and one when it comes back.

Configuration errors (missing config, pending profile, unsupported TLS) keep their
descriptive, translated status texts. Those are actionable for the user and do not flap.
