### PR TITLE
[openwebnet] Prevent `NullPointerExeption` in openwebnet dim message

### DIFF
--- a/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/handler/OpenWebNetEnergyHandler.java
+++ b/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/handler/OpenWebNetEnergyHandler.java
@@ -224,18 +224,14 @@ public class OpenWebNetEnergyHandler extends OpenWebNetThingHandler {
         if (msg.isCommand()) {
             logger.warn("handleMessage() Ignoring unsupported command for thing {}. Frame={}", getThing().getUID(),
                     msg);
-            return;
         } else {
-            // fix: check for correct DIM (ActivePower / 113)
-            if (msg.getDim().equals(EnergyManagement.DimEnergyMgmt.ACTIVE_POWER)) {
-                updateActivePower(msg);
-            } else if (msg.getDim().equals(EnergyManagement.DimEnergyMgmt.PARTIAL_TOTALIZER_CURRENT_DAY)) {
-                updateCurrentDayTotalizer(msg);
-            } else if (msg.getDim().equals(EnergyManagement.DimEnergyMgmt.PARTIAL_TOTALIZER_CURRENT_MONTH)) {
-                updateCurrentMonthTotalizer(msg);
-            } else {
-                logger.debug("handleMessage() Ignoring message {} because it's not related to active power value.",
-                        msg);
+            switch (msg.getDim()) {
+                case null -> logger.warn("handleMessage() Ignoring message {} because dimension is null.", msg);
+                case EnergyManagement.DimEnergyMgmt.ACTIVE_POWER -> updateActivePower(msg);
+                case EnergyManagement.DimEnergyMgmt.PARTIAL_TOTALIZER_CURRENT_DAY -> updateCurrentDayTotalizer(msg);
+                case EnergyManagement.DimEnergyMgmt.PARTIAL_TOTALIZER_CURRENT_MONTH -> updateCurrentMonthTotalizer(msg);
+                default -> logger.warn(
+                        "handleMessage() Ignoring message {} because it's not related to active power value.", msg);
             }
         }
     }


### PR DESCRIPTION
Refactors OpenWebNetEnergyHandler#handleMessage to simplify the logic for handling  Openwebnet messages 
## Main Changes:
Replaced the conditional if-else structure with a switch expression for improved readability and maintainability.
Added a case to log a warning when the dimension (dim) is null.
Updated logging behavior for unsupported or unrelated dimensions for better clarity during runtime.
fixes #21367 