### PR TITLE
[homeconnectdirect] Fill program command channel when appliance state is unknown

### DIFF
--- a/bundles/org.openhab.binding.homeconnectdirect/src/main/java/org/openhab/binding/homeconnectdirect/internal/handler/BaseHomeConnectDirectHandler.java
+++ b/bundles/org.openhab.binding.homeconnectdirect/src/main/java/org/openhab/binding/homeconnectdirect/internal/handler/BaseHomeConnectDirectHandler.java
@@ -580,8 +580,12 @@ public class BaseHomeConnectDirectHandler extends BaseThingHandler implements We
                 updateCommandDescriptions();
             } else if (DeviceDescriptionType.SELECTED_PROGRAM.equals(deviceDescriptionChange.type())) {
                 updateSelectedProgramDescription();
+                // the write access of the selected program determines which program commands are possible
+                updateCommandDescriptions();
             } else if (DeviceDescriptionType.ACTIVE_PROGRAM.equals(deviceDescriptionChange.type())) {
                 updateActiveProgramDescription();
+                // the write access of the active program determines whether a program can be started
+                updateCommandDescriptions();
             } else if (OPERATION_STATE_KEY.equals(deviceDescriptionChange.key())) {
                 updateStatusDescriptionIfLinked(CHANNEL_OPERATION_STATE, OPERATION_STATE_KEY);
             } else if (PROGRAM_PROGRESS_KEY.equals(deviceDescriptionChange.key())) {
@@ -1183,6 +1187,16 @@ public class BaseHomeConnectDirectHandler extends BaseThingHandler implements We
                             && deviceDescriptionService.getSelectedProgram(true) != null) {
                         commandOptions = List
                                 .of(new CommandOption(COMMAND_START, translationProvider.getText(I18N_START_PROGRAM)));
+                    }
+                    if (commandOptions.isEmpty()) {
+                        // the appliance does not announce the possible program commands in every state (e.g. as long
+                        // as remote start is not activated), offer all of them instead of leaving the channel empty
+                        logger.debug("Could not determine the possible program commands, offer all of them ({}).",
+                                thing.getUID());
+                        commandOptions = List.of(
+                                new CommandOption(COMMAND_START, translationProvider.getText(I18N_START_PROGRAM)),
+                                new CommandOption(COMMAND_PAUSE, translationProvider.getText(I18N_PAUSE_PROGRAM)),
+                                new CommandOption(COMMAND_RESUME, translationProvider.getText(I18N_RESUME_PROGRAM)));
                     }
 
                     setCommandOptions(channel.getUID(), commandOptions);


### PR DESCRIPTION
Related to #21340

The `program-command` channel of a washing machine stayed empty, so the program
could not be started from the UI.

Appliances do not announce the possible program commands in every state. On a
Siemens washer, `BSH.Common.Command.PauseProgram`, `ResumeProgram` and
`AbortProgram` all live in the `LaundryCare.Common.CommandList.RemoteStart`
command list with `access="none"`, and `activeProgram` is `access="read"` as long
as remote start is not activated. Neither the pause and resume options nor the
start fallback could be determined, and the resulting empty list also wiped the
static options declared by the channel type.

This PR offers start, pause and resume as a fallback whenever no command option
can be determined, instead of leaving the channel empty. It also refreshes the
command options when the description of the selected or the active program
changes. Their write access decides whether a program can be started, but so far
only changes of a command or a command list triggered a refresh.

Marked as draft: this needs verification on a real appliance. In particular it is
still open whether an appliance announces the write access of the active program
once remote start is activated. If it does not, `handleCommand` still refuses to
send the start request and logs a warning, and the fallback option alone will not
be enough.
