### PR TITLE
Ignore generated integration test files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 
 .metadata/
 bin/
+generated/
 target/
 src-gen/
 xtend-gen/


### PR DESCRIPTION
Ignore the `generated` directories created by bnd when running integration tests.
This way the real build error of failing integration tests is no longer obscured by the error of changed files.

When test preparation fails, for example because bundles cannot be resolved, bnd can leave a temporary `launch*.properties` file behind. This then causes the changed-files check to fail, as happened in this build:

https://github.com/openhab/openhab-addons/actions/runs/31677377310/job/94374812202

The underlying cleanup issue has been reported upstream:

https://github.com/bndtools/bnd/issues/7372

The same type of generated directory is already ignored in openhab-core.