### PR TITLE
Resolve runbundles for jUPnP 3.0.5 upgrade

### DIFF
--- a/itests/itest-common.bndrun
+++ b/itests/itest-common.bndrun
@@ -11,12 +11,14 @@
 # Run all integration tests which are named xyzTest
 Test-Cases: ${classes;CONCRETE;PUBLIC;NAMED;*Test}
 
-# We would like to use:
-# - the SLF4J API and implementation provided by Pax Logging
-# - the Configuration Admin API exported by Apache Felix Config Admin
+# We would like to use the following bundles to ensure deterministic bundle resolution:
+# - the JAX-RS API provided by Apache Aries (org.apache.aries.javax.jax.rs-api)
+# - the Configuration Admin API exported by Apache Felix Config Admin (org.apache.felix.configadmin)
+# - the SLF4J API and implementation provided by Pax Logging (org.ops4j.pax.logging.pax-logging-api)
 -runblacklist.itest-common: \
-	bnd.identity;id='slf4j.api',\
-	bnd.identity;id='org.osgi.service.cm'
+	bnd.identity;id='jakarta.ws.rs-api',\
+	bnd.identity;id='org.osgi.service.cm',\
+	bnd.identity;id='slf4j.api'
 
 # Used by Objenesis/Mockito and not actually optional
 -runsystempackages: sun.reflect

--- a/itests/org.openhab.binding.avmfritz.tests/itest.bndrun
+++ b/itests/org.openhab.binding.avmfritz.tests/itest.bndrun
@@ -91,6 +91,6 @@ Fragment-Host: org.openhab.binding.avmfritz
 	org.openhab.core.thing;version='[5.3.0,5.3.1)',\
 	org.openhab.core.transform;version='[5.3.0,5.3.1)',\
 	biz.aQute.tester.junit-platform;version='[7.3.0,7.3.1)',\
-	org.jupnp;version='[3.0.4,3.0.5)',\
 	jakarta.annotation-api;version='[2.1.1,2.1.2)',\
-	org.openhab.core.semantics;version='[5.3.0,5.3.1)'
+	org.openhab.core.semantics;version='[5.3.0,5.3.1)',\
+	org.jupnp;version='[3.0.5,3.0.6)'

--- a/itests/org.openhab.binding.hue.tests/itest.bndrun
+++ b/itests/org.openhab.binding.hue.tests/itest.bndrun
@@ -96,7 +96,7 @@ Fragment-Host: org.openhab.binding.hue
 	org.openhab.core.thing;version='[5.3.0,5.3.1)',\
 	org.openhab.core.transform;version='[5.3.0,5.3.1)',\
 	biz.aQute.tester.junit-platform;version='[7.3.0,7.3.1)',\
-	org.jupnp;version='[3.0.4,3.0.5)',\
 	jakarta.annotation-api;version='[2.1.1,2.1.2)',\
 	org.openhab.core.semantics;version='[5.3.0,5.3.1)',\
-	org.eclipse.jdt.annotation;version='[2.4.100,2.4.101)'
+	org.eclipse.jdt.annotation;version='[2.4.100,2.4.101)',\
+	org.jupnp;version='[3.0.5,3.0.6)'


### PR DESCRIPTION
Also blacklists `jakarta.ws.rs-api` to prevent it from sometimes being resolved by GHA. Everything part of `jakarta.ws.rs-api` (and more) is also provided by `org.apache.aries.javax.jax.rs-api`.

For the same reasons it is already [blacklisted in openhab-core](https://github.com/openhab/openhab-core/blob/5a98f916e9f8e0f393503ec709631aa3d20887a4/itests/org.openhab.core.io.rest.core.tests/itest.bndrun#L9-L10).