### PR TITLE
[avmfritz] Fix itest

### DIFF
--- a/bundles/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/discovery/AVMFritzDiscoveryService.java
+++ b/bundles/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/discovery/AVMFritzDiscoveryService.java
@@ -17,6 +17,7 @@ import static org.openhab.binding.avmfritz.internal.AVMFritzBindingConstants.*;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -53,18 +54,26 @@ import org.slf4j.LoggerFactory;
 @NonNullByDefault
 public class AVMFritzDiscoveryService extends AbstractThingHandlerDiscoveryService<AVMFritzBaseBridgeHandler>
         implements FritzAhaStatusListener, DiscoveryService {
+    private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES = Stream.of(SUPPORTED_LIGHTING_THING_TYPES,
+            SUPPORTED_BUTTON_THING_TYPES_UIDS, SUPPORTED_HEATING_THING_TYPES, SUPPORTED_POWER_METER_THING_TYPES,
+            SUPPORTED_DEVICE_THING_TYPES_UIDS, SUPPORTED_GROUP_THING_TYPES_UIDS).flatMap(Set::stream)
+            .collect(Collectors.toUnmodifiableSet());
+
     private final Logger logger = LoggerFactory.getLogger(AVMFritzDiscoveryService.class);
     private final Bundle bundle;
 
     @Activate
     public AVMFritzDiscoveryService(final @Reference LocaleProvider localeProvider,
             final @Reference TranslationProvider i18nProvider) {
-        super(AVMFritzBaseBridgeHandler.class,
-                Stream.of(SUPPORTED_LIGHTING_THING_TYPES, SUPPORTED_BUTTON_THING_TYPES_UIDS,
-                        SUPPORTED_HEATING_THING_TYPES, SUPPORTED_POWER_METER_THING_TYPES,
-                        SUPPORTED_DEVICE_THING_TYPES_UIDS, SUPPORTED_GROUP_THING_TYPES_UIDS).flatMap(Set::stream)
-                        .collect(Collectors.toUnmodifiableSet()),
-                30);
+        super(AVMFritzBaseBridgeHandler.class, SUPPORTED_THING_TYPES, 30);
+        this.localeProvider = localeProvider;
+        this.i18nProvider = i18nProvider;
+        this.bundle = FrameworkUtil.getBundle(AVMFritzDiscoveryService.class);
+    }
+
+    AVMFritzDiscoveryService(ScheduledExecutorService scheduler, LocaleProvider localeProvider,
+            TranslationProvider i18nProvider) {
+        super(scheduler, AVMFritzBaseBridgeHandler.class, SUPPORTED_THING_TYPES, 30, true, null, null);
         this.localeProvider = localeProvider;
         this.i18nProvider = i18nProvider;
         this.bundle = FrameworkUtil.getBundle(AVMFritzDiscoveryService.class);

--- a/itests/org.openhab.binding.avmfritz.tests/src/main/java/org/openhab/binding/avmfritz/internal/discovery/AVMFritzDiscoveryServiceOSGiTest.java
+++ b/itests/org.openhab.binding.avmfritz.tests/src/main/java/org/openhab/binding/avmfritz/internal/discovery/AVMFritzDiscoveryServiceOSGiTest.java
@@ -21,6 +21,8 @@ import java.io.StringReader;
 import java.time.Instant;
 import java.util.Collection;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import javax.xml.bind.JAXBException;
 import javax.xml.bind.Unmarshaller;
@@ -31,7 +33,6 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.openhab.binding.avmfritz.internal.dto.AVMFritzBaseModel;
 import org.openhab.binding.avmfritz.internal.dto.DeviceListModel;
@@ -53,12 +54,12 @@ import org.openhab.core.thing.ThingUID;
  * @author Ulrich Mertin - Added support for HAN-FUN blinds
  */
 @NonNullByDefault
-@Disabled("Often blocks indefinitely, see: https://github.com/openhab/openhab-addons/issues/16536")
 public class AVMFritzDiscoveryServiceOSGiTest extends AVMFritzThingHandlerOSGiTest {
 
     private static final ThingUID BRIGE_THING_ID = new ThingUID("avmfritz:fritzbox:1");
 
-    private @Nullable DiscoveryResult discoveryResult;
+    private volatile @Nullable DiscoveryResult discoveryResult;
+    private CountDownLatch discoveryResultAvailable = new CountDownLatch(1);
     private @NonNullByDefault({}) AVMFritzDiscoveryService discovery;
 
     private final DiscoveryListener listener = new DiscoveryListener() {
@@ -70,6 +71,7 @@ public class AVMFritzDiscoveryServiceOSGiTest extends AVMFritzThingHandlerOSGiTe
         @Override
         public void thingDiscovered(DiscoveryService source, DiscoveryResult result) {
             discoveryResult = result;
+            discoveryResultAvailable.countDown();
         }
 
         @Override
@@ -83,6 +85,7 @@ public class AVMFritzDiscoveryServiceOSGiTest extends AVMFritzThingHandlerOSGiTe
     @BeforeEach
     public void setUp() {
         super.setUp();
+        discoveryResultAvailable = new CountDownLatch(1);
         discovery = new AVMFritzDiscoveryService(mock(LocaleProvider.class), mock(TranslationProvider.class));
         discovery.setThingHandler(bridgeHandler);
         discovery.addDiscoveryListener(listener);
@@ -91,6 +94,15 @@ public class AVMFritzDiscoveryServiceOSGiTest extends AVMFritzThingHandlerOSGiTe
     @AfterEach
     public void cleanUp() {
         discoveryResult = null;
+    }
+
+    private void awaitDiscoveryResult() {
+        try {
+            assertTrue(discoveryResultAvailable.await(5, TimeUnit.SECONDS), "Timed out waiting for discovery result");
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            fail("Interrupted while waiting for discovery result", e);
+        }
     }
 
     @Test
@@ -182,6 +194,7 @@ public class AVMFritzDiscoveryServiceOSGiTest extends AVMFritzThingHandlerOSGiTe
         assertEquals(1, device.getPresent());
 
         discovery.onDeviceAdded(device);
+        awaitDiscoveryResult();
         assertNotNull(discoveryResult);
 
         assertEquals(DiscoveryResultFlag.NEW, discoveryResult.getFlag());
@@ -242,6 +255,7 @@ public class AVMFritzDiscoveryServiceOSGiTest extends AVMFritzThingHandlerOSGiTe
         assertEquals(1, device.getPresent());
 
         discovery.onDeviceAdded(device);
+        awaitDiscoveryResult();
         assertNotNull(discoveryResult);
 
         assertEquals(DiscoveryResultFlag.NEW, discoveryResult.getFlag());
@@ -307,6 +321,7 @@ public class AVMFritzDiscoveryServiceOSGiTest extends AVMFritzThingHandlerOSGiTe
         assertNotNull(device);
 
         discovery.onDeviceAdded(device);
+        awaitDiscoveryResult();
         assertNotNull(discoveryResult);
 
         assertEquals(DiscoveryResultFlag.NEW, discoveryResult.getFlag());
@@ -360,6 +375,7 @@ public class AVMFritzDiscoveryServiceOSGiTest extends AVMFritzThingHandlerOSGiTe
         assertNotNull(device);
 
         discovery.onDeviceAdded(device);
+        awaitDiscoveryResult();
         assertNotNull(discoveryResult);
 
         assertEquals(DiscoveryResultFlag.NEW, discoveryResult.getFlag());
@@ -416,6 +432,7 @@ public class AVMFritzDiscoveryServiceOSGiTest extends AVMFritzThingHandlerOSGiTe
         assertNotNull(device);
 
         discovery.onDeviceAdded(device);
+        awaitDiscoveryResult();
         assertNotNull(discoveryResult);
 
         assertEquals(DiscoveryResultFlag.NEW, discoveryResult.getFlag());
@@ -472,6 +489,7 @@ public class AVMFritzDiscoveryServiceOSGiTest extends AVMFritzThingHandlerOSGiTe
         assertNotNull(device);
 
         discovery.onDeviceAdded(device);
+        awaitDiscoveryResult();
         assertNotNull(discoveryResult);
 
         assertEquals(DiscoveryResultFlag.NEW, discoveryResult.getFlag());
@@ -528,6 +546,7 @@ public class AVMFritzDiscoveryServiceOSGiTest extends AVMFritzThingHandlerOSGiTe
         assertNotNull(device);
 
         discovery.onDeviceAdded(device);
+        awaitDiscoveryResult();
         assertNotNull(discoveryResult);
 
         assertEquals(DiscoveryResultFlag.NEW, discoveryResult.getFlag());
@@ -577,6 +596,7 @@ public class AVMFritzDiscoveryServiceOSGiTest extends AVMFritzThingHandlerOSGiTe
         assertNotNull(device);
 
         discovery.onDeviceAdded(device);
+        awaitDiscoveryResult();
         assertNotNull(discoveryResult);
 
         assertEquals(DiscoveryResultFlag.NEW, discoveryResult.getFlag());
@@ -650,6 +670,7 @@ public class AVMFritzDiscoveryServiceOSGiTest extends AVMFritzThingHandlerOSGiTe
         assertNotNull(device);
 
         discovery.onDeviceAdded(device);
+        awaitDiscoveryResult();
         assertNotNull(discoveryResult);
 
         assertEquals(DiscoveryResultFlag.NEW, discoveryResult.getFlag());
@@ -696,6 +717,7 @@ public class AVMFritzDiscoveryServiceOSGiTest extends AVMFritzThingHandlerOSGiTe
         assertNotNull(device);
 
         discovery.onDeviceAdded(device);
+        awaitDiscoveryResult();
         assertNotNull(discoveryResult);
 
         assertEquals(DiscoveryResultFlag.NEW, discoveryResult.getFlag());
@@ -742,6 +764,7 @@ public class AVMFritzDiscoveryServiceOSGiTest extends AVMFritzThingHandlerOSGiTe
         assertNotNull(device);
 
         discovery.onDeviceAdded(device);
+        awaitDiscoveryResult();
         assertNotNull(discoveryResult);
 
         assertEquals(DiscoveryResultFlag.NEW, discoveryResult.getFlag());
@@ -788,6 +811,7 @@ public class AVMFritzDiscoveryServiceOSGiTest extends AVMFritzThingHandlerOSGiTe
         assertNotNull(device);
 
         discovery.onDeviceAdded(device);
+        awaitDiscoveryResult();
         assertNotNull(discoveryResult);
 
         assertEquals(DiscoveryResultFlag.NEW, discoveryResult.getFlag());
@@ -834,6 +858,7 @@ public class AVMFritzDiscoveryServiceOSGiTest extends AVMFritzThingHandlerOSGiTe
         assertNotNull(device);
 
         discovery.onDeviceAdded(device);
+        awaitDiscoveryResult();
         assertNotNull(discoveryResult);
 
         assertEquals(DiscoveryResultFlag.NEW, discoveryResult.getFlag());
@@ -890,6 +915,7 @@ public class AVMFritzDiscoveryServiceOSGiTest extends AVMFritzThingHandlerOSGiTe
         assertNotNull(device);
 
         discovery.onDeviceAdded(device);
+        awaitDiscoveryResult();
         assertNotNull(discoveryResult);
 
         assertEquals(DiscoveryResultFlag.NEW, discoveryResult.getFlag());
@@ -950,6 +976,7 @@ public class AVMFritzDiscoveryServiceOSGiTest extends AVMFritzThingHandlerOSGiTe
         assertNotNull(device);
 
         discovery.onDeviceAdded(device);
+        awaitDiscoveryResult();
         assertNotNull(discoveryResult);
 
         assertEquals(DiscoveryResultFlag.NEW, discoveryResult.getFlag());
@@ -1005,6 +1032,7 @@ public class AVMFritzDiscoveryServiceOSGiTest extends AVMFritzThingHandlerOSGiTe
         assertNotNull(device);
 
         discovery.onDeviceAdded(device);
+        awaitDiscoveryResult();
         assertNotNull(discoveryResult);
 
         assertEquals(DiscoveryResultFlag.NEW, discoveryResult.getFlag());

--- a/itests/org.openhab.binding.avmfritz.tests/src/main/java/org/openhab/binding/avmfritz/internal/discovery/AVMFritzDiscoveryServiceOSGiTest.java
+++ b/itests/org.openhab.binding.avmfritz.tests/src/main/java/org/openhab/binding/avmfritz/internal/discovery/AVMFritzDiscoveryServiceOSGiTest.java
@@ -21,8 +21,6 @@ import java.io.StringReader;
 import java.time.Instant;
 import java.util.Collection;
 import java.util.List;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 
 import javax.xml.bind.JAXBException;
 import javax.xml.bind.Unmarshaller;
@@ -46,6 +44,7 @@ import org.openhab.core.i18n.LocaleProvider;
 import org.openhab.core.i18n.TranslationProvider;
 import org.openhab.core.thing.ThingTypeUID;
 import org.openhab.core.thing.ThingUID;
+import org.openhab.core.util.SameThreadExecutorService;
 
 /**
  * Tests for {@link AVMFritzDiscoveryService}.
@@ -58,8 +57,7 @@ public class AVMFritzDiscoveryServiceOSGiTest extends AVMFritzThingHandlerOSGiTe
 
     private static final ThingUID BRIGE_THING_ID = new ThingUID("avmfritz:fritzbox:1");
 
-    private volatile @Nullable DiscoveryResult discoveryResult;
-    private CountDownLatch discoveryResultAvailable = new CountDownLatch(1);
+    private @Nullable DiscoveryResult discoveryResult;
     private @NonNullByDefault({}) AVMFritzDiscoveryService discovery;
 
     private final DiscoveryListener listener = new DiscoveryListener() {
@@ -71,7 +69,6 @@ public class AVMFritzDiscoveryServiceOSGiTest extends AVMFritzThingHandlerOSGiTe
         @Override
         public void thingDiscovered(DiscoveryService source, DiscoveryResult result) {
             discoveryResult = result;
-            discoveryResultAvailable.countDown();
         }
 
         @Override
@@ -85,8 +82,8 @@ public class AVMFritzDiscoveryServiceOSGiTest extends AVMFritzThingHandlerOSGiTe
     @BeforeEach
     public void setUp() {
         super.setUp();
-        discoveryResultAvailable = new CountDownLatch(1);
-        discovery = new AVMFritzDiscoveryService(mock(LocaleProvider.class), mock(TranslationProvider.class));
+        discovery = new AVMFritzDiscoveryService(new SameThreadExecutorService(), mock(LocaleProvider.class),
+                mock(TranslationProvider.class));
         discovery.setThingHandler(bridgeHandler);
         discovery.addDiscoveryListener(listener);
     }
@@ -94,15 +91,6 @@ public class AVMFritzDiscoveryServiceOSGiTest extends AVMFritzThingHandlerOSGiTe
     @AfterEach
     public void cleanUp() {
         discoveryResult = null;
-    }
-
-    private void awaitDiscoveryResult() {
-        try {
-            assertTrue(discoveryResultAvailable.await(5, TimeUnit.SECONDS), "Timed out waiting for discovery result");
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            fail("Interrupted while waiting for discovery result", e);
-        }
     }
 
     @Test
@@ -194,7 +182,6 @@ public class AVMFritzDiscoveryServiceOSGiTest extends AVMFritzThingHandlerOSGiTe
         assertEquals(1, device.getPresent());
 
         discovery.onDeviceAdded(device);
-        awaitDiscoveryResult();
         assertNotNull(discoveryResult);
 
         assertEquals(DiscoveryResultFlag.NEW, discoveryResult.getFlag());
@@ -255,7 +242,6 @@ public class AVMFritzDiscoveryServiceOSGiTest extends AVMFritzThingHandlerOSGiTe
         assertEquals(1, device.getPresent());
 
         discovery.onDeviceAdded(device);
-        awaitDiscoveryResult();
         assertNotNull(discoveryResult);
 
         assertEquals(DiscoveryResultFlag.NEW, discoveryResult.getFlag());
@@ -321,7 +307,6 @@ public class AVMFritzDiscoveryServiceOSGiTest extends AVMFritzThingHandlerOSGiTe
         assertNotNull(device);
 
         discovery.onDeviceAdded(device);
-        awaitDiscoveryResult();
         assertNotNull(discoveryResult);
 
         assertEquals(DiscoveryResultFlag.NEW, discoveryResult.getFlag());
@@ -375,7 +360,6 @@ public class AVMFritzDiscoveryServiceOSGiTest extends AVMFritzThingHandlerOSGiTe
         assertNotNull(device);
 
         discovery.onDeviceAdded(device);
-        awaitDiscoveryResult();
         assertNotNull(discoveryResult);
 
         assertEquals(DiscoveryResultFlag.NEW, discoveryResult.getFlag());
@@ -432,7 +416,6 @@ public class AVMFritzDiscoveryServiceOSGiTest extends AVMFritzThingHandlerOSGiTe
         assertNotNull(device);
 
         discovery.onDeviceAdded(device);
-        awaitDiscoveryResult();
         assertNotNull(discoveryResult);
 
         assertEquals(DiscoveryResultFlag.NEW, discoveryResult.getFlag());
@@ -489,7 +472,6 @@ public class AVMFritzDiscoveryServiceOSGiTest extends AVMFritzThingHandlerOSGiTe
         assertNotNull(device);
 
         discovery.onDeviceAdded(device);
-        awaitDiscoveryResult();
         assertNotNull(discoveryResult);
 
         assertEquals(DiscoveryResultFlag.NEW, discoveryResult.getFlag());
@@ -546,7 +528,6 @@ public class AVMFritzDiscoveryServiceOSGiTest extends AVMFritzThingHandlerOSGiTe
         assertNotNull(device);
 
         discovery.onDeviceAdded(device);
-        awaitDiscoveryResult();
         assertNotNull(discoveryResult);
 
         assertEquals(DiscoveryResultFlag.NEW, discoveryResult.getFlag());
@@ -596,7 +577,6 @@ public class AVMFritzDiscoveryServiceOSGiTest extends AVMFritzThingHandlerOSGiTe
         assertNotNull(device);
 
         discovery.onDeviceAdded(device);
-        awaitDiscoveryResult();
         assertNotNull(discoveryResult);
 
         assertEquals(DiscoveryResultFlag.NEW, discoveryResult.getFlag());
@@ -670,7 +650,6 @@ public class AVMFritzDiscoveryServiceOSGiTest extends AVMFritzThingHandlerOSGiTe
         assertNotNull(device);
 
         discovery.onDeviceAdded(device);
-        awaitDiscoveryResult();
         assertNotNull(discoveryResult);
 
         assertEquals(DiscoveryResultFlag.NEW, discoveryResult.getFlag());
@@ -717,7 +696,6 @@ public class AVMFritzDiscoveryServiceOSGiTest extends AVMFritzThingHandlerOSGiTe
         assertNotNull(device);
 
         discovery.onDeviceAdded(device);
-        awaitDiscoveryResult();
         assertNotNull(discoveryResult);
 
         assertEquals(DiscoveryResultFlag.NEW, discoveryResult.getFlag());
@@ -764,7 +742,6 @@ public class AVMFritzDiscoveryServiceOSGiTest extends AVMFritzThingHandlerOSGiTe
         assertNotNull(device);
 
         discovery.onDeviceAdded(device);
-        awaitDiscoveryResult();
         assertNotNull(discoveryResult);
 
         assertEquals(DiscoveryResultFlag.NEW, discoveryResult.getFlag());
@@ -811,7 +788,6 @@ public class AVMFritzDiscoveryServiceOSGiTest extends AVMFritzThingHandlerOSGiTe
         assertNotNull(device);
 
         discovery.onDeviceAdded(device);
-        awaitDiscoveryResult();
         assertNotNull(discoveryResult);
 
         assertEquals(DiscoveryResultFlag.NEW, discoveryResult.getFlag());
@@ -858,7 +834,6 @@ public class AVMFritzDiscoveryServiceOSGiTest extends AVMFritzThingHandlerOSGiTe
         assertNotNull(device);
 
         discovery.onDeviceAdded(device);
-        awaitDiscoveryResult();
         assertNotNull(discoveryResult);
 
         assertEquals(DiscoveryResultFlag.NEW, discoveryResult.getFlag());
@@ -915,7 +890,6 @@ public class AVMFritzDiscoveryServiceOSGiTest extends AVMFritzThingHandlerOSGiTe
         assertNotNull(device);
 
         discovery.onDeviceAdded(device);
-        awaitDiscoveryResult();
         assertNotNull(discoveryResult);
 
         assertEquals(DiscoveryResultFlag.NEW, discoveryResult.getFlag());
@@ -976,7 +950,6 @@ public class AVMFritzDiscoveryServiceOSGiTest extends AVMFritzThingHandlerOSGiTe
         assertNotNull(device);
 
         discovery.onDeviceAdded(device);
-        awaitDiscoveryResult();
         assertNotNull(discoveryResult);
 
         assertEquals(DiscoveryResultFlag.NEW, discoveryResult.getFlag());
@@ -1032,7 +1005,6 @@ public class AVMFritzDiscoveryServiceOSGiTest extends AVMFritzThingHandlerOSGiTe
         assertNotNull(device);
 
         discovery.onDeviceAdded(device);
-        awaitDiscoveryResult();
         assertNotNull(discoveryResult);
 
         assertEquals(DiscoveryResultFlag.NEW, discoveryResult.getFlag());

--- a/itests/org.openhab.binding.avmfritz.tests/src/main/java/org/openhab/binding/avmfritz/internal/handler/AVMFritzThingHandlerOSGiTest.java
+++ b/itests/org.openhab.binding.avmfritz.tests/src/main/java/org/openhab/binding/avmfritz/internal/handler/AVMFritzThingHandlerOSGiTest.java
@@ -19,19 +19,11 @@ import static org.openhab.binding.avmfritz.internal.AVMFritzBindingConstants.*;
 import java.util.Map;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.eclipse.jetty.client.HttpClient;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.openhab.binding.avmfritz.internal.AVMFritzDynamicCommandDescriptionProvider;
 import org.openhab.core.config.core.Configuration;
 import org.openhab.core.test.java.JavaOSGiTest;
-import org.openhab.core.test.storage.VolatileStorageService;
 import org.openhab.core.thing.Bridge;
-import org.openhab.core.thing.ManagedThingProvider;
-import org.openhab.core.thing.ThingProvider;
-import org.openhab.core.thing.binding.ThingHandler;
 import org.openhab.core.thing.binding.ThingHandlerCallback;
 import org.openhab.core.thing.binding.builder.BridgeBuilder;
 
@@ -43,60 +35,25 @@ import org.openhab.core.thing.binding.builder.BridgeBuilder;
 @NonNullByDefault
 public abstract class AVMFritzThingHandlerOSGiTest extends JavaOSGiTest {
 
-    private static HttpClient httpClient = new HttpClient();
-
-    private VolatileStorageService volatileStorageService = new VolatileStorageService();
-    private @NonNullByDefault({}) ManagedThingProvider managedThingProvider;
-
     protected @NonNullByDefault({}) Bridge bridge;
     protected @NonNullByDefault({}) BoxHandler bridgeHandler;
 
-    @BeforeAll
-    public static void setUpClass() throws Exception {
-        httpClient.start();
-    }
-
     @BeforeEach
     public void setUp() {
-        registerService(volatileStorageService);
-
-        managedThingProvider = getService(ThingProvider.class, ManagedThingProvider.class);
-        assertNotNull(managedThingProvider, "Could not get ManagedThingProvider");
-
         bridge = buildBridge();
         assertNotNull(bridge.getConfiguration());
 
-        managedThingProvider.add(bridge);
-
         ThingHandlerCallback callback = mock(ThingHandlerCallback.class);
 
-        bridgeHandler = new BoxHandler(bridge, httpClient, mock(AVMFritzDynamicCommandDescriptionProvider.class));
+        bridgeHandler = new BoxHandler(bridge, mock(), mock(AVMFritzDynamicCommandDescriptionProvider.class));
         assertNotNull(bridgeHandler);
 
         bridgeHandler.setCallback(callback);
-
-        ThingHandler oldHandler = bridge.getHandler();
-        if (oldHandler != null) {
-            oldHandler.dispose();
-        }
         bridge.setHandler(bridgeHandler);
         assertNotNull(bridge.getHandler());
 
-        bridgeHandler.initialize();
-    }
-
-    @AfterEach
-    public void tearDown() {
-        if (bridge != null) {
-            managedThingProvider.remove(bridge.getUID());
-        }
-
-        unregisterService(volatileStorageService);
-    }
-
-    @AfterAll
-    public static void tearDownClass() throws Exception {
-        httpClient.stop();
+        // Discovery tests only need the handler's type and UID mapping. Initializing it would authenticate against
+        // the configured host and make these tests depend on the network.
     }
 
     private Bridge buildBridge() {


### PR DESCRIPTION
The tests were previously disabled because they could block indefinitely. The available thread dump available in the linked issue is a few years old, but it showed that test setup initialized a real BoxHandler, causing an authentication request to fritz.box. This network connection was not needed for any of the discovery assertions and made the tests dependent on the local environment.

While re-enabling the tests, another source of instability became visible: discovery listeners are now notified asynchronously by openHAB Core, while the tests checked the result immediately. @wborn i remember that @wborn posted this somewhere in the last few weeks, but i couldn't find it again.

Anyway, this PR :
- removes unnecessary handler initialization and external network access from the test setup;
- waits explicitly for asynchronous discovery callbacks;
- re-enables all discovery tests.

The existing discovery coverage and assertions remain unchanged.

Fixes: #16536