### PR TITLE
[teslascope] Remove deprecated apiKey support

### DIFF
--- a/bundles/org.openhab.binding.teslascope/README.md
+++ b/bundles/org.openhab.binding.teslascope/README.md
@@ -22,7 +22,7 @@ As a minimum, the personalAccessToken is needed:
 
 | Thing Parameter     | Default Value | Required | Advanced | Description                                                                          |
 |---------------------|---------------|----------|----------|--------------------------------------------------------------------------------------|
-| personalAccessToken | N/A           | No       | No       | Personal Access Token generated from the Teslascope website                          |
+| personalAccessToken | N/A           | Yes      | No       | Personal Access Token generated from the Teslascope website                          |
 | refreshInterval     | 60            | No       | Yes      | The frequency with which to refresh information from Teslascope specified in seconds |
 
 ## `vehicle` Thing Configuration

--- a/bundles/org.openhab.binding.teslascope/README.md
+++ b/bundles/org.openhab.binding.teslascope/README.md
@@ -18,11 +18,10 @@ Account configuration is necessary.
 The easiest way to do this is from the UI.
 Just add a new Thing, select the Teslascope binding, then Teslascope Account Binding Thing, and enter the personalAccessToken which can be generated from the Teslascope website.
 
-As a minimum, the personalAccessToken or API key (deprecated) is needed:
+As a minimum, the personalAccessToken is needed:
 
 | Thing Parameter     | Default Value | Required | Advanced | Description                                                                          |
 |---------------------|---------------|----------|----------|--------------------------------------------------------------------------------------|
-| apiKey              | N/A           | No       | No       | API Key from the Teslascope website (deprecated)                                     |
 | personalAccessToken | N/A           | No       | No       | Personal Access Token generated from the Teslascope website                          |
 | refreshInterval     | 60            | No       | Yes      | The frequency with which to refresh information from Teslascope specified in seconds |
 

--- a/bundles/org.openhab.binding.teslascope/src/main/java/org/openhab/binding/teslascope/internal/TeslascopeAccountConfiguration.java
+++ b/bundles/org.openhab.binding.teslascope/src/main/java/org/openhab/binding/teslascope/internal/TeslascopeAccountConfiguration.java
@@ -21,11 +21,6 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
  */
 @NonNullByDefault
 public class TeslascopeAccountConfiguration {
-    /**
-     * Teslascope is phasing out support for apiKey in lieu of Personal Access Tokens
-     */
-    @Deprecated
-    public String apiKey = "";
     public String personalAccessToken = "";
     public int refreshInterval = 60;
 }

--- a/bundles/org.openhab.binding.teslascope/src/main/java/org/openhab/binding/teslascope/internal/TeslascopeAccountHandler.java
+++ b/bundles/org.openhab.binding.teslascope/src/main/java/org/openhab/binding/teslascope/internal/TeslascopeAccountHandler.java
@@ -69,7 +69,7 @@ public class TeslascopeAccountHandler extends BaseBridgeHandler {
         TeslascopeAccountConfiguration config = this.config;
         if (config != null) {
             try {
-                return webTargets.getVehicleList(config.apiKey, config.personalAccessToken);
+                return webTargets.getVehicleList(config.personalAccessToken);
             } catch (TeslascopeAuthenticationException e) {
                 updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
                         "Authentication problem: " + e.getMessage());
@@ -85,7 +85,7 @@ public class TeslascopeAccountHandler extends BaseBridgeHandler {
             throws TeslascopeCommunicationException, TeslascopeAuthenticationException {
         TeslascopeAccountConfiguration config = this.config;
         if (config != null) {
-            return webTargets.getDetailedInformation(publicID, config.apiKey, config.personalAccessToken);
+            return webTargets.getDetailedInformation(publicID, config.personalAccessToken);
         }
         return "";
     }
@@ -94,7 +94,7 @@ public class TeslascopeAccountHandler extends BaseBridgeHandler {
             throws TeslascopeCommunicationException, TeslascopeAuthenticationException {
         TeslascopeAccountConfiguration config = this.config;
         if (config != null) {
-            webTargets.sendCommand(publicID, config.apiKey, config.personalAccessToken, command);
+            webTargets.sendCommand(publicID, config.personalAccessToken, command);
         }
     }
 
@@ -102,7 +102,7 @@ public class TeslascopeAccountHandler extends BaseBridgeHandler {
             throws TeslascopeCommunicationException, TeslascopeAuthenticationException {
         TeslascopeAccountConfiguration config = this.config;
         if (config != null) {
-            webTargets.sendCommand(publicID, config.apiKey, config.personalAccessToken, command, params);
+            webTargets.sendCommand(publicID, config.personalAccessToken, command, params);
         }
     }
 
@@ -114,11 +114,7 @@ public class TeslascopeAccountHandler extends BaseBridgeHandler {
     @Override
     public void initialize() {
         TeslascopeAccountConfiguration localConfig = config = getConfigAs(TeslascopeAccountConfiguration.class);
-        if (!localConfig.apiKey.isBlank() && localConfig.personalAccessToken.isBlank()) {
-            logger.warn(
-                    "ApiKey is deprecated and is expected to stop working in late 2026. Please migrate to a Personal Access Token.");
-        }
-        if (localConfig.apiKey.isBlank() && localConfig.personalAccessToken.isBlank()) {
+        if (localConfig.personalAccessToken.isBlank()) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
                     "@text/offline.conf-error.no-credentials");
             return;

--- a/bundles/org.openhab.binding.teslascope/src/main/java/org/openhab/binding/teslascope/internal/TeslascopeWebTargets.java
+++ b/bundles/org.openhab.binding.teslascope/src/main/java/org/openhab/binding/teslascope/internal/TeslascopeWebTargets.java
@@ -45,53 +45,32 @@ public class TeslascopeWebTargets {
         this.httpClient = httpClient;
     }
 
-    public String getVehicleList(String apiKey, String personalAccessToken)
+    public String getVehicleList(String personalAccessToken)
             throws TeslascopeCommunicationException, TeslascopeAuthenticationException {
-        if (personalAccessToken.isBlank()) {
-            return invoke(BASE_URI + "vehicles?api_key=" + apiKey, HttpMethod.GET, "");
-        } else {
-            return invoke(BASE_URI + "vehicles", HttpMethod.GET, personalAccessToken);
-        }
+        return invoke(BASE_URI + "vehicles", HttpMethod.GET, personalAccessToken);
     }
 
-    public String getDetailedInformation(String publicID, String apiKey, String personalAccessToken)
+    public String getDetailedInformation(String publicID, String personalAccessToken)
             throws TeslascopeCommunicationException, TeslascopeAuthenticationException {
-        if (personalAccessToken.isBlank()) {
-            return invoke(BASE_VEHICLE_URI + publicID + "/detailed?api_key=" + apiKey, HttpMethod.GET, "");
-        } else {
-            return invoke(BASE_VEHICLE_URI + publicID + "/detailed", HttpMethod.GET, personalAccessToken);
-        }
+        return invoke(BASE_VEHICLE_URI + publicID + "/detailed", HttpMethod.GET, personalAccessToken);
     }
 
-    public void sendCommand(String publicID, String apiKey, String personalAccessToken, String command)
+    public void sendCommand(String publicID, String personalAccessToken, String command)
             throws TeslascopeCommunicationException, TeslascopeAuthenticationException {
-        if (personalAccessToken.isBlank()) {
-            invoke(BASE_VEHICLE_URI + publicID + "/command/" + command + "?api_key=" + apiKey, HttpMethod.POST, "");
-        } else {
-            invoke(BASE_VEHICLE_URI + publicID + "/command/" + command, HttpMethod.POST, personalAccessToken);
-        }
+        invoke(BASE_VEHICLE_URI + publicID + "/command/" + command, HttpMethod.POST, personalAccessToken);
         return;
     }
 
-    public void sendCommand(String publicID, String apiKey, String personalAccessToken, String command, String params)
+    public void sendCommand(String publicID, String personalAccessToken, String command, String params)
             throws TeslascopeCommunicationException, TeslascopeAuthenticationException {
         String cleanParams = (params == null) ? "" : params.replaceFirst("^[?&]", "");
 
-        if (personalAccessToken.isBlank()) {
-            // Legacy API Key method (needs & separator because ? is already used)
-            String url = BASE_VEHICLE_URI + publicID + "/command/" + command + "?api_key=" + apiKey;
-            if (!cleanParams.isEmpty()) {
-                url += "&" + cleanParams;
-            }
-            invoke(url, HttpMethod.POST, "");
-        } else {
-            // Personal Access Token method (needs ? separator)
-            String url = BASE_VEHICLE_URI + publicID + "/command/" + command;
-            if (!cleanParams.isEmpty()) {
-                url += "?" + cleanParams;
-            }
-            invoke(url, HttpMethod.POST, personalAccessToken);
+        // Personal Access Token method (needs ? separator)
+        String url = BASE_VEHICLE_URI + publicID + "/command/" + command;
+        if (!cleanParams.isEmpty()) {
+            url += "?" + cleanParams;
         }
+        invoke(url, HttpMethod.POST, personalAccessToken);
     }
 
     private String invoke(String uri, HttpMethod method, String personalAccessToken)

--- a/bundles/org.openhab.binding.teslascope/src/main/resources/OH-INF/i18n/teslascope.properties
+++ b/bundles/org.openhab.binding.teslascope/src/main/resources/OH-INF/i18n/teslascope.properties
@@ -12,8 +12,6 @@ thing-type.teslascope.vehicle.description = Access to Tesla Vehicle data via the
 
 # thing types config
 
-thing-type.config.teslascope.account.apiKey.label = apiKey
-thing-type.config.teslascope.account.apiKey.description = apiKey provided by Teslascope (Deprecated - use Personal Access Token instead)
 thing-type.config.teslascope.account.personalAccessToken.label = Personal Access Token
 thing-type.config.teslascope.account.personalAccessToken.description = Personal Access Token provided by Teslascope
 thing-type.config.teslascope.account.refreshInterval.label = Refresh Interval
@@ -197,8 +195,6 @@ thing-type.teslascope.service.description = Access to Tesla Vehicle data via the
 
 # thing types config
 
-thing-type.config.teslascope.service.apiKey.label = apiKey
-thing-type.config.teslascope.service.apiKey.description = apiKey provided by Teslascope
 thing-type.config.teslascope.service.publicID.label = Vehicle Public ID
 thing-type.config.teslascope.service.publicID.description = Vehicle public ID listed in Teslascope
 thing-type.config.teslascope.service.refreshInterval.label = Refresh Interval

--- a/bundles/org.openhab.binding.teslascope/src/main/resources/OH-INF/i18n/teslascope.properties
+++ b/bundles/org.openhab.binding.teslascope/src/main/resources/OH-INF/i18n/teslascope.properties
@@ -12,6 +12,8 @@ thing-type.teslascope.vehicle.description = Access to Tesla Vehicle data via the
 
 # thing types config
 
+thing-type.config.teslascope.account.apiKey.label = apiKey
+thing-type.config.teslascope.account.apiKey.description = apiKey provided by Teslascope (Deprecated - use Personal Access Token instead)
 thing-type.config.teslascope.account.personalAccessToken.label = Personal Access Token
 thing-type.config.teslascope.account.personalAccessToken.description = Personal Access Token provided by Teslascope
 thing-type.config.teslascope.account.refreshInterval.label = Refresh Interval

--- a/bundles/org.openhab.binding.teslascope/src/main/resources/OH-INF/i18n/teslascope.properties
+++ b/bundles/org.openhab.binding.teslascope/src/main/resources/OH-INF/i18n/teslascope.properties
@@ -12,8 +12,6 @@ thing-type.teslascope.vehicle.description = Access to Tesla Vehicle data via the
 
 # thing types config
 
-thing-type.config.teslascope.account.apiKey.label = apiKey
-thing-type.config.teslascope.account.apiKey.description = apiKey provided by Teslascope (Deprecated - use Personal Access Token instead)
 thing-type.config.teslascope.account.personalAccessToken.label = Personal Access Token
 thing-type.config.teslascope.account.personalAccessToken.description = Personal Access Token provided by Teslascope
 thing-type.config.teslascope.account.refreshInterval.label = Refresh Interval

--- a/bundles/org.openhab.binding.teslascope/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.teslascope/src/main/resources/OH-INF/thing/thing-types.xml
@@ -9,11 +9,7 @@
 		<description>Access to Tesla Vehicle data via the Teslascope developer API</description>
 		<semantic-equipment-tag>WebService</semantic-equipment-tag>
 		<config-description>
-			<parameter name="apiKey" type="text" required="false">
-				<label>apiKey</label>
-				<description>apiKey provided by Teslascope (Deprecated - use Personal Access Token instead)</description>
-			</parameter>
-			<parameter name="personalAccessToken" type="text" required="false">
+			<parameter name="personalAccessToken" type="text" required="true">
 				<label>Personal Access Token</label>
 				<description>Personal Access Token provided by Teslascope</description>
 			</parameter>


### PR DESCRIPTION
The Teslascope service has deprecated the apikey method in favour of oauth and Personal Access Tokens (PATs).
Support for PATs was added on OH 5.2, and a warning was added to logs for users who are using ApiKeys to encourage then to nove to PATs.

The Teslascope maintainer intends to remove support for apiKeys at the end of 2026, which aligns nicely with the OH 5.3 release cycle, so this PR removes support for apikey and leaves only support for PATs.

This is a breaking change for anyone who has ignored the release notes for 5.2.