### PR TITLE
[solarman] Remove limitation for minimal Refresh Interval value of 30 seconds

### DIFF
--- a/bundles/org.openhab.binding.solarman/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.solarman/src/main/resources/OH-INF/thing/thing-types.xml
@@ -52,7 +52,7 @@
 				<description>Serial number of the Solarman logger.</description>
 				<advanced>false</advanced>
 			</parameter>
-			<parameter name="refreshInterval" type="integer" required="false" unit="s" min="30">
+			<parameter name="refreshInterval" type="integer" required="false" unit="s" min="1">
 				<label>Refresh Interval</label>
 				<description>Interval to query the logger (default 60).</description>
 				<default>60</default>


### PR DESCRIPTION
According to https://github.com/jmccrohan/pysolarmanv5/issues/107#issuecomment-5301978941 for Solarman logger there is no justification to have the refreshInterval period restricted to at least 30 seconds.  I tried with 1s on what I have, and it works.