### PR TITLE
[avmfritz] Fix authentication blocking initialize

### DIFF
--- a/bundles/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/callmonitor/CallMonitor.java
+++ b/bundles/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/callmonitor/CallMonitor.java
@@ -93,7 +93,7 @@ public class CallMonitor {
     public class CallMonitorThread extends Thread {
 
         // Socket to connect
-        private @Nullable Socket socket;
+        private volatile @Nullable Socket socket;
 
         // Thread control flag
         private boolean interrupted = false;
@@ -115,8 +115,9 @@ public class CallMonitor {
                 try {
                     logger.debug("Call Monitor thread [{}] attempting connection to FRITZ!Box on {}:{}.",
                             Thread.currentThread().threadId(), ip, MONITOR_PORT);
-                    socket = new Socket(ip, MONITOR_PORT);
-                    reader = new BufferedReader(new InputStreamReader(socket.getInputStream()));
+                    Socket newSocket = new Socket(ip, MONITOR_PORT);
+                    socket = newSocket;
+                    reader = new BufferedReader(new InputStreamReader(newSocket.getInputStream()));
                     // reset the retry interval
                     reconnectTime = 60000L;
                 } catch (IOException e) {
@@ -171,9 +172,10 @@ public class CallMonitor {
         @Override
         public void interrupt() {
             interrupted = true;
-            if (socket != null) {
+            Socket currentSocket = socket;
+            if (currentSocket != null) {
                 try {
-                    socket.close();
+                    currentSocket.close();
                     logger.debug("Socket to FRITZ!Box closed.");
                 } catch (IOException e) {
                     logger.warn("Failed to close connection to FRITZ!Box.", e);

--- a/bundles/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/discovery/AVMFritzUpnpDiscoveryParticipant.java
+++ b/bundles/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/discovery/AVMFritzUpnpDiscoveryParticipant.java
@@ -29,7 +29,6 @@ import org.openhab.core.config.discovery.DiscoveryResult;
 import org.openhab.core.config.discovery.DiscoveryResultBuilder;
 import org.openhab.core.config.discovery.DiscoveryService;
 import org.openhab.core.config.discovery.upnp.UpnpDiscoveryParticipant;
-import org.openhab.core.config.discovery.upnp.internal.UpnpDiscoveryService;
 import org.openhab.core.thing.ThingTypeUID;
 import org.openhab.core.thing.ThingUID;
 import org.osgi.service.component.ComponentContext;
@@ -41,7 +40,7 @@ import org.slf4j.LoggerFactory;
 
 /**
  * The {@link AVMFritzUpnpDiscoveryParticipant} is responsible for discovering new and removed FRITZ!Box devices. It
- * uses the central {@link UpnpDiscoveryService}.
+ * uses the central {@link org.openhab.core.config.discovery.upnp.internal.UpnpDiscoveryService}.
  *
  * @author Robert Bausdorf - Initial contribution
  * @author Christoph Weitkamp - Added support for groups

--- a/bundles/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/handler/AVMFritzBaseBridgeHandler.java
+++ b/bundles/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/handler/AVMFritzBaseBridgeHandler.java
@@ -148,7 +148,9 @@ public abstract class AVMFritzBaseBridgeHandler extends BaseBridgeHandler {
     protected synchronized void manageConnections() {
         AVMFritzBoxConfiguration config = getConfigAs(AVMFritzBoxConfiguration.class);
         if (this.connection == null) {
-            this.connection = new FritzAhaWebInterface(config, this, httpClient);
+            FritzAhaWebInterface webInterface = new FritzAhaWebInterface(config, this, httpClient);
+            this.connection = webInterface;
+            webInterface.authenticate();
             stopPolling();
             startPolling();
         }
@@ -169,6 +171,12 @@ public abstract class AVMFritzBaseBridgeHandler extends BaseBridgeHandler {
     @Override
     public void dispose() {
         stopPolling();
+        FritzAhaWebInterface webInterface = connection;
+        connection = null;
+        if (webInterface != null) {
+            webInterface.dispose();
+        }
+        super.dispose();
     }
 
     @Override

--- a/bundles/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/handler/AVMFritzBaseBridgeHandler.java
+++ b/bundles/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/handler/AVMFritzBaseBridgeHandler.java
@@ -29,7 +29,6 @@ import java.util.stream.Collectors;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.jetty.client.HttpClient;
-import org.openhab.binding.avmfritz.internal.AVMFritzBindingConstants;
 import org.openhab.binding.avmfritz.internal.AVMFritzDynamicCommandDescriptionProvider;
 import org.openhab.binding.avmfritz.internal.config.AVMFritzBoxConfiguration;
 import org.openhab.binding.avmfritz.internal.discovery.AVMFritzDiscoveryService;
@@ -39,7 +38,6 @@ import org.openhab.binding.avmfritz.internal.dto.GroupModel;
 import org.openhab.binding.avmfritz.internal.dto.templates.TemplateModel;
 import org.openhab.binding.avmfritz.internal.hardware.FritzAhaStatusListener;
 import org.openhab.binding.avmfritz.internal.hardware.FritzAhaWebInterface;
-import org.openhab.binding.avmfritz.internal.hardware.callbacks.FritzAhaApplyTemplateCallback;
 import org.openhab.binding.avmfritz.internal.hardware.callbacks.FritzAhaUpdateCallback;
 import org.openhab.binding.avmfritz.internal.hardware.callbacks.FritzAhaUpdateTemplatesCallback;
 import org.openhab.core.library.types.StringType;
@@ -260,7 +258,8 @@ public abstract class AVMFritzBaseBridgeHandler extends BaseBridgeHandler {
     }
 
     /**
-     * Called from {@link FritzAhaApplyTemplateCallback} to provide new templates for things.
+     * Called from {@link org.openhab.binding.avmfritz.internal.hardware.callbacks.FritzAhaApplyTemplateCallback} to
+     * provide new templates for things.
      *
      * @param templateList list of template models
      */
@@ -296,7 +295,7 @@ public abstract class AVMFritzBaseBridgeHandler extends BaseBridgeHandler {
 
     /**
      * Builds a {@link ThingUID} from a device model. The UID is build from the
-     * {@link AVMFritzBindingConstants#BINDING_ID} and
+     * {@link org.openhab.binding.avmfritz.internal.AVMFritzBindingConstants#BINDING_ID} and
      * value of {@link AVMFritzBaseModel#getProductName()} in which all characters NOT matching the RegEx [^a-zA-Z0-9_]
      * are replaced by "_".
      *

--- a/bundles/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/handler/AVMFritzBaseThingHandler.java
+++ b/bundles/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/handler/AVMFritzBaseThingHandler.java
@@ -521,33 +521,31 @@ public abstract class AVMFritzBaseThingHandler extends BaseThingHandler implemen
                 }
                 break;
             case CHANNEL_SETTEMP:
-                BigDecimal temperature = null;
+                BigDecimal fritzTemperature = null;
                 if (command instanceof DecimalType decimalCommand) {
-                    temperature = normalizeCelsius(decimalCommand.toBigDecimal());
+                    fritzTemperature = fromCelsius(normalizeCelsius(decimalCommand.toBigDecimal()));
                 } else if (command instanceof QuantityType quantityCommand) {
                     @SuppressWarnings("unchecked")
                     QuantityType<Temperature> convertedCommand = ((QuantityType<Temperature>) command)
                             .toUnit(SIUnits.CELSIUS);
                     if (convertedCommand != null) {
-                        temperature = normalizeCelsius(convertedCommand.toBigDecimal());
+                        fritzTemperature = fromCelsius(normalizeCelsius(convertedCommand.toBigDecimal()));
                     } else {
                         logger.warn("Unable to convert unit from '{}' to '{}'. Skipping command.",
                                 quantityCommand.getUnit(), SIUnits.CELSIUS);
                     }
                 } else if (command instanceof IncreaseDecreaseType) {
-                    temperature = currentDevice.getHkr().getTsoll();
-                    if (IncreaseDecreaseType.INCREASE.equals(command)) {
-                        temperature.add(BigDecimal.ONE);
-                    } else {
-                        temperature.subtract(BigDecimal.ONE);
-                    }
+                    BigDecimal temperature = toCelsius(currentDevice.getHkr().getTsoll());
+                    temperature = IncreaseDecreaseType.INCREASE.equals(command) ? temperature.add(BigDecimal.ONE)
+                            : temperature.subtract(BigDecimal.ONE);
+                    fritzTemperature = fromCelsius(temperature);
                 } else if (command instanceof OnOffType) {
-                    temperature = OnOffType.ON.equals(command) ? TEMP_FRITZ_ON : TEMP_FRITZ_OFF;
+                    fritzTemperature = OnOffType.ON.equals(command) ? TEMP_FRITZ_ON : TEMP_FRITZ_OFF;
                 }
-                if (temperature != null) {
-                    fritzBox.setSetTemp(ain, fromCelsius(temperature));
+                if (fritzTemperature != null) {
+                    fritzBox.setSetTemp(ain, fritzTemperature);
                     HeatingModel heatingModel = currentDevice.getHkr();
-                    heatingModel.setTsoll(temperature);
+                    heatingModel.setTsoll(fritzTemperature);
                     updateState(CHANNEL_RADIATOR_MODE, new StringType(heatingModel.getRadiatorMode()));
                 }
                 break;

--- a/bundles/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/handler/AVMFritzBaseThingHandler.java
+++ b/bundles/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/handler/AVMFritzBaseThingHandler.java
@@ -474,11 +474,12 @@ public abstract class AVMFritzBaseThingHandler extends BaseThingHandler implemen
                 } else if (command instanceof OnOffType) {
                     fritzBox.setSwitch(ain, OnOffType.ON.equals(command));
                 } else if (command instanceof IncreaseDecreaseType) {
-                    brightness = currentDevice.getLevelControlModel().getLevelPercentage();
-                    if (IncreaseDecreaseType.INCREASE.equals(command)) {
-                        brightness.add(BigDecimal.TEN);
-                    } else {
-                        brightness.subtract(BigDecimal.TEN);
+                    LevelControlModel levelControlModel = currentDevice.getLevelControlModel();
+                    if (levelControlModel != null) {
+                        brightness = levelControlModel.getLevelPercentage();
+                        brightness = IncreaseDecreaseType.INCREASE.equals(command) ? brightness.add(BigDecimal.TEN)
+                                : brightness.subtract(BigDecimal.TEN);
+                        brightness = brightness.max(BigDecimal.ZERO).min(PercentType.HUNDRED.toBigDecimal());
                     }
                 }
                 if (brightness != null) {

--- a/bundles/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/handler/BoxHandler.java
+++ b/bundles/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/handler/BoxHandler.java
@@ -86,8 +86,9 @@ public class BoxHandler extends AVMFritzBaseBridgeHandler {
 
     @Override
     public void dispose() {
-        if (callMonitor != null) {
-            callMonitor.dispose();
+        CallMonitor cm = callMonitor;
+        if (cm != null) {
+            cm.dispose();
             callMonitor = null;
         }
         super.dispose();

--- a/bundles/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/handler/BoxHandler.java
+++ b/bundles/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/handler/BoxHandler.java
@@ -65,7 +65,9 @@ public class BoxHandler extends AVMFritzBaseBridgeHandler {
         }
         if (this.connection == null) {
             if (config.password != null) {
-                this.connection = new FritzAhaWebInterface(config, this, httpClient);
+                FritzAhaWebInterface webInterface = new FritzAhaWebInterface(config, this, httpClient);
+                this.connection = webInterface;
+                webInterface.authenticate();
                 stopPolling();
                 startPolling();
             } else {

--- a/bundles/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/handler/Powerline546EHandler.java
+++ b/bundles/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/handler/Powerline546EHandler.java
@@ -22,7 +22,6 @@ import java.util.function.Predicate;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.jetty.client.HttpClient;
-import org.openhab.binding.avmfritz.internal.AVMFritzBindingConstants;
 import org.openhab.binding.avmfritz.internal.AVMFritzDynamicCommandDescriptionProvider;
 import org.openhab.binding.avmfritz.internal.config.AVMFritzBoxConfiguration;
 import org.openhab.binding.avmfritz.internal.config.AVMFritzDeviceConfiguration;
@@ -233,7 +232,7 @@ public class Powerline546EHandler extends AVMFritzBaseBridgeHandler implements F
 
     /**
      * Builds a {@link ThingUID} from a device model. The UID is build from the
-     * {@link AVMFritzBindingConstants#BINDING_ID} and value of
+     * {@link org.openhab.binding.avmfritz.internal.AVMFritzBindingConstants#BINDING_ID} and value of
      * {@link AVMFritzBaseModel#getProductName()} in which all characters NOT matching
      * the regex [^a-zA-Z0-9_] are replaced by "_".
      *

--- a/bundles/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/hardware/FritzAhaWebInterface.java
+++ b/bundles/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/hardware/FritzAhaWebInterface.java
@@ -210,21 +210,17 @@ public class FritzAhaWebInterface {
 
     private void completeAuthentication(CompletableFuture<Boolean> currentAuthentication, @Nullable String newSid,
             ThingStatusDetail statusDetail, @Nullable String description) {
-        boolean currentAttempt;
         synchronized (authenticationLock) {
-            currentAttempt = currentAuthentication.equals(authentication) && !disposed;
-            if (currentAttempt) {
-                sid = newSid;
-                authentication = null;
+            if (currentAuthentication != authentication || disposed) {
+                currentAuthentication.complete(false);
+                return;
             }
+            sid = newSid;
+            boolean authenticated = newSid != null;
+            handler.setStatusInfo(authenticated ? ThingStatus.ONLINE : ThingStatus.OFFLINE, statusDetail, description);
+            currentAuthentication.complete(authenticated);
+            authentication = null;
         }
-        if (!currentAttempt) {
-            currentAuthentication.complete(false);
-            return;
-        }
-        boolean authenticated = newSid != null;
-        handler.setStatusInfo(authenticated ? ThingStatus.ONLINE : ThingStatus.OFFLINE, statusDetail, description);
-        currentAuthentication.complete(authenticated);
     }
 
     /**

--- a/bundles/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/hardware/FritzAhaWebInterface.java
+++ b/bundles/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/hardware/FritzAhaWebInterface.java
@@ -211,7 +211,7 @@ public class FritzAhaWebInterface {
     private void completeAuthentication(CompletableFuture<Boolean> currentAuthentication, @Nullable String newSid,
             ThingStatusDetail statusDetail, @Nullable String description) {
         synchronized (authenticationLock) {
-            if (currentAuthentication != authentication || disposed) {
+            if (!currentAuthentication.equals(authentication) || disposed) {
                 currentAuthentication.complete(false);
                 return;
             }

--- a/bundles/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/hardware/FritzAhaWebInterface.java
+++ b/bundles/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/hardware/FritzAhaWebInterface.java
@@ -16,16 +16,17 @@ import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-import java.util.concurrent.ExecutionException;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
+import java.util.function.Consumer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.jetty.client.HttpClient;
-import org.eclipse.jetty.client.api.ContentResponse;
+import org.eclipse.jetty.client.api.Result;
+import org.eclipse.jetty.client.util.BufferingResponseListener;
 import org.eclipse.jetty.client.util.StringContentProvider;
 import org.eclipse.jetty.http.HttpMethod;
 import org.openhab.binding.avmfritz.internal.config.AVMFritzBoxConfiguration;
@@ -57,6 +58,7 @@ import org.slf4j.LoggerFactory;
  * @author Christoph Weitkamp - Added support for groups
  * @author Ulrich Mertin - Added support for HAN-FUN blinds
  * @author Christoph Sommer - Added support for color temperature
+ * @author Leo Siepel - Made authentication non-blocking
  */
 @NonNullByDefault
 public class FritzAhaWebInterface {
@@ -88,78 +90,141 @@ public class FritzAhaWebInterface {
      * Shared instance of HTTP client for asynchronous calls
      */
     private final HttpClient httpClient;
+    private final Object authenticationLock = new Object();
     /**
      * Current session ID
      */
-    private @Nullable String sid;
+    private volatile @Nullable String sid;
+    private volatile boolean disposed;
+    private @Nullable CompletableFuture<Boolean> authentication;
 
     /**
      * This method authenticates with the FRITZ!OS Web Interface and updates the session ID accordingly
      */
-    public void authenticate() {
-        sid = null;
+    public CompletableFuture<Boolean> authenticate() {
+        CompletableFuture<Boolean> currentAuthentication;
+        synchronized (authenticationLock) {
+            if (disposed) {
+                return CompletableFuture.completedFuture(false);
+            }
+            if (sid != null) {
+                return CompletableFuture.completedFuture(true);
+            }
+            CompletableFuture<Boolean> ongoingAuthentication = authentication;
+            if (ongoingAuthentication != null) {
+                return ongoingAuthentication;
+            }
+            currentAuthentication = new CompletableFuture<>();
+            authentication = currentAuthentication;
+        }
         String localPassword = config.password;
         if (localPassword == null || localPassword.trim().isEmpty()) {
-            handler.setStatusInfo(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
+            completeAuthentication(currentAuthentication, null, ThingStatusDetail.CONFIGURATION_ERROR,
                     "Please configure the password.");
-            return;
+            return currentAuthentication;
         }
-        String loginXml = syncGet(getURL(WEBSERVICE_PATH, addSID("")));
-        if (loginXml == null) {
-            handler.setStatusInfo(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
-                    "FRITZ!Box does not respond.");
-            return;
-        }
+        requestLoginPage(currentAuthentication, getURL(WEBSERVICE_PATH),
+                loginXml -> processInitialLoginResponse(currentAuthentication, loginXml));
+        return currentAuthentication;
+    }
+
+    private void processInitialLoginResponse(CompletableFuture<Boolean> currentAuthentication, String loginXml) {
         Matcher sidmatch = SID_PATTERN.matcher(loginXml);
         if (!sidmatch.find()) {
-            handler.setStatusInfo(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
+            completeAuthentication(currentAuthentication, null, ThingStatusDetail.COMMUNICATION_ERROR,
                     "FRITZ!Box does not respond with SID.");
             return;
         }
         String localSid = sidmatch.group(1);
         Matcher accmatch = ACCESS_PATTERN.matcher(loginXml);
-        if (accmatch.find()) {
-            if ("2".equals(accmatch.group(1))) {
-                sid = localSid;
-                handler.setStatusInfo(ThingStatus.ONLINE, ThingStatusDetail.NONE, null);
-                return;
-            }
+        if (accmatch.find() && "2".equals(accmatch.group(1))) {
+            completeAuthentication(currentAuthentication, localSid, ThingStatusDetail.NONE, null);
+            return;
         }
         Matcher challengematch = CHALLENGE_PATTERN.matcher(loginXml);
         if (!challengematch.find()) {
-            handler.setStatusInfo(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
+            completeAuthentication(currentAuthentication, null, ThingStatusDetail.COMMUNICATION_ERROR,
                     "FRITZ!Box does not respond with challenge for authentication.");
             return;
         }
         String challenge = challengematch.group(1);
         String response = createResponse(challenge);
         String localUser = config.user;
-        loginXml = syncGet(getURL(WEBSERVICE_PATH,
-                (localUser == null || localUser.isEmpty() ? "" : ("username=" + localUser + "&")) + "response="
-                        + response));
-        if (loginXml == null) {
-            handler.setStatusInfo(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
-                    "FRITZ!Box does not respond.");
-            return;
-        }
-        sidmatch = SID_PATTERN.matcher(loginXml);
+        requestLoginPage(currentAuthentication,
+                getURL(WEBSERVICE_PATH,
+                        (localUser == null || localUser.isEmpty() ? "" : ("username=" + localUser + "&")) + "response="
+                                + response),
+                authenticatedLoginXml -> processAuthenticatedLoginResponse(currentAuthentication, authenticatedLoginXml,
+                        localUser));
+    }
+
+    private void processAuthenticatedLoginResponse(CompletableFuture<Boolean> currentAuthentication, String loginXml,
+            @Nullable String localUser) {
+        Matcher sidmatch = SID_PATTERN.matcher(loginXml);
         if (!sidmatch.find()) {
-            handler.setStatusInfo(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
+            completeAuthentication(currentAuthentication, null, ThingStatusDetail.COMMUNICATION_ERROR,
                     "FRITZ!Box does not respond with SID.");
             return;
         }
-        localSid = sidmatch.group(1);
-        accmatch = ACCESS_PATTERN.matcher(loginXml);
-        if (accmatch.find()) {
-            if ("2".equals(accmatch.group(1))) {
-                sid = localSid;
-                handler.setStatusInfo(ThingStatus.ONLINE, ThingStatusDetail.NONE, null);
-                return;
+        String localSid = sidmatch.group(1);
+        Matcher accmatch = ACCESS_PATTERN.matcher(loginXml);
+        if (accmatch.find() && "2".equals(accmatch.group(1))) {
+            completeAuthentication(currentAuthentication, localSid, ThingStatusDetail.NONE, null);
+            return;
+        }
+        completeAuthentication(currentAuthentication, null, ThingStatusDetail.CONFIGURATION_ERROR, "User "
+                + (localUser == null ? "" : localUser) + " has no access to FRITZ!Box home automation functions.");
+    }
+
+    private void requestLoginPage(CompletableFuture<Boolean> currentAuthentication, String url,
+            Consumer<String> responseConsumer) {
+        try {
+            httpClient.newRequest(url).timeout(config.syncTimeout, TimeUnit.MILLISECONDS).method(HttpMethod.GET)
+                    .send(new BufferingResponseListener() {
+                        @Override
+                        public void onComplete(@NonNullByDefault({}) Result result) {
+                            String content = getContentAsString();
+                            if (result.isSucceeded() && result.getResponse().getStatus() == 200 && content != null) {
+                                logger.debug("Authentication GET response complete");
+                                try {
+                                    responseConsumer.accept(content);
+                                } catch (RuntimeException e) {
+                                    logger.debug("Failed to process authentication response", e);
+                                    completeAuthentication(currentAuthentication, null,
+                                            ThingStatusDetail.COMMUNICATION_ERROR,
+                                            "FRITZ!Box returned an invalid authentication response.");
+                                }
+                            } else {
+                                logger.debug("Authentication GET response failed", result.getFailure());
+                                completeAuthentication(currentAuthentication, null,
+                                        ThingStatusDetail.COMMUNICATION_ERROR, "FRITZ!Box does not respond.");
+                            }
+                        }
+                    });
+        } catch (RuntimeException e) {
+            logger.debug("Authentication GET request failed", e);
+            completeAuthentication(currentAuthentication, null, ThingStatusDetail.COMMUNICATION_ERROR,
+                    "FRITZ!Box does not respond.");
+        }
+    }
+
+    private void completeAuthentication(CompletableFuture<Boolean> currentAuthentication, @Nullable String newSid,
+            ThingStatusDetail statusDetail, @Nullable String description) {
+        boolean currentAttempt;
+        synchronized (authenticationLock) {
+            currentAttempt = currentAuthentication.equals(authentication) && !disposed;
+            if (currentAttempt) {
+                sid = newSid;
+                authentication = null;
             }
         }
-        handler.setStatusInfo(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, "User "
-                + (localUser == null ? "" : localUser) + " has no access to FRITZ!Box home automation functions.");
-        return;
+        if (!currentAttempt) {
+            currentAuthentication.complete(false);
+            return;
+        }
+        boolean authenticated = newSid != null;
+        handler.setStatusInfo(authenticated ? ThingStatus.ONLINE : ThingStatus.OFFLINE, statusDetail, description);
+        currentAuthentication.complete(authenticated);
     }
 
     /**
@@ -204,8 +269,19 @@ public class FritzAhaWebInterface {
         this.config = config;
         this.handler = handler;
         this.httpClient = httpClient;
-        authenticate();
-        logger.debug("Starting with SID {}", sid);
+    }
+
+    public void dispose() {
+        CompletableFuture<Boolean> currentAuthentication;
+        synchronized (authenticationLock) {
+            disposed = true;
+            sid = null;
+            currentAuthentication = authentication;
+            authentication = null;
+        }
+        if (currentAuthentication != null) {
+            currentAuthentication.complete(false);
+        }
     }
 
     /**
@@ -230,33 +306,11 @@ public class FritzAhaWebInterface {
     }
 
     public String addSID(String path) {
-        if (sid == null) {
+        String currentSid = sid;
+        if (currentSid == null) {
             return path;
         } else {
-            return (path.isEmpty() ? "" : path + "&") + "sid=" + sid;
-        }
-    }
-
-    /**
-     * Sends a HTTP GET request using the synchronous client
-     *
-     * @param path Path of the requested resource
-     * @return response
-     */
-    public @Nullable String syncGet(String path) {
-        try {
-            ContentResponse contentResponse = httpClient.newRequest(path)
-                    .timeout(config.syncTimeout, TimeUnit.MILLISECONDS).method(HttpMethod.GET).send();
-            String content = contentResponse.getContentAsString();
-            logger.debug("GET response complete: {}", content);
-            return content;
-        } catch (ExecutionException | TimeoutException e) {
-            logger.debug("GET response failed: {}", e.getLocalizedMessage(), e);
-            return null;
-        } catch (InterruptedException e) {
-            logger.debug("GET response interrupted: {}", e.getLocalizedMessage(), e);
-            Thread.currentThread().interrupt();
-            return null;
+            return (path.isEmpty() ? "" : path + "&") + "sid=" + currentSid;
         }
     }
 
@@ -268,12 +322,14 @@ public class FritzAhaWebInterface {
      * @param callback Callback to handle the response with
      */
     public FritzAhaContentExchange asyncGet(String path, String args, FritzAhaCallback callback) {
-        if (!isAuthenticated()) {
-            authenticate();
-        }
         FritzAhaContentExchange getExchange = new FritzAhaContentExchange(callback);
-        httpClient.newRequest(getURL(path, addSID(args))).method(HttpMethod.GET).onResponseSuccess(getExchange)
-                .onResponseFailure(getExchange).send(getExchange);
+        authenticate().thenAccept(authenticated -> {
+            if (authenticated && !disposed) {
+                httpClient.newRequest(getURL(path, addSID(args))).timeout(config.asyncTimeout, TimeUnit.MILLISECONDS)
+                        .method(HttpMethod.GET).onResponseSuccess(getExchange).onResponseFailure(getExchange)
+                        .send(getExchange);
+            }
+        });
         return getExchange;
     }
 
@@ -289,14 +345,21 @@ public class FritzAhaWebInterface {
      * @param callback Callback to handle the response with
      */
     public FritzAhaContentExchange asyncPost(String path, String args, FritzAhaCallback callback) {
-        if (!isAuthenticated()) {
-            authenticate();
-        }
         FritzAhaContentExchange postExchange = new FritzAhaContentExchange(callback);
-        httpClient.newRequest(getURL(path)).timeout(config.asyncTimeout, TimeUnit.MILLISECONDS).method(HttpMethod.POST)
-                .onResponseSuccess(postExchange).onResponseFailure(postExchange)
-                .content(new StringContentProvider(addSID(args), StandardCharsets.UTF_8)).send(postExchange);
+        authenticate().thenAccept(authenticated -> {
+            if (authenticated && !disposed) {
+                httpClient.newRequest(getURL(path)).timeout(config.asyncTimeout, TimeUnit.MILLISECONDS)
+                        .method(HttpMethod.POST).onResponseSuccess(postExchange).onResponseFailure(postExchange)
+                        .content(new StringContentProvider(addSID(args), StandardCharsets.UTF_8)).send(postExchange);
+            }
+        });
         return postExchange;
+    }
+
+    public void invalidateAuthentication() {
+        synchronized (authenticationLock) {
+            sid = null;
+        }
     }
 
     public FritzAhaContentExchange applyTemplate(String ain) {

--- a/bundles/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/hardware/callbacks/FritzAhaReauthCallback.java
+++ b/bundles/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/hardware/callbacks/FritzAhaReauthCallback.java
@@ -100,7 +100,7 @@ public class FritzAhaReauthCallback implements FritzAhaCallback {
         if (status != 200 || "".equals(response) || ".".equals(response)) {
             validRequest = false;
             if (retries >= 1) {
-                webIface.authenticate();
+                webIface.invalidateAuthentication();
                 retries--;
                 switch (httpMethod) {
                     case GET:

--- a/bundles/org.openhab.binding.avmfritz/src/test/java/org/openhab/binding/avmfritz/internal/hardware/FritzAhaWebInterfaceTest.java
+++ b/bundles/org.openhab.binding.avmfritz/src/test/java/org/openhab/binding/avmfritz/internal/hardware/FritzAhaWebInterfaceTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.avmfritz.internal.hardware;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jetty.client.HttpClient;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.openhab.binding.avmfritz.internal.config.AVMFritzBoxConfiguration;
+import org.openhab.binding.avmfritz.internal.handler.AVMFritzBaseBridgeHandler;
+
+/**
+ * Unit tests for {@link FritzAhaWebInterface}.
+ *
+ * @author Leo Siepel - Initial contribution
+ */
+@ExtendWith(MockitoExtension.class)
+@NonNullByDefault
+public class FritzAhaWebInterfaceTest {
+
+    private @Mock @NonNullByDefault({}) AVMFritzBaseBridgeHandler handler;
+
+    @Test
+    public void authenticationDoesNotBlock() throws Exception {
+        AVMFritzBoxConfiguration config = new AVMFritzBoxConfiguration();
+        config.ipAddress = "127.0.0.1";
+        config.password = "password";
+        config.syncTimeout = TimeUnit.SECONDS.toMillis(10);
+
+        CountDownLatch requestAccepted = new CountDownLatch(1);
+        CountDownLatch releaseServer = new CountDownLatch(1);
+        ExecutorService serverExecutor = Executors.newSingleThreadExecutor();
+        try (ServerSocket serverSocket = new ServerSocket(0)) {
+            config.port = serverSocket.getLocalPort();
+            serverExecutor.submit(() -> acceptWithoutResponding(serverSocket, requestAccepted, releaseServer));
+
+            HttpClient httpClient = new HttpClient();
+            httpClient.start();
+            try {
+                FritzAhaWebInterface webInterface = new FritzAhaWebInterface(config, handler, httpClient);
+                try {
+                    assertTimeoutPreemptively(Duration.ofSeconds(2), webInterface::authenticate);
+                    assertTrue(requestAccepted.await(2, TimeUnit.SECONDS));
+                } finally {
+                    webInterface.dispose();
+                }
+            } finally {
+                releaseServer.countDown();
+                httpClient.stop();
+            }
+        } finally {
+            releaseServer.countDown();
+            serverExecutor.shutdownNow();
+        }
+    }
+
+    @Test
+    public void authenticationCompletesWhenResponseProcessingFails() throws Exception {
+        AVMFritzBoxConfiguration config = new AVMFritzBoxConfiguration();
+        config.ipAddress = "127.0.0.1";
+        config.password = "password";
+
+        ExecutorService serverExecutor = Executors.newSingleThreadExecutor();
+        try (ServerSocket serverSocket = new ServerSocket(0)) {
+            config.port = serverSocket.getLocalPort();
+            serverExecutor.submit(() -> respondWithChallenge(serverSocket));
+
+            HttpClient httpClient = new HttpClient();
+            httpClient.start();
+            FritzAhaWebInterface webInterface = new FritzAhaWebInterface(config, handler, httpClient) {
+                @Override
+                protected String createResponse(String challenge) {
+                    throw new IllegalArgumentException("Invalid challenge");
+                }
+            };
+            try {
+                CompletableFuture<Boolean> authentication = webInterface.authenticate();
+                assertFalse(authentication.get(2, TimeUnit.SECONDS));
+            } finally {
+                webInterface.dispose();
+                httpClient.stop();
+            }
+        } finally {
+            serverExecutor.shutdownNow();
+        }
+    }
+
+    private void acceptWithoutResponding(ServerSocket serverSocket, CountDownLatch requestAccepted,
+            CountDownLatch releaseServer) {
+        try (Socket ignored = serverSocket.accept()) {
+            requestAccepted.countDown();
+            releaseServer.await();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        } catch (Exception e) {
+            // The server socket may be closed during test cleanup.
+        }
+    }
+
+    private void respondWithChallenge(ServerSocket serverSocket) {
+        String content = "<SessionInfo><SID>0000000000000000</SID><Challenge>12345678</Challenge></SessionInfo>";
+        try (Socket socket = serverSocket.accept();
+                BufferedReader reader = new BufferedReader(
+                        new InputStreamReader(socket.getInputStream(), StandardCharsets.UTF_8))) {
+            String line;
+            while ((line = reader.readLine()) != null && !line.isEmpty()) {
+                // Read the complete request header before responding.
+            }
+            String response = "HTTP/1.1 200 OK\r\nContent-Length: " + content.getBytes(StandardCharsets.UTF_8).length
+                    + "\r\nConnection: close\r\n\r\n" + content;
+            socket.getOutputStream().write(response.getBytes(StandardCharsets.UTF_8));
+        } catch (Exception e) {
+            // The server socket may be closed during test cleanup.
+        }
+    }
+}

--- a/bundles/org.openhab.binding.avmfritz/src/test/java/org/openhab/binding/avmfritz/internal/hardware/FritzAhaWebInterfaceTest.java
+++ b/bundles/org.openhab.binding.avmfritz/src/test/java/org/openhab/binding/avmfritz/internal/hardware/FritzAhaWebInterfaceTest.java
@@ -13,8 +13,11 @@
 package org.openhab.binding.avmfritz.internal.hardware;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
 
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
@@ -27,6 +30,8 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jetty.client.HttpClient;
@@ -113,6 +118,25 @@ public class FritzAhaWebInterfaceTest {
         }
     }
 
+    @Test
+    public void authenticationRemainsCurrentUntilStatusUpdateCompletes() {
+        AVMFritzBoxConfiguration config = new AVMFritzBoxConfiguration();
+        FritzAhaWebInterface webInterface = new FritzAhaWebInterface(config, handler, new HttpClient());
+        AtomicBoolean firstStatusUpdate = new AtomicBoolean(true);
+        AtomicReference<CompletableFuture<Boolean>> authenticationDuringStatusUpdate = new AtomicReference<>();
+        doAnswer(invocation -> {
+            if (firstStatusUpdate.getAndSet(false)) {
+                authenticationDuringStatusUpdate.set(webInterface.authenticate());
+            }
+            return null;
+        }).when(handler).setStatusInfo(any(), any(), any());
+
+        CompletableFuture<Boolean> authentication = webInterface.authenticate();
+
+        assertSame(authentication, authenticationDuringStatusUpdate.get());
+        webInterface.dispose();
+    }
+
     private void acceptWithoutResponding(ServerSocket serverSocket, CountDownLatch requestAccepted,
             CountDownLatch releaseServer) {
         try (Socket ignored = serverSocket.accept()) {
@@ -131,9 +155,9 @@ public class FritzAhaWebInterfaceTest {
                 BufferedReader reader = new BufferedReader(
                         new InputStreamReader(socket.getInputStream(), StandardCharsets.UTF_8))) {
             String line;
-            while ((line = reader.readLine()) != null && !line.isEmpty()) {
-                // Read the complete request header before responding.
-            }
+            do {
+                line = reader.readLine();
+            } while (line != null && !line.isEmpty());
             String response = "HTTP/1.1 200 OK\r\nContent-Length: " + content.getBytes(StandardCharsets.UTF_8).length
                     + "\r\nConnection: close\r\n\r\n" + content;
             socket.getOutputStream().write(response.getBytes(StandardCharsets.UTF_8));


### PR DESCRIPTION
While fixing failing itest, it was discovered that the initialize method of the BoxHandler was blocking I/O while doing authentication. This PR makes authentication asynchronous and also fixes some build warnings.

When looking closer i found more to fix. So here are 4 specifcally crafted commits.  Once tests are confirmed i can carve out the two other bug fixes and create seperate PR's for easy backporting and creating release notes.

brightness bug:
- Fixes brightness INCREASE and DECREASE commands, whose calculated BigDecimal results were previously discarded. (immutable BigDecimal)
- Keeps resulting brightness to the valid 0–100% range.

temperature bug:
- Fixes temperature INCREASE and DECREASE commands suffering from the same immutable-BigDecimal issue.
- Keeps calculations in Celsius and converts to the FRITZ!Box half-degree representation exactly once.

Testable jar: 5.2.0 or later: https://1drv.ms/u/c/70ea7ac46bc61c73/IQBdmRSY7dX1TJVQkJefmXHLAV6e5KLaXleWfOROP_d2JMQ?e=OB5oDo