### PR TITLE
[solarman] deye_hybrid definition: deduplicate A6 register

### DIFF
--- a/bundles/org.openhab.binding.solarman/src/main/resources/definitions/deye_hybrid.yaml
+++ b/bundles/org.openhab.binding.solarman/src/main/resources/definitions/deye_hybrid.yaml
@@ -536,28 +536,6 @@ parameters:
       -  key: 1
          value: "On-Grid"
 
-    - name: "Gen-connected Status"
-      class: ""
-      uom: ""
-      state_class: ""      
-      scale: 1
-      rule: 1
-      registers: [0x00A6]
-      isstr: true
-      lookup: 
-      -  key: 0
-         value: "none"
-      -  key: 1
-         value: "On"
-
-    - name: "Gen Power"
-      class: "power"
-      state_class: "measurement"      
-      uom: "W"
-      scale: 1
-      rule: 1
-      registers: [0x00A6]
-
     - name: "Work Mode"
       class: ""
       state_class: ""      


### PR DESCRIPTION
Solarman logger is a wrapper around Modbus. The A6 register cannot stand at the same time for “Micro-inverter Power”, “Gen-connected Status” and “Gen Power”.

According to https://marklabs.pl/en/deye-modbus-complete-register-list/ for the same register different Deye models provide different information.  Deye Modbus registers are described at https://github.com/kbialek/deye-inverter-mqtt/blob/main/README.md .  “Deye SG01LP1” is “deye_hybrid” and https://github.com/kbialek/deye-inverter-mqtt/blob/main/docs/metric_group_deye_hybrid.md says A6 register is “Micro-inverter Power”.  Therefore the A6 register is neither “Gen-connected Status” nor “Gen Power”.
    
However I have no idea what “Micro-inverter Power” means for an inverter, which is not microinverter.

Utilizing A6 for different purpose should be done by providing a different YAML device definition.