### PR TITLE
Fix four unstable integration test projects

### DIFF
--- a/itests/org.openhab.binding.mielecloud.tests/src/main/java/org/openhab/binding/mielecloud/internal/handler/AbstractMieleThingHandlerTest.java
+++ b/itests/org.openhab.binding.mielecloud.tests/src/main/java/org/openhab/binding/mielecloud/internal/handler/AbstractMieleThingHandlerTest.java
@@ -310,6 +310,7 @@ public abstract class AbstractMieleThingHandlerTest extends JavaOSGiTest {
         ItemChannelLinkRegistry itemChannelLinkRegistry = getService(ItemChannelLinkRegistry.class,
                 ItemChannelLinkRegistry.class);
         assertNotNull(itemChannelLinkRegistry);
+        itemChannelLinkRegistry.waitForCompletedAsyncActivationTasks();
 
         for (Channel channel : thing.getChannels()) {
             String itemName = channel.getUID().getId();

--- a/itests/org.openhab.binding.modbus.tests/src/main/java/org/openhab/binding/modbus/tests/AbstractModbusOSGiTest.java
+++ b/itests/org.openhab.binding.modbus.tests/src/main/java/org/openhab/binding/modbus/tests/AbstractModbusOSGiTest.java
@@ -156,6 +156,7 @@ public abstract class AbstractModbusOSGiTest extends JavaOSGiTest {
         assertThat("Could not get ItemRegistry", itemRegistry, is(notNullValue()));
         itemChannelLinkRegistry = getService(ItemChannelLinkRegistry.class);
         assertThat("Could not get ItemChannelLinkRegistry", itemChannelLinkRegistry, is(notNullValue()));
+        itemChannelLinkRegistry.waitForCompletedAsyncActivationTasks();
 
         coreItemFactory = new CoreItemFactory(mockedUnitProvider);
 

--- a/itests/org.openhab.binding.ntp.tests/src/main/java/org/openhab/binding/ntp/test/NtpOSGiTest.java
+++ b/itests/org.openhab.binding.ntp.tests/src/main/java/org/openhab/binding/ntp/test/NtpOSGiTest.java
@@ -63,6 +63,7 @@ import org.openhab.core.thing.binding.ThingHandler;
 import org.openhab.core.thing.binding.builder.ChannelBuilder;
 import org.openhab.core.thing.binding.builder.ThingBuilder;
 import org.openhab.core.thing.link.ItemChannelLink;
+import org.openhab.core.thing.link.ItemChannelLinkRegistry;
 import org.openhab.core.thing.link.ManagedItemChannelLinkProvider;
 import org.openhab.core.thing.type.ChannelKind;
 import org.openhab.core.thing.type.ChannelTypeBuilder;
@@ -161,6 +162,10 @@ public class NtpOSGiTest extends JavaOSGiTest {
 
         itemRegistry = getService(ItemRegistry.class);
         assertNotNull(itemRegistry);
+
+        ItemChannelLinkRegistry itemChannelLinkRegistry = getService(ItemChannelLinkRegistry.class);
+        assertNotNull(itemChannelLinkRegistry);
+        itemChannelLinkRegistry.waitForCompletedAsyncActivationTasks();
 
         channelTypeUID = new ChannelTypeUID(NtpBindingConstants.BINDING_ID + ":channelType");
         channelTypeProvider = mock(ChannelTypeProvider.class);

--- a/itests/org.openhab.binding.systeminfo.tests/src/main/java/org/openhab/binding/systeminfo/test/SystemInfoOSGiTest.java
+++ b/itests/org.openhab.binding.systeminfo.tests/src/main/java/org/openhab/binding/systeminfo/test/SystemInfoOSGiTest.java
@@ -81,6 +81,7 @@ import org.openhab.core.thing.binding.ThingHandlerFactory;
 import org.openhab.core.thing.binding.builder.ChannelBuilder;
 import org.openhab.core.thing.binding.builder.ThingBuilder;
 import org.openhab.core.thing.link.ItemChannelLink;
+import org.openhab.core.thing.link.ItemChannelLinkRegistry;
 import org.openhab.core.thing.link.ManagedItemChannelLinkProvider;
 import org.openhab.core.thing.type.ChannelKind;
 import org.openhab.core.thing.type.ChannelTypeUID;
@@ -187,6 +188,10 @@ public class SystemInfoOSGiTest extends JavaOSGiTest {
             itemChannelLinkProvider = getService(ManagedItemChannelLinkProvider.class);
             assertThat(itemChannelLinkProvider, is(notNullValue()));
         });
+
+        ItemChannelLinkRegistry itemChannelLinkRegistry = getService(ItemChannelLinkRegistry.class);
+        assertThat(itemChannelLinkRegistry, is(notNullValue()));
+        itemChannelLinkRegistry.waitForCompletedAsyncActivationTasks();
 
         waitForAssert(() -> {
             unitProvider = getService(UnitProvider.class);


### PR DESCRIPTION
Fixes: https://github.com/openhab/openhab-addons/issues/15683
Fixes: https://github.com/openhab/openhab-addons/issues/9720
Fixes: https://github.com/openhab/openhab-addons/issues/13524
Fixes: https://github.com/openhab/openhab-addons/issues/13938

All four itest have been unstable due to (rather tehoretically) race condition in core. `AbstractRegistry` takes a provider snapshot before registering its change listener. A provider change in between can therefore be missed permanently. My attempt to fix this in core failed. I tride to add an atomic “subscribe and return snapshot” operation, but that only move the problem elsewhere. I found it to risky to place it all under a lock, as i can;t oversee all possible side-effects.

The imeplemented `itemChannelLinkRegistry.waitForCompletedAsyncActivationTasks();` workaround as suggested by @wborn is probably the best for now.
