### PR TITLE
[smartmeter] Fix test

### DIFF
--- a/bundles/org.openhab.binding.smartmeter/src/test/java/org/openhab/binding/smartmeter/MockMeterReaderConnector.java
+++ b/bundles/org.openhab.binding.smartmeter/src/test/java/org/openhab/binding/smartmeter/MockMeterReaderConnector.java
@@ -19,6 +19,8 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.smartmeter.connectors.ConnectorBase;
 
+import io.reactivex.FlowableEmitter;
+
 /**
  *
  * @author Matthias Steigenberger - Initial contribution
@@ -27,13 +29,16 @@ import org.openhab.binding.smartmeter.connectors.ConnectorBase;
 @NonNullByDefault
 public class MockMeterReaderConnector extends ConnectorBase<Object> {
 
-    private boolean applyRetry;
-    private Supplier<Object> readNextSupplier;
+    private final boolean applyRetry;
+    private final Supplier<Object> readNextSupplier;
+    private final Runnable emissionFinished;
 
-    protected MockMeterReaderConnector(String portName, boolean applyRetry, Supplier<Object> readNextSupplier) {
+    protected MockMeterReaderConnector(String portName, boolean applyRetry, Supplier<Object> readNextSupplier,
+            Runnable emissionFinished) {
         super(portName);
         this.applyRetry = applyRetry;
         this.readNextSupplier = readNextSupplier;
+        this.emissionFinished = emissionFinished;
     }
 
     @Override
@@ -53,6 +58,16 @@ public class MockMeterReaderConnector extends ConnectorBase<Object> {
                 throw cause;
             }
             throw e;
+        }
+    }
+
+    @Override
+    protected void emitValues(byte @Nullable [] initMessage, FlowableEmitter<@Nullable Object> emitter)
+            throws IOException {
+        try {
+            super.emitValues(initMessage, emitter);
+        } finally {
+            emissionFinished.run();
         }
     }
 

--- a/bundles/org.openhab.binding.smartmeter/src/test/java/org/openhab/binding/smartmeter/MockMeterReaderConnector.java
+++ b/bundles/org.openhab.binding.smartmeter/src/test/java/org/openhab/binding/smartmeter/MockMeterReaderConnector.java
@@ -19,8 +19,6 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.smartmeter.connectors.ConnectorBase;
 
-import io.reactivex.FlowableEmitter;
-
 /**
  *
  * @author Matthias Steigenberger - Initial contribution
@@ -31,14 +29,11 @@ public class MockMeterReaderConnector extends ConnectorBase<Object> {
 
     private final boolean applyRetry;
     private final Supplier<Object> readNextSupplier;
-    private final Runnable emissionFinished;
 
-    protected MockMeterReaderConnector(String portName, boolean applyRetry, Supplier<Object> readNextSupplier,
-            Runnable emissionFinished) {
+    protected MockMeterReaderConnector(String portName, boolean applyRetry, Supplier<Object> readNextSupplier) {
         super(portName);
         this.applyRetry = applyRetry;
         this.readNextSupplier = readNextSupplier;
-        this.emissionFinished = emissionFinished;
     }
 
     @Override
@@ -58,16 +53,6 @@ public class MockMeterReaderConnector extends ConnectorBase<Object> {
                 throw cause;
             }
             throw e;
-        }
-    }
-
-    @Override
-    protected void emitValues(byte @Nullable [] initMessage, FlowableEmitter<@Nullable Object> emitter)
-            throws IOException {
-        try {
-            super.emitValues(initMessage, emitter);
-        } finally {
-            emissionFinished.run();
         }
     }
 

--- a/bundles/org.openhab.binding.smartmeter/src/test/java/org/openhab/binding/smartmeter/RetrySuppressingExecutor.java
+++ b/bundles/org.openhab.binding.smartmeter/src/test/java/org/openhab/binding/smartmeter/RetrySuppressingExecutor.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.openhab.binding.smartmeter;
+
+import java.time.Duration;
+import java.util.Objects;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
+/**
+ *
+ * @author Leo Siepel - Initial contribution
+ *
+ */
+@NonNullByDefault
+public class RetrySuppressingExecutor extends ScheduledThreadPoolExecutor {
+
+    private final Duration retryDelay;
+    private final AtomicBoolean suppressNextRetry = new AtomicBoolean();
+    private final CountDownLatch retrySuppressed = new CountDownLatch(1);
+    private final CountDownLatch sourceTaskFinished = new CountDownLatch(1);
+    private @Nullable Thread sourceThread;
+
+    RetrySuppressingExecutor(int corePoolSize, Duration retryDelay) {
+        super(corePoolSize);
+        this.retryDelay = retryDelay;
+    }
+
+    void suppressNextRetry() {
+        suppressNextRetry.set(true);
+    }
+
+    void awaitRetrySuppressed(Duration timeout) {
+        await(retrySuppressed, timeout, "The outer retry was not suppressed");
+    }
+
+    void markSourceTask() {
+        sourceThread = Thread.currentThread();
+    }
+
+    void awaitSourceTaskFinished(Duration timeout) {
+        await(sourceTaskFinished, timeout, "The meter source task did not finish");
+    }
+
+    private void await(CountDownLatch latch, Duration timeout, String failureMessage) {
+        try {
+            if (!latch.await(timeout.toMillis(), TimeUnit.MILLISECONDS)) {
+                throw new AssertionError(failureMessage);
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new AssertionError("Interrupted while waiting for an executor event", e);
+        }
+    }
+
+    @Override
+    @NonNullByDefault({})
+    protected void afterExecute(Runnable runnable, Throwable throwable) {
+        super.afterExecute(runnable, throwable);
+        if (Thread.currentThread().equals(sourceThread)) {
+            sourceTaskFinished.countDown();
+        }
+    }
+
+    @Override
+    public <V> ScheduledFuture<V> schedule(@Nullable Callable<V> task, long delay, @Nullable TimeUnit unit) {
+        Callable<V> callable = Objects.requireNonNull(task);
+        TimeUnit timeUnit = Objects.requireNonNull(unit);
+        if (timeUnit.toMillis(delay) == retryDelay.toMillis() && suppressNextRetry.compareAndSet(true, false)) {
+            ScheduledFuture<V> future = super.schedule(() -> null, delay, timeUnit);
+            retrySuppressed.countDown();
+            return future;
+        }
+        return super.schedule(callable, delay, timeUnit);
+    }
+}

--- a/bundles/org.openhab.binding.smartmeter/src/test/java/org/openhab/binding/smartmeter/TestMeterReading.java
+++ b/bundles/org.openhab.binding.smartmeter/src/test/java/org/openhab/binding/smartmeter/TestMeterReading.java
@@ -22,6 +22,7 @@ import java.time.Duration;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Supplier;
@@ -29,6 +30,7 @@ import java.util.function.Supplier;
 import javax.measure.Quantity;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
@@ -55,6 +57,32 @@ public class TestMeterReading {
 
     private static final Duration EVENT_TIMEOUT = Duration.ofSeconds(10);
     private static final Duration READ_PERIOD = Duration.ofMillis(100);
+
+    private class SourceTaskExecutor extends ScheduledThreadPoolExecutor {
+        private final CountDownLatch sourceTaskFinished = new CountDownLatch(1);
+        private @Nullable Thread sourceThread;
+
+        SourceTaskExecutor() {
+            super(2);
+        }
+
+        void markSourceTask() {
+            sourceThread = Thread.currentThread();
+        }
+
+        void awaitSourceTaskFinished() {
+            await(sourceTaskFinished, "The meter source task did not finish");
+        }
+
+        @Override
+        @NonNullByDefault({})
+        protected void afterExecute(Runnable runnable, Throwable throwable) {
+            super.afterExecute(runnable, throwable);
+            if (Thread.currentThread() == sourceThread) {
+                sourceTaskFinished.countDown();
+            }
+        }
+    }
 
     @AfterEach
     public void resetRxJavaPlugins() {
@@ -143,12 +171,13 @@ public class TestMeterReading {
         final int timeout = 1000;
         CountDownLatch readStarted = new CountDownLatch(1);
         CountDownLatch releaseRead = new CountDownLatch(1);
-        CountDownLatch emissionFinished = new CountDownLatch(1);
+        SourceTaskExecutor executorService = new SourceTaskExecutor();
         MockMeterReaderConnector connector = spy(getMockedConnector(true, () -> {
+            executorService.markSourceTask();
             readStarted.countDown();
             awaitUninterruptibly(releaseRead);
             throw new UncheckedIOException(new IOException("simulated read failure"));
-        }, emissionFinished::countDown));
+        }));
         MeterDevice<Object> meter = getMeterDevice(connector);
         @SuppressWarnings("unchecked")
         Consumer<Throwable> errorHandler = mock(Consumer.class);
@@ -160,13 +189,12 @@ public class TestMeterReading {
             return null;
         }).when(changeListener).errorOccurred(any());
         meter.addValueChangeListener(changeListener);
-        ScheduledExecutorService executorService = Executors.newScheduledThreadPool(2);
         Disposable disposable = meter.readValues(timeout, executorService, Duration.ZERO);
         try {
             await(readStarted, "The meter read did not start");
             await(timeoutOccurred, "The meter read did not time out");
             releaseRead.countDown();
-            await(emissionFinished, "The canceled meter read did not finish");
+            executorService.awaitSourceTaskFinished();
             verify(changeListener, times(1)).errorOccurred(any(TimeoutException.class));
             verifyNoInteractions(errorHandler);
         } finally {
@@ -176,13 +204,7 @@ public class TestMeterReading {
     }
 
     MockMeterReaderConnector getMockedConnector(boolean applyRetry, Supplier<Object> readNextSupplier) {
-        return getMockedConnector(applyRetry, readNextSupplier, () -> {
-        });
-    }
-
-    MockMeterReaderConnector getMockedConnector(boolean applyRetry, Supplier<Object> readNextSupplier,
-            Runnable emissionFinished) {
-        return new MockMeterReaderConnector("Test port", applyRetry, readNextSupplier, emissionFinished);
+        return new MockMeterReaderConnector("Test port", applyRetry, readNextSupplier);
     }
 
     MeterDevice<Object> getMeterDevice(ConnectorBase<Object> connector) {

--- a/bundles/org.openhab.binding.smartmeter/src/test/java/org/openhab/binding/smartmeter/TestMeterReading.java
+++ b/bundles/org.openhab.binding.smartmeter/src/test/java/org/openhab/binding/smartmeter/TestMeterReading.java
@@ -14,15 +14,14 @@ package org.openhab.binding.smartmeter;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.*;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.time.Duration;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Supplier;
@@ -30,10 +29,8 @@ import java.util.function.Supplier;
 import javax.measure.Quantity;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.eclipse.jdt.annotation.Nullable;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 import org.openhab.binding.smartmeter.connectors.ConnectorBase;
 import org.openhab.binding.smartmeter.connectors.IMeterReaderConnector;
@@ -55,34 +52,14 @@ import io.reactivex.plugins.RxJavaPlugins;
 @NonNullByDefault
 public class TestMeterReading {
 
+    private static final Duration OUTER_RETRY_DELAY = Duration.ofSeconds(2);
+
+    private RetrySuppressingExecutor createRetrySuppressingExecutor(int threadCount) {
+        return new RetrySuppressingExecutor(threadCount, OUTER_RETRY_DELAY);
+    }
+
     private static final Duration EVENT_TIMEOUT = Duration.ofSeconds(10);
     private static final Duration READ_PERIOD = Duration.ofMillis(100);
-
-    private class SourceTaskExecutor extends ScheduledThreadPoolExecutor {
-        private final CountDownLatch sourceTaskFinished = new CountDownLatch(1);
-        private @Nullable Thread sourceThread;
-
-        SourceTaskExecutor() {
-            super(2);
-        }
-
-        void markSourceTask() {
-            sourceThread = Thread.currentThread();
-        }
-
-        void awaitSourceTaskFinished() {
-            await(sourceTaskFinished, "The meter source task did not finish");
-        }
-
-        @Override
-        @NonNullByDefault({})
-        protected void afterExecute(Runnable runnable, Throwable throwable) {
-            super.afterExecute(runnable, throwable);
-            if (Thread.currentThread().equals(sourceThread)) {
-                sourceTaskFinished.countDown();
-            }
-        }
-    }
 
     @AfterEach
     public void resetRxJavaPlugins() {
@@ -96,20 +73,25 @@ public class TestMeterReading {
         MeterDevice<Object> meter = getMeterDevice(connector);
         MeterValueListener changeListener = Mockito.mock(MeterValueListener.class);
         CountDownLatch valuesChanged = new CountDownLatch(executionCount);
+        RetrySuppressingExecutor executorService = createRetrySuppressingExecutor(1);
+
         doAnswer(invocation -> {
             valuesChanged.countDown();
             return null;
         }).when(changeListener).valueChanged(any());
         meter.addValueChangeListener(changeListener);
-        ScheduledExecutorService executorService = Executors.newScheduledThreadPool(1);
+
         Disposable disposable = meter.readValues(EVENT_TIMEOUT.toMillis(), executorService, READ_PERIOD);
+
         try {
             await(valuesChanged, "Did not receive the expected meter values");
-            verify(changeListener, atLeast(executionCount)).valueChanged(any());
-            verify(changeListener, never()).errorOccurred(any());
+            executorService.suppressNextRetry();
         } finally {
             dispose(disposable, executorService);
         }
+
+        verify(changeListener, atLeast(executionCount)).valueChanged(any());
+        verify(changeListener, never()).errorOccurred(any());
     }
 
     @Test
@@ -120,20 +102,26 @@ public class TestMeterReading {
         MeterDevice<Object> meter = getMeterDevice(connector);
         MeterValueListener changeListener = Mockito.mock(MeterValueListener.class);
         CountDownLatch readingError = new CountDownLatch(1);
+        RetrySuppressingExecutor executorService = createRetrySuppressingExecutor(1);
+
         doAnswer(invocation -> {
+            executorService.suppressNextRetry();
             readingError.countDown();
             return null;
         }).when(changeListener).errorOccurred(any());
         meter.addValueChangeListener(changeListener);
-        ScheduledExecutorService executorService = Executors.newScheduledThreadPool(1);
+
         Disposable disposable = meter.readValues(EVENT_TIMEOUT.toMillis(), executorService, READ_PERIOD);
+
         try {
             await(readingError, "Did not receive the expected reading error");
+            executorService.awaitRetrySuppressed(EVENT_TIMEOUT);
         } finally {
             dispose(disposable, executorService);
         }
+
         verify(changeListener, times(1)).errorOccurred(any());
-        verify(connector, times(ConnectorBase.NUMBER_OF_RETRIES)).retryHook(ArgumentMatchers.anyInt());
+        verify(connector, times(ConnectorBase.NUMBER_OF_RETRIES)).retryHook(anyInt());
     }
 
     @Test
@@ -149,21 +137,27 @@ public class TestMeterReading {
         MeterDevice<Object> meter = getMeterDevice(connector);
         MeterValueListener changeListener = Mockito.mock(MeterValueListener.class);
         CountDownLatch timeoutOccurred = new CountDownLatch(1);
+        RetrySuppressingExecutor executorService = createRetrySuppressingExecutor(2);
+
         doAnswer(invocation -> {
+            executorService.suppressNextRetry();
             timeoutOccurred.countDown();
             return null;
         }).when(changeListener).errorOccurred(any());
         meter.addValueChangeListener(changeListener);
-        ScheduledExecutorService executorService = Executors.newScheduledThreadPool(2);
+
         Disposable disposable = meter.readValues(timeout, executorService, Duration.ZERO);
+
         try {
             await(readStarted, "The meter read did not start");
             await(timeoutOccurred, "The meter read did not time out");
-            verify(changeListener, times(1)).errorOccurred(any(TimeoutException.class));
+            executorService.awaitRetrySuppressed(EVENT_TIMEOUT);
         } finally {
             releaseRead.countDown();
             dispose(disposable, executorService);
         }
+
+        verify(changeListener, times(1)).errorOccurred(any(TimeoutException.class));
     }
 
     @Test
@@ -171,7 +165,7 @@ public class TestMeterReading {
         final int timeout = 1000;
         CountDownLatch readStarted = new CountDownLatch(1);
         CountDownLatch releaseRead = new CountDownLatch(1);
-        SourceTaskExecutor executorService = new SourceTaskExecutor();
+        RetrySuppressingExecutor executorService = createRetrySuppressingExecutor(2);
         MockMeterReaderConnector connector = spy(getMockedConnector(true, () -> {
             executorService.markSourceTask();
             readStarted.countDown();
@@ -185,22 +179,27 @@ public class TestMeterReading {
         MeterValueListener changeListener = Mockito.mock(MeterValueListener.class);
         CountDownLatch timeoutOccurred = new CountDownLatch(1);
         doAnswer(invocation -> {
+            executorService.suppressNextRetry();
             timeoutOccurred.countDown();
             return null;
         }).when(changeListener).errorOccurred(any());
         meter.addValueChangeListener(changeListener);
+
         Disposable disposable = meter.readValues(timeout, executorService, Duration.ZERO);
+
         try {
             await(readStarted, "The meter read did not start");
             await(timeoutOccurred, "The meter read did not time out");
+            executorService.awaitRetrySuppressed(EVENT_TIMEOUT);
             releaseRead.countDown();
-            executorService.awaitSourceTaskFinished();
-            verify(changeListener, times(1)).errorOccurred(any(TimeoutException.class));
-            verifyNoInteractions(errorHandler);
+            executorService.awaitSourceTaskFinished(EVENT_TIMEOUT);
         } finally {
             releaseRead.countDown();
             dispose(disposable, executorService);
         }
+
+        verify(changeListener, times(1)).errorOccurred(any(TimeoutException.class));
+        verifyNoInteractions(errorHandler);
     }
 
     MockMeterReaderConnector getMockedConnector(boolean applyRetry, Supplier<Object> readNextSupplier) {

--- a/bundles/org.openhab.binding.smartmeter/src/test/java/org/openhab/binding/smartmeter/TestMeterReading.java
+++ b/bundles/org.openhab.binding.smartmeter/src/test/java/org/openhab/binding/smartmeter/TestMeterReading.java
@@ -78,7 +78,7 @@ public class TestMeterReading {
         @NonNullByDefault({})
         protected void afterExecute(Runnable runnable, Throwable throwable) {
             super.afterExecute(runnable, throwable);
-            if (Thread.currentThread() == sourceThread) {
+            if (Thread.currentThread().equals(sourceThread)) {
                 sourceTaskFinished.countDown();
             }
         }

--- a/bundles/org.openhab.binding.smartmeter/src/test/java/org/openhab/binding/smartmeter/TestMeterReading.java
+++ b/bundles/org.openhab.binding.smartmeter/src/test/java/org/openhab/binding/smartmeter/TestMeterReading.java
@@ -12,18 +12,25 @@
  */
 package org.openhab.binding.smartmeter;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.time.Duration;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 import javax.measure.Quantity;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
@@ -36,7 +43,6 @@ import org.openhab.binding.smartmeter.internal.helper.ProtocolMode;
 import org.openhab.core.io.transport.serial.SerialPortManager;
 
 import io.reactivex.disposables.Disposable;
-import io.reactivex.functions.Consumer;
 import io.reactivex.plugins.RxJavaPlugins;
 
 /**
@@ -47,94 +53,136 @@ import io.reactivex.plugins.RxJavaPlugins;
 @NonNullByDefault
 public class TestMeterReading {
 
+    private static final Duration EVENT_TIMEOUT = Duration.ofSeconds(10);
+    private static final Duration READ_PERIOD = Duration.ofMillis(100);
+
+    @AfterEach
+    public void resetRxJavaPlugins() {
+        RxJavaPlugins.reset();
+    }
+
     @Test
-    public void testContinousReading() throws Exception {
-        final Duration period = Duration.ofSeconds(1);
+    public void testContinousReading() {
         final int executionCount = 5;
         MockMeterReaderConnector connector = getMockedConnector(false, () -> new Object());
         MeterDevice<Object> meter = getMeterDevice(connector);
         MeterValueListener changeListener = Mockito.mock(MeterValueListener.class);
+        CountDownLatch valuesChanged = new CountDownLatch(executionCount);
+        doAnswer(invocation -> {
+            valuesChanged.countDown();
+            return null;
+        }).when(changeListener).valueChanged(any());
         meter.addValueChangeListener(changeListener);
-        long executionTime = period.toMillis() * executionCount;
-        Disposable disposable = meter.readValues(executionTime, Executors.newScheduledThreadPool(1), period);
+        ScheduledExecutorService executorService = Executors.newScheduledThreadPool(1);
+        Disposable disposable = meter.readValues(EVENT_TIMEOUT.toMillis(), executorService, READ_PERIOD);
         try {
-            verify(changeListener, after(executionTime + period.toMillis() / 2 + 50).never()).errorOccurred(any());
-            verify(changeListener, times(executionCount)).valueChanged(any());
+            await(valuesChanged, "Did not receive the expected meter values");
+            verify(changeListener, atLeast(executionCount)).valueChanged(any());
+            verify(changeListener, never()).errorOccurred(any());
         } finally {
-            disposable.dispose();
+            dispose(disposable, executorService);
         }
     }
 
     @Test
     public void testRetryHandling() {
-        final Duration period = Duration.ofSeconds(1);
         MockMeterReaderConnector connector = spy(getMockedConnector(true, () -> {
             throw new IllegalArgumentException();
         }));
         MeterDevice<Object> meter = getMeterDevice(connector);
         MeterValueListener changeListener = Mockito.mock(MeterValueListener.class);
+        CountDownLatch readingError = new CountDownLatch(1);
+        doAnswer(invocation -> {
+            readingError.countDown();
+            return null;
+        }).when(changeListener).errorOccurred(any());
         meter.addValueChangeListener(changeListener);
-        Disposable disposable = meter.readValues(5000, Executors.newScheduledThreadPool(1), period);
+        ScheduledExecutorService executorService = Executors.newScheduledThreadPool(1);
+        Disposable disposable = meter.readValues(EVENT_TIMEOUT.toMillis(), executorService, READ_PERIOD);
         try {
-            verify(changeListener, after(
-                    period.toMillis() + 2 * period.toMillis() * ConnectorBase.NUMBER_OF_RETRIES + period.toMillis() / 2)
-                    .times(1)).errorOccurred(any());
+            await(readingError, "Did not receive the expected reading error");
+            verify(changeListener, times(1)).errorOccurred(any());
             verify(connector, times(ConnectorBase.NUMBER_OF_RETRIES)).retryHook(ArgumentMatchers.anyInt());
         } finally {
-            disposable.dispose();
+            dispose(disposable, executorService);
         }
     }
 
     @Test
     public void testTimeoutHandling() {
-        final Duration period = Duration.ofSeconds(2);
-        final int timeout = 5000;
+        final int timeout = 1000;
+        CountDownLatch readStarted = new CountDownLatch(1);
+        CountDownLatch releaseRead = new CountDownLatch(1);
         MockMeterReaderConnector connector = spy(getMockedConnector(true, () -> {
-            try {
-                Thread.sleep(timeout);
-            } catch (InterruptedException e) {
-            }
+            readStarted.countDown();
+            awaitUninterruptibly(releaseRead);
             return new Object();
         }));
         MeterDevice<Object> meter = getMeterDevice(connector);
         MeterValueListener changeListener = Mockito.mock(MeterValueListener.class);
+        CountDownLatch timeoutOccurred = new CountDownLatch(1);
+        doAnswer(invocation -> {
+            timeoutOccurred.countDown();
+            return null;
+        }).when(changeListener).errorOccurred(any());
         meter.addValueChangeListener(changeListener);
-        Disposable disposable = meter.readValues(timeout / 2, Executors.newScheduledThreadPool(2), period);
+        ScheduledExecutorService executorService = Executors.newScheduledThreadPool(2);
+        Disposable disposable = meter.readValues(timeout, executorService, Duration.ZERO);
         try {
-            verify(changeListener, timeout(timeout)).errorOccurred(any(TimeoutException.class));
+            await(readStarted, "The meter read did not start");
+            await(timeoutOccurred, "The meter read did not time out");
+            verify(changeListener, times(1)).errorOccurred(any(TimeoutException.class));
         } finally {
-            disposable.dispose();
+            releaseRead.countDown();
+            dispose(disposable, executorService);
         }
     }
 
     @Test
     public void shouldNotReportToFallbackException() {
-        final Duration period = Duration.ofSeconds(2);
-        final int timeout = 5000;
+        final int timeout = 1000;
+        CountDownLatch readStarted = new CountDownLatch(1);
+        CountDownLatch releaseRead = new CountDownLatch(1);
+        CountDownLatch emissionFinished = new CountDownLatch(1);
         MockMeterReaderConnector connector = spy(getMockedConnector(true, () -> {
-            try {
-                Thread.sleep(timeout);
-            } catch (InterruptedException e) {
-            }
-            throw new RuntimeException(new IOException("fucked up"));
-        }));
+            readStarted.countDown();
+            awaitUninterruptibly(releaseRead);
+            throw new UncheckedIOException(new IOException("simulated read failure"));
+        }, emissionFinished::countDown));
         MeterDevice<Object> meter = getMeterDevice(connector);
         @SuppressWarnings("unchecked")
         Consumer<Throwable> errorHandler = mock(Consumer.class);
         RxJavaPlugins.setErrorHandler(errorHandler);
         MeterValueListener changeListener = Mockito.mock(MeterValueListener.class);
+        CountDownLatch timeoutOccurred = new CountDownLatch(1);
+        doAnswer(invocation -> {
+            timeoutOccurred.countDown();
+            return null;
+        }).when(changeListener).errorOccurred(any());
         meter.addValueChangeListener(changeListener);
-        Disposable disposable = meter.readValues(timeout / 2, Executors.newScheduledThreadPool(2), period);
+        ScheduledExecutorService executorService = Executors.newScheduledThreadPool(2);
+        Disposable disposable = meter.readValues(timeout, executorService, Duration.ZERO);
         try {
-            verify(changeListener, timeout(timeout)).errorOccurred(any(TimeoutException.class));
-            verifyNoMoreInteractions(errorHandler);
+            await(readStarted, "The meter read did not start");
+            await(timeoutOccurred, "The meter read did not time out");
+            releaseRead.countDown();
+            await(emissionFinished, "The canceled meter read did not finish");
+            verify(changeListener, times(1)).errorOccurred(any(TimeoutException.class));
+            verifyNoInteractions(errorHandler);
         } finally {
-            disposable.dispose();
+            releaseRead.countDown();
+            dispose(disposable, executorService);
         }
     }
 
     MockMeterReaderConnector getMockedConnector(boolean applyRetry, Supplier<Object> readNextSupplier) {
-        return new MockMeterReaderConnector("Test port", applyRetry, readNextSupplier);
+        return getMockedConnector(applyRetry, readNextSupplier, () -> {
+        });
+    }
+
+    MockMeterReaderConnector getMockedConnector(boolean applyRetry, Supplier<Object> readNextSupplier,
+            Runnable emissionFinished) {
+        return new MockMeterReaderConnector("Test port", applyRetry, readNextSupplier, emissionFinished);
     }
 
     MeterDevice<Object> getMeterDevice(ConnectorBase<Object> connector) {
@@ -153,5 +201,41 @@ public class TestMeterReading {
                 addObisCache(new MeterValue("123", "333", null));
             }
         };
+    }
+
+    private void await(CountDownLatch latch, String failureMessage) {
+        try {
+            assertTrue(latch.await(EVENT_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS), failureMessage);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new AssertionError("Interrupted while waiting for an asynchronous test event", e);
+        }
+    }
+
+    private void awaitUninterruptibly(CountDownLatch latch) {
+        boolean interrupted = false;
+        while (true) {
+            try {
+                latch.await();
+                break;
+            } catch (InterruptedException e) {
+                interrupted = true;
+            }
+        }
+        if (interrupted) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    private void dispose(Disposable disposable, ScheduledExecutorService executorService) {
+        disposable.dispose();
+        executorService.shutdownNow();
+        try {
+            assertTrue(executorService.awaitTermination(EVENT_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS),
+                    "Executor did not terminate");
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new AssertionError("Interrupted while terminating the executor", e);
+        }
     }
 }

--- a/bundles/org.openhab.binding.smartmeter/src/test/java/org/openhab/binding/smartmeter/TestMeterReading.java
+++ b/bundles/org.openhab.binding.smartmeter/src/test/java/org/openhab/binding/smartmeter/TestMeterReading.java
@@ -24,7 +24,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 import javax.measure.Quantity;
@@ -43,6 +42,7 @@ import org.openhab.binding.smartmeter.internal.helper.ProtocolMode;
 import org.openhab.core.io.transport.serial.SerialPortManager;
 
 import io.reactivex.disposables.Disposable;
+import io.reactivex.functions.Consumer;
 import io.reactivex.plugins.RxJavaPlugins;
 
 /**
@@ -62,7 +62,7 @@ public class TestMeterReading {
     }
 
     @Test
-    public void testContinousReading() {
+    public void testContinuousReading() {
         final int executionCount = 5;
         MockMeterReaderConnector connector = getMockedConnector(false, () -> new Object());
         MeterDevice<Object> meter = getMeterDevice(connector);

--- a/bundles/org.openhab.binding.smartmeter/src/test/java/org/openhab/binding/smartmeter/TestMeterReading.java
+++ b/bundles/org.openhab.binding.smartmeter/src/test/java/org/openhab/binding/smartmeter/TestMeterReading.java
@@ -129,11 +129,11 @@ public class TestMeterReading {
         Disposable disposable = meter.readValues(EVENT_TIMEOUT.toMillis(), executorService, READ_PERIOD);
         try {
             await(readingError, "Did not receive the expected reading error");
-            verify(changeListener, times(1)).errorOccurred(any());
-            verify(connector, times(ConnectorBase.NUMBER_OF_RETRIES)).retryHook(ArgumentMatchers.anyInt());
         } finally {
             dispose(disposable, executorService);
         }
+        verify(changeListener, times(1)).errorOccurred(any());
+        verify(connector, times(ConnectorBase.NUMBER_OF_RETRIES)).retryHook(ArgumentMatchers.anyInt());
     }
 
     @Test


### PR DESCRIPTION
Fixes: #15198

The tests relied on fixed timing margins and Mockito's time-based verification.
On slower or congested build runners, not all scheduled readings completed before verification, resulting in missing value updates or timeout notifications.

- Synchronize tests with observable events using bounded `CountDownLatch` waits.
- Make timeout and fallback-exception ordering deterministic.
- Use shorter polling intervals while retaining generous test timeouts.
- Dispose subscriptions and terminate test executors after every test.
- Reset the global RxJava error handler after each test.

Created by codex, reviewed manually. 