### PR TITLE
Clarify integration test synchronization

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -252,6 +252,8 @@ When modifying existing behavior, inspect existing tests first and extend them r
 - Integration tests are located in the `itests/` directory.
 - Use bndrun configurations to define realistic OSGi runtime environments.
 - For lifecycle-sensitive changes, consider activation, deactivation, reactivation, service arrival/removal, and different installation orders where relevant.
+- In bnd-based integration tests, do not infer a service-availability race merely from a direct `getService(...)` call during test setup. Services supplied by the resolved runtime are normally available before the tests execute; use polling only when the specific service can actually arrive asynchronously after test execution has started.
+- When an integration test modifies a provider tracked by an `AbstractRegistry`-based registry, ensure asynchronous registry activation has completed before modifying the provider. Use `waitForCompletedAsyncActivationTasks()` when available, before adding, updating, or removing provider elements.
 
 ### Build Validation
 


### PR DESCRIPTION
Improvement to the AI/development guidance for bnd-based integration tests.

This clarifies two related cases:

- A direct `getService(...)` call during integration-test setup should not by itself be treated as evidence of a service-availability race when the service is supplied by the resolved bnd runtime.
- Tests that modify providers tracked by an `AbstractRegistry`-based registry should wait for asynchronous registry activation to complete first, using `waitForCompletedAsyncActivationTasks()` when available.

The first rule avoids false-positive review findings such as https://github.com/openhab/openhab-addons/pull/21410#discussion_r3791712945. The second helps coding and review agents recognize the actual startup synchronization needed to avoid the flaky-test pattern addressed by that PR.

This is documentation-only guidance; no runtime behavior is changed.