### PR TITLE
[pythonscripting] Fix pip initialisation

### DIFF
--- a/bundles/org.openhab.automation.pythonscripting/src/main/java/org/openhab/automation/pythonscripting/internal/PythonScriptEngineFactory.java
+++ b/bundles/org.openhab.automation.pythonscripting/src/main/java/org/openhab/automation/pythonscripting/internal/PythonScriptEngineFactory.java
@@ -83,7 +83,6 @@ public class PythonScriptEngineFactory implements ScriptEngineFactory, ScriptEng
 
         this.pythonDependencyTracker = pythonDependencyTracker;
         this.configuration = new PythonScriptEngineConfiguration(config);
-        this.configuration.init(this);
 
         Engine.Builder engineBuilder = createEngineBuilder();
         if (configuration.isDebuggerEnabled()) {
@@ -109,6 +108,8 @@ public class PythonScriptEngineFactory implements ScriptEngineFactory, ScriptEng
         } else {
             this.engine = createEngineBuilder().build();
         }
+
+        this.configuration.init(this);
 
         if (getLanguage() == null) {
             logger.error(


### PR DESCRIPTION
This fixed bug affects only people with an active venv setup and preconfigured pip modules.

It was discussed and tested here

https://community.openhab.org/t/python3-binding-discussion/161914/258

The fix just moved the init function call after the engine initialization, because the init function depends on a initialized engine.

This fix could also be a candidate for backporting to 5.2.x
