### PR TITLE
Clean up issue and pull request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -42,6 +42,6 @@ type: Bug
 
 ## Your Environment
 <!-- Include as many relevant details about the environment you experienced the bug in -->
-* Version used: (e.g., openHAB and add-on versions)
-* Environment name and version (e.g. Chrome 76, Java 8, Node.js 12.9, ...):
-* Operating System and version (desktop or mobile, Windows 10, Raspbian Buster, ...):
+- Version used: (e.g., openHAB and add-on versions)
+- Environment name and version (e.g. Chrome 151, Java 21, Node.js 24.19.0, ...):
+- Operating System and version (desktop or mobile, Windows 11, Raspberry Pi OS Trixie, ...):

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -14,6 +14,6 @@ type: Feature
 
 ## Your Environment
 <!-- Include as many relevant details about the environment when applicable -->
-* Version used: (e.g., openHAB and add-on versions)
-* Environment name and version (e.g. Chrome 76, Java 8, Node.js 12.9, ...):
-* Operating System and version (desktop or mobile, Windows 10, Raspbian Buster, ...):
+- Version used: (e.g., openHAB and add-on versions)
+- Environment name and version (e.g. Chrome 151, Java 21, Node.js 24.19.0, ...):
+- Operating System and version (desktop or mobile, Windows 11, Raspberry Pi OS Trixie, ...):

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -49,9 +49,6 @@ Please keep the following in mind:
 
 # Testing
 
-Your pull request will automatically be built and available under the following folder:
-https://openhab.jfrog.io/ui/native/libs-pullrequest-local/org/openhab/addons/bundles/
-
 It is a good practice to add a URL to your built JAR in this pull request description,
 so it is easier for the community to test your Add-on.
 If your pull request contains a new binding, it will likely take some time

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -308,6 +308,5 @@ Before considering a change complete:
 When creating a pull request, read and follow `.github/PULL_REQUEST_TEMPLATE.md` for the repository's current PR requirements.
 
 - Treat HTML-commented template text as instructions and write visible Markdown that addresses the applicable requirements; do not copy the comment delimiters or leave the PR description hidden inside an HTML comment.
-- The template's guidance about linking to automatically generated pull-request build artifacts is currently outdated; do not add such artifact links.
 - Before creating or updating a pull request, verify that its title and description still match the current diff and scope, especially after follow-up changes.
 - Treat the template as the source of truth for the remaining pull-request requirements rather than duplicating them here.


### PR DESCRIPTION
* Update outdated environment examples in the issue templates.
* Use the configured dash style for unordered Markdown lists.
* Remove the obsolete JFrog pull request artifact location from the pull request template.
* Remove the corresponding temporary exception from `AGENTS.md`.

The recommendation to provide a URL to a built JAR remains, so contributors can still host test artifacts themselves when useful.