### PR TITLE
[hue] Report the actual Zigbee status in the thing status (API v2)

### DIFF
--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/HueBindingConstants.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/HueBindingConstants.java
@@ -135,6 +135,8 @@ public class HueBindingConstants {
     // I18N string references
     public static final String TEXT_OFFLINE_COMMUNICATION_ERROR = "@text/offline.communication-error";
     public static final String TEXT_OFFLINE_CONFIGURATION_ERROR_INVALID_SSL_CERIFICATE = "@text/offline.conf-error-invalid-ssl-certificate";
+    public static final String TEXT_OFFLINE_ZIGBEE_CONNECTIVITY_ISSUE = "@text/offline.api2.comm-error.zigbee-connectivity-issue";
+    public static final String TEXT_OFFLINE_ZIGBEE_DISCONNECTED = "@text/offline.api2.comm-error.zigbee-disconnected";
 
     // Config status messages
     public static final String IP_ADDRESS_MISSING = "missing-ip-address-configuration";

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/api/dto/clip2/Resource.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/api/dto/clip2/Resource.java
@@ -833,11 +833,18 @@ public class Resource {
     }
 
     public @Nullable ZigbeeStatus getZigbeeStatus() {
+        String value = getZigbeeStatusValue();
+        return Objects.nonNull(value) ? ZigbeeStatus.of(value) : null;
+    }
+
+    /**
+     * Get the Zigbee status value exactly as the bridge reported it, or null if the resource does not contain one.
+     * Note that {@link ZigbeeStatus#of(String)} maps any unrecognised value to {@link ZigbeeStatus#DISCONNECTED}, so
+     * a caller that must not confuse an unrecognised value with a genuine disconnect has to consult this method.
+     */
+    public @Nullable String getZigbeeStatusValue() {
         JsonElement status = this.status;
-        if (Objects.nonNull(status) && status.isJsonPrimitive()) {
-            return ZigbeeStatus.of(status.getAsString());
-        }
-        return null;
+        return Objects.nonNull(status) && status.isJsonPrimitive() ? status.getAsString() : null;
     }
 
     public boolean hasFullState() {

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/api/dto/clip2/enums/ZigbeeStatus.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/api/dto/clip2/enums/ZigbeeStatus.java
@@ -27,7 +27,9 @@ public enum ZigbeeStatus {
     CONNECTED,
     DISCONNECTED,
     CONNECTIVITY_ISSUE,
-    UNIDIRECTIONAL_INCOMING;
+    UNIDIRECTIONAL_INCOMING,
+    // documented for 'zgp_connectivity' resources, a pending pairing rather than a connectivity issue
+    PENDING_DISCOVERY;
 
     private static final Set<ZigbeeStatus> CONNECTIVITY_ISSUES = Set.of(DISCONNECTED, CONNECTIVITY_ISSUE);
 

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/Clip2ThingHandler.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/Clip2ThingHandler.java
@@ -87,6 +87,7 @@ import org.openhab.core.thing.Thing;
 import org.openhab.core.thing.ThingRegistry;
 import org.openhab.core.thing.ThingStatus;
 import org.openhab.core.thing.ThingStatusDetail;
+import org.openhab.core.thing.ThingStatusInfo;
 import org.openhab.core.thing.ThingTypeUID;
 import org.openhab.core.thing.ThingUID;
 import org.openhab.core.thing.binding.BaseThingHandler;
@@ -1025,7 +1026,7 @@ public class Clip2ThingHandler extends BaseThingHandler {
      * @param resource the Resource containing the new channel state.
      * @return true if the channel was found and updated.
      */
-    private boolean updateChannels(Resource resource) {
+    boolean updateChannels(Resource resource) {
         logger.debug("{} -> updateChannels() from resource {}", resourceId, resource);
         boolean fullUpdate = resource.hasFullState();
         switch (resource.getType()) {
@@ -1200,9 +1201,16 @@ public class Clip2ThingHandler extends BaseThingHandler {
                     thing.getStatus(), zigbeeStatus);
             hasConnectivityIssue = zigbeeStatus.isConnectivityIssue();
             if (hasConnectivityIssue) {
-                if (thing.getStatusInfo().getStatusDetail() != ThingStatusDetail.COMMUNICATION_ERROR) {
-                    updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.NONE,
-                            "@text/offline.api2.comm-error.zigbee-connectivity-issue");
+                // unknown values also parse to DISCONNECTED, so only a literal 'disconnected' gets its own text
+                String description = ZigbeeStatus.DISCONNECTED.name().equalsIgnoreCase(resource.getZigbeeStatusValue())
+                        ? TEXT_OFFLINE_ZIGBEE_DISCONNECTED
+                        : TEXT_OFFLINE_ZIGBEE_CONNECTIVITY_ISSUE;
+                // publish unless the thing already shows exactly this, so that a status set by anybody else heals
+                ThingStatusInfo statusInfo = thing.getStatusInfo();
+                if (statusInfo.getStatus() != ThingStatus.OFFLINE
+                        || statusInfo.getStatusDetail() != ThingStatusDetail.COMMUNICATION_ERROR
+                        || !description.equals(statusInfo.getDescription())) {
+                    updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, description);
                     supportedChannelIdSet.forEach(channelId -> updateState(channelId, UnDefType.UNDEF));
                 }
                 return;

--- a/bundles/org.openhab.binding.hue/src/main/resources/OH-INF/i18n/hue.properties
+++ b/bundles/org.openhab.binding.hue/src/main/resources/OH-INF/i18n/hue.properties
@@ -348,6 +348,7 @@ offline.group-removed = Hue Bridge reports group as removed.
 # api v2 offline configuration error descriptions
 
 offline.api2.comm-error.zigbee-connectivity-issue = Zigbee connectivity issue.
+offline.api2.comm-error.zigbee-disconnected = Zigbee device disconnected.
 offline.api2.comm-error.exception = An unexpected exception occurred: {0}
 offline.api2.conf-error.certificate-load = Certificate loading failed. Please check your configuration settings (network address, type of certificate).
 offline.api2.conf-error.assets-not-loaded = Bridge/Thing handler assets not loaded.

--- a/bundles/org.openhab.binding.hue/src/test/java/org/openhab/binding/hue/internal/handler/Clip2ThingHandlerConnectivityTest.java
+++ b/bundles/org.openhab.binding.hue/src/test/java/org/openhab/binding/hue/internal/handler/Clip2ThingHandlerConnectivityTest.java
@@ -60,7 +60,7 @@ import com.google.gson.GsonBuilder;
  */
 @NonNullByDefault
 @SuppressWarnings("null") // Mockito is not designed with null type annotations in mind
-class Clip2ThingHandlerTest {
+class Clip2ThingHandlerConnectivityTest {
 
     private static final Gson GSON = new GsonBuilder().registerTypeAdapter(Instant.class, new InstantDeserializer())
             .create();

--- a/bundles/org.openhab.binding.hue/src/test/java/org/openhab/binding/hue/internal/handler/Clip2ThingHandlerTest.java
+++ b/bundles/org.openhab.binding.hue/src/test/java/org/openhab/binding/hue/internal/handler/Clip2ThingHandlerTest.java
@@ -194,6 +194,16 @@ class Clip2ThingHandlerTest {
     }
 
     @Test
+    void testPendingDiscoveryIsNotAConnectivityIssue() {
+        Fixture fixture = fixture();
+
+        // documented for 'zgp_connectivity' resources, which are routed through the same handling
+        fixture.handler.updateChannels(zigbeeResource("pending_discovery"));
+
+        assertEquals(ThingStatus.ONLINE, fixture.statusInfo.get().getStatus());
+    }
+
+    @Test
     void testUnchangedStatusIsPublishedOnlyOnce() {
         Fixture fixture = fixture();
         fixture.handler.updateChannels(devicePowerResource());

--- a/bundles/org.openhab.binding.hue/src/test/java/org/openhab/binding/hue/internal/handler/Clip2ThingHandlerTest.java
+++ b/bundles/org.openhab.binding.hue/src/test/java/org/openhab/binding/hue/internal/handler/Clip2ThingHandlerTest.java
@@ -1,0 +1,295 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hue.internal.handler;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+import static org.openhab.binding.hue.internal.HueBindingConstants.*;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.openhab.binding.hue.internal.api.dto.clip2.Resource;
+import org.openhab.binding.hue.internal.api.dto.clip2.Resources;
+import org.openhab.binding.hue.internal.api.dto.clip2.enums.ContentType;
+import org.openhab.binding.hue.internal.api.dto.clip2.enums.ResourceType;
+import org.openhab.binding.hue.internal.api.dto.clip2.enums.UpdateStatusV2;
+import org.openhab.binding.hue.internal.api.dto.clip2.enums.ZigbeeStatus;
+import org.openhab.binding.hue.internal.api.serialization.InstantDeserializer;
+import org.openhab.core.thing.Thing;
+import org.openhab.core.thing.ThingRegistry;
+import org.openhab.core.thing.ThingStatus;
+import org.openhab.core.thing.ThingStatusDetail;
+import org.openhab.core.thing.ThingStatusInfo;
+import org.openhab.core.thing.ThingUID;
+import org.openhab.core.thing.binding.ThingHandlerCallback;
+import org.openhab.core.thing.binding.builder.ThingStatusInfoBuilder;
+import org.openhab.core.thing.link.ItemChannelLinkRegistry;
+import org.openhab.core.types.UnDefType;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+
+/**
+ * Tests for the Zigbee connectivity handling of {@link Clip2ThingHandler}.
+ *
+ * @author Martin Littkovsky - Initial contribution
+ */
+@NonNullByDefault
+@SuppressWarnings("null") // Mockito is not designed with null type annotations in mind
+class Clip2ThingHandlerTest {
+
+    private static final Gson GSON = new GsonBuilder().registerTypeAdapter(Instant.class, new InstantDeserializer())
+            .create();
+    private static final ThingUID THING_UID = new ThingUID(THING_TYPE_DEVICE, "test");
+
+    /**
+     * A handler under test, its mocked callback, and a mirror of the thing status: whatever the handler publishes
+     * through the callback is written back into the thing mock, so the handler observes its own status writes the
+     * way it would at runtime. {@link #setThingStatus} simulates a status written by anybody else.
+     */
+    private static class Fixture {
+        private final ThingHandlerCallback callback = mock(ThingHandlerCallback.class);
+        private final AtomicReference<ThingStatusInfo> statusInfo = new AtomicReference<>(
+                ThingStatusInfoBuilder.create(ThingStatus.UNKNOWN, ThingStatusDetail.NONE).build());
+        private final Clip2ThingHandler handler;
+
+        private Fixture(Map<String, String> properties) {
+            Thing thing = mock(Thing.class);
+            when(thing.getThingTypeUID()).thenReturn(THING_TYPE_DEVICE);
+            when(thing.getUID()).thenReturn(THING_UID);
+            when(thing.getProperties()).thenReturn(properties);
+            when(thing.getStatusInfo()).thenAnswer(invocation -> statusInfo.get());
+            when(thing.getStatus()).thenAnswer(invocation -> statusInfo.get().getStatus());
+            doAnswer(invocation -> {
+                statusInfo.set(invocation.getArgument(1));
+                return null;
+            }).when(callback).statusUpdated(any(), any());
+            handler = new Clip2ThingHandler(thing, mock(Clip2StateDescriptionProvider.class), mock(ThingRegistry.class),
+                    mock(ItemChannelLinkRegistry.class));
+            handler.setCallback(callback);
+        }
+
+        private void setThingStatus(ThingStatus thingStatus, ThingStatusDetail detail, @Nullable String description) {
+            statusInfo.set(ThingStatusInfoBuilder.create(thingStatus, detail).withDescription(description).build());
+        }
+    }
+
+    private Fixture fixture() {
+        return new Fixture(Map.of());
+    }
+
+    /**
+     * Load a test JSON payload string from a file.
+     */
+    private String load(String fileName) {
+        try {
+            return Files.readString(Path.of("src/test/resources", fileName + ".json"), StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            fail(e.getMessage());
+            return "";
+        }
+    }
+
+    private List<Resource> loadResources(ResourceType resourceType) {
+        Resources resources = GSON.fromJson(load(resourceType.name().toLowerCase(Locale.ROOT)), Resources.class);
+        assertNotNull(resources);
+        List<Resource> list = resources.getResources();
+        assertNotNull(list);
+        return list;
+    }
+
+    /**
+     * Get the first resource from the 'zigbee_connectivity' fixture that reports the given status.
+     */
+    private Resource zigbeeResource(ZigbeeStatus zigbeeStatus) {
+        Resource resource = loadResources(ResourceType.ZIGBEE_CONNECTIVITY).stream()
+                .filter(r -> zigbeeStatus == r.getZigbeeStatus()).findFirst().orElse(null);
+        assertNotNull(resource);
+        return resource;
+    }
+
+    /**
+     * Build a 'zigbee_connectivity' resource carrying a status value that the fixture does not contain.
+     */
+    private Resource zigbeeResource(String statusValue) {
+        Resource resource = GSON.fromJson(
+                "{\"type\":\"zigbee_connectivity\",\"id\":\"test\",\"status\":\"" + statusValue + "\"}",
+                Resource.class);
+        assertNotNull(resource);
+        return resource;
+    }
+
+    /**
+     * Get a full state 'device_power' resource. Feeding it to the handler makes the handler adopt supported channels,
+     * which is what makes the UNDEF sweep on a connectivity issue observable.
+     */
+    private Resource devicePowerResource() {
+        return loadResources(ResourceType.DEVICE_POWER).get(0).setContentType(ContentType.FULL_STATE);
+    }
+
+    private ThingStatusInfo captureSingleStatus(ThingHandlerCallback callback) {
+        ArgumentCaptor<ThingStatusInfo> captor = ArgumentCaptor.forClass(ThingStatusInfo.class);
+        verify(callback).statusUpdated(any(), captor.capture());
+        return Objects.requireNonNull(captor.getValue());
+    }
+
+    @Test
+    void testDisconnectedIsReportedAsDisconnected() {
+        Fixture fixture = fixture();
+
+        fixture.handler.updateChannels(zigbeeResource("disconnected"));
+
+        ThingStatusInfo statusInfo = captureSingleStatus(fixture.callback);
+        assertEquals(ThingStatus.OFFLINE, statusInfo.getStatus());
+        assertEquals(ThingStatusDetail.COMMUNICATION_ERROR, statusInfo.getStatusDetail());
+        assertEquals(TEXT_OFFLINE_ZIGBEE_DISCONNECTED, statusInfo.getDescription());
+    }
+
+    @Test
+    void testConnectivityIssueIsReportedAsConnectivityIssue() {
+        Fixture fixture = fixture();
+
+        fixture.handler.updateChannels(zigbeeResource(ZigbeeStatus.CONNECTIVITY_ISSUE));
+
+        ThingStatusInfo statusInfo = captureSingleStatus(fixture.callback);
+        assertEquals(ThingStatus.OFFLINE, statusInfo.getStatus());
+        assertEquals(ThingStatusDetail.COMMUNICATION_ERROR, statusInfo.getStatusDetail());
+        assertEquals(TEXT_OFFLINE_ZIGBEE_CONNECTIVITY_ISSUE, statusInfo.getDescription());
+    }
+
+    @Test
+    void testUnrecognisedStatusIsNotReportedAsDisconnected() {
+        Fixture fixture = fixture();
+
+        // ZigbeeStatus.of() maps this to DISCONNECTED, but the bridge did not report a disconnect
+        fixture.handler.updateChannels(zigbeeResource("a_future_zigbee_status"));
+
+        ThingStatusInfo statusInfo = captureSingleStatus(fixture.callback);
+        assertEquals(ThingStatus.OFFLINE, statusInfo.getStatus());
+        assertEquals(TEXT_OFFLINE_ZIGBEE_CONNECTIVITY_ISSUE, statusInfo.getDescription());
+    }
+
+    @Test
+    void testUnchangedStatusIsPublishedOnlyOnce() {
+        Fixture fixture = fixture();
+        fixture.handler.updateChannels(devicePowerResource());
+
+        fixture.handler.updateChannels(zigbeeResource(ZigbeeStatus.CONNECTIVITY_ISSUE));
+
+        verify(fixture.callback, times(1)).statusUpdated(any(), any());
+        verify(fixture.callback, atLeastOnce()).stateUpdated(any(), eq(UnDefType.UNDEF));
+
+        clearInvocations(fixture.callback);
+        fixture.handler.updateChannels(zigbeeResource(ZigbeeStatus.CONNECTIVITY_ISSUE));
+
+        verify(fixture.callback, never()).statusUpdated(any(), any());
+        verify(fixture.callback, never()).stateUpdated(any(), eq(UnDefType.UNDEF));
+    }
+
+    @Test
+    void testChangeBetweenIssueStatesIsPublished() {
+        Fixture fixture = fixture();
+        fixture.handler.updateChannels(devicePowerResource());
+
+        fixture.handler.updateChannels(zigbeeResource(ZigbeeStatus.CONNECTIVITY_ISSUE));
+        clearInvocations(fixture.callback);
+        fixture.handler.updateChannels(zigbeeResource("disconnected"));
+
+        ThingStatusInfo statusInfo = captureSingleStatus(fixture.callback);
+        assertEquals(ThingStatus.OFFLINE, statusInfo.getStatus());
+        assertEquals(TEXT_OFFLINE_ZIGBEE_DISCONNECTED, statusInfo.getDescription());
+        verify(fixture.callback, atLeastOnce()).stateUpdated(any(), eq(UnDefType.UNDEF));
+    }
+
+    @Test
+    void testIssueIsPublishedAgainAfterRecovery() {
+        Fixture fixture = fixture();
+
+        fixture.handler.updateChannels(zigbeeResource(ZigbeeStatus.CONNECTIVITY_ISSUE));
+        fixture.handler.updateChannels(zigbeeResource(ZigbeeStatus.CONNECTED));
+        assertEquals(ThingStatus.ONLINE, fixture.statusInfo.get().getStatus());
+
+        clearInvocations(fixture.callback);
+        fixture.handler.updateChannels(zigbeeResource(ZigbeeStatus.CONNECTIVITY_ISSUE));
+
+        ThingStatusInfo statusInfo = captureSingleStatus(fixture.callback);
+        assertEquals(ThingStatus.OFFLINE, statusInfo.getStatus());
+        assertEquals(TEXT_OFFLINE_ZIGBEE_CONNECTIVITY_ISSUE, statusInfo.getDescription());
+    }
+
+    @Test
+    void testIssueIsPublishedAgainAfterRecoveryIntoFirmwareUpdate() {
+        // a recovery that does not end ONLINE: the handler keeps the thing OFFLINE while a firmware update installs
+        Fixture fixture = new Fixture(Map.of(PROPERTY_FIRMWARE_UPDATE_STATE, UpdateStatusV2.INSTALLING.toString()));
+
+        fixture.handler.updateChannels(zigbeeResource(ZigbeeStatus.CONNECTIVITY_ISSUE));
+        fixture.handler.updateChannels(zigbeeResource(ZigbeeStatus.CONNECTED));
+        assertEquals(ThingStatusDetail.FIRMWARE_UPDATING, fixture.statusInfo.get().getStatusDetail());
+
+        clearInvocations(fixture.callback);
+        fixture.handler.updateChannels(zigbeeResource(ZigbeeStatus.CONNECTIVITY_ISSUE));
+
+        ThingStatusInfo statusInfo = captureSingleStatus(fixture.callback);
+        assertEquals(ThingStatus.OFFLINE, statusInfo.getStatus());
+        assertEquals(ThingStatusDetail.COMMUNICATION_ERROR, statusInfo.getStatusDetail());
+    }
+
+    @Test
+    void testIssueIsPublishedAgainAfterAnotherWriterSetTheThingOnline() {
+        Fixture fixture = fixture();
+
+        fixture.handler.updateChannels(zigbeeResource(ZigbeeStatus.CONNECTIVITY_ISSUE));
+
+        // e.g. the default bridge status handling puts the thing back ONLINE once the bridge has returned; the
+        // status description may well be carried over, as refreshSoftwareStatusUI() does elsewhere in this binding
+        fixture.setThingStatus(ThingStatus.ONLINE, ThingStatusDetail.NONE, TEXT_OFFLINE_ZIGBEE_CONNECTIVITY_ISSUE);
+        clearInvocations(fixture.callback);
+        fixture.handler.updateChannels(zigbeeResource(ZigbeeStatus.CONNECTIVITY_ISSUE));
+
+        ThingStatusInfo statusInfo = captureSingleStatus(fixture.callback);
+        assertEquals(ThingStatus.OFFLINE, statusInfo.getStatus());
+        assertEquals(ThingStatusDetail.COMMUNICATION_ERROR, statusInfo.getStatusDetail());
+    }
+
+    @Test
+    void testIssueIsPublishedAgainAfterAnotherWriterSetTheThingGone() {
+        Fixture fixture = fixture();
+
+        fixture.handler.updateChannels(zigbeeResource(ZigbeeStatus.CONNECTIVITY_ISSUE));
+
+        // onResourcesList() sets this when the resource id is transiently missing from a full resource list
+        fixture.setThingStatus(ThingStatus.OFFLINE, ThingStatusDetail.GONE,
+                "@text/offline.api2.gone.resource-id-unknown");
+        clearInvocations(fixture.callback);
+        fixture.handler.updateChannels(zigbeeResource(ZigbeeStatus.CONNECTIVITY_ISSUE));
+
+        ThingStatusInfo statusInfo = captureSingleStatus(fixture.callback);
+        assertEquals(ThingStatus.OFFLINE, statusInfo.getStatus());
+        assertEquals(ThingStatusDetail.COMMUNICATION_ERROR, statusInfo.getStatusDetail());
+        assertEquals(TEXT_OFFLINE_ZIGBEE_CONNECTIVITY_ISSUE, statusInfo.getDescription());
+    }
+}


### PR DESCRIPTION
# Description

Fixes #21433

The Hue bridge reports four `zigbee_connectivity` states. Two of them are treated as a connectivity issue by the binding: `DISCONNECTED` and `CONNECTIVITY_ISSUE`. The bridge distinguishes the two, but both produced the same thing status description, so neither the thing status nor the event log said which one had been reported:

```text
2026-08-17 07:54:22 [ThingStatusInfoChangedEvent] - Thing 'hue:device:...:fe9a07a9-...'
    changed from ONLINE to OFFLINE: Zigbee connectivity issue.
2026-08-17 07:55:36 [ThingStatusInfoChangedEvent] - Thing 'hue:device:...:fe9a07a9-...'
    changed from OFFLINE: Zigbee connectivity issue. to ONLINE
```

Which of the two it is decides where to look next: at the device, or at the radio path. The enum value is available at the point where the status is written, and it was discarded there.

## Changes

1. **The two connectivity issue states get their own status description.** `DISCONNECTED` now reads `Zigbee device disconnected.`; `CONNECTIVITY_ISSUE` keeps the existing text and the existing i18n key. The specific text is only used when the bridge literally reported `disconnected`, because `ZigbeeStatus.of()` maps any unrecognised value to `DISCONNECTED` as well - an unknown future state must not be presented as a confirmed disconnect. `Resource` gained an accessor for the raw value for that check; `ZigbeeStatus.of()` itself is unchanged.

2. **The status detail is `COMMUNICATION_ERROR` instead of `NONE`.** This is what the guard on the very next line tested for, what the description's own i18n key (`offline.api2.comm-error.…`) already says, and what `updateDependencies()` uses for the comparable failure. Because the code wrote `NONE`, that guard cannot recognise its own write, so the block re-runs for every further connectivity resource that arrives while the issue persists, re-posting `UNDEF` to every channel each time. That is not free: core suppresses a repeated *thing status* only for `ThingStatusInfoChangedEvent`, while every `updateState()` is an item state update that fires received-update rules and `everyUpdate` persistence strategies.

3. **The guard is now a comparison against what the thing already shows.** The status is published unless the thing is already exactly `OFFLINE` with detail `COMMUNICATION_ERROR` and this description, so a change *between* the two issue states - and equally a change from an unrecognised value to a literal `disconnected` - is published rather than suppressed. Because the comparison is against the live status rather than against a remembered one, it also heals a status written by anybody else on the next delivery: the default bridge status handling putting a child thing back `ONLINE` once the bridge returns, or `OFFLINE(GONE)` from a full resource list that transiently lacks the device. It introduces no state of its own.

4. **`PENDING_DISCOVERY` is a known state now** (added on review request): it is documented for `zgp_connectivity`, which #20456 routes through the same method, so it can genuinely reach `ZigbeeStatus.of()` on Green Power devices. It is not a connectivity issue, so the thing stays online. The test class is renamed to `Clip2ThingHandlerConnectivityTest`, also on review request.

## Relation to #20758

That PR (draft) touches the same three files: it adds a status *description* while the thing is `ONLINE` (low battery), whereas this one sets the description while the thing is `OFFLINE` on a Zigbee connectivity issue. The two paths do not overlap functionally; the only textual overlap is the `HueBindingConstants` I18N block. This is the same shape #20758 uses: comparing against the live status info heals any status written by somebody else, whatever it is, and needs no extra state.

## What is deliberately NOT in this PR

- **`UNIDIRECTIONAL_INCOMING` is left out of the connectivity issue set.** It looks like an asymmetry - a device the bridge can hear but not command stays `ONLINE` - but there are two reasons not to touch it. Battery powered "Friends of Hue" sensors report it while asleep, which is exactly what #17876 / #17878 fixed. And since #20456 routes `zgp_connectivity` through the same method, it would now also hit Zigbee Green Power devices, which transmit inbound only by design - the single sample in `src/test/resources/zgp_connectivity.json` reports precisely this state. Treating it as an error would take every Green Power device offline.
- **`ZigbeeStatus.of()` still falls back to `DISCONNECTED` for a genuinely unrecognised value.** With `pending_discovery` in the enum (change 4), the fallback now only covers values that are unknown to the Hue API documentation as well; this PR only makes sure such a value is not reported as a confirmed disconnect.
- **No change to retry, reconnect, refresh or channel handling.** The channels still go `UNDEF` on a connectivity issue, and the recovery path is untouched.

## Testing

- 131 unit tests pass (121 existing, 10 new); the static-analysis report shows 0 errors, 0 warnings and no new info-level findings for the touched files (re-established on the current revision).
- The new `Clip2ThingHandlerConnectivityTest` drives `updateChannels()` with `zigbee_connectivity` resources against a mocked `ThingHandlerCallback` that mirrors the published status back into the thing mock, so the handler sees its own writes as it would at runtime. It pins the two descriptions, the `COMMUNICATION_ERROR` detail, an unrecognised status not being reported as a disconnect, one status update (and one `UNDEF` sweep) per state rather than per resource, a change between the two issue states, a recurring issue after recovery (including a recovery that ends in a firmware update rather than `ONLINE`), and a status written by another writer being corrected - both an `ONLINE` write that carries the description over and an `OFFLINE(GONE)` write. Each test was verified to fail against the corresponding mutation of the production code.
- The log excerpt above is from a production openHAB 5.2.1 installation with 25 Hue devices on a CLIP v2 bridge, where three lights in one part of the flat dropped out four times in 41 hours - all four reported with the generic text, which is what prompted this change.

**Field result (2026-08-18 19:18, production installation):** the next real outage hit one of the known dropout-prone lights (a bedroom Beyond) with the patched build running. The thing status carried the distinct state end to end:

```
19:18:48  updateConnectivityState() thingStatus:ONLINE, zigbeeStatus:Connectivity issue
19:18:48  Thing ... changed from ONLINE to OFFLINE (COMMUNICATION_ERROR): Zigbee connectivity issue.
19:19:56  updateConnectivityState() thingStatus:OFFLINE, zigbeeStatus:Connected
19:19:56  Thing ... changed ... to ONLINE
```

68-second outage, self-healed; the description names `connectivity_issue` (degraded radio path), which finally distinguishes these events from a power loss - exactly the diagnosis this installation needed and could not make before.

## Notes for review

- **Only one new i18n key.** Keeping `offline.api2.comm-error.zigbee-connectivity-issue` for `CONNECTIVITY_ISSUE` preserves its existing translation instead of retiring a translated key and adding two new untranslated ones. The two keys are pulled up into `HueBindingConstants`, following the existing constant pattern in that block (which #20758 also extends).
- **No new handler state is introduced.** Earlier drafts of this change remembered the last published description in a field; comparing against the live status info does the same job, heals foreign writes as a side effect, and makes the diff smaller - so there is also no new field to reason about alongside the (un)synchronised status fields of this path.
- **`updateChannels()` is now package-private** so the test can drive the real resource dispatch instead of reaching into the private connectivity helper. Nothing else about it changed.
- **The status detail change is user-visible.** A rule or UI that keyed on `statusDetail == NONE` for an offline Hue device will now see `COMMUNICATION_ERROR`. That seems clearly the right way round - the previous value was neither intended by the surrounding code nor accurate - but it is a visible change and not purely internal.

