### PR TITLE
[amazonechocontrol] Improve handling of throttled notification polls

### DIFF
--- a/bundles/org.openhab.binding.amazonechocontrol/README.md
+++ b/bundles/org.openhab.binding.amazonechocontrol/README.md
@@ -190,6 +190,9 @@ You will find the serial number in the Alexa app or on the webpage YOUR_OPENHAB/
 | ascendingAlarm        | Switch      | R/W         | echo, echoshow, echospot      | Ascending alarm up to the configured volume                                                                                                                                                                                             |
 | doNotDisturb          | Switch      | R/W         | echo, echoshow, echospot      | Do Not Disturb mode enabled                                                                                                                                                                                                             |
 
+The `nextReminder`, `nextAlarm`, `nextMusicAlarm` and `nextTimer` channels keep their last known value if a request to Amazon fails.
+After three consecutive failed requests they are set to `UNDEF`, because the binding does not know the state anymore.
+
 ## Advanced Feature Technically Experienced Users
 
 The url <YOUR_OPENHAB>/amazonechocontrol/<YOUR_ACCOUNT>/PROXY/<API_URL> provides a proxy server with an authenticated connection to the Amazon Alexa server.

--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/connection/Connection.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/connection/Connection.java
@@ -1390,14 +1390,14 @@ public class Connection {
         }
     }
 
-    public List<NotificationTO> getNotifications() {
-        try {
-            return requestBuilder.get(getAlexaServer() + "/api/notifications")
-                    .syncSend(NotificationListResponseTO.class).notifications;
-        } catch (ConnectionException e) {
-            logger.warn("Failed to get notifications: {}", e.getMessage());
-        }
-        return List.of();
+    public List<NotificationTO> getNotifications() throws ConnectionException {
+        // Unlike the neighbouring getters that swallow a ConnectionException and return an empty
+        // list, this one propagates it: an empty list here was indistinguishable from "no
+        // notifications set" (see AccountHandler#refreshNotifications for what that used to
+        // break). The other swallowing getters feed command options and per-device states, where
+        // an empty result is not published as a statement about the device.
+        return requestBuilder.get(getAlexaServer() + "/api/notifications")
+                .syncSend(NotificationListResponseTO.class).notifications;
     }
 
     public NotificationTO getNotification(String notificationId) throws ConnectionException {

--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/connection/Connection.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/connection/Connection.java
@@ -1391,11 +1391,7 @@ public class Connection {
     }
 
     public List<NotificationTO> getNotifications() throws ConnectionException {
-        // Unlike the neighbouring getters that swallow a ConnectionException and return an empty
-        // list, this one propagates it: an empty list here was indistinguishable from "no
-        // notifications set" (see AccountHandler#refreshNotifications for what that used to
-        // break). The other swallowing getters feed command options and per-device states, where
-        // an empty result is not published as a statement about the device.
+        // propagates the exception: an empty list is indistinguishable from "no notifications set"
         return requestBuilder.get(getAlexaServer() + "/api/notifications")
                 .syncSend(NotificationListResponseTO.class).notifications;
     }

--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/handler/AccountHandler.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/handler/AccountHandler.java
@@ -100,10 +100,12 @@ import com.google.gson.JsonSyntaxException;
  * Handles the connection to the amazon server.
  *
  * @author Michael Geramb - Initial Contribution
+ * @author Martin Littkovsky - Backoff for failed notification polls
  */
 @NonNullByDefault
 public class AccountHandler extends BaseBridgeHandler implements PushConnection.Listener {
-    private static final int CHECK_DATA_INTERVAL = 3600; // in seconds (always refresh every hour)
+    // package-private: NotificationPollBackoff caps its retry delay at this interval
+    static final int CHECK_DATA_INTERVAL = 3600; // in seconds (always refresh every hour)
     private static final int CHECK_LOGIN_INTERVAL = 60; // in seconds (always check every minute)
 
     private final Logger logger = LoggerFactory.getLogger(AccountHandler.class);
@@ -132,6 +134,7 @@ public class AccountHandler extends BaseBridgeHandler implements PushConnection.
     private long nextDataRefresh = 0;
     private long nextLoginCheck = 0;
     private long nextRefreshNotifications = 0;
+    private final NotificationPollBackoff notificationPollBackoff = new NotificationPollBackoff();
 
     private final LinkedBlockingQueue<String> requestedDeviceUpdates = new LinkedBlockingQueue<>();
     private @Nullable SmartHomeDeviceStateGroupUpdateCalculator smartHomeDeviceStateGroupUpdateCalculator;
@@ -382,6 +385,12 @@ public class AccountHandler extends BaseBridgeHandler implements PushConnection.
         // force data check
         nextLoginCheck = 0;
         nextDataRefresh = 0;
+        // A new session invalidates the reason for the current backoff: failures caused by the
+        // expired one must not keep the poll silent for up to an hour after the fix. This is the
+        // only place a live handler regains a connection after the stored session died, so
+        // resetConnection() - which logs out and goes OFFLINE - does not need the reset.
+        notificationPollBackoff.reset();
+        nextRefreshNotifications = 0;
     }
 
     private void storeSession() {
@@ -402,7 +411,12 @@ public class AccountHandler extends BaseBridgeHandler implements PushConnection.
                         nextDataRefresh = now + CHECK_DATA_INTERVAL * 1000;
                         refreshData();
                     }
-                    if (now > nextRefreshNotifications) {
+                    // Either deadline may wake the poll, but not while the backoff is still
+                    // waiting: on an account that has never polled successfully
+                    // nextRefreshNotifications stays 0, so without the second condition this
+                    // gate would be true on every tick and log a skip once per second.
+                    if (notificationPollBackoff.isDue(now)
+                            || (now > nextRefreshNotifications && !notificationPollBackoff.shouldSkip(now))) {
                         refreshNotifications();
                     }
                 }
@@ -416,11 +430,56 @@ public class AccountHandler extends BaseBridgeHandler implements PushConnection.
         if (!connection.isLoggedIn()) {
             return;
         }
+        if (notificationPollBackoff.shouldSkip(System.currentTimeMillis())) {
+            // Push messages call in here directly and bypass the interval check in
+            // checkLoginAndData(), so the backoff has to be honoured here as well - otherwise
+            // a device that keeps sending PUSH_NOTIFICATION_CHANGE would poll a throttled
+            // endpoint as fast as the messages arrive.
+            logger.debug("notification poll for {} is backing off, skipping refresh",
+                    getThing().getUID().getAsString());
+            return;
+        }
         logger.debug("refresh notifications {}", getThing().getUID().getAsString());
         ZonedDateTime requestTime = ZonedDateTime.now();
-        List<Notification> notifications = connection.getNotifications().stream()
-                .map(n -> map(n, requestTime, ZonedDateTime.now())).filter(Objects::nonNull)
-                .map(Objects::requireNonNull).toList();
+        List<Notification> notifications;
+        try {
+            notifications = connection.getNotifications().stream().map(n -> map(n, requestTime, ZonedDateTime.now()))
+                    .filter(Objects::nonNull).map(Objects::requireNonNull).toList();
+        } catch (ConnectionException e) {
+            // A single failed request is not an empty notification list: wiping the next*
+            // channels on every throttled poll claimed "no alarm set" while the truth was
+            // "Amazon did not answer", and it left nextRefreshNotifications at
+            // Long.MAX_VALUE, silently disabling the event-driven refresh. Keep the last
+            // known state through short outages - but once the outage is sustained, the
+            // binding genuinely does not know the state anymore and says so with UNDEF.
+            // The retry deadline belongs to the backoff, not to nextRefreshNotifications: that
+            // field keeps the wake-up time of the success path (the next alarm, or never), and
+            // mixing both into it let a concurrent success overwrite the retry deadline with
+            // Long.MAX_VALUE while the failure count still said "backing off" - a poll that
+            // would never have become due again.
+            NotificationPollBackoff.Failure failure = notificationPollBackoff.onFailure(System.currentTimeMillis());
+            if (failure.firstOfStreak()) {
+                logger.warn("Failed to get notifications for {}, next attempt in {} s: {}",
+                        getThing().getUID().getAsString(), failure.delaySeconds(), e.getMessage());
+            } else {
+                logger.debug("Failed to get notifications for {}, next attempt in {} s: {}",
+                        getThing().getUID().getAsString(), failure.delaySeconds(), e.getMessage());
+            }
+            if (failure.crossedUndefThreshold()) {
+                logger.warn("Setting notification channels of {} to UNDEF after {} consecutive poll failures",
+                        getThing().getUID().getAsString(), NotificationPollBackoff.FAILURES_BEFORE_UNDEF);
+            }
+            if (failure.publishUndef()) {
+                // Repeated on every further failure, not only on the one that crossed the
+                // threshold: the call is idempotent, and an echo handler that registers during
+                // the outage would otherwise never learn that the state is unknown.
+                echoHandlers.values().forEach(echoHandler -> echoHandler.updateNotifications(List.of()));
+            }
+            return;
+        }
+        if (notificationPollBackoff.onSuccess()) {
+            logger.info("Successfully polled notifications for {} again", getThing().getUID().getAsString());
+        }
         echoHandlers.values().forEach(echoHandler -> echoHandler.updateNotifications(notifications));
         ZonedDateTime first = notifications.stream().map(Notification::nextAlarmTime)
                 .min(ChronoZonedDateTime::compareTo).orElse(null);

--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/handler/AccountHandler.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/handler/AccountHandler.java
@@ -104,7 +104,6 @@ import com.google.gson.JsonSyntaxException;
  */
 @NonNullByDefault
 public class AccountHandler extends BaseBridgeHandler implements PushConnection.Listener {
-    // package-private: NotificationPollBackoff caps its retry delay at this interval
     static final int CHECK_DATA_INTERVAL = 3600; // in seconds (always refresh every hour)
     private static final int CHECK_LOGIN_INTERVAL = 60; // in seconds (always check every minute)
 
@@ -385,10 +384,7 @@ public class AccountHandler extends BaseBridgeHandler implements PushConnection.
         // force data check
         nextLoginCheck = 0;
         nextDataRefresh = 0;
-        // A new session invalidates the reason for the current backoff: failures caused by the
-        // expired one must not keep the poll silent for up to an hour after the fix. This is the
-        // only place a live handler regains a connection after the stored session died, so
-        // resetConnection() - which logs out and goes OFFLINE - does not need the reset.
+        // failures of the expired session must not delay polls on the new one
         notificationPollBackoff.reset();
         nextRefreshNotifications = 0;
     }
@@ -411,10 +407,7 @@ public class AccountHandler extends BaseBridgeHandler implements PushConnection.
                         nextDataRefresh = now + CHECK_DATA_INTERVAL * 1000;
                         refreshData();
                     }
-                    // Either deadline may wake the poll, but not while the backoff is still
-                    // waiting: on an account that has never polled successfully
-                    // nextRefreshNotifications stays 0, so without the second condition this
-                    // gate would be true on every tick and log a skip once per second.
+                    // the shouldSkip check keeps a pending backoff from logging a skip on every tick
                     if (notificationPollBackoff.isDue(now)
                             || (now > nextRefreshNotifications && !notificationPollBackoff.shouldSkip(now))) {
                         refreshNotifications();
@@ -431,10 +424,7 @@ public class AccountHandler extends BaseBridgeHandler implements PushConnection.
             return;
         }
         if (notificationPollBackoff.shouldSkip(System.currentTimeMillis())) {
-            // Push messages call in here directly and bypass the interval check in
-            // checkLoginAndData(), so the backoff has to be honoured here as well - otherwise
-            // a device that keeps sending PUSH_NOTIFICATION_CHANGE would poll a throttled
-            // endpoint as fast as the messages arrive.
+            // push messages call in here directly, bypassing the interval check in checkLoginAndData()
             logger.debug("notification poll for {} is backing off, skipping refresh",
                     getThing().getUID().getAsString());
             return;
@@ -446,17 +436,6 @@ public class AccountHandler extends BaseBridgeHandler implements PushConnection.
             notifications = connection.getNotifications().stream().map(n -> map(n, requestTime, ZonedDateTime.now()))
                     .filter(Objects::nonNull).map(Objects::requireNonNull).toList();
         } catch (ConnectionException e) {
-            // A single failed request is not an empty notification list: wiping the next*
-            // channels on every throttled poll claimed "no alarm set" while the truth was
-            // "Amazon did not answer", and it left nextRefreshNotifications at
-            // Long.MAX_VALUE, silently disabling the event-driven refresh. Keep the last
-            // known state through short outages - but once the outage is sustained, the
-            // binding genuinely does not know the state anymore and says so with UNDEF.
-            // The retry deadline belongs to the backoff, not to nextRefreshNotifications: that
-            // field keeps the wake-up time of the success path (the next alarm, or never), and
-            // mixing both into it let a concurrent success overwrite the retry deadline with
-            // Long.MAX_VALUE while the failure count still said "backing off" - a poll that
-            // would never have become due again.
             NotificationPollBackoff.Failure failure = notificationPollBackoff.onFailure(System.currentTimeMillis());
             if (failure.firstOfStreak()) {
                 logger.warn("Failed to get notifications for {}, next attempt in {} s: {}",
@@ -470,9 +449,7 @@ public class AccountHandler extends BaseBridgeHandler implements PushConnection.
                         getThing().getUID().getAsString(), NotificationPollBackoff.FAILURES_BEFORE_UNDEF);
             }
             if (failure.publishUndef()) {
-                // Repeated on every further failure, not only on the one that crossed the
-                // threshold: the call is idempotent, and an echo handler that registers during
-                // the outage would otherwise never learn that the state is unknown.
+                // repeated on every failure so that a handler registering during the outage is told as well
                 echoHandlers.values().forEach(echoHandler -> echoHandler.updateNotifications(List.of()));
             }
             return;

--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/handler/AccountHandler.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/handler/AccountHandler.java
@@ -134,6 +134,10 @@ public class AccountHandler extends BaseBridgeHandler implements PushConnection.
     private long nextLoginCheck = 0;
     private long nextRefreshNotifications = 0;
     private final NotificationPollBackoff notificationPollBackoff = new NotificationPollBackoff();
+    // Guards accepting a poll result as one step: validating the attempt, publishing it and
+    // recording when the next poll is due. Split apart, setConnection() can land in between and
+    // the replaced session's result overwrites the reset the new session depends on.
+    private final Object notificationCommit = new Object();
 
     private final LinkedBlockingQueue<String> requestedDeviceUpdates = new LinkedBlockingQueue<>();
     private @Nullable SmartHomeDeviceStateGroupUpdateCalculator smartHomeDeviceStateGroupUpdateCalculator;
@@ -385,8 +389,10 @@ public class AccountHandler extends BaseBridgeHandler implements PushConnection.
         nextLoginCheck = 0;
         nextDataRefresh = 0;
         // failures of the expired session must not delay polls on the new one
-        notificationPollBackoff.reset();
-        nextRefreshNotifications = 0;
+        synchronized (notificationCommit) {
+            notificationPollBackoff.reset();
+            nextRefreshNotifications = 0;
+        }
     }
 
     private void storeSession() {
@@ -409,8 +415,12 @@ public class AccountHandler extends BaseBridgeHandler implements PushConnection.
                     }
                     // the checks only keep the tick quiet, admission is decided by tryStart() in
                     // refreshNotifications()
-                    if (notificationPollBackoff.isDue(now)
-                            || (now > nextRefreshNotifications && !notificationPollBackoff.shouldSkip(now))) {
+                    boolean notificationPollDue;
+                    synchronized (notificationCommit) {
+                        notificationPollDue = notificationPollBackoff.isDue(now)
+                                || (now > nextRefreshNotifications && !notificationPollBackoff.shouldSkip(now));
+                    }
+                    if (notificationPollDue) {
                         refreshNotifications();
                     }
                 }
@@ -441,57 +451,63 @@ public class AccountHandler extends BaseBridgeHandler implements PushConnection.
                         .map(n -> map(n, requestTime, ZonedDateTime.now())).filter(Objects::nonNull)
                         .map(Objects::requireNonNull).toList();
             } catch (ConnectionException e) {
-                NotificationPollBackoff.Failure failure = notificationPollBackoff.onFailure(start.token(),
-                        System.currentTimeMillis());
-                if (failure == null) {
-                    // the failure of a replaced connection must not throttle the new one
-                    logger.debug("Discarding notification poll failure of a replaced connection for {}",
+                synchronized (notificationCommit) {
+                    NotificationPollBackoff.Failure failure = notificationPollBackoff.onFailure(start.token(),
+                            System.currentTimeMillis());
+                    if (failure == null) {
+                        // the failure of a replaced connection must not throttle the new one
+                        logger.debug("Discarding notification poll failure of a replaced connection for {}",
+                                getThing().getUID().getAsString());
+                        return;
+                    }
+                    if (failure.firstOfStreak()) {
+                        logger.warn("Failed to get notifications for {}, next attempt in {} s: {}",
+                                getThing().getUID().getAsString(), failure.delaySeconds(), e.getMessage());
+                    } else {
+                        logger.debug("Failed to get notifications for {}, next attempt in {} s: {}",
+                                getThing().getUID().getAsString(), failure.delaySeconds(), e.getMessage());
+                    }
+                    if (failure.crossedUndefThreshold()) {
+                        logger.warn("Setting notification channels of {} to UNDEF after {} consecutive poll failures",
+                                getThing().getUID().getAsString(), NotificationPollBackoff.FAILURES_BEFORE_UNDEF);
+                    }
+                    if (failure.publishUndef()) {
+                        // repeated on every failure so that a handler registering during the outage is told as well
+                        echoHandlers.values().forEach(echoHandler -> echoHandler.updateNotifications(List.of()));
+                    }
+                    return;
+                }
+            }
+            synchronized (notificationCommit) {
+                NotificationPollBackoff.Success success = notificationPollBackoff.onSuccess(start.token());
+                if (success == null) {
+                    // the result of a replaced connection must neither confirm the new one nor delay its first poll
+                    logger.debug("Discarding notification poll result of a replaced connection for {}",
                             getThing().getUID().getAsString());
                     return;
                 }
-                if (failure.firstOfStreak()) {
-                    logger.warn("Failed to get notifications for {}, next attempt in {} s: {}",
-                            getThing().getUID().getAsString(), failure.delaySeconds(), e.getMessage());
+                if (success.endedStreak()) {
+                    logger.info("Successfully polled notifications for {} again", getThing().getUID().getAsString());
+                }
+                echoHandlers.values().forEach(echoHandler -> echoHandler.updateNotifications(notifications));
+                ZonedDateTime first = notifications.stream().map(Notification::nextAlarmTime)
+                        .min(ChronoZonedDateTime::compareTo).orElse(null);
+                if (first != null) {
+                    nextRefreshNotifications = first.toEpochSecond() * 1000;
                 } else {
-                    logger.debug("Failed to get notifications for {}, next attempt in {} s: {}",
-                            getThing().getUID().getAsString(), failure.delaySeconds(), e.getMessage());
+                    nextRefreshNotifications = Long.MAX_VALUE;
                 }
-                if (failure.crossedUndefThreshold()) {
-                    logger.warn("Setting notification channels of {} to UNDEF after {} consecutive poll failures",
-                            getThing().getUID().getAsString(), NotificationPollBackoff.FAILURES_BEFORE_UNDEF);
+                if (success.pollAgain()) {
+                    // a trigger refused during this poll may announce data this response predates
+                    nextRefreshNotifications = 0;
                 }
-                if (failure.publishUndef()) {
-                    // repeated on every failure so that a handler registering during the outage is told as well
-                    echoHandlers.values().forEach(echoHandler -> echoHandler.updateNotifications(List.of()));
-                }
-                return;
-            }
-            NotificationPollBackoff.Success success = notificationPollBackoff.onSuccess(start.token());
-            if (success == null) {
-                // the result of a replaced connection must neither confirm the new one nor delay its first poll
-                logger.debug("Discarding notification poll result of a replaced connection for {}",
-                        getThing().getUID().getAsString());
-                return;
-            }
-            if (success.endedStreak()) {
-                logger.info("Successfully polled notifications for {} again", getThing().getUID().getAsString());
-            }
-            echoHandlers.values().forEach(echoHandler -> echoHandler.updateNotifications(notifications));
-            ZonedDateTime first = notifications.stream().map(Notification::nextAlarmTime)
-                    .min(ChronoZonedDateTime::compareTo).orElse(null);
-            if (first != null) {
-                nextRefreshNotifications = first.toEpochSecond() * 1000;
-            } else {
-                nextRefreshNotifications = Long.MAX_VALUE;
-            }
-            if (success.pollAgain()) {
-                // a trigger refused during this poll may announce data this response predates
-                nextRefreshNotifications = 0;
             }
         } finally {
             // an attempt ending without a recorded result must neither block polling nor swallow a refused trigger
-            if (notificationPollBackoff.abort(start.token())) {
-                nextRefreshNotifications = 0;
+            synchronized (notificationCommit) {
+                if (notificationPollBackoff.abort(start.token())) {
+                    nextRefreshNotifications = 0;
+                }
             }
         }
     }

--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/handler/AccountHandler.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/handler/AccountHandler.java
@@ -407,7 +407,8 @@ public class AccountHandler extends BaseBridgeHandler implements PushConnection.
                         nextDataRefresh = now + CHECK_DATA_INTERVAL * 1000;
                         refreshData();
                     }
-                    // the shouldSkip check keeps a pending backoff from logging a skip on every tick
+                    // the checks only keep the tick quiet, admission is decided by tryStart() in
+                    // refreshNotifications()
                     if (notificationPollBackoff.isDue(now)
                             || (now > nextRefreshNotifications && !notificationPollBackoff.shouldSkip(now))) {
                         refreshNotifications();
@@ -423,47 +424,75 @@ public class AccountHandler extends BaseBridgeHandler implements PushConnection.
         if (!connection.isLoggedIn()) {
             return;
         }
-        if (notificationPollBackoff.shouldSkip(System.currentTimeMillis())) {
+        NotificationPollBackoff.Start start = notificationPollBackoff.tryStart(System.currentTimeMillis());
+        if (start.outcome() != NotificationPollBackoff.Start.Outcome.STARTED) {
             // push messages call in here directly, bypassing the interval check in checkLoginAndData()
-            logger.debug("notification poll for {} is backing off, skipping refresh",
-                    getThing().getUID().getAsString());
+            logger.debug("notification poll for {} is {}, skipping refresh", getThing().getUID().getAsString(),
+                    start.outcome() == NotificationPollBackoff.Start.Outcome.BACKING_OFF ? "backing off"
+                            : "already running");
             return;
         }
         logger.debug("refresh notifications {}", getThing().getUID().getAsString());
-        ZonedDateTime requestTime = ZonedDateTime.now();
-        List<Notification> notifications;
         try {
-            notifications = connection.getNotifications().stream().map(n -> map(n, requestTime, ZonedDateTime.now()))
-                    .filter(Objects::nonNull).map(Objects::requireNonNull).toList();
-        } catch (ConnectionException e) {
-            NotificationPollBackoff.Failure failure = notificationPollBackoff.onFailure(System.currentTimeMillis());
-            if (failure.firstOfStreak()) {
-                logger.warn("Failed to get notifications for {}, next attempt in {} s: {}",
-                        getThing().getUID().getAsString(), failure.delaySeconds(), e.getMessage());
+            ZonedDateTime requestTime = ZonedDateTime.now();
+            List<Notification> notifications;
+            try {
+                notifications = connection.getNotifications().stream()
+                        .map(n -> map(n, requestTime, ZonedDateTime.now())).filter(Objects::nonNull)
+                        .map(Objects::requireNonNull).toList();
+            } catch (ConnectionException e) {
+                NotificationPollBackoff.Failure failure = notificationPollBackoff.onFailure(start.token(),
+                        System.currentTimeMillis());
+                if (failure == null) {
+                    // the failure of a replaced connection must not throttle the new one
+                    logger.debug("Discarding notification poll failure of a replaced connection for {}",
+                            getThing().getUID().getAsString());
+                    return;
+                }
+                if (failure.firstOfStreak()) {
+                    logger.warn("Failed to get notifications for {}, next attempt in {} s: {}",
+                            getThing().getUID().getAsString(), failure.delaySeconds(), e.getMessage());
+                } else {
+                    logger.debug("Failed to get notifications for {}, next attempt in {} s: {}",
+                            getThing().getUID().getAsString(), failure.delaySeconds(), e.getMessage());
+                }
+                if (failure.crossedUndefThreshold()) {
+                    logger.warn("Setting notification channels of {} to UNDEF after {} consecutive poll failures",
+                            getThing().getUID().getAsString(), NotificationPollBackoff.FAILURES_BEFORE_UNDEF);
+                }
+                if (failure.publishUndef()) {
+                    // repeated on every failure so that a handler registering during the outage is told as well
+                    echoHandlers.values().forEach(echoHandler -> echoHandler.updateNotifications(List.of()));
+                }
+                return;
+            }
+            NotificationPollBackoff.Success success = notificationPollBackoff.onSuccess(start.token());
+            if (success == null) {
+                // the result of a replaced connection must neither confirm the new one nor delay its first poll
+                logger.debug("Discarding notification poll result of a replaced connection for {}",
+                        getThing().getUID().getAsString());
+                return;
+            }
+            if (success.endedStreak()) {
+                logger.info("Successfully polled notifications for {} again", getThing().getUID().getAsString());
+            }
+            echoHandlers.values().forEach(echoHandler -> echoHandler.updateNotifications(notifications));
+            ZonedDateTime first = notifications.stream().map(Notification::nextAlarmTime)
+                    .min(ChronoZonedDateTime::compareTo).orElse(null);
+            if (first != null) {
+                nextRefreshNotifications = first.toEpochSecond() * 1000;
             } else {
-                logger.debug("Failed to get notifications for {}, next attempt in {} s: {}",
-                        getThing().getUID().getAsString(), failure.delaySeconds(), e.getMessage());
+                nextRefreshNotifications = Long.MAX_VALUE;
             }
-            if (failure.crossedUndefThreshold()) {
-                logger.warn("Setting notification channels of {} to UNDEF after {} consecutive poll failures",
-                        getThing().getUID().getAsString(), NotificationPollBackoff.FAILURES_BEFORE_UNDEF);
+            if (success.pollAgain()) {
+                // a trigger refused during this poll may announce data this response predates
+                nextRefreshNotifications = 0;
             }
-            if (failure.publishUndef()) {
-                // repeated on every failure so that a handler registering during the outage is told as well
-                echoHandlers.values().forEach(echoHandler -> echoHandler.updateNotifications(List.of()));
+        } finally {
+            // an attempt ending without a recorded result must neither block polling nor swallow a refused trigger
+            if (notificationPollBackoff.abort(start.token())) {
+                nextRefreshNotifications = 0;
             }
-            return;
-        }
-        if (notificationPollBackoff.onSuccess()) {
-            logger.info("Successfully polled notifications for {} again", getThing().getUID().getAsString());
-        }
-        echoHandlers.values().forEach(echoHandler -> echoHandler.updateNotifications(notifications));
-        ZonedDateTime first = notifications.stream().map(Notification::nextAlarmTime)
-                .min(ChronoZonedDateTime::compareTo).orElse(null);
-        if (first != null) {
-            nextRefreshNotifications = first.toEpochSecond() * 1000;
-        } else {
-            nextRefreshNotifications = Long.MAX_VALUE;
         }
     }
 

--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/handler/AccountHandler.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/handler/AccountHandler.java
@@ -134,9 +134,8 @@ public class AccountHandler extends BaseBridgeHandler implements PushConnection.
     private long nextLoginCheck = 0;
     private long nextRefreshNotifications = 0;
     private final NotificationPollBackoff notificationPollBackoff = new NotificationPollBackoff();
-    // Guards accepting a poll result as one step: validating the attempt, publishing it and
-    // recording when the next poll is due. Split apart, setConnection() can land in between and
-    // the replaced session's result overwrites the reset the new session depends on.
+    // Held while a poll result is accepted as one step: validate the attempt, publish it, record the
+    // next due time. Split apart, setConnection() lands in between and the replaced session wins.
     private final Object notificationCommit = new Object();
 
     private final LinkedBlockingQueue<String> requestedDeviceUpdates = new LinkedBlockingQueue<>();
@@ -413,14 +412,12 @@ public class AccountHandler extends BaseBridgeHandler implements PushConnection.
                         nextDataRefresh = now + CHECK_DATA_INTERVAL * 1000;
                         refreshData();
                     }
-                    // the checks only keep the tick quiet, admission is decided by tryStart() in
-                    // refreshNotifications()
-                    boolean notificationPollDue;
+                    boolean notificationPollLooksDue;
                     synchronized (notificationCommit) {
-                        notificationPollDue = notificationPollBackoff.isDue(now)
+                        notificationPollLooksDue = notificationPollBackoff.isDue(now)
                                 || (now > nextRefreshNotifications && !notificationPollBackoff.shouldSkip(now));
                     }
-                    if (notificationPollDue) {
+                    if (notificationPollLooksDue) {
                         refreshNotifications();
                     }
                 }

--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/handler/NotificationPollBackoff.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/handler/NotificationPollBackoff.java
@@ -17,7 +17,8 @@ import org.eclipse.jdt.annotation.Nullable;
 
 /**
  * Tracks consecutive failures of the notification poll and admits one running attempt at a time,
- * identified by a token. The retry delay doubles from {@link #MIN_INTERVAL} to {@link #MAX_INTERVAL}.
+ * identified by a token. The retry delay doubles from {@link #MIN_INTERVAL_SECONDS} to
+ * {@link #MAX_INTERVAL_SECONDS}.
  *
  * @author Martin Littkovsky - Initial contribution
  */

--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/handler/NotificationPollBackoff.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/handler/NotificationPollBackoff.java
@@ -16,12 +16,8 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 
 /**
- * The {@link NotificationPollBackoff} tracks consecutive failures of the notification poll: when the next
- * attempt is due, whether the failure is worth a warning and whether the channels shall be set to UNDEF. The
- * retry delay doubles from {@link #MIN_INTERVAL} up to {@link #MAX_INTERVAL}. A poll has to be reserved
- * through {@link #tryStart(long)}, which admits a single running attempt at a time and hands out a token
- * identifying it; {@link #reset()} releases the running attempt, whose late result is then discarded. All
- * state sits behind one lock, which is deliberately not held across the network call.
+ * Tracks consecutive failures of the notification poll and admits one running attempt at a time,
+ * identified by a token. The retry delay doubles from {@link #MIN_INTERVAL} to {@link #MAX_INTERVAL}.
  *
  * @author Martin Littkovsky - Initial contribution
  */
@@ -42,11 +38,7 @@ class NotificationPollBackoff {
     private long inFlightToken = NO_ATTEMPT;
     private boolean pollAgain = false;
 
-    /**
-     * The decision on starting a poll: only {@link Outcome#STARTED} permits the request, and {@code token}
-     * then identifies the attempt for {@link #onSuccess(long)}, {@link #onFailure(long, long)} and
-     * {@link #abort(long)}.
-     */
+    /** The decision on starting a poll; {@code token} identifies the attempt that {@link Outcome#STARTED} grants. */
     record Start(Outcome outcome, long token) {
         enum Outcome {
             STARTED,
@@ -55,30 +47,15 @@ class NotificationPollBackoff {
         }
     }
 
-    /**
-     * The reaction to a single failed poll.
-     *
-     * @param firstOfStreak this is the first failure after a successful poll
-     * @param crossedUndefThreshold this failure is the one that reached {@link #FAILURES_BEFORE_UNDEF}
-     * @param publishUndef the channels no longer describe reality and shall be set to UNDEF
-     * @param delaySeconds seconds to wait before the next attempt
-     */
+    /** The reaction to a single failed poll. */
     record Failure(boolean firstOfStreak, boolean crossedUndefThreshold, boolean publishUndef, int delaySeconds) {
     }
 
-    /**
-     * The reaction to a successful poll.
-     *
-     * @param endedStreak the poll ended a failure streak
-     * @param pollAgain a trigger was refused while this attempt was running and shall be caught up on
-     */
+    /** The reaction to a successful poll. */
     record Success(boolean endedStreak, boolean pollAgain) {
     }
 
-    /**
-     * Atomically decides whether a poll may run now and reserves it, admitting one running attempt at a time; a
-     * trigger refused because an attempt is already running is remembered and handed to whoever ends that attempt.
-     */
+    /** Reserves a poll if one may run now; a trigger refused meanwhile is handed to whoever ends the attempt. */
     synchronized Start tryStart(long now) {
         if (inFlightToken != NO_ATTEMPT) {
             pollAgain = true;
@@ -91,12 +68,7 @@ class NotificationPollBackoff {
         return new Start(Start.Outcome.STARTED, inFlightToken);
     }
 
-    /**
-     * Records a failed poll.
-     *
-     * @return the reaction, or {@code null} if the attempt was superseded by a {@link #reset()} and its result
-     *         is discarded
-     */
+    /** Records a failed poll; {@code null} when a {@link #reset()} superseded the attempt. */
     synchronized @Nullable Failure onFailure(long token, long now) {
         if (token == NO_ATTEMPT || token != inFlightToken) {
             return null;
@@ -113,12 +85,7 @@ class NotificationPollBackoff {
                 delaySeconds);
     }
 
-    /**
-     * Records a successful poll and clears the backoff.
-     *
-     * @return the reaction, or {@code null} if the attempt was superseded by a {@link #reset()} and its result
-     *         is discarded
-     */
+    /** Records a successful poll and clears the backoff; {@code null} when superseded. */
     synchronized @Nullable Success onSuccess(long token) {
         if (token == NO_ATTEMPT || token != inFlightToken) {
             return null;
@@ -129,12 +96,7 @@ class NotificationPollBackoff {
         return new Success(endedStreak, catchUp);
     }
 
-    /**
-     * Releases a reserved attempt that reported neither success nor failure, and is a no-op otherwise.
-     *
-     * @return {@code true} if a trigger was refused while the released attempt was running and shall be caught
-     *         up on
-     */
+    /** Releases an attempt that reported neither success nor failure; {@code true} if a trigger waits. */
     synchronized boolean abort(long token) {
         if (token != NO_ATTEMPT && token == inFlightToken) {
             inFlightToken = NO_ATTEMPT;
@@ -145,10 +107,7 @@ class NotificationPollBackoff {
         return false;
     }
 
-    /**
-     * Clears the backoff without reporting a recovery, for example after a re-login; a running attempt is
-     * released so the next poll may start immediately, and its late result will be discarded.
-     */
+    /** Clears the backoff and releases a running attempt, whose late result is then discarded. */
     synchronized void reset() {
         failures = 0;
         interval = MIN_INTERVAL;

--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/handler/NotificationPollBackoff.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/handler/NotificationPollBackoff.java
@@ -15,19 +15,10 @@ package org.openhab.binding.amazonechocontrol.internal.handler;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 
 /**
- * The {@link NotificationPollBackoff} tracks consecutive failures of the notification poll and derives the
- * reaction to each of them: when the next attempt is due, whether the failure is worth a warning and whether
- * the notification channels still describe reality.
- * <p>
- * Amazon throttles the notification endpoint aggressively and a flat retry interval keeps a throttled account
- * throttled, because every retry is itself a counted request. The delay therefore doubles from
- * {@link #MIN_INTERVAL} up to {@link #MAX_INTERVAL}, which is the regular refresh interval.
- * <p>
- * The failure count, the current delay and the resulting deadline are one state, so they live in one object
- * behind one lock: the poll is triggered both from the polling job and from push messages arriving on an HTTP
- * client thread. Keeping the deadline in a separate field of the caller allowed an interleaving in which a
- * successful poll and a failing one each wrote one half of the state, leaving a backoff that was never due.
- * The lock is deliberately not held across the network call - it only guards these fields.
+ * The {@link NotificationPollBackoff} tracks consecutive failures of the notification poll: when the next
+ * attempt is due, whether the failure is worth a warning and whether the channels shall be set to UNDEF. The
+ * retry delay doubles from {@link #MIN_INTERVAL} up to {@link #MAX_INTERVAL}. Failure count, delay and
+ * deadline are one state behind one lock, which is deliberately not held across the network call.
  *
  * @author Martin Littkovsky - Initial contribution
  */
@@ -35,9 +26,8 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 class NotificationPollBackoff {
     /** Delay before the first retry, in seconds. */
     static final int MIN_INTERVAL = 300;
-    /** Upper bound of the retry delay, in seconds. Backing off further than the regular poll is pointless. */
+    /** Upper bound of the retry delay, in seconds. */
     static final int MAX_INTERVAL = AccountHandler.CHECK_DATA_INTERVAL;
-    /** Number of consecutive failures after which the notification channels are set to UNDEF. */
     static final int FAILURES_BEFORE_UNDEF = 3;
 
     private int interval = MIN_INTERVAL;
@@ -55,12 +45,6 @@ class NotificationPollBackoff {
     record Failure(boolean firstOfStreak, boolean crossedUndefThreshold, boolean publishUndef, int delaySeconds) {
     }
 
-    /**
-     * Records a failed poll and schedules the next attempt.
-     *
-     * @param now the current time in milliseconds
-     * @return the reaction to this failure
-     */
     synchronized Failure onFailure(long now) {
         failures++;
         int delaySeconds = interval;
@@ -91,18 +75,10 @@ class NotificationPollBackoff {
         nextAttempt = 0;
     }
 
-    /**
-     * @param now the current time in milliseconds
-     * @return {@code true} if a poll has to wait, because the previous one failed and the delay has not elapsed
-     */
     synchronized boolean shouldSkip(long now) {
         return failures > 0 && now < nextAttempt;
     }
 
-    /**
-     * @param now the current time in milliseconds
-     * @return {@code true} if a failed poll is due to be retried
-     */
     synchronized boolean isDue(long now) {
         return failures > 0 && now >= nextAttempt;
     }

--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/handler/NotificationPollBackoff.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/handler/NotificationPollBackoff.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.amazonechocontrol.internal.handler;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * The {@link NotificationPollBackoff} tracks consecutive failures of the notification poll and derives the
+ * reaction to each of them: when the next attempt is due, whether the failure is worth a warning and whether
+ * the notification channels still describe reality.
+ * <p>
+ * Amazon throttles the notification endpoint aggressively and a flat retry interval keeps a throttled account
+ * throttled, because every retry is itself a counted request. The delay therefore doubles from
+ * {@link #MIN_INTERVAL} up to {@link #MAX_INTERVAL}, which is the regular refresh interval.
+ * <p>
+ * The failure count, the current delay and the resulting deadline are one state, so they live in one object
+ * behind one lock: the poll is triggered both from the polling job and from push messages arriving on an HTTP
+ * client thread. Keeping the deadline in a separate field of the caller allowed an interleaving in which a
+ * successful poll and a failing one each wrote one half of the state, leaving a backoff that was never due.
+ * The lock is deliberately not held across the network call - it only guards these fields.
+ *
+ * @author Martin Littkovsky - Initial contribution
+ */
+@NonNullByDefault
+class NotificationPollBackoff {
+    /** Delay before the first retry, in seconds. */
+    static final int MIN_INTERVAL = 300;
+    /** Upper bound of the retry delay, in seconds. Backing off further than the regular poll is pointless. */
+    static final int MAX_INTERVAL = AccountHandler.CHECK_DATA_INTERVAL;
+    /** Number of consecutive failures after which the notification channels are set to UNDEF. */
+    static final int FAILURES_BEFORE_UNDEF = 3;
+
+    private int interval = MIN_INTERVAL;
+    private int failures = 0;
+    private long nextAttempt = 0;
+
+    /**
+     * The reaction to a single failed poll.
+     *
+     * @param firstOfStreak this is the first failure after a successful poll
+     * @param crossedUndefThreshold this failure is the one that reached {@link #FAILURES_BEFORE_UNDEF}
+     * @param publishUndef the channels no longer describe reality and shall be set to UNDEF
+     * @param delaySeconds seconds to wait before the next attempt
+     */
+    record Failure(boolean firstOfStreak, boolean crossedUndefThreshold, boolean publishUndef, int delaySeconds) {
+    }
+
+    /**
+     * Records a failed poll and schedules the next attempt.
+     *
+     * @param now the current time in milliseconds
+     * @return the reaction to this failure
+     */
+    synchronized Failure onFailure(long now) {
+        failures++;
+        int delaySeconds = interval;
+        interval = Math.min(interval * 2, MAX_INTERVAL);
+        nextAttempt = now + delaySeconds * 1000L;
+        // publishUndef is ">=", not "==": a handler that registers during an outage has to be told as well.
+        return new Failure(failures == 1, failures == FAILURES_BEFORE_UNDEF, failures >= FAILURES_BEFORE_UNDEF,
+                delaySeconds);
+    }
+
+    /**
+     * Records a successful poll and clears the backoff.
+     *
+     * @return {@code true} if this poll ended a failure streak
+     */
+    synchronized boolean onSuccess() {
+        boolean recovered = failures > 0;
+        reset();
+        return recovered;
+    }
+
+    /**
+     * Clears the backoff without reporting a recovery, for example after a re-login.
+     */
+    synchronized void reset() {
+        failures = 0;
+        interval = MIN_INTERVAL;
+        nextAttempt = 0;
+    }
+
+    /**
+     * @param now the current time in milliseconds
+     * @return {@code true} if a poll has to wait, because the previous one failed and the delay has not elapsed
+     */
+    synchronized boolean shouldSkip(long now) {
+        return failures > 0 && now < nextAttempt;
+    }
+
+    /**
+     * @param now the current time in milliseconds
+     * @return {@code true} if a failed poll is due to be retried
+     */
+    synchronized boolean isDue(long now) {
+        return failures > 0 && now >= nextAttempt;
+    }
+}

--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/handler/NotificationPollBackoff.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/handler/NotificationPollBackoff.java
@@ -23,22 +23,20 @@ import org.eclipse.jdt.annotation.Nullable;
  */
 @NonNullByDefault
 class NotificationPollBackoff {
-    /** Delay before the first retry, in seconds. */
-    static final int MIN_INTERVAL = 300;
-    /** Upper bound of the retry delay, in seconds. */
-    static final int MAX_INTERVAL = AccountHandler.CHECK_DATA_INTERVAL;
+    static final int MIN_INTERVAL_SECONDS = 300;
+    static final int MAX_INTERVAL_SECONDS = AccountHandler.CHECK_DATA_INTERVAL;
     static final int FAILURES_BEFORE_UNDEF = 3;
 
     private static final long NO_ATTEMPT = 0;
 
-    private int interval = MIN_INTERVAL;
+    private int intervalSeconds = MIN_INTERVAL_SECONDS;
     private int failures = 0;
     private long nextAttempt = 0;
     private long attemptCounter = 0;
     private long inFlightToken = NO_ATTEMPT;
     private boolean pollAgain = false;
 
-    /** The decision on starting a poll; {@code token} identifies the attempt that {@link Outcome#STARTED} grants. */
+    /** {@code token} identifies the one attempt that {@link Outcome#STARTED} grants; it is the key to ending it. */
     record Start(Outcome outcome, long token) {
         enum Outcome {
             STARTED,
@@ -47,11 +45,9 @@ class NotificationPollBackoff {
         }
     }
 
-    /** The reaction to a single failed poll. */
     record Failure(boolean firstOfStreak, boolean crossedUndefThreshold, boolean publishUndef, int delaySeconds) {
     }
 
-    /** The reaction to a successful poll. */
     record Success(boolean endedStreak, boolean pollAgain) {
     }
 
@@ -77,8 +73,8 @@ class NotificationPollBackoff {
         // a trigger refused during this attempt expires here, because a push must not undercut the backoff deadline
         pollAgain = false;
         failures++;
-        int delaySeconds = interval;
-        interval = Math.min(interval * 2, MAX_INTERVAL);
+        int delaySeconds = intervalSeconds;
+        intervalSeconds = Math.min(intervalSeconds * 2, MAX_INTERVAL_SECONDS);
         nextAttempt = now + delaySeconds * 1000L;
         // publishUndef is ">=", not "==": a handler that registers during an outage has to be told as well.
         return new Failure(failures == 1, failures == FAILURES_BEFORE_UNDEF, failures >= FAILURES_BEFORE_UNDEF,
@@ -110,19 +106,17 @@ class NotificationPollBackoff {
     /** Clears the backoff and releases a running attempt, whose late result is then discarded. */
     synchronized void reset() {
         failures = 0;
-        interval = MIN_INTERVAL;
+        intervalSeconds = MIN_INTERVAL_SECONDS;
         nextAttempt = 0;
         inFlightToken = NO_ATTEMPT;
         // a pending catch-up is dropped, because the caller resetting the backoff polls immediately anyway
         pollAgain = false;
     }
 
-    /** A poll right now would be refused, because of a pending backoff delay or a running attempt. */
     synchronized boolean shouldSkip(long now) {
         return inFlightToken != NO_ATTEMPT || (failures > 0 && now < nextAttempt);
     }
 
-    /** A failed poll is ready for its retry and no attempt is running. */
     synchronized boolean isDue(long now) {
         return inFlightToken == NO_ATTEMPT && failures > 0 && now >= nextAttempt;
     }

--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/handler/NotificationPollBackoff.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/handler/NotificationPollBackoff.java
@@ -13,12 +13,15 @@
 package org.openhab.binding.amazonechocontrol.internal.handler;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 
 /**
  * The {@link NotificationPollBackoff} tracks consecutive failures of the notification poll: when the next
  * attempt is due, whether the failure is worth a warning and whether the channels shall be set to UNDEF. The
- * retry delay doubles from {@link #MIN_INTERVAL} up to {@link #MAX_INTERVAL}. Failure count, delay and
- * deadline are one state behind one lock, which is deliberately not held across the network call.
+ * retry delay doubles from {@link #MIN_INTERVAL} up to {@link #MAX_INTERVAL}. A poll has to be reserved
+ * through {@link #tryStart(long)}, which admits a single running attempt at a time and hands out a token
+ * identifying it; {@link #reset()} releases the running attempt, whose late result is then discarded. All
+ * state sits behind one lock, which is deliberately not held across the network call.
  *
  * @author Martin Littkovsky - Initial contribution
  */
@@ -30,9 +33,27 @@ class NotificationPollBackoff {
     static final int MAX_INTERVAL = AccountHandler.CHECK_DATA_INTERVAL;
     static final int FAILURES_BEFORE_UNDEF = 3;
 
+    private static final long NO_ATTEMPT = 0;
+
     private int interval = MIN_INTERVAL;
     private int failures = 0;
     private long nextAttempt = 0;
+    private long attemptCounter = 0;
+    private long inFlightToken = NO_ATTEMPT;
+    private boolean pollAgain = false;
+
+    /**
+     * The decision on starting a poll: only {@link Outcome#STARTED} permits the request, and {@code token}
+     * then identifies the attempt for {@link #onSuccess(long)}, {@link #onFailure(long, long)} and
+     * {@link #abort(long)}.
+     */
+    record Start(Outcome outcome, long token) {
+        enum Outcome {
+            STARTED,
+            BACKING_OFF,
+            ALREADY_RUNNING
+        }
+    }
 
     /**
      * The reaction to a single failed poll.
@@ -45,7 +66,44 @@ class NotificationPollBackoff {
     record Failure(boolean firstOfStreak, boolean crossedUndefThreshold, boolean publishUndef, int delaySeconds) {
     }
 
-    synchronized Failure onFailure(long now) {
+    /**
+     * The reaction to a successful poll.
+     *
+     * @param endedStreak the poll ended a failure streak
+     * @param pollAgain a trigger was refused while this attempt was running and shall be caught up on
+     */
+    record Success(boolean endedStreak, boolean pollAgain) {
+    }
+
+    /**
+     * Atomically decides whether a poll may run now and reserves it, admitting one running attempt at a time; a
+     * trigger refused because an attempt is already running is remembered and handed to whoever ends that attempt.
+     */
+    synchronized Start tryStart(long now) {
+        if (inFlightToken != NO_ATTEMPT) {
+            pollAgain = true;
+            return new Start(Start.Outcome.ALREADY_RUNNING, NO_ATTEMPT);
+        }
+        if (failures > 0 && now < nextAttempt) {
+            return new Start(Start.Outcome.BACKING_OFF, NO_ATTEMPT);
+        }
+        inFlightToken = ++attemptCounter;
+        return new Start(Start.Outcome.STARTED, inFlightToken);
+    }
+
+    /**
+     * Records a failed poll.
+     *
+     * @return the reaction, or {@code null} if the attempt was superseded by a {@link #reset()} and its result
+     *         is discarded
+     */
+    synchronized @Nullable Failure onFailure(long token, long now) {
+        if (token == NO_ATTEMPT || token != inFlightToken) {
+            return null;
+        }
+        inFlightToken = NO_ATTEMPT;
+        // a trigger refused during this attempt expires here, because a push must not undercut the backoff deadline
+        pollAgain = false;
         failures++;
         int delaySeconds = interval;
         interval = Math.min(interval * 2, MAX_INTERVAL);
@@ -58,28 +116,55 @@ class NotificationPollBackoff {
     /**
      * Records a successful poll and clears the backoff.
      *
-     * @return {@code true} if this poll ended a failure streak
+     * @return the reaction, or {@code null} if the attempt was superseded by a {@link #reset()} and its result
+     *         is discarded
      */
-    synchronized boolean onSuccess() {
-        boolean recovered = failures > 0;
+    synchronized @Nullable Success onSuccess(long token) {
+        if (token == NO_ATTEMPT || token != inFlightToken) {
+            return null;
+        }
+        boolean endedStreak = failures > 0;
+        boolean catchUp = pollAgain;
         reset();
-        return recovered;
+        return new Success(endedStreak, catchUp);
     }
 
     /**
-     * Clears the backoff without reporting a recovery, for example after a re-login.
+     * Releases a reserved attempt that reported neither success nor failure, and is a no-op otherwise.
+     *
+     * @return {@code true} if a trigger was refused while the released attempt was running and shall be caught
+     *         up on
+     */
+    synchronized boolean abort(long token) {
+        if (token != NO_ATTEMPT && token == inFlightToken) {
+            inFlightToken = NO_ATTEMPT;
+            boolean catchUp = pollAgain;
+            pollAgain = false;
+            return catchUp;
+        }
+        return false;
+    }
+
+    /**
+     * Clears the backoff without reporting a recovery, for example after a re-login; a running attempt is
+     * released so the next poll may start immediately, and its late result will be discarded.
      */
     synchronized void reset() {
         failures = 0;
         interval = MIN_INTERVAL;
         nextAttempt = 0;
+        inFlightToken = NO_ATTEMPT;
+        // a pending catch-up is dropped, because the caller resetting the backoff polls immediately anyway
+        pollAgain = false;
     }
 
+    /** A poll right now would be refused, because of a pending backoff delay or a running attempt. */
     synchronized boolean shouldSkip(long now) {
-        return failures > 0 && now < nextAttempt;
+        return inFlightToken != NO_ATTEMPT || (failures > 0 && now < nextAttempt);
     }
 
+    /** A failed poll is ready for its retry and no attempt is running. */
     synchronized boolean isDue(long now) {
-        return failures > 0 && now >= nextAttempt;
+        return inFlightToken == NO_ATTEMPT && failures > 0 && now >= nextAttempt;
     }
 }

--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/util/HttpRequestBuilder.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/util/HttpRequestBuilder.java
@@ -309,26 +309,11 @@ public class HttpRequestBuilder {
         }
     }
 
-    /**
-     * Determines whether a failed response is the result of rate limiting.
-     *
-     * @param responseStatus the HTTP status of the response
-     * @param amznErrorType the value of the {@code x-amzn-ErrorType} header, {@code null} if absent
-     * @return {@code true} if the request was throttled
-     */
     static boolean isThrottled(int responseStatus, @Nullable String amznErrorType) {
         return responseStatus == TOO_MANY_REQUESTS_429
                 || (amznErrorType != null && amznErrorType.startsWith(THROTTLING_EXCEPTION));
     }
 
-    /**
-     * Builds the reason part of the exception message for a failed response.
-     *
-     * @param reason the reason from the status line, generic for Amazon API errors and {@code null} for
-     *            responses that carry no reason phrase at all
-     * @param amznErrorType the value of the {@code x-amzn-ErrorType} header, {@code null} if absent
-     * @return the reason, extended by the error type if the header carried one
-     */
     static String buildFailureReason(@Nullable String reason, @Nullable String amznErrorType) {
         String statusReason = reason == null || reason.isBlank() ? NO_REASON_GIVEN : reason;
         return amznErrorType == null || amznErrorType.isBlank() ? statusReason
@@ -410,15 +395,11 @@ public class HttpRequestBuilder {
                 // handle queue expired
                 httpResponse.completeExceptionally(new ConnectionException("Queue expired"));
             } else {
-                // Amazon reports the real failure cause in the x-amzn-ErrorType header (e.g.
-                // "ThrottlingException:..." with a body of {"message":"Rate exceeded"}), while
-                // the status line only carries a generic reason like "Bad Request". Surface it,
-                // otherwise a rate limit is indistinguishable from a malformed request. The
-                // lookup is case-insensitive, HttpFields#get compares header names that way.
+                // Amazon reports the real failure cause in the x-amzn-ErrorType header, the status
+                // line only carries a generic reason like "Bad Request"
                 String amznErrorType = headers.get(AMZN_ERROR_TYPE_HEADER);
                 if (amznErrorType != null && !amznErrorType.isBlank() && !logger.isTraceEnabled()) {
-                    // The response body of a failed call is not logged anywhere below TRACE
-                    // (which also dumps cookies) - log body and error type here, cookie-free.
+                    // below TRACE (which also dumps cookies) this is the only place the failure body is logged
                     logger.debug("< {} to {} failed: {}, x-amzn-ErrorType = {}, content = {}", params.method(),
                             requestUri, responseStatus, amznErrorType,
                             content.length() > MAX_LOGGED_CONTENT_LENGTH
@@ -426,10 +407,7 @@ public class HttpRequestBuilder {
                                     : content);
                 }
                 boolean throttled = isThrottled(responseStatus, amznErrorType);
-                // A throttled request must not burn its retries after fixed 2 s pauses: the
-                // limit window is longer than that, and every retry is itself a counted request
-                // that keeps the window open. Fail fast; the caller's next regular cycle is the
-                // retry. FailMode.NORMAL is not affected, it never retries in the first place.
+                // a throttled request is not retried: every retry is itself a counted request
                 if (failMode == EXCEPTION || retryCounter == 0 || (throttled && failMode != NORMAL)) {
                     if (responseStatus == 0) {
                         httpResponse.completeExceptionally(new ConnectionException("Request aborted."));

--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/util/HttpRequestBuilder.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/util/HttpRequestBuilder.java
@@ -68,7 +68,6 @@ public class HttpRequestBuilder {
             + DI_OS_VERSION + "/iPhone";
     private static final String AMZN_ERROR_TYPE_HEADER = "x-amzn-ErrorType";
     private static final String THROTTLING_EXCEPTION = "ThrottlingException";
-    private static final int MAX_LOGGED_CONTENT_LENGTH = 512;
     private static final String NO_REASON_GIVEN = "no reason given";
 
     private final Logger logger = LoggerFactory.getLogger(HttpRequestBuilder.class);
@@ -399,12 +398,8 @@ public class HttpRequestBuilder {
                 // line only carries a generic reason like "Bad Request"
                 String amznErrorType = headers.get(AMZN_ERROR_TYPE_HEADER);
                 if (amznErrorType != null && !amznErrorType.isBlank() && !logger.isTraceEnabled()) {
-                    // below TRACE (which also dumps cookies) this is the only place the failure body is logged
-                    logger.debug("< {} to {} failed: {}, x-amzn-ErrorType = {}, content = {}", params.method(),
-                            requestUri, responseStatus, amznErrorType,
-                            content.length() > MAX_LOGGED_CONTENT_LENGTH
-                                    ? content.substring(0, MAX_LOGGED_CONTENT_LENGTH) + "..."
-                                    : content);
+                    logger.debug("< {} to {} failed: {}, x-amzn-ErrorType = {}", params.method(), requestUri,
+                            responseStatus, amznErrorType);
                 }
                 boolean throttled = isThrottled(responseStatus, amznErrorType);
                 // a throttled request is not retried: every retry is itself a counted request

--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/util/HttpRequestBuilder.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/util/HttpRequestBuilder.java
@@ -319,7 +319,7 @@ public class HttpRequestBuilder {
                 : statusReason + " (" + AMZN_ERROR_TYPE_HEADER + ": " + amznErrorType + ")";
     }
 
-    // package-private so that HttpRequestBuilderTest can drive onComplete() directly
+    /** Package-private so that HttpRequestBuilderTest can drive onComplete() directly. */
     class HttpResponseListener extends BufferingResponseListener {
         private static final int MAX_REDIRECTS = 30;
         private static final int MAX_RETRIES = 3;

--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/util/HttpRequestBuilder.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/util/HttpRequestBuilder.java
@@ -60,11 +60,16 @@ import com.google.gson.reflect.TypeToken;
  * The {@link HttpRequestBuilder} creates customized requests for Alexa API requests
  *
  * @author Jan N. Klug - Initial contribution
+ * @author Martin Littkovsky - Fail fast on throttled requests
  */
 @NonNullByDefault
 public class HttpRequestBuilder {
     private static final String DEFAULT_USER_AGENT = "AmazonWebView/Amazon Alexa/" + API_VERSION + "/iOS/"
             + DI_OS_VERSION + "/iPhone";
+    private static final String AMZN_ERROR_TYPE_HEADER = "x-amzn-ErrorType";
+    private static final String THROTTLING_EXCEPTION = "ThrottlingException";
+    private static final int MAX_LOGGED_CONTENT_LENGTH = 512;
+    private static final String NO_REASON_GIVEN = "no reason given";
 
     private final Logger logger = LoggerFactory.getLogger(HttpRequestBuilder.class);
 
@@ -304,7 +309,34 @@ public class HttpRequestBuilder {
         }
     }
 
-    private class HttpResponseListener extends BufferingResponseListener {
+    /**
+     * Determines whether a failed response is the result of rate limiting.
+     *
+     * @param responseStatus the HTTP status of the response
+     * @param amznErrorType the value of the {@code x-amzn-ErrorType} header, {@code null} if absent
+     * @return {@code true} if the request was throttled
+     */
+    static boolean isThrottled(int responseStatus, @Nullable String amznErrorType) {
+        return responseStatus == TOO_MANY_REQUESTS_429
+                || (amznErrorType != null && amznErrorType.startsWith(THROTTLING_EXCEPTION));
+    }
+
+    /**
+     * Builds the reason part of the exception message for a failed response.
+     *
+     * @param reason the reason from the status line, generic for Amazon API errors and {@code null} for
+     *            responses that carry no reason phrase at all
+     * @param amznErrorType the value of the {@code x-amzn-ErrorType} header, {@code null} if absent
+     * @return the reason, extended by the error type if the header carried one
+     */
+    static String buildFailureReason(@Nullable String reason, @Nullable String amznErrorType) {
+        String statusReason = reason == null || reason.isBlank() ? NO_REASON_GIVEN : reason;
+        return amznErrorType == null || amznErrorType.isBlank() ? statusReason
+                : statusReason + " (" + AMZN_ERROR_TYPE_HEADER + ": " + amznErrorType + ")";
+    }
+
+    // package-private so that HttpRequestBuilderTest can drive onComplete() directly
+    class HttpResponseListener extends BufferingResponseListener {
         private static final int MAX_REDIRECTS = 30;
         private static final int MAX_RETRIES = 3;
 
@@ -378,12 +410,33 @@ public class HttpRequestBuilder {
                 // handle queue expired
                 httpResponse.completeExceptionally(new ConnectionException("Queue expired"));
             } else {
-                if (failMode == EXCEPTION || retryCounter == 0) {
+                // Amazon reports the real failure cause in the x-amzn-ErrorType header (e.g.
+                // "ThrottlingException:..." with a body of {"message":"Rate exceeded"}), while
+                // the status line only carries a generic reason like "Bad Request". Surface it,
+                // otherwise a rate limit is indistinguishable from a malformed request. The
+                // lookup is case-insensitive, HttpFields#get compares header names that way.
+                String amznErrorType = headers.get(AMZN_ERROR_TYPE_HEADER);
+                if (amznErrorType != null && !amznErrorType.isBlank() && !logger.isTraceEnabled()) {
+                    // The response body of a failed call is not logged anywhere below TRACE
+                    // (which also dumps cookies) - log body and error type here, cookie-free.
+                    logger.debug("< {} to {} failed: {}, x-amzn-ErrorType = {}, content = {}", params.method(),
+                            requestUri, responseStatus, amznErrorType,
+                            content.length() > MAX_LOGGED_CONTENT_LENGTH
+                                    ? content.substring(0, MAX_LOGGED_CONTENT_LENGTH) + "..."
+                                    : content);
+                }
+                boolean throttled = isThrottled(responseStatus, amznErrorType);
+                // A throttled request must not burn its retries after fixed 2 s pauses: the
+                // limit window is longer than that, and every retry is itself a counted request
+                // that keeps the window open. Fail fast; the caller's next regular cycle is the
+                // retry. FailMode.NORMAL is not affected, it never retries in the first place.
+                if (failMode == EXCEPTION || retryCounter == 0 || (throttled && failMode != NORMAL)) {
                     if (responseStatus == 0) {
                         httpResponse.completeExceptionally(new ConnectionException("Request aborted."));
+                        return;
                     }
-                    httpResponse.completeExceptionally(new ConnectionException(
-                            requestUri + " failed with code " + responseStatus + ": " + response.getReason()));
+                    httpResponse.completeExceptionally(new ConnectionException(requestUri + " failed with code "
+                            + responseStatus + ": " + buildFailureReason(response.getReason(), amznErrorType)));
                 } else if (failMode == NORMAL) {
                     httpResponse.complete(new HttpResponse(responseStatus, headers, content));
                 } else {
@@ -400,7 +453,7 @@ public class HttpRequestBuilder {
         }
     }
 
-    private record RequestParams(HttpMethod method, @Nullable String requestContent, boolean json,
+    record RequestParams(HttpMethod method, @Nullable String requestContent, boolean json,
             Map<String, String> customHeaders) {
         public boolean equals(@Nullable Object o) {
             if (this == o) {

--- a/bundles/org.openhab.binding.amazonechocontrol/src/test/java/org/openhab/binding/amazonechocontrol/internal/handler/NotificationCommitStructureTest.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/test/java/org/openhab/binding/amazonechocontrol/internal/handler/NotificationCommitStructureTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.amazonechocontrol.internal.handler;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Guards that accepting a notification poll result stays one step: the verdict, the publication and the
+ * next-poll time under {@code notificationCommit}, the network call outside it. Asserted against the source
+ * because this bundle has no harness that can instantiate {@link AccountHandler}.
+ *
+ * @author Martin Littkovsky - Initial contribution
+ */
+@NonNullByDefault
+class NotificationCommitStructureTest {
+
+    private static final Path SOURCE = Path
+            .of("src/main/java/org/openhab/binding/amazonechocontrol/internal/handler/AccountHandler.java");
+
+    private static String refreshNotifications() throws IOException {
+        String source = Files.readString(SOURCE);
+        int start = source.indexOf("private void refreshNotifications()");
+        assertTrue(start > 0, "refreshNotifications() not found - this test cannot guard what it cannot read");
+        return source.substring(start, source.indexOf("\n    private void refreshData()", start));
+    }
+
+    /** The {@code notificationCommit} block that encloses the given marker. */
+    private static String guardedBlock(String body, String marker) {
+        int at = body.indexOf(marker);
+        assertTrue(at > 0, marker + " not found - this test is testing nothing");
+        int start = body.lastIndexOf("synchronized (notificationCommit) {", at);
+        assertTrue(start > 0, marker + " is not preceded by a notificationCommit block");
+        int depth = 0;
+        for (int i = body.indexOf('{', start); i < body.length(); i++) {
+            char c = body.charAt(i);
+            if (c == '{') {
+                depth++;
+            } else if (c == '}' && --depth == 0) {
+                return body.substring(start, i);
+            }
+        }
+        throw new IllegalStateException("unbalanced braces");
+    }
+
+    @Test
+    void theResultIsPublishedInsideTheGuardedBlock() throws IOException {
+        String body = refreshNotifications();
+        String block = guardedBlock(body, "notificationPollBackoff.onSuccess");
+
+        assertTrue(block.contains("notificationPollBackoff.onSuccess"), "the verdict belongs in the block");
+        assertTrue(block.contains("updateNotifications(notifications)"),
+                "publishing outside the block lets a replaced connection publish after its result was rejected");
+        assertTrue(block.contains("nextRefreshNotifications = "),
+                "the next-poll time outside the block would overwrite the reset a new session depends on");
+    }
+
+    @Test
+    void theFailureVerdictAndItsUndefAreOneStep() throws IOException {
+        String body = refreshNotifications();
+        String block = guardedBlock(body, "notificationPollBackoff.onFailure");
+
+        assertTrue(block.contains("notificationPollBackoff.onFailure"), "the verdict belongs in the block");
+        assertTrue(block.contains("updateNotifications(List.of())"),
+                "UNDEF outside the block can reach the channels after the connection was replaced");
+    }
+
+    @Test
+    void theNetworkCallStaysOutsideTheGuardedBlock() throws IOException {
+        String body = refreshNotifications();
+        int poll = body.indexOf("connection.getNotifications()");
+        assertTrue(poll > 0, "the poll itself is gone - this test is testing nothing");
+        assertTrue(poll < body.indexOf("synchronized (notificationCommit) {"),
+                "holding the commit lock across the HTTP call would block setConnection() for the request timeout");
+    }
+
+    @Test
+    void setConnectionResetsUnderTheSameLock() throws IOException {
+        String source = Files.readString(SOURCE);
+        int start = source.indexOf("public void setConnection(Connection newConnection)");
+        assertTrue(start > 0, "setConnection() not found");
+        String body = source.substring(start, source.indexOf("\n    private void storeSession()", start));
+        String block = guardedBlock(body, "notificationPollBackoff.reset()");
+
+        assertTrue(block.contains("notificationPollBackoff.reset()") && block.contains("nextRefreshNotifications = 0"),
+                "the reset must be atomic against a poll committing its result");
+    }
+}

--- a/bundles/org.openhab.binding.amazonechocontrol/src/test/java/org/openhab/binding/amazonechocontrol/internal/handler/NotificationPollBackoffTest.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/test/java/org/openhab/binding/amazonechocontrol/internal/handler/NotificationPollBackoffTest.java
@@ -15,10 +15,16 @@ package org.openhab.binding.amazonechocontrol.internal.handler;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+
+import java.util.Objects;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.junit.jupiter.api.Test;
 import org.openhab.binding.amazonechocontrol.internal.handler.NotificationPollBackoff.Failure;
+import org.openhab.binding.amazonechocontrol.internal.handler.NotificationPollBackoff.Start;
+import org.openhab.binding.amazonechocontrol.internal.handler.NotificationPollBackoff.Success;
 
 /**
  * The {@link NotificationPollBackoffTest} contains tests for the {@link NotificationPollBackoff} class
@@ -29,51 +35,77 @@ import org.openhab.binding.amazonechocontrol.internal.handler.NotificationPollBa
 public class NotificationPollBackoffTest {
     private static final long NOW = 1_700_000_000_000L;
 
+    private long start(NotificationPollBackoff backoff, long now) {
+        Start start = backoff.tryStart(now);
+        assertThat(start.outcome(), is(Start.Outcome.STARTED));
+        return start.token();
+    }
+
+    private Failure fail(NotificationPollBackoff backoff, long now) {
+        Failure failure = backoff.onFailure(start(backoff, now), now);
+        assertThat(failure, is(notNullValue()));
+        return Objects.requireNonNull(failure);
+    }
+
+    private Success succeed(NotificationPollBackoff backoff, long now) {
+        Success success = backoff.onSuccess(start(backoff, now));
+        assertThat(success, is(notNullValue()));
+        return Objects.requireNonNull(success);
+    }
+
     @Test
     public void testDelayDoublesUpToMaximum() {
         NotificationPollBackoff backoff = new NotificationPollBackoff();
+        long now = NOW;
 
-        assertThat(backoff.onFailure(NOW).delaySeconds(), is(300));
-        assertThat(backoff.onFailure(NOW).delaySeconds(), is(600));
-        assertThat(backoff.onFailure(NOW).delaySeconds(), is(1200));
-        assertThat(backoff.onFailure(NOW).delaySeconds(), is(2400));
-        assertThat(backoff.onFailure(NOW).delaySeconds(), is(3600));
-        assertThat(backoff.onFailure(NOW).delaySeconds(), is(3600));
+        for (int expectedDelay : new int[] { 300, 600, 1200, 2400, 3600, 3600 }) {
+            Failure failure = fail(backoff, now);
+            assertThat(failure.delaySeconds(), is(expectedDelay));
+            now += failure.delaySeconds() * 1000L;
+        }
     }
 
     @Test
     public void testOnlyTheFirstFailureOfAStreakIsFlagged() {
         NotificationPollBackoff backoff = new NotificationPollBackoff();
+        long now = NOW;
 
-        assertThat(backoff.onFailure(NOW).firstOfStreak(), is(true));
-        assertThat(backoff.onFailure(NOW).firstOfStreak(), is(false));
-        assertThat(backoff.onFailure(NOW).firstOfStreak(), is(false));
+        assertThat(fail(backoff, now).firstOfStreak(), is(true));
+        now += 300_000L;
+        assertThat(fail(backoff, now).firstOfStreak(), is(false));
+        now += 600_000L;
+        assertThat(fail(backoff, now).firstOfStreak(), is(false));
+        now += 1_200_000L;
 
-        backoff.onSuccess();
+        succeed(backoff, now);
 
-        assertThat(backoff.onFailure(NOW).firstOfStreak(), is(true));
+        assertThat(fail(backoff, now).firstOfStreak(), is(true));
     }
 
     @Test
     public void testUndefIsPublishedFromTheThirdFailureOnwards() {
         NotificationPollBackoff backoff = new NotificationPollBackoff();
+        long now = NOW;
 
-        assertThat(backoff.onFailure(NOW).publishUndef(), is(false));
-        assertThat(backoff.onFailure(NOW).publishUndef(), is(false));
-        assertThat(backoff.onFailure(NOW).publishUndef(), is(true));
-        assertThat(backoff.onFailure(NOW).publishUndef(), is(true));
-        assertThat(backoff.onFailure(NOW).publishUndef(), is(true));
+        boolean[] expected = { false, false, true, true, true };
+        for (boolean expectedUndef : expected) {
+            Failure failure = fail(backoff, now);
+            assertThat(failure.publishUndef(), is(expectedUndef));
+            now += failure.delaySeconds() * 1000L;
+        }
     }
 
     @Test
     public void testUndefThresholdIsCrossedOnlyOnce() {
         NotificationPollBackoff backoff = new NotificationPollBackoff();
+        long now = NOW;
 
-        assertThat(backoff.onFailure(NOW).crossedUndefThreshold(), is(false));
-        assertThat(backoff.onFailure(NOW).crossedUndefThreshold(), is(false));
-        assertThat(backoff.onFailure(NOW).crossedUndefThreshold(), is(true));
-        assertThat(backoff.onFailure(NOW).crossedUndefThreshold(), is(false));
-        assertThat(backoff.onFailure(NOW).crossedUndefThreshold(), is(false));
+        boolean[] expected = { false, false, true, false, false };
+        for (boolean expectedCrossing : expected) {
+            Failure failure = fail(backoff, now);
+            assertThat(failure.crossedUndefThreshold(), is(expectedCrossing));
+            now += failure.delaySeconds() * 1000L;
+        }
     }
 
     @Test
@@ -83,43 +115,48 @@ public class NotificationPollBackoffTest {
         assertThat(backoff.shouldSkip(NOW), is(false));
         assertThat(backoff.isDue(NOW), is(false));
 
-        backoff.onFailure(NOW);
+        fail(backoff, NOW);
 
         assertThat(backoff.shouldSkip(NOW), is(true));
         assertThat(backoff.shouldSkip(NOW + 299_999L), is(true));
         assertThat(backoff.isDue(NOW + 299_999L), is(false));
         assertThat(backoff.shouldSkip(NOW + 300_000L), is(false));
         assertThat(backoff.isDue(NOW + 300_000L), is(true));
+
+        assertThat(backoff.tryStart(NOW + 299_999L).outcome(), is(Start.Outcome.BACKING_OFF));
     }
 
     @Test
     public void testEveryFailureSchedulesAFiniteRetry() {
         NotificationPollBackoff backoff = new NotificationPollBackoff();
+        long now = NOW;
 
         for (int attempt = 0; attempt < 8; attempt++) {
-            Failure failure = backoff.onFailure(NOW);
+            Failure failure = fail(backoff, now);
             assertThat(failure.delaySeconds(), lessThanOrEqualTo(NotificationPollBackoff.MAX_INTERVAL));
-            assertThat(backoff.shouldSkip(NOW), is(true));
-            assertThat(backoff.isDue(NOW + failure.delaySeconds() * 1000L), is(true));
+            assertThat(backoff.shouldSkip(now), is(true));
+            now += failure.delaySeconds() * 1000L;
+            assertThat(backoff.isDue(now), is(true));
         }
 
-        assertThat(backoff.onSuccess(), is(true));
-        assertThat(backoff.shouldSkip(NOW), is(false));
+        assertThat(succeed(backoff, now).endedStreak(), is(true));
+        assertThat(backoff.shouldSkip(now), is(false));
         assertThat(backoff.isDue(Long.MAX_VALUE), is(false));
     }
 
     @Test
     public void testSuccessResetsCounterAndDelay() {
         NotificationPollBackoff backoff = new NotificationPollBackoff();
+        long now = NOW;
 
-        backoff.onFailure(NOW);
-        backoff.onFailure(NOW);
-        backoff.onFailure(NOW);
+        now += fail(backoff, now).delaySeconds() * 1000L;
+        now += fail(backoff, now).delaySeconds() * 1000L;
+        now += fail(backoff, now).delaySeconds() * 1000L;
 
-        assertThat(backoff.onSuccess(), is(true));
-        assertThat(backoff.shouldSkip(NOW), is(false));
+        assertThat(succeed(backoff, now).endedStreak(), is(true));
+        assertThat(backoff.shouldSkip(now), is(false));
 
-        Failure afterReset = backoff.onFailure(NOW);
+        Failure afterReset = fail(backoff, now);
         assertThat(afterReset.delaySeconds(), is(300));
         assertThat(afterReset.firstOfStreak(), is(true));
         assertThat(afterReset.publishUndef(), is(false));
@@ -130,21 +167,173 @@ public class NotificationPollBackoffTest {
     public void testSuccessWithoutPrecedingFailureDoesNotReportRecovery() {
         NotificationPollBackoff backoff = new NotificationPollBackoff();
 
-        assertThat(backoff.onSuccess(), is(false));
-        assertThat(backoff.onSuccess(), is(false));
+        assertThat(succeed(backoff, NOW).endedStreak(), is(false));
+        assertThat(succeed(backoff, NOW).endedStreak(), is(false));
     }
 
     @Test
     public void testResetClearsTheBackoffSilently() {
         NotificationPollBackoff backoff = new NotificationPollBackoff();
+        long now = NOW;
 
-        backoff.onFailure(NOW);
-        backoff.onFailure(NOW);
+        now += fail(backoff, now).delaySeconds() * 1000L;
+        now += fail(backoff, now).delaySeconds() * 1000L;
         backoff.reset();
 
-        assertThat(backoff.shouldSkip(NOW), is(false));
+        assertThat(backoff.shouldSkip(now), is(false));
+        assertThat(backoff.isDue(now), is(false));
+        assertThat(succeed(backoff, now).endedStreak(), is(false));
+        assertThat(fail(backoff, now).delaySeconds(), is(300));
+    }
+
+    @Test
+    public void testSecondCallerDuringFlightIsRefused() {
+        NotificationPollBackoff backoff = new NotificationPollBackoff();
+
+        long token = start(backoff, NOW);
+
+        assertThat(backoff.tryStart(NOW).outcome(), is(Start.Outcome.ALREADY_RUNNING));
+        assertThat(backoff.shouldSkip(NOW), is(true));
         assertThat(backoff.isDue(NOW), is(false));
-        assertThat(backoff.onSuccess(), is(false));
-        assertThat(backoff.onFailure(NOW).delaySeconds(), is(300));
+
+        assertThat(backoff.onSuccess(token), is(notNullValue()));
+        assertThat(backoff.tryStart(NOW).outcome(), is(Start.Outcome.STARTED));
+    }
+
+    @Test
+    public void testFailureReleasesTheFlightForTheRetry() {
+        NotificationPollBackoff backoff = new NotificationPollBackoff();
+
+        long token = start(backoff, NOW);
+        Failure failure = Objects.requireNonNull(backoff.onFailure(token, NOW));
+
+        assertThat(backoff.tryStart(NOW).outcome(), is(Start.Outcome.BACKING_OFF));
+        assertThat(backoff.tryStart(NOW + failure.delaySeconds() * 1000L).outcome(), is(Start.Outcome.STARTED));
+    }
+
+    @Test
+    public void testResetReleasesTheRunningAttemptImmediately() {
+        NotificationPollBackoff backoff = new NotificationPollBackoff();
+
+        start(backoff, NOW);
+        backoff.reset();
+
+        assertThat(backoff.tryStart(NOW).outcome(), is(Start.Outcome.STARTED));
+    }
+
+    @Test
+    public void testLateFailureOfReplacedAttemptIsDiscarded() {
+        NotificationPollBackoff backoff = new NotificationPollBackoff();
+
+        long oldToken = start(backoff, NOW);
+        backoff.reset();
+        long newToken = start(backoff, NOW);
+
+        assertThat(backoff.onFailure(oldToken, NOW), is(nullValue()));
+        assertThat(backoff.tryStart(NOW).outcome(), is(Start.Outcome.ALREADY_RUNNING));
+
+        Failure failure = Objects.requireNonNull(backoff.onFailure(newToken, NOW));
+        assertThat(failure.firstOfStreak(), is(true));
+        assertThat(failure.delaySeconds(), is(300));
+    }
+
+    @Test
+    public void testLateSuccessOfReplacedAttemptIsDiscarded() {
+        NotificationPollBackoff backoff = new NotificationPollBackoff();
+
+        long oldToken = start(backoff, NOW);
+        backoff.reset();
+        fail(backoff, NOW);
+
+        assertThat(backoff.onSuccess(oldToken), is(nullValue()));
+        assertThat(backoff.shouldSkip(NOW), is(true));
+        assertThat(backoff.tryStart(NOW).outcome(), is(Start.Outcome.BACKING_OFF));
+    }
+
+    @Test
+    public void testAbortReleasesWithoutRecordingAResult() {
+        NotificationPollBackoff backoff = new NotificationPollBackoff();
+
+        long token = start(backoff, NOW);
+        backoff.abort(token);
+
+        assertThat(backoff.shouldSkip(NOW), is(false));
+        assertThat(fail(backoff, NOW).firstOfStreak(), is(true));
+    }
+
+    @Test
+    public void testStaleAbortDoesNotReleaseTheNextAttempt() {
+        NotificationPollBackoff backoff = new NotificationPollBackoff();
+
+        long oldToken = start(backoff, NOW);
+        assertThat(backoff.onSuccess(oldToken), is(notNullValue()));
+        start(backoff, NOW);
+
+        assertThat(backoff.abort(oldToken), is(false));
+
+        assertThat(backoff.tryStart(NOW).outcome(), is(Start.Outcome.ALREADY_RUNNING));
+    }
+
+    @Test
+    public void testRefusedTriggerIsHandedToTheFinishingSuccess() {
+        NotificationPollBackoff backoff = new NotificationPollBackoff();
+
+        long token = start(backoff, NOW);
+        assertThat(backoff.tryStart(NOW).outcome(), is(Start.Outcome.ALREADY_RUNNING));
+
+        Success success = Objects.requireNonNull(backoff.onSuccess(token));
+        assertThat(success.pollAgain(), is(true));
+
+        assertThat(succeed(backoff, NOW).pollAgain(), is(false));
+    }
+
+    @Test
+    public void testDoubleRefusalNeedsOnlyOneCatchUp() {
+        NotificationPollBackoff backoff = new NotificationPollBackoff();
+
+        long token = start(backoff, NOW);
+        assertThat(backoff.tryStart(NOW).outcome(), is(Start.Outcome.ALREADY_RUNNING));
+        assertThat(backoff.tryStart(NOW).outcome(), is(Start.Outcome.ALREADY_RUNNING));
+
+        assertThat(Objects.requireNonNull(backoff.onSuccess(token)).pollAgain(), is(true));
+        assertThat(succeed(backoff, NOW).pollAgain(), is(false));
+    }
+
+    @Test
+    public void testRefusedTriggerExpiresOnFailure() {
+        NotificationPollBackoff backoff = new NotificationPollBackoff();
+
+        long token = start(backoff, NOW);
+        assertThat(backoff.tryStart(NOW).outcome(), is(Start.Outcome.ALREADY_RUNNING));
+
+        Failure failure = Objects.requireNonNull(backoff.onFailure(token, NOW));
+
+        assertThat(backoff.tryStart(NOW + failure.delaySeconds() * 1000L - 1).outcome(), is(Start.Outcome.BACKING_OFF));
+        assertThat(succeed(backoff, NOW + failure.delaySeconds() * 1000L).pollAgain(), is(false));
+    }
+
+    @Test
+    public void testResetDiscardsARefusedTrigger() {
+        NotificationPollBackoff backoff = new NotificationPollBackoff();
+
+        start(backoff, NOW);
+        assertThat(backoff.tryStart(NOW).outcome(), is(Start.Outcome.ALREADY_RUNNING));
+        backoff.reset();
+
+        assertThat(succeed(backoff, NOW).pollAgain(), is(false));
+    }
+
+    @Test
+    public void testAbortHandsBackTheRefusedTrigger() {
+        NotificationPollBackoff backoff = new NotificationPollBackoff();
+
+        long token = start(backoff, NOW);
+        assertThat(backoff.abort(token), is(false));
+
+        token = start(backoff, NOW);
+        assertThat(backoff.tryStart(NOW).outcome(), is(Start.Outcome.ALREADY_RUNNING));
+        assertThat(backoff.abort(token), is(true));
+        assertThat(backoff.abort(token), is(false));
+        assertThat(succeed(backoff, NOW).pollAgain(), is(false));
     }
 }

--- a/bundles/org.openhab.binding.amazonechocontrol/src/test/java/org/openhab/binding/amazonechocontrol/internal/handler/NotificationPollBackoffTest.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/test/java/org/openhab/binding/amazonechocontrol/internal/handler/NotificationPollBackoffTest.java
@@ -133,7 +133,7 @@ public class NotificationPollBackoffTest {
 
         for (int attempt = 0; attempt < 8; attempt++) {
             Failure failure = fail(backoff, now);
-            assertThat(failure.delaySeconds(), lessThanOrEqualTo(NotificationPollBackoff.MAX_INTERVAL));
+            assertThat(failure.delaySeconds(), lessThanOrEqualTo(NotificationPollBackoff.MAX_INTERVAL_SECONDS));
             assertThat(backoff.shouldSkip(now), is(true));
             now += failure.delaySeconds() * 1000L;
             assertThat(backoff.isDue(now), is(true));

--- a/bundles/org.openhab.binding.amazonechocontrol/src/test/java/org/openhab/binding/amazonechocontrol/internal/handler/NotificationPollBackoffTest.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/test/java/org/openhab/binding/amazonechocontrol/internal/handler/NotificationPollBackoffTest.java
@@ -60,7 +60,6 @@ public class NotificationPollBackoffTest {
 
         assertThat(backoff.onFailure(NOW).publishUndef(), is(false));
         assertThat(backoff.onFailure(NOW).publishUndef(), is(false));
-        // every further failure repeats it, so that a handler registering during the outage is told as well
         assertThat(backoff.onFailure(NOW).publishUndef(), is(true));
         assertThat(backoff.onFailure(NOW).publishUndef(), is(true));
         assertThat(backoff.onFailure(NOW).publishUndef(), is(true));
@@ -97,12 +96,6 @@ public class NotificationPollBackoffTest {
     public void testEveryFailureSchedulesAFiniteRetry() {
         NotificationPollBackoff backoff = new NotificationPollBackoff();
 
-        // Guards the starvation this class was extracted for: the retry deadline used to live in a
-        // separate, unsynchronized field of the caller, so a poll succeeding on the push thread could
-        // overwrite it with Long.MAX_VALUE while a poll failing on the timer thread had just raised the
-        // failure count - the poll then reported "backing off" forever and never became due again.
-        // Count and deadline are now decided in one guarded step, so neither arrival order can produce
-        // a backoff without a reachable deadline.
         for (int attempt = 0; attempt < 8; attempt++) {
             Failure failure = backoff.onFailure(NOW);
             assertThat(failure.delaySeconds(), lessThanOrEqualTo(NotificationPollBackoff.MAX_INTERVAL));
@@ -110,7 +103,6 @@ public class NotificationPollBackoffTest {
             assertThat(backoff.isDue(NOW + failure.delaySeconds() * 1000L), is(true));
         }
 
-        // and after a success there is no deadline left to wait for, however far the clock is ahead
         assertThat(backoff.onSuccess(), is(true));
         assertThat(backoff.shouldSkip(NOW), is(false));
         assertThat(backoff.isDue(Long.MAX_VALUE), is(false));
@@ -152,7 +144,6 @@ public class NotificationPollBackoffTest {
 
         assertThat(backoff.shouldSkip(NOW), is(false));
         assertThat(backoff.isDue(NOW), is(false));
-        // a reset is not a recovery, so the next success has nothing to report
         assertThat(backoff.onSuccess(), is(false));
         assertThat(backoff.onFailure(NOW).delaySeconds(), is(300));
     }

--- a/bundles/org.openhab.binding.amazonechocontrol/src/test/java/org/openhab/binding/amazonechocontrol/internal/handler/NotificationPollBackoffTest.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/test/java/org/openhab/binding/amazonechocontrol/internal/handler/NotificationPollBackoffTest.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.amazonechocontrol.internal.handler;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.jupiter.api.Test;
+import org.openhab.binding.amazonechocontrol.internal.handler.NotificationPollBackoff.Failure;
+
+/**
+ * The {@link NotificationPollBackoffTest} contains tests for the {@link NotificationPollBackoff} class
+ *
+ * @author Martin Littkovsky - Initial contribution
+ */
+@NonNullByDefault
+public class NotificationPollBackoffTest {
+    private static final long NOW = 1_700_000_000_000L;
+
+    @Test
+    public void testDelayDoublesUpToMaximum() {
+        NotificationPollBackoff backoff = new NotificationPollBackoff();
+
+        assertThat(backoff.onFailure(NOW).delaySeconds(), is(300));
+        assertThat(backoff.onFailure(NOW).delaySeconds(), is(600));
+        assertThat(backoff.onFailure(NOW).delaySeconds(), is(1200));
+        assertThat(backoff.onFailure(NOW).delaySeconds(), is(2400));
+        assertThat(backoff.onFailure(NOW).delaySeconds(), is(3600));
+        assertThat(backoff.onFailure(NOW).delaySeconds(), is(3600));
+    }
+
+    @Test
+    public void testOnlyTheFirstFailureOfAStreakIsFlagged() {
+        NotificationPollBackoff backoff = new NotificationPollBackoff();
+
+        assertThat(backoff.onFailure(NOW).firstOfStreak(), is(true));
+        assertThat(backoff.onFailure(NOW).firstOfStreak(), is(false));
+        assertThat(backoff.onFailure(NOW).firstOfStreak(), is(false));
+
+        backoff.onSuccess();
+
+        assertThat(backoff.onFailure(NOW).firstOfStreak(), is(true));
+    }
+
+    @Test
+    public void testUndefIsPublishedFromTheThirdFailureOnwards() {
+        NotificationPollBackoff backoff = new NotificationPollBackoff();
+
+        assertThat(backoff.onFailure(NOW).publishUndef(), is(false));
+        assertThat(backoff.onFailure(NOW).publishUndef(), is(false));
+        // every further failure repeats it, so that a handler registering during the outage is told as well
+        assertThat(backoff.onFailure(NOW).publishUndef(), is(true));
+        assertThat(backoff.onFailure(NOW).publishUndef(), is(true));
+        assertThat(backoff.onFailure(NOW).publishUndef(), is(true));
+    }
+
+    @Test
+    public void testUndefThresholdIsCrossedOnlyOnce() {
+        NotificationPollBackoff backoff = new NotificationPollBackoff();
+
+        assertThat(backoff.onFailure(NOW).crossedUndefThreshold(), is(false));
+        assertThat(backoff.onFailure(NOW).crossedUndefThreshold(), is(false));
+        assertThat(backoff.onFailure(NOW).crossedUndefThreshold(), is(true));
+        assertThat(backoff.onFailure(NOW).crossedUndefThreshold(), is(false));
+        assertThat(backoff.onFailure(NOW).crossedUndefThreshold(), is(false));
+    }
+
+    @Test
+    public void testPollWaitsUntilTheDelayElapsed() {
+        NotificationPollBackoff backoff = new NotificationPollBackoff();
+
+        assertThat(backoff.shouldSkip(NOW), is(false));
+        assertThat(backoff.isDue(NOW), is(false));
+
+        backoff.onFailure(NOW);
+
+        assertThat(backoff.shouldSkip(NOW), is(true));
+        assertThat(backoff.shouldSkip(NOW + 299_999L), is(true));
+        assertThat(backoff.isDue(NOW + 299_999L), is(false));
+        assertThat(backoff.shouldSkip(NOW + 300_000L), is(false));
+        assertThat(backoff.isDue(NOW + 300_000L), is(true));
+    }
+
+    @Test
+    public void testEveryFailureSchedulesAFiniteRetry() {
+        NotificationPollBackoff backoff = new NotificationPollBackoff();
+
+        // Guards the starvation this class was extracted for: the retry deadline used to live in a
+        // separate, unsynchronized field of the caller, so a poll succeeding on the push thread could
+        // overwrite it with Long.MAX_VALUE while a poll failing on the timer thread had just raised the
+        // failure count - the poll then reported "backing off" forever and never became due again.
+        // Count and deadline are now decided in one guarded step, so neither arrival order can produce
+        // a backoff without a reachable deadline.
+        for (int attempt = 0; attempt < 8; attempt++) {
+            Failure failure = backoff.onFailure(NOW);
+            assertThat(failure.delaySeconds(), lessThanOrEqualTo(NotificationPollBackoff.MAX_INTERVAL));
+            assertThat(backoff.shouldSkip(NOW), is(true));
+            assertThat(backoff.isDue(NOW + failure.delaySeconds() * 1000L), is(true));
+        }
+
+        // and after a success there is no deadline left to wait for, however far the clock is ahead
+        assertThat(backoff.onSuccess(), is(true));
+        assertThat(backoff.shouldSkip(NOW), is(false));
+        assertThat(backoff.isDue(Long.MAX_VALUE), is(false));
+    }
+
+    @Test
+    public void testSuccessResetsCounterAndDelay() {
+        NotificationPollBackoff backoff = new NotificationPollBackoff();
+
+        backoff.onFailure(NOW);
+        backoff.onFailure(NOW);
+        backoff.onFailure(NOW);
+
+        assertThat(backoff.onSuccess(), is(true));
+        assertThat(backoff.shouldSkip(NOW), is(false));
+
+        Failure afterReset = backoff.onFailure(NOW);
+        assertThat(afterReset.delaySeconds(), is(300));
+        assertThat(afterReset.firstOfStreak(), is(true));
+        assertThat(afterReset.publishUndef(), is(false));
+        assertThat(afterReset.crossedUndefThreshold(), is(false));
+    }
+
+    @Test
+    public void testSuccessWithoutPrecedingFailureDoesNotReportRecovery() {
+        NotificationPollBackoff backoff = new NotificationPollBackoff();
+
+        assertThat(backoff.onSuccess(), is(false));
+        assertThat(backoff.onSuccess(), is(false));
+    }
+
+    @Test
+    public void testResetClearsTheBackoffSilently() {
+        NotificationPollBackoff backoff = new NotificationPollBackoff();
+
+        backoff.onFailure(NOW);
+        backoff.onFailure(NOW);
+        backoff.reset();
+
+        assertThat(backoff.shouldSkip(NOW), is(false));
+        assertThat(backoff.isDue(NOW), is(false));
+        // a reset is not a recovery, so the next success has nothing to report
+        assertThat(backoff.onSuccess(), is(false));
+        assertThat(backoff.onFailure(NOW).delaySeconds(), is(300));
+    }
+}

--- a/bundles/org.openhab.binding.amazonechocontrol/src/test/java/org/openhab/binding/amazonechocontrol/internal/util/HttpRequestBuilderTest.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/test/java/org/openhab/binding/amazonechocontrol/internal/util/HttpRequestBuilderTest.java
@@ -99,8 +99,7 @@ public class HttpRequestBuilderTest {
     @Test
     public void testThrottledResponseFailsFastInsteadOfRetrying() {
         HttpClient httpClient = mock(HttpClient.class);
-        // a retry would build a new request from the client, so hand out one that does not fail the test
-        // with a NullPointerException before the assertion below can report the actual regression
+        // stubbed so that a regression retries instead of failing with a NullPointerException
         when(httpClient.newRequest(any(URI.class))).thenReturn(mock(Request.class, RETURNS_SELF));
         HttpRequestBuilder requestBuilder = new HttpRequestBuilder(httpClient, new CookieManager(), new Gson());
 
@@ -112,7 +111,6 @@ public class HttpRequestBuilderTest {
         requestBuilder.new HttpResponseListener(httpResponse, params, false, FailMode.RETRY)
                 .onComplete(throttledResult(headers));
 
-        // the point of the fail-fast: no second request against an endpoint that just rejected us
         verify(httpClient, never()).newRequest(any(URI.class));
         assertThat(httpResponse.isCompletedExceptionally(), is(true));
         ExecutionException failure = assertThrows(ExecutionException.class, httpResponse::get);

--- a/bundles/org.openhab.binding.amazonechocontrol/src/test/java/org/openhab/binding/amazonechocontrol/internal/util/HttpRequestBuilderTest.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/test/java/org/openhab/binding/amazonechocontrol/internal/util/HttpRequestBuilderTest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.amazonechocontrol.internal.util;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Answers.RETURNS_SELF;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.openhab.binding.amazonechocontrol.internal.util.HttpRequestBuilder.buildFailureReason;
+import static org.openhab.binding.amazonechocontrol.internal.util.HttpRequestBuilder.isThrottled;
+
+import java.net.CookieManager;
+import java.net.URI;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.api.Request;
+import org.eclipse.jetty.client.api.Response;
+import org.eclipse.jetty.client.api.Result;
+import org.eclipse.jetty.http.HttpFields;
+import org.eclipse.jetty.http.HttpMethod;
+import org.junit.jupiter.api.Test;
+import org.openhab.binding.amazonechocontrol.internal.util.HttpRequestBuilder.FailMode;
+import org.openhab.binding.amazonechocontrol.internal.util.HttpRequestBuilder.HttpResponse;
+import org.openhab.binding.amazonechocontrol.internal.util.HttpRequestBuilder.RequestParams;
+
+import com.google.gson.Gson;
+
+/**
+ * The {@link HttpRequestBuilderTest} contains tests for the failure handling of the {@link HttpRequestBuilder}
+ * class
+ *
+ * @author Martin Littkovsky - Initial contribution
+ */
+@NonNullByDefault
+public class HttpRequestBuilderTest {
+    private static final String THROTTLING_ERROR_TYPE = "ThrottlingException:"
+            + "http://internal.amazon.com/coral/com.amazon.alexa.exceptions/";
+    private static final URI REQUEST_URI = URI.create("https://alexa.amazon.de/api/notifications");
+
+    @Test
+    public void testMissingErrorTypeHeaderIsNotThrottled() {
+        assertThat(isThrottled(400, null), is(false));
+        assertThat(buildFailureReason("Bad Request", null), is("Bad Request"));
+    }
+
+    @Test
+    public void testBlankErrorTypeHeaderIsNotThrottled() {
+        assertThat(isThrottled(400, ""), is(false));
+        assertThat(buildFailureReason("Bad Request", ""), is("Bad Request"));
+    }
+
+    @Test
+    public void testThrottlingErrorTypeIsThrottledAndAppendedToTheReason() {
+        assertThat(isThrottled(400, THROTTLING_ERROR_TYPE), is(true));
+        assertThat(buildFailureReason("Bad Request", THROTTLING_ERROR_TYPE),
+                is("Bad Request (x-amzn-ErrorType: " + THROTTLING_ERROR_TYPE + ")"));
+    }
+
+    @Test
+    public void testTooManyRequestsIsThrottledWithoutTheHeader() {
+        assertThat(isThrottled(429, null), is(true));
+    }
+
+    @Test
+    public void testOtherErrorTypeIsNotThrottledButStillAppended() {
+        assertThat(isThrottled(400, "ValidationException"), is(false));
+        assertThat(buildFailureReason("Bad Request", "ValidationException"),
+                is("Bad Request (x-amzn-ErrorType: ValidationException)"));
+    }
+
+    @Test
+    public void testMissingReasonPhraseIsReplacedByAPlaceholder() {
+        assertThat(buildFailureReason(null, null), is("no reason given"));
+        assertThat(buildFailureReason("", null), is("no reason given"));
+        assertThat(buildFailureReason(null, THROTTLING_ERROR_TYPE),
+                is("no reason given (x-amzn-ErrorType: " + THROTTLING_ERROR_TYPE + ")"));
+    }
+
+    @Test
+    public void testThrottledResponseFailsFastInsteadOfRetrying() {
+        HttpClient httpClient = mock(HttpClient.class);
+        // a retry would build a new request from the client, so hand out one that does not fail the test
+        // with a NullPointerException before the assertion below can report the actual regression
+        when(httpClient.newRequest(any(URI.class))).thenReturn(mock(Request.class, RETURNS_SELF));
+        HttpRequestBuilder requestBuilder = new HttpRequestBuilder(httpClient, new CookieManager(), new Gson());
+
+        HttpFields headers = new HttpFields();
+        headers.add("x-amzn-ErrorType", THROTTLING_ERROR_TYPE);
+
+        CompletableFuture<HttpResponse> httpResponse = new CompletableFuture<>();
+        RequestParams params = new RequestParams(HttpMethod.GET, null, false, Map.of());
+        requestBuilder.new HttpResponseListener(httpResponse, params, false, FailMode.RETRY)
+                .onComplete(throttledResult(headers));
+
+        // the point of the fail-fast: no second request against an endpoint that just rejected us
+        verify(httpClient, never()).newRequest(any(URI.class));
+        assertThat(httpResponse.isCompletedExceptionally(), is(true));
+        ExecutionException failure = assertThrows(ExecutionException.class, httpResponse::get);
+        assertThat(failure.getCause().getMessage(), containsString("ThrottlingException"));
+    }
+
+    private Result throttledResult(HttpFields headers) {
+        Request request = mock(Request.class);
+        when(request.getURI()).thenReturn(REQUEST_URI);
+        Response response = mock(Response.class);
+        when(response.getRequest()).thenReturn(request);
+        when(response.getStatus()).thenReturn(400);
+        when(response.getHeaders()).thenReturn(headers);
+        when(response.getReason()).thenReturn("Bad Request");
+        Result result = mock(Result.class);
+        when(result.getResponse()).thenReturn(response);
+        return result;
+    }
+}


### PR DESCRIPTION
# Description

On some accounts the hourly notifications poll (`/api/notifications`) fails on every cycle with `400: Bad Request` (#21146, #19714). The real cause is throttling: Amazon answers with `x-amzn-ErrorType: ThrottlingException` and `{"message":"Rate exceeded"}`, but the binding never reads that header — and a failed poll was indistinguishable from "no notifications set" (#20018).

# Changes

1. **Surface the real cause:** `x-amzn-ErrorType` is appended to the exception message and logged at DEBUG; response bodies stay at TRACE.
2. **Fail fast on throttled responses** (`429`, or a `ThrottlingException` header) instead of burning the generic retries — every retry is itself a counted request that keeps the account throttled. `FailMode.NORMAL` is unaffected.
3. **One poll at a time** (added in the review round): the poll decision and its reservation are one atomic step with a unique in-flight token — concurrent triggers wait for the next cycle, a late result from a superseded poll is discarded, and a push trigger arriving during an in-flight poll schedules one catch-up poll instead of being lost.
4. **A failed poll is not an empty notification list:** the last known state survives short outages; after three consecutive failures the `next*` channels go `UNDEF`. Retries back off exponentially (300 s doubling up to the hourly refresh), the push path honours the backoff, failures log once per streak.

# Testing

148 unit tests (28 new): the backoff ladder, the `UNDEF` threshold, the throttling classification, no-second-request on a throttled fail-fast, and the token/serialization behavior of the review round. SAT report clean against `main`, re-established on the current revision. Verified on a production installation (build of 2026-08-19, before the review round's concurrency rework — that rework's behavior is pinned by the added unit tests): the ladder runs to the second, `UNDEF` appears after the third failure, no idle polling. Measured over two days: more than 100 attempts at spacings from seconds up to a deliberate 10.7-hour silence — every one answered `400 ThrottlingException`. For such an account the endpoint is effectively permanently locked; the value of this PR there is the honest diagnosis, the strongly reduced request pressure, and channels that say `UNDEF` instead of pretending "no alarm set". Occasionally-throttled accounts additionally gain the transient-failure tolerance.

Fixes the misleading diagnosis of #21146 / #19714; related: #19781, #20018 (on a permanently throttled account the `next*` channels still end up `UNDEF` — but now `UNDEF` means what it says).

A follow-up PR will skip this poll entirely while no notification channel is linked.

**Transparency:** this patch was developed with AI assistance (Claude); every commit carries an `AI-assisted-by` trailer. All changes were built, tested and verified on a production system by the author.

