### PR TITLE
[marytts] Update dependencies

### DIFF
--- a/bundles/org.openhab.voice.marytts/pom.xml
+++ b/bundles/org.openhab.voice.marytts/pom.xml
@@ -201,6 +201,25 @@ SPI-Consumer: java.util.ServiceLoader#load(java.lang.Class[marytts.config.MaryCo
         </plugin>
       </plugins>
     </pluginManagement>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>add-source</goal>
+            </goals>
+            <phase>generate-sources</phase>
+            <configuration>
+              <sources>
+                <source>src/3rdparty/java</source>
+              </sources>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
   </build>
 
 </project>

--- a/bundles/org.openhab.voice.marytts/pom.xml
+++ b/bundles/org.openhab.voice.marytts/pom.xml
@@ -15,7 +15,7 @@
   <name>openHAB Add-ons :: Bundles :: Voice :: Mary Text-to-Speech</name>
 
   <properties>
-    <bnd.importpackage>com.twmacinta.util;resolution:=optional;gnu.trove;resolution:=optional;Jampack;resolution:=optional;com.sun.*;resolution:=optional;jdk.javadoc.doclet;resolution:=optional;org.apache.http*;resolution:=optional;org.hsqldb;resolution:=optional;org.jdesktop.layout*;resolution:=optional;org.apache.xerces.impl*;resolution:=optional;sun.nio.ch.*;resolution:=optional</bnd.importpackage>
+    <bnd.importpackage>com.twmacinta.util;resolution:=optional,gnu.trove;resolution:=optional,Jampack;resolution:=optional,com.sun.*;resolution:=optional,jdk.javadoc.doclet;resolution:=optional,org.apache.http*;resolution:=optional,org.hsqldb;resolution:=optional,org.jdesktop.layout*;resolution:=optional,org.apache.xerces.impl*;resolution:=optional,sun.nio.ch.*;resolution:=optional</bnd.importpackage>
     <dfkimarytts.version>5.2.1</dfkimarytts.version>
   </properties>
 

--- a/bundles/org.openhab.voice.marytts/pom.xml
+++ b/bundles/org.openhab.voice.marytts/pom.xml
@@ -15,14 +15,15 @@
   <name>openHAB Add-ons :: Bundles :: Voice :: Mary Text-to-Speech</name>
 
   <properties>
-    <bnd.importpackage>com.twmacinta.util;resolution:=optional,gnu.trove;resolution:=optional,Jampack;resolution:=optional,net.didion.jwnl*;resolution:=optional,org.apache.http*;resolution:=optional,org.apache.xerces.impl*;resolution:=optional,org.hsqldb;resolution:=optional,org.jdesktop.layout*;resolution:=optional;sun.nio.ch.*</bnd.importpackage>
+    <bnd.importpackage>com.twmacinta.util;resolution:=optional;gnu.trove;resolution:=optional;Jampack;resolution:=optional;com.sun.*;resolution:=optional;jdk.javadoc.doclet;resolution:=optional;org.apache.http*;resolution:=optional;org.hsqldb;resolution:=optional;org.jdesktop.layout*;resolution:=optional;org.apache.xerces.impl*;resolution:=optional;sun.nio.ch.*;resolution:=optional</bnd.importpackage>
+    <dfkimarytts.version>5.2.1</dfkimarytts.version>
   </properties>
 
   <dependencies>
     <dependency>
       <groupId>com.ibm.icu</groupId>
       <artifactId>icu4j</artifactId>
-      <version>54.1.1</version>
+      <version>78.3</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -46,7 +47,7 @@
     <dependency>
       <groupId>de.dfki.lt.jtok</groupId>
       <artifactId>jtok-core</artifactId>
-      <version>1.9.3</version>
+      <version>1.9.4</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>
@@ -62,13 +63,13 @@
     <dependency>
       <groupId>de.dfki.mary</groupId>
       <artifactId>emotionml-checker-java</artifactId>
-      <version>1.1</version>
+      <version>1.2.3</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>de.dfki.mary</groupId>
       <artifactId>marytts-common</artifactId>
-      <version>5.2.1</version>
+      <version>${dfkimarytts.version}</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>
@@ -84,25 +85,25 @@
     <dependency>
       <groupId>de.dfki.mary</groupId>
       <artifactId>marytts-lang-de</artifactId>
-      <version>5.2.1</version>
+      <version>${dfkimarytts.version}</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>de.dfki.mary</groupId>
       <artifactId>marytts-lang-en</artifactId>
-      <version>5.2.1</version>
+      <version>${dfkimarytts.version}</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>de.dfki.mary</groupId>
       <artifactId>marytts-runtime</artifactId>
-      <version>5.2.1</version>
+      <version>${dfkimarytts.version}</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>de.dfki.mary</groupId>
       <artifactId>marytts-signalproc</artifactId>
-      <version>5.2.1</version>
+      <version>${dfkimarytts.version}</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -122,7 +123,7 @@
     <dependency>
       <groupId>de.dfki.mary</groupId>
       <artifactId>voice-cmu-slt-hsmm</artifactId>
-      <version>5.2.1</version>
+      <version>${dfkimarytts.version}</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -130,6 +131,18 @@
       <artifactId>jama</artifactId>
       <version>1.0.3</version>
       <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-1.2-api</artifactId>
+      <version>2.25.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <version>2.25.2</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.opennlp</groupId>
@@ -140,7 +153,7 @@
     <dependency>
       <groupId>org.apache.opennlp</groupId>
       <artifactId>opennlp-tools</artifactId>
-      <version>1.5.3</version>
+      <version>2.5.11</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/bundles/org.openhab.voice.marytts/src/3rdparty/java/marytts/modules/OpenNLPPosTagger.java
+++ b/bundles/org.openhab.voice.marytts/src/3rdparty/java/marytts/modules/OpenNLPPosTagger.java
@@ -1,14 +1,21 @@
-/*
- * Copyright (c) 2010-2026 Contributors to the openHAB project
+/**
+ * Copyright 2007 DFKI GmbH.
+ * All Rights Reserved.  Use is subject to license terms.
  *
- * See the NOTICE file(s) distributed with this work for additional
- * information.
+ * This file is part of MARY TTS.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0
+ * MARY TTS is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
  *
- * SPDX-License-Identifier: EPL-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
  */
 package marytts.modules;
 

--- a/bundles/org.openhab.voice.marytts/src/main/java/marytts/modules/OpenNLPPosTagger.java
+++ b/bundles/org.openhab.voice.marytts/src/main/java/marytts/modules/OpenNLPPosTagger.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package marytts.modules;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.StringTokenizer;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.traversal.NodeIterator;
+import org.w3c.dom.traversal.TreeWalker;
+
+import marytts.datatypes.MaryData;
+import marytts.datatypes.MaryDataType;
+import marytts.server.MaryProperties;
+import marytts.util.MaryUtils;
+import marytts.util.dom.MaryDomUtils;
+import opennlp.tools.postag.POSModel;
+import opennlp.tools.postag.POSTagFormat;
+import opennlp.tools.postag.POSTaggerME;
+
+/**
+ * OpenNLP POS tagger compatible with the model and tag set expected by MaryTTS 5.2.1.
+ *
+ * <p>
+ * MaryTTS 5.2.1 uses OpenNLP's removed {@code tag(List)} API and the legacy one-argument constructor. This replacement
+ * uses the current array API and explicitly retains Penn Treebank output, on which MaryTTS's English prosody rules
+ * depend.
+ *
+ * @author Leo Siepel - Initial contribution
+ */
+@NonNullByDefault
+public class OpenNLPPosTagger extends InternalModule {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(OpenNLPPosTagger.class);
+
+    private final String propertyPrefix;
+
+    private @Nullable POSTaggerME tagger;
+    private @Nullable Map<String, String> posMapper;
+
+    public OpenNLPPosTagger(String locale, String propertyPrefix) throws Exception {
+        super("OpenNLPPosTagger", MaryDataType.WORDS, MaryDataType.PARTSOFSPEECH, MaryUtils.string2locale(locale));
+        this.propertyPrefix = propertyPrefix.endsWith(".") ? propertyPrefix : propertyPrefix + ".";
+    }
+
+    @Override
+    public void startup() throws Exception {
+        super.startup();
+
+        try (InputStream modelStream = MaryProperties.needStream(propertyPrefix + "model")) {
+            tagger = new POSTaggerME(new POSModel(modelStream), POSTagFormat.PENN);
+        }
+
+        InputStream posMapStream = MaryProperties.getStream(propertyPrefix + "posMap");
+        if (posMapStream != null) {
+            posMapper = readPosMapper(posMapStream);
+        }
+    }
+
+    private Map<String, String> readPosMapper(InputStream posMapStream) throws Exception {
+        Map<String, String> mapper = new HashMap<>();
+        try (posMapStream; BufferedReader reader = new BufferedReader(new InputStreamReader(posMapStream, UTF_8))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                if (!line.startsWith("#") && !line.isBlank()) {
+                    StringTokenizer tokenizer = new StringTokenizer(line);
+                    mapper.put(tokenizer.nextToken(), tokenizer.nextToken());
+                }
+            }
+        }
+        return mapper;
+    }
+
+    @Override
+    public MaryData process(@NonNullByDefault({}) MaryData input) throws Exception {
+        Document document = input.getDocument();
+        NodeIterator sentenceIterator = MaryDomUtils.createNodeIterator(document, document, "s");
+
+        Element sentence;
+        while ((sentence = (Element) sentenceIterator.nextNode()) != null) {
+            tagSentence(sentence);
+        }
+
+        MaryData output = new MaryData(getOutputType(), input.getLocale());
+        output.setDocument(document);
+        return output;
+    }
+
+    private void tagSentence(Element sentence) {
+        TreeWalker tokenWalker = MaryDomUtils.createTreeWalker(sentence, "t");
+        List<Element> tokens = new ArrayList<>();
+        List<String> words = new ArrayList<>();
+
+        Element token;
+        while ((token = (Element) tokenWalker.nextNode()) != null) {
+            tokens.add(token);
+            words.add(MaryDomUtils.tokenText(token));
+        }
+
+        // OpenNLP cannot determine useful context from a one-token sentence.
+        if (words.size() == 1) {
+            words.add(".");
+        }
+
+        String[] tags;
+        synchronized (this) {
+            POSTaggerME tagger = this.tagger;
+            if (tagger != null) {
+                tags = tagger.tag(words.toArray(String[]::new));
+            } else {
+                tags = new String[words.size()];
+            }
+        }
+
+        for (int i = 0; i < tokens.size(); i++) {
+            Element currentToken = tokens.get(i);
+            if (!currentToken.hasAttribute("pos")) {
+                currentToken.setAttribute("pos", mapPosTag(tags[i]));
+            }
+        }
+    }
+
+    private String mapPosTag(String posTag) {
+        Map<String, String> posMapper = this.posMapper;
+        if (posMapper == null) {
+            return posTag;
+        }
+
+        String mappedTag = posMapper.get(posTag);
+        if (mappedTag == null) {
+            LOGGER.warn("POS map file incomplete: do not know how to map '{}'", posTag);
+            return posTag;
+        }
+        return mappedTag;
+    }
+}

--- a/bundles/org.openhab.voice.marytts/src/main/java/marytts/modules/OpenNLPPosTagger.java
+++ b/bundles/org.openhab.voice.marytts/src/main/java/marytts/modules/OpenNLPPosTagger.java
@@ -49,7 +49,8 @@ import opennlp.tools.postag.POSTaggerME;
  * uses the current array API and explicitly retains Penn Treebank output, on which MaryTTS's English prosody rules
  * depend.
  *
- * @author Leo Siepel - Initial contribution
+ * @author Marc Schröder - Initial contribution
+ * @author Leo Siepel - Refactored for use with openHAB's MaryTTS runtime
  */
 @NonNullByDefault
 public class OpenNLPPosTagger extends InternalModule {

--- a/bundles/org.openhab.voice.marytts/src/main/java/marytts/modules/OpenNLPPosTagger.java
+++ b/bundles/org.openhab.voice.marytts/src/main/java/marytts/modules/OpenNLPPosTagger.java
@@ -87,7 +87,11 @@ public class OpenNLPPosTagger extends InternalModule {
             while ((line = reader.readLine()) != null) {
                 if (!line.startsWith("#") && !line.isBlank()) {
                     StringTokenizer tokenizer = new StringTokenizer(line);
-                    mapper.put(tokenizer.nextToken(), tokenizer.nextToken());
+                    if (tokenizer.countTokens() >= 2) {
+                        mapper.put(tokenizer.nextToken(), tokenizer.nextToken());
+                    } else {
+                        LOGGER.warn("Invalid POS map line (expected 2 tokens): '{}'", line);
+                    }
                 }
             }
         }

--- a/bundles/org.openhab.voice.marytts/src/test/java/org/openhab/voice/marytts/internal/MaryTTSRuntimeTest.java
+++ b/bundles/org.openhab.voice.marytts/src/test/java/org/openhab/voice/marytts/internal/MaryTTSRuntimeTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.voice.marytts.internal;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Locale;
+import java.util.stream.IntStream;
+
+import javax.sound.sampled.AudioInputStream;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+
+import marytts.LocalMaryInterface;
+import marytts.MaryInterface;
+import marytts.util.dom.MaryDomUtils;
+
+/**
+ * Runtime compatibility tests for MaryTTS and its upgraded dependencies.
+ *
+ * @author Leo Siepel - Initial contribution
+ */
+public class MaryTTSRuntimeTest {
+
+    private static MaryInterface marytts;
+
+    @BeforeAll
+    public static void setUp() throws Exception {
+        System.setProperty("mary.base", "target");
+        marytts = new LocalMaryInterface();
+        marytts.setLocale(Locale.US);
+        marytts.setInputType("TEXT");
+    }
+
+    @Test
+    public void posTaggerRetainsPennTreebankTags() throws Exception {
+        marytts.setOutputType("PARTSOFSPEECH");
+
+        Document document = marytts.generateXML("I want to go to the store.");
+        NodeList tokens = document.getElementsByTagName("t");
+        String[] words = IntStream.range(0, tokens.getLength())
+                .mapToObj(i -> MaryDomUtils.tokenText((Element) tokens.item(i))).toArray(String[]::new);
+        String[] tags = IntStream.range(0, tokens.getLength())
+                .mapToObj(i -> ((Element) tokens.item(i)).getAttribute("pos")).toArray(String[]::new);
+
+        assertArrayEquals(new String[] { "I", "want", "to", "go", "to", "the", "store", "." }, words);
+        assertArrayEquals(new String[] { "PRP", "VBP", "TO", "VB", "TO", "DT", "NN", "." }, tags);
+    }
+
+    @Test
+    public void englishSynthesisProducesAudio() throws Exception {
+        marytts.setOutputType("AUDIO");
+
+        try (AudioInputStream audio = marytts.generateAudio("This is a synthesis test.")) {
+            int frameSize = Math.max(1, audio.getFormat().getFrameSize());
+            byte[] audioData = new byte[frameSize * 256];
+            assertTrue(audio.read(audioData) > 0);
+        }
+    }
+}


### PR DESCRIPTION
- upgrades dependency's (mainly fixing CVE's in opennlp-tools)
- addresses https://github.com/openhab/openhab-addons/pull/21184#discussion_r3788894849

Supersedes: #21184

A testable jar openHAB 5.2.0 or later: https://1drv.ms/u/c/70ea7ac46bc61c73/IQB2hr85jNn6SIYlC_lGI9UZAVQDSKjNS3O0QOOAjEg_oZw?e=8Mqtrg