### PR TITLE
[amazonechocontrol] Poll notifications only while a channel is linked

### DIFF
--- a/bundles/org.openhab.binding.amazonechocontrol/README.md
+++ b/bundles/org.openhab.binding.amazonechocontrol/README.md
@@ -190,6 +190,7 @@ You will find the serial number in the Alexa app or on the webpage YOUR_OPENHAB/
 | ascendingAlarm        | Switch      | R/W         | echo, echoshow, echospot      | Ascending alarm up to the configured volume                                                                                                                                                                                             |
 | doNotDisturb          | Switch      | R/W         | echo, echoshow, echospot      | Do Not Disturb mode enabled                                                                                                                                                                                                             |
 
+The `nextReminder`, `nextAlarm`, `nextMusicAlarm` and `nextTimer` channels are only polled from Amazon while at least one of them is linked to an item on any Echo thing of the account; linking a channel resumes the polling within a few seconds.
 The `nextReminder`, `nextAlarm`, `nextMusicAlarm` and `nextTimer` channels keep their last known value if a request to Amazon fails.
 After three consecutive failed requests they are set to `UNDEF`, because the binding does not know the state anymore.
 

--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/handler/AccountHandler.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/handler/AccountHandler.java
@@ -100,8 +100,8 @@ import com.google.gson.JsonSyntaxException;
  * Handles the connection to the amazon server.
  *
  * @author Michael Geramb - Initial Contribution
- * @author Martin Littkovsky - Backoff for failed notification polls, skip polls while no notification channel is
- *         linked
+ * @author Martin Littkovsky - Backoff for failed notification polls
+ * @author Martin Littkovsky - Skip polls while no notification channel is linked
  */
 @NonNullByDefault
 public class AccountHandler extends BaseBridgeHandler implements PushConnection.Listener {
@@ -440,11 +440,7 @@ public class AccountHandler extends BaseBridgeHandler implements PushConnection.
             return;
         }
         if (!hasLinkedNotificationTargets()) {
-            if (!notificationPollSuspended) {
-                notificationPollSuspended = true;
-                logger.debug("Skipping notification polls for {}: no echo thing has a notification channel linked",
-                        getThing().getUID().getAsString());
-            }
+            suspendNotificationPolls();
             return;
         }
         if (notificationPollSuspended) {
@@ -538,6 +534,21 @@ public class AccountHandler extends BaseBridgeHandler implements PushConnection.
     void notificationChannelLinked() {
         if (notificationPollSuspended) {
             nextRefreshNotifications = 0;
+        }
+    }
+
+    /** The link is already gone when the core calls this, so the check sees the state that remains. */
+    void notificationChannelUnlinked() {
+        if (!hasLinkedNotificationTargets()) {
+            suspendNotificationPolls();
+        }
+    }
+
+    private void suspendNotificationPolls() {
+        if (!notificationPollSuspended) {
+            notificationPollSuspended = true;
+            logger.debug("Skipping notification polls for {}: no echo thing has a notification channel linked",
+                    getThing().getUID().getAsString());
         }
     }
 

--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/handler/AccountHandler.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/handler/AccountHandler.java
@@ -100,7 +100,8 @@ import com.google.gson.JsonSyntaxException;
  * Handles the connection to the amazon server.
  *
  * @author Michael Geramb - Initial Contribution
- * @author Martin Littkovsky - Backoff for failed notification polls
+ * @author Martin Littkovsky - Backoff for failed notification polls, skip polls while no notification channel is
+ *         linked
  */
 @NonNullByDefault
 public class AccountHandler extends BaseBridgeHandler implements PushConnection.Listener {
@@ -132,11 +133,14 @@ public class AccountHandler extends BaseBridgeHandler implements PushConnection.
     private int lastMessageId = 1000;
     private long nextDataRefresh = 0;
     private long nextLoginCheck = 0;
-    private long nextRefreshNotifications = 0;
+    // volatile: armed to 0 by notificationChannelLinked() from the thread that created the link
+    private volatile long nextRefreshNotifications = 0;
     private final NotificationPollBackoff notificationPollBackoff = new NotificationPollBackoff();
     // Held while a poll result is accepted as one step: validate the attempt, publish it, record the
     // next due time. Split apart, setConnection() lands in between and the replaced session wins.
     private final Object notificationCommit = new Object();
+    // set while polls are skipped for lack of linked channels, so the transition is logged once per suspension
+    private volatile boolean notificationPollSuspended = false;
 
     private final LinkedBlockingQueue<String> requestedDeviceUpdates = new LinkedBlockingQueue<>();
     private @Nullable SmartHomeDeviceStateGroupUpdateCalculator smartHomeDeviceStateGroupUpdateCalculator;
@@ -412,14 +416,7 @@ public class AccountHandler extends BaseBridgeHandler implements PushConnection.
                         nextDataRefresh = now + CHECK_DATA_INTERVAL * 1000;
                         refreshData();
                     }
-                    boolean notificationPollLooksDue;
-                    synchronized (notificationCommit) {
-                        notificationPollLooksDue = notificationPollBackoff.isDue(now)
-                                || (now > nextRefreshNotifications && !notificationPollBackoff.shouldSkip(now));
-                    }
-                    if (notificationPollLooksDue) {
-                        refreshNotifications();
-                    }
+                    refreshNotificationsIfDue(now);
                 }
             } catch (RuntimeException e) { // this handler can be removed later, if we know that nothing else can fail.
                 logger.warn("checkData fails with unexpected error", e);
@@ -427,9 +424,36 @@ public class AccountHandler extends BaseBridgeHandler implements PushConnection.
         }
     }
 
-    private void refreshNotifications() {
+    void refreshNotificationsIfDue(long now) {
+        // the shouldSkip check keeps a pending backoff from logging a skip on every tick
+        boolean looksDue;
+        synchronized (notificationCommit) {
+            looksDue = notificationPollBackoff.isDue(now)
+                    || (now > nextRefreshNotifications && !notificationPollBackoff.shouldSkip(now));
+        }
+        if (looksDue) {
+            refreshNotifications();
+        }
+    }
+
+    void refreshNotifications() {
         if (!connection.isLoggedIn()) {
             return;
+        }
+        if (!hasLinkedNotificationTargets()) {
+            // re-evaluated on every attempt, so echo handlers registering after the account handler
+            // started - the normal boot order - open the gate on the next attempt
+            if (!notificationPollSuspended) {
+                notificationPollSuspended = true;
+                logger.debug("Skipping notification polls for {}: no echo thing has a notification channel linked",
+                        getThing().getUID().getAsString());
+            }
+            return;
+        }
+        if (notificationPollSuspended) {
+            notificationPollSuspended = false;
+            logger.debug("Resuming notification polls for {}: a notification channel is linked",
+                    getThing().getUID().getAsString());
         }
         NotificationPollBackoff.Start start = notificationPollBackoff.tryStart(System.currentTimeMillis());
         if (start.outcome() != NotificationPollBackoff.Start.Outcome.STARTED) {
@@ -506,6 +530,25 @@ public class AccountHandler extends BaseBridgeHandler implements PushConnection.
                     nextRefreshNotifications = 0;
                 }
             }
+        }
+    }
+
+    /**
+     * @return {@code true} if at least one echo thing of this account has one of the channels fed by the
+     *         notification poll linked
+     */
+    private boolean hasLinkedNotificationTargets() {
+        return echoHandlers.values().stream().anyMatch(EchoHandler::hasLinkedNotificationChannel);
+    }
+
+    /**
+     * Called by an echo handler when one of its notification channels got linked. Only arms the deadline
+     * for the next scheduler tick instead of polling: the core delivers channelLinked() synchronously on
+     * the thread that created the link, so no I/O may happen here.
+     */
+    void notificationChannelLinked() {
+        if (notificationPollSuspended) {
+            nextRefreshNotifications = 0;
         }
     }
 

--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/handler/AccountHandler.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/handler/AccountHandler.java
@@ -133,13 +133,12 @@ public class AccountHandler extends BaseBridgeHandler implements PushConnection.
     private int lastMessageId = 1000;
     private long nextDataRefresh = 0;
     private long nextLoginCheck = 0;
-    // volatile: armed to 0 by notificationChannelLinked() from the thread that created the link
+    // volatile: armed from the thread that creates a link, read by the scheduler
     private volatile long nextRefreshNotifications = 0;
     private final NotificationPollBackoff notificationPollBackoff = new NotificationPollBackoff();
     // Held while a poll result is accepted as one step: validate the attempt, publish it, record the
     // next due time. Split apart, setConnection() lands in between and the replaced session wins.
     private final Object notificationCommit = new Object();
-    // set while polls are skipped for lack of linked channels, so the transition is logged once per suspension
     private volatile boolean notificationPollSuspended = false;
 
     private final LinkedBlockingQueue<String> requestedDeviceUpdates = new LinkedBlockingQueue<>();
@@ -441,8 +440,6 @@ public class AccountHandler extends BaseBridgeHandler implements PushConnection.
             return;
         }
         if (!hasLinkedNotificationTargets()) {
-            // re-evaluated on every attempt, so echo handlers registering after the account handler
-            // started - the normal boot order - open the gate on the next attempt
             if (!notificationPollSuspended) {
                 notificationPollSuspended = true;
                 logger.debug("Skipping notification polls for {}: no echo thing has a notification channel linked",
@@ -533,19 +530,11 @@ public class AccountHandler extends BaseBridgeHandler implements PushConnection.
         }
     }
 
-    /**
-     * @return {@code true} if at least one echo thing of this account has one of the channels fed by the
-     *         notification poll linked
-     */
     private boolean hasLinkedNotificationTargets() {
         return echoHandlers.values().stream().anyMatch(EchoHandler::hasLinkedNotificationChannel);
     }
 
-    /**
-     * Called by an echo handler when one of its notification channels got linked. Only arms the deadline
-     * for the next scheduler tick instead of polling: the core delivers channelLinked() synchronously on
-     * the thread that created the link, so no I/O may happen here.
-     */
+    /** Arms the next tick rather than polling: the core calls this on the linking thread, so no I/O here. */
     void notificationChannelLinked() {
         if (notificationPollSuspended) {
             nextRefreshNotifications = 0;

--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/handler/EchoHandler.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/handler/EchoHandler.java
@@ -98,9 +98,14 @@ import com.google.gson.JsonSyntaxException;
  * The {@link EchoHandler} is responsible for the handling of the echo device
  *
  * @author Michael Geramb - Initial contribution
+ * @author Martin Littkovsky - Report linked notification channels, so the account only polls for a consumer
  */
 @NonNullByDefault
 public class EchoHandler extends BaseThingHandler {
+    /** The channels fed exclusively by the notification poll of the account handler. */
+    private static final Set<String> NOTIFICATION_CHANNELS = Set.of(CHANNEL_NEXT_ALARM, CHANNEL_NEXT_MUSIC_ALARM,
+            CHANNEL_NEXT_REMINDER, CHANNEL_NEXT_TIMER);
+
     private final Logger logger = LoggerFactory.getLogger(EchoHandler.class);
     private final Gson gson;
     private final AmazonEchoControlStateDescriptionProvider dynamicStateDescriptionProvider;
@@ -203,6 +208,28 @@ public class EchoHandler extends BaseThingHandler {
 
     public String getSerialNumber() {
         return Objects.requireNonNullElse((String) getConfig().get(DEVICE_PROPERTY_SERIAL_NUMBER), "");
+    }
+
+    /**
+     * @return {@code true} if at least one of the channels fed by the notification poll is linked
+     */
+    boolean hasLinkedNotificationChannel() {
+        // isLinked() logs a warning while the callback is already gone during disposal, so a handler
+        // without a callback counts as unlinked instead
+        if (getCallback() == null) {
+            return false;
+        }
+        return NOTIFICATION_CHANNELS.stream().anyMatch(this::isLinked);
+    }
+
+    @Override
+    public void channelLinked(ChannelUID channelUID) {
+        super.channelLinked(channelUID);
+        if (NOTIFICATION_CHANNELS.contains(channelUID.getId())) {
+            // the REFRESH sent by the core does not always force a data refresh, so a suspended poll
+            // is woken explicitly - a flag write only, no I/O on this thread
+            getAccountHandler().ifPresent(AccountHandler::notificationChannelLinked);
+        }
     }
 
     @Override

--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/handler/EchoHandler.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/handler/EchoHandler.java
@@ -102,7 +102,6 @@ import com.google.gson.JsonSyntaxException;
  */
 @NonNullByDefault
 public class EchoHandler extends BaseThingHandler {
-    /** The channels fed exclusively by the notification poll of the account handler. */
     private static final Set<String> NOTIFICATION_CHANNELS = Set.of(CHANNEL_NEXT_ALARM, CHANNEL_NEXT_MUSIC_ALARM,
             CHANNEL_NEXT_REMINDER, CHANNEL_NEXT_TIMER);
 
@@ -210,12 +209,7 @@ public class EchoHandler extends BaseThingHandler {
         return Objects.requireNonNullElse((String) getConfig().get(DEVICE_PROPERTY_SERIAL_NUMBER), "");
     }
 
-    /**
-     * @return {@code true} if at least one of the channels fed by the notification poll is linked
-     */
     boolean hasLinkedNotificationChannel() {
-        // isLinked() logs a warning while the callback is already gone during disposal, so a handler
-        // without a callback counts as unlinked instead
         if (getCallback() == null) {
             return false;
         }
@@ -226,8 +220,6 @@ public class EchoHandler extends BaseThingHandler {
     public void channelLinked(ChannelUID channelUID) {
         super.channelLinked(channelUID);
         if (NOTIFICATION_CHANNELS.contains(channelUID.getId())) {
-            // the REFRESH sent by the core does not always force a data refresh, so a suspended poll
-            // is woken explicitly - a flag write only, no I/O on this thread
             getAccountHandler().ifPresent(AccountHandler::notificationChannelLinked);
         }
     }

--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/handler/EchoHandler.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/handler/EchoHandler.java
@@ -225,6 +225,14 @@ public class EchoHandler extends BaseThingHandler {
     }
 
     @Override
+    public void channelUnlinked(ChannelUID channelUID) {
+        super.channelUnlinked(channelUID);
+        if (NOTIFICATION_CHANNELS.contains(channelUID.getId())) {
+            getAccountHandler().ifPresent(AccountHandler::notificationChannelUnlinked);
+        }
+    }
+
+    @Override
     public void handleCommand(ChannelUID channelUID, Command command) {
         if (command instanceof RefreshType) {
             State state = stateCache.get(channelUID.getId());

--- a/bundles/org.openhab.binding.amazonechocontrol/src/test/java/org/openhab/binding/amazonechocontrol/internal/handler/AccountHandlerNotificationGateTest.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/test/java/org/openhab/binding/amazonechocontrol/internal/handler/AccountHandlerNotificationGateTest.java
@@ -1,0 +1,320 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.amazonechocontrol.internal.handler;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.openhab.binding.amazonechocontrol.internal.AmazonEchoControlBindingConstants.CHANNEL_NEXT_ALARM;
+import static org.openhab.binding.amazonechocontrol.internal.AmazonEchoControlBindingConstants.CHANNEL_NEXT_MUSIC_ALARM;
+import static org.openhab.binding.amazonechocontrol.internal.AmazonEchoControlBindingConstants.CHANNEL_NEXT_REMINDER;
+import static org.openhab.binding.amazonechocontrol.internal.AmazonEchoControlBindingConstants.CHANNEL_NEXT_TIMER;
+import static org.openhab.binding.amazonechocontrol.internal.AmazonEchoControlBindingConstants.CHANNEL_VOLUME;
+import static org.openhab.binding.amazonechocontrol.internal.AmazonEchoControlBindingConstants.DEVICE_PROPERTY_SERIAL_NUMBER;
+import static org.openhab.binding.amazonechocontrol.internal.AmazonEchoControlBindingConstants.THING_TYPE_ACCOUNT;
+import static org.openhab.binding.amazonechocontrol.internal.AmazonEchoControlBindingConstants.THING_TYPE_ECHO;
+
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.http2.client.HTTP2Client;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openhab.binding.amazonechocontrol.internal.AmazonEchoControlCommandDescriptionProvider;
+import org.openhab.binding.amazonechocontrol.internal.AmazonEchoControlStateDescriptionProvider;
+import org.openhab.binding.amazonechocontrol.internal.ConnectionException;
+import org.openhab.binding.amazonechocontrol.internal.connection.Connection;
+import org.openhab.binding.amazonechocontrol.internal.connection.LoginData;
+import org.openhab.binding.amazonechocontrol.internal.dto.push.PushCommandTO;
+import org.openhab.core.config.core.Configuration;
+import org.openhab.core.storage.Storage;
+import org.openhab.core.thing.Bridge;
+import org.openhab.core.thing.ChannelUID;
+import org.openhab.core.thing.Thing;
+import org.openhab.core.thing.ThingUID;
+import org.openhab.core.thing.binding.ThingHandlerCallback;
+
+import com.google.gson.Gson;
+
+/**
+ * The {@link AccountHandlerNotificationGateTest} contains tests for the link gate in front of the
+ * notification poll of the {@link AccountHandler}.
+ *
+ * @author Martin Littkovsky - Initial contribution
+ */
+@NonNullByDefault
+public class AccountHandlerNotificationGateTest {
+    private static final ThingUID ACCOUNT_UID = new ThingUID(THING_TYPE_ACCOUNT, "account1");
+    private static final ThingUID ECHO_UID = new ThingUID(THING_TYPE_ECHO, "account1", "echo1");
+    private static final String ECHO_SERIAL = "SERIAL_ECHO_1";
+
+    private @NonNullByDefault({}) AccountHandler accountHandler;
+    private @NonNullByDefault({}) EchoHandler echoHandler;
+    private @NonNullByDefault({}) Thing echoThing;
+    private @NonNullByDefault({}) Connection connection;
+    private @NonNullByDefault({}) ThingHandlerCallback echoCallback;
+
+    @BeforeEach
+    public void setUp() throws ConnectionException {
+        Bridge bridge = mock(Bridge.class);
+        when(bridge.getUID()).thenReturn(ACCOUNT_UID);
+
+        @SuppressWarnings("unchecked")
+        Storage<String> storage = (Storage<String>) mock(Storage.class);
+        accountHandler = new AccountHandler(bridge, storage, new Gson(), mock(HttpClient.class),
+                mock(HTTP2Client.class), mock(AmazonEchoControlCommandDescriptionProvider.class));
+        accountHandler.setCallback(mock(ThingHandlerCallback.class));
+        when(bridge.getHandler()).thenReturn(accountHandler);
+
+        connection = mock(Connection.class);
+        when(connection.isLoggedIn()).thenReturn(true);
+        LoginData loginData = mock(LoginData.class);
+        when(loginData.serializeLoginData()).thenReturn("");
+        when(connection.getLoginData()).thenReturn(loginData);
+        when(connection.getNotifications()).thenReturn(List.of());
+        accountHandler.setConnection(connection);
+
+        echoThing = mock(Thing.class);
+        when(echoThing.getUID()).thenReturn(ECHO_UID);
+        when(echoThing.getBridgeUID()).thenReturn(ACCOUNT_UID);
+        when(echoThing.getConfiguration())
+                .thenReturn(new Configuration(Map.of(DEVICE_PROPERTY_SERIAL_NUMBER, ECHO_SERIAL)));
+
+        echoCallback = mock(ThingHandlerCallback.class);
+        when(echoCallback.getBridge(ACCOUNT_UID)).thenReturn(bridge);
+        echoHandler = spy(
+                new EchoHandler(echoThing, new Gson(), mock(AmazonEchoControlStateDescriptionProvider.class)));
+        echoHandler.setCallback(echoCallback);
+        echoHandler.initialize();
+    }
+
+    private void registerEchoHandler() {
+        accountHandler.childHandlerInitialized(echoHandler, echoThing);
+    }
+
+    private void linkChannel(String channelId) {
+        when(echoCallback.isChannelLinked(new ChannelUID(ECHO_UID, channelId))).thenReturn(true);
+    }
+
+    private void pushNotificationChange() {
+        PushCommandTO pushCommand = new PushCommandTO();
+        pushCommand.command = "PUSH_NOTIFICATION_CHANGE";
+        pushCommand.payload = "";
+        accountHandler.onPushCommandReceived(pushCommand);
+    }
+
+    @Test
+    public void testNoRequestWhileNoNotificationChannelIsLinked() throws ConnectionException {
+        registerEchoHandler();
+
+        accountHandler.refreshNotifications();
+        accountHandler.refreshNotifications();
+
+        verify(connection, never()).getNotifications();
+    }
+
+    @Test
+    public void testNoRequestWhileOnlyOtherChannelsAreLinked() throws ConnectionException {
+        registerEchoHandler();
+        linkChannel(CHANNEL_VOLUME);
+
+        accountHandler.refreshNotifications();
+
+        verify(connection, never()).getNotifications();
+    }
+
+    @Test
+    public void testPollsWhileANotificationChannelIsLinked() throws ConnectionException {
+        registerEchoHandler();
+        linkChannel(CHANNEL_NEXT_TIMER);
+
+        accountHandler.refreshNotifications();
+
+        verify(connection, times(1)).getNotifications();
+        verify(echoHandler, times(1)).updateNotifications(any());
+    }
+
+    @Test
+    public void testEachNotificationChannelOpensTheGate() throws ConnectionException {
+        registerEchoHandler();
+        int expectedPolls = 0;
+        for (String channelId : List.of(CHANNEL_NEXT_ALARM, CHANNEL_NEXT_MUSIC_ALARM, CHANNEL_NEXT_REMINDER,
+                CHANNEL_NEXT_TIMER)) {
+            when(echoCallback.isChannelLinked(any(ChannelUID.class))).thenReturn(false);
+            linkChannel(channelId);
+
+            accountHandler.refreshNotifications();
+
+            verify(connection, times(++expectedPolls)).getNotifications();
+        }
+    }
+
+    @Test
+    public void testPushRefreshIsGatedWhileUnlinked() throws ConnectionException {
+        registerEchoHandler();
+
+        pushNotificationChange();
+
+        verify(connection, never()).getNotifications();
+    }
+
+    @Test
+    public void testPushRefreshPollsWhileLinked() throws ConnectionException {
+        registerEchoHandler();
+        linkChannel(CHANNEL_NEXT_ALARM);
+
+        pushNotificationChange();
+
+        verify(connection, times(1)).getNotifications();
+    }
+
+    @Test
+    public void testChannelLinkWhileSuspendedWakesTheNextTick() throws ConnectionException {
+        registerEchoHandler();
+        linkChannel(CHANNEL_NEXT_ALARM);
+        accountHandler.refreshNotifications();
+        verify(connection, times(1)).getNotifications();
+
+        when(echoCallback.isChannelLinked(any(ChannelUID.class))).thenReturn(false);
+        accountHandler.refreshNotifications();
+        accountHandler.refreshNotificationsIfDue(System.currentTimeMillis());
+        verify(connection, times(1)).getNotifications();
+
+        linkChannel(CHANNEL_NEXT_ALARM);
+        echoHandler.channelLinked(new ChannelUID(ECHO_UID, CHANNEL_NEXT_ALARM));
+        verify(connection, times(1)).getNotifications();
+        accountHandler.refreshNotificationsIfDue(System.currentTimeMillis());
+        verify(connection, times(2)).getNotifications();
+
+        accountHandler.refreshNotificationsIfDue(System.currentTimeMillis());
+        verify(connection, times(2)).getNotifications();
+    }
+
+    @Test
+    public void testChannelLinkBurstWakesExactlyOnePoll() throws ConnectionException {
+        registerEchoHandler();
+        accountHandler.refreshNotifications();
+        linkChannel(CHANNEL_NEXT_ALARM);
+        linkChannel(CHANNEL_NEXT_TIMER);
+
+        echoHandler.channelLinked(new ChannelUID(ECHO_UID, CHANNEL_NEXT_ALARM));
+        echoHandler.channelLinked(new ChannelUID(ECHO_UID, CHANNEL_NEXT_TIMER));
+        verify(connection, never()).getNotifications();
+
+        accountHandler.refreshNotificationsIfDue(System.currentTimeMillis());
+
+        verify(connection, times(1)).getNotifications();
+    }
+
+    @Test
+    public void testChannelLinkWhileActiveDoesNotWakeAPoll() throws ConnectionException {
+        registerEchoHandler();
+        linkChannel(CHANNEL_NEXT_ALARM);
+        accountHandler.refreshNotifications();
+        verify(connection, times(1)).getNotifications();
+
+        echoHandler.channelLinked(new ChannelUID(ECHO_UID, CHANNEL_NEXT_ALARM));
+        accountHandler.refreshNotificationsIfDue(System.currentTimeMillis());
+
+        verify(connection, times(1)).getNotifications();
+    }
+
+    @Test
+    public void testLinkingANonNotificationChannelDoesNotPoll() throws ConnectionException {
+        registerEchoHandler();
+        accountHandler.refreshNotifications();
+        linkChannel(CHANNEL_VOLUME);
+
+        echoHandler.channelLinked(new ChannelUID(ECHO_UID, CHANNEL_VOLUME));
+        accountHandler.refreshNotificationsIfDue(System.currentTimeMillis());
+
+        verify(connection, never()).getNotifications();
+    }
+
+    @Test
+    public void testChannelLinkWakeRespectsTheBackoff() throws ConnectionException {
+        registerEchoHandler();
+        linkChannel(CHANNEL_NEXT_ALARM);
+        when(connection.getNotifications()).thenThrow(new ConnectionException("HTTP 429"));
+        accountHandler.refreshNotifications();
+        verify(connection, times(1)).getNotifications();
+
+        when(echoCallback.isChannelLinked(any(ChannelUID.class))).thenReturn(false);
+        accountHandler.refreshNotifications();
+        linkChannel(CHANNEL_NEXT_ALARM);
+        echoHandler.channelLinked(new ChannelUID(ECHO_UID, CHANNEL_NEXT_ALARM));
+        accountHandler.refreshNotificationsIfDue(System.currentTimeMillis());
+
+        verify(connection, times(1)).getNotifications();
+    }
+
+    @Test
+    public void testEchoHandlerRegisteredAfterAccountStartOpensTheGate() throws ConnectionException {
+        accountHandler.refreshNotifications();
+        verify(connection, never()).getNotifications();
+
+        linkChannel(CHANNEL_NEXT_REMINDER);
+        registerEchoHandler();
+        accountHandler.refreshNotifications();
+
+        verify(connection, times(1)).getNotifications();
+    }
+
+    @Test
+    public void testDisposedEchoHandlerNoLongerHoldsTheGateOpen() throws ConnectionException {
+        registerEchoHandler();
+        linkChannel(CHANNEL_NEXT_ALARM);
+        accountHandler.refreshNotifications();
+        verify(connection, times(1)).getNotifications();
+
+        accountHandler.childHandlerDisposed(echoHandler, echoThing);
+        accountHandler.refreshNotifications();
+
+        verify(connection, times(1)).getNotifications();
+    }
+
+    @Test
+    public void testEchoHandlerWithoutCallbackCountsAsUnlinked() throws ConnectionException {
+        registerEchoHandler();
+        linkChannel(CHANNEL_NEXT_ALARM);
+        echoHandler.setCallback(null);
+
+        accountHandler.refreshNotifications();
+
+        verify(connection, never()).getNotifications();
+    }
+
+    @Test
+    public void testSkipsLeaveTheBackoffUntouched() throws ConnectionException {
+        registerEchoHandler();
+        linkChannel(CHANNEL_NEXT_ALARM);
+        when(connection.getNotifications()).thenThrow(new ConnectionException("HTTP 429"));
+        accountHandler.refreshNotifications();
+        verify(connection, times(1)).getNotifications();
+
+        when(echoCallback.isChannelLinked(any(ChannelUID.class))).thenReturn(false);
+        accountHandler.refreshNotifications();
+        accountHandler.refreshNotifications();
+
+        linkChannel(CHANNEL_NEXT_ALARM);
+        accountHandler.refreshNotifications();
+
+        verify(connection, times(1)).getNotifications();
+    }
+}

--- a/bundles/org.openhab.binding.amazonechocontrol/src/test/java/org/openhab/binding/amazonechocontrol/internal/handler/AccountHandlerNotificationGateTest.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/test/java/org/openhab/binding/amazonechocontrol/internal/handler/AccountHandlerNotificationGateTest.java
@@ -207,6 +207,22 @@ public class AccountHandlerNotificationGateTest {
     }
 
     @Test
+    public void testRelinkBeforeTheNextAttemptStillWakesTheTick() throws ConnectionException {
+        registerEchoHandler();
+        linkChannel(CHANNEL_NEXT_ALARM);
+        accountHandler.refreshNotifications();
+        verify(connection, times(1)).getNotifications();
+
+        when(echoCallback.isChannelLinked(any(ChannelUID.class))).thenReturn(false);
+        echoHandler.channelUnlinked(new ChannelUID(ECHO_UID, CHANNEL_NEXT_ALARM));
+        linkChannel(CHANNEL_NEXT_ALARM);
+        echoHandler.channelLinked(new ChannelUID(ECHO_UID, CHANNEL_NEXT_ALARM));
+
+        accountHandler.refreshNotificationsIfDue(System.currentTimeMillis());
+        verify(connection, times(2)).getNotifications();
+    }
+
+    @Test
     public void testChannelLinkBurstWakesExactlyOnePoll() throws ConnectionException {
         registerEchoHandler();
         accountHandler.refreshNotifications();

--- a/bundles/org.openhab.binding.amazonechocontrol/src/test/java/org/openhab/binding/amazonechocontrol/internal/handler/NotificationCommitStructureTest.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/test/java/org/openhab/binding/amazonechocontrol/internal/handler/NotificationCommitStructureTest.java
@@ -36,7 +36,7 @@ class NotificationCommitStructureTest {
 
     private static String refreshNotifications() throws IOException {
         String source = Files.readString(SOURCE);
-        int start = source.indexOf("private void refreshNotifications()");
+        int start = source.indexOf("void refreshNotifications()");
         assertTrue(start > 0, "refreshNotifications() not found - this test cannot guard what it cannot read");
         return source.substring(start, source.indexOf("\n    private void refreshData()", start));
     }


### PR DESCRIPTION
## Problem

The account bridge polls `/api/notifications` on a schedule and on every `PUSH_NOTIFICATION_CHANGE`, but the result feeds only the `nextAlarm`, `nextTimer`, `nextReminder` and `nextMusicAlarm` channels of the Echo things. An installation where none of them is linked pays requests to an endpoint Amazon throttles aggressively (see #20018, #21146) for data without a consumer.

## Changes

- `AccountHandler.refreshNotifications()` skips the request while no Echo thing has one of these channels linked; all trigger paths run through it. The link itself is the switch — no configuration flag is added.
- A skip leaves the retry backoff from #21439 untouched and logs one DEBUG line per suspension, plus one on resume.
- `EchoHandler` reports linked notification channels and overrides `channelLinked()`: linking while suspended arms the poll deadline for the next scheduler tick — no I/O on the linking thread, a burst of link events (saving an `.items` file) collapses into one attempt, and the woken poll still respects gate and backoff. The gate is re-evaluated on every attempt, so an Echo handler registering after the account handler (the normal boot order) opens it on the next attempt, and a disposed handler stops holding it open.
- README: one sentence documenting that these channels are only polled while linked.

## Testing

- 15 new JUnit/Mockito tests (`AccountHandlerNotificationGateTest`): gating per channel, push path, wake on link, link bursts, boot order, disposal window, backoff interaction. Full suite: 151 tests green.
- Verified on a production installation (28 unlinked notification channels): after the bundle swap the account logged a single "Skipping notification polls … no echo thing has a notification channel linked" line and issued zero requests to /api/notifications, where the previous build attempted its first poll within seconds of initialization.

**Transparency:** this patch was developed with AI assistance (Claude); every commit carries an `AI-assisted-by` trailer. All changes were built, tested and verified on a production system by the author.

