### PR TITLE
Fix Graal initialization

### DIFF
--- a/bundles/org.openhab.automation.jsscripting/pom.xml
+++ b/bundles/org.openhab.automation.jsscripting/pom.xml
@@ -19,6 +19,11 @@
   </properties>
 
   <dependencies>
+    <dependency>
+      <groupId>org.openhab.core.bundles</groupId>
+      <artifactId>org.openhab.core.graal</artifactId>
+      <version>${project.version}</version>
+    </dependency>
     <!-- Graal Polyglot Framework -->
     <dependency>
       <groupId>org.openhab.osgiify</groupId>

--- a/bundles/org.openhab.automation.jsscripting/src/main/feature/feature.xml
+++ b/bundles/org.openhab.automation.jsscripting/src/main/feature/feature.xml
@@ -5,22 +5,10 @@
 
 	<feature name="openhab-automation-jsscripting" description="JavaScript Scripting" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
-		<bundle dependency="true" start-level="78">mvn:org.openhab.osgiify/org.graalvm.js.js-language/${graalvm.version}</bundle>
-		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.js.js-scriptengine/${graalvm.version}</bundle>
-		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.polyglot.polyglot/${graalvm.version}</bundle>
-		<bundle dependency="true" start-level="78">mvn:org.openhab.osgiify/org.graalvm.regex.regex/${graalvm.version}</bundle>
-		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.sdk.collections/${graalvm.version}</bundle>
-		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.sdk.jniutils/${graalvm.version}</bundle>
-		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.sdk.nativeimage/${graalvm.version}</bundle>
-		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.sdk.word/${graalvm.version}</bundle>
-		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.shadowed.icu4j/${graalvm.version}</bundle>
-		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.shadowed.json/${graalvm.version}</bundle>
-		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.shadowed.xz/${graalvm.version}</bundle>
-		<bundle dependency="true" start-level="78">mvn:org.openhab.osgiify/org.graalvm.tools.chromeinspector-tool/${graalvm.version}</bundle>
-		<bundle dependency="true" start-level="78">mvn:org.openhab.osgiify/org.graalvm.tools.profiler-tool/${graalvm.version}</bundle>
-		<bundle dependency="true" start-level="79">mvn:org.openhab.osgiify/org.graalvm.truffle.truffle-api/${graalvm.version}</bundle>
-		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.truffle.truffle-compiler/${graalvm.version}</bundle>
-		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.truffle.truffle-runtime/${graalvm.version}</bundle>
+
+		<requirement>openhab.tp;filter:="(feature=graal-javascript)"</requirement>
+		<feature dependency="true">openhab.tp-graal-javascript</feature>
+
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.automation.jsscripting/${project.version}</bundle>
 	</feature>
 </features>

--- a/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/GraalJSScriptEngineFactory.java
+++ b/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/GraalJSScriptEngineFactory.java
@@ -30,12 +30,15 @@ import org.openhab.core.OpenHAB;
 import org.openhab.core.automation.module.script.ScriptDependencyTracker;
 import org.openhab.core.automation.module.script.ScriptEngineFactory;
 import org.openhab.core.config.core.ConfigurableService;
+import org.openhab.core.graal.GraalUtil;
 import org.osgi.framework.Constants;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Modified;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.event.Level;
@@ -70,53 +73,65 @@ public class GraalJSScriptEngineFactory implements ScriptEngineFactory {
     /**
      * Shared Polyglot {@link Engine} instance to be used by all instances of {@link OpenhabGraalJSScriptEngine}.
      */
-    private final Engine engine;
+    private final @Nullable Engine engine;
 
     private final JSScriptServiceUtil jsScriptServiceUtil;
-    private final JSDependencyTracker jsDependencyTracker;
+    private volatile @Nullable JSDependencyTracker jsDependencyTracker;
 
     @Activate
     public GraalJSScriptEngineFactory(final @Reference JSScriptServiceUtil jsScriptServiceUtil, //
-            final @Reference JSDependencyTracker jsDependencyTracker, //
-            final @Reference OSGiScriptExtensionProvider osgiScriptExtensionProvider, // declare dependency on
-                                                                                      // OSGiScriptExtensionProvider to
-                                                                                      // fix a timing issue where
-                                                                                      // openhab-js attempts to lookup
-                                                                                      // OSGi services before
-                                                                                      // OSGiScriptExtensionProvider is
-                                                                                      // active
-            Map<String, Object> config) {
+            /*
+             * declare dependency on OSGiScriptExtensionProvider to fix a timing issue where openhab-js attempts to
+             * lookup OSGi services before OSGiScriptExtensionProvider is active
+             */
+            final @Reference OSGiScriptExtensionProvider osgiScriptExtensionProvider, Map<String, Object> config) {
         logger.debug("Loading GraalJSScriptEngineFactory");
 
-        this.jsDependencyTracker = jsDependencyTracker;
         this.jsScriptServiceUtil = jsScriptServiceUtil;
         this.configuration = new GraalJSScriptEngineConfiguration(config);
 
-        if (configuration.isDebuggerEnabled()) {
-            Engine.Builder engineBuilder = createEngineBuilder();
-            engineBuilder //
-                    .option("inspect", "0.0.0.0:" + configuration.getDebuggerPort()) //
-                    .option("inspect.Suspend", "false") // Don't pause at startup waiting for debugger to attach
-                    .option("inspect.WaitAttached", "false") // Don't block code execution waiting for debugger to
-                                                             // attach
-                    .option("inspect.Secure", "false"); // Disable TLS
-            Engine engine;
-            try {
-                engine = engineBuilder.build();
-            } catch (RuntimeException e) {
-                logger.error(
-                        "Failed to initialize Graal JavaScript engine with debugger support. Continuing without debugger support.",
-                        e);
-                engine = createEngineBuilder().build();
-            }
-            logger.info("Debugger support is enabled for JavaScript Scripting.");
-            this.engine = engine;
-        } else {
-            this.engine = createEngineBuilder().build();
+        Engine engine;
+        try {
+            engine = createEngine();
+            logger.debug("GraalJS engine created; language resolution deferred to first use");
+        } catch (Exception e) {
+            logger.error("Failed to create GraalJS engine", e);
+            engine = null;
         }
+        this.engine = engine;
+    }
 
-        if (getLanguage() == null) {
-            logger.error(LANG_NOT_INITIALIZED_MSG);
+    private Engine createEngine() {
+        Thread thread = Thread.currentThread();
+
+        // The classloader is swapped during creation to make sure the engine can "see" what it needs
+        ClassLoader original = thread.getContextClassLoader();
+        try {
+            thread.setContextClassLoader(GraalJSScriptEngineFactory.class.getClassLoader());
+            if (configuration.isDebuggerEnabled()) {
+                Engine.Builder engineBuilder = createEngineBuilder();
+                engineBuilder //
+                        .option("inspect", "0.0.0.0:" + configuration.getDebuggerPort()) //
+                        .option("inspect.Suspend", "false") // Don't pause at startup waiting for debugger to attach
+                        .option("inspect.WaitAttached", "false") // Don't block code execution waiting for debugger to
+                                                                 // attach
+                        .option("inspect.Secure", "false"); // Disable TLS
+                Engine engine;
+                try {
+                    engine = engineBuilder.build();
+                } catch (RuntimeException e) {
+                    logger.error(
+                            "Failed to initialize Graal JavaScript engine with debugger support. Continuing without debugger support.",
+                            e);
+                    engine = createEngineBuilder().build();
+                }
+                logger.info("Debugger support is enabled for JavaScript Scripting.");
+                return engine;
+            } else {
+                return createEngineBuilder().build();
+            }
+        } finally {
+            thread.setContextClassLoader(original);
         }
     }
 
@@ -134,12 +149,27 @@ public class GraalJSScriptEngineFactory implements ScriptEngineFactory {
 
     @Deactivate
     public void dispose() {
-        this.engine.close();
+        Engine engine = this.engine;
+        if (engine != null) {
+            engine.close();
+        }
+        GraalUtil.clearCache();
     }
 
     @Modified
     protected void modified(Map<String, ?> config) {
         configuration.modified(config);
+    }
+
+    @Reference(cardinality = ReferenceCardinality.OPTIONAL, policy = ReferencePolicy.DYNAMIC)
+    protected void setJsDependencyTracker(JSDependencyTracker tracker) {
+        this.jsDependencyTracker = tracker;
+    }
+
+    protected void unsetJsDependencyTracker(JSDependencyTracker tracker) {
+        if (this.jsDependencyTracker == tracker) {
+            this.jsDependencyTracker = null;
+        }
     }
 
     @Override
@@ -157,7 +187,15 @@ public class GraalJSScriptEngineFactory implements ScriptEngineFactory {
         if (!SCRIPT_TYPES.contains(scriptType)) {
             return null;
         }
-        if (getLanguage() == null) {
+
+        if (engine == null) {
+            logger.error("Graal engine not initialized");
+            return null;
+        }
+
+        // Use the common lock to safely get the language
+        Language language = GraalUtil.getLanguage(engine, OpenhabGraalJSScriptEngine.LANGUAGE_ID);
+        if (language == null) {
             logger.error(LANG_NOT_INITIALIZED_MSG);
             return null;
         }
@@ -170,12 +208,8 @@ public class GraalJSScriptEngineFactory implements ScriptEngineFactory {
         return jsDependencyTracker;
     }
 
-    /**
-     * Gets the Graal language of {@link OpenhabGraalJSScriptEngine}.
-     *
-     * @return the Graal language of {@link OpenhabGraalJSScriptEngine} or {@code null} if not available
-     */
-    private @Nullable Language getLanguage() {
-        return engine.getLanguages().get(OpenhabGraalJSScriptEngine.LANGUAGE_ID);
+    @Override
+    public boolean isReady() {
+        return GraalUtil.getLanguage(engine, OpenhabGraalJSScriptEngine.LANGUAGE_ID) != null;
     }
 }

--- a/bundles/org.openhab.automation.pythonscripting/pom.xml
+++ b/bundles/org.openhab.automation.pythonscripting/pom.xml
@@ -19,6 +19,11 @@
   </properties>
 
   <dependencies>
+    <dependency>
+      <groupId>org.openhab.core.bundles</groupId>
+      <artifactId>org.openhab.core.graal</artifactId>
+      <version>${project.version}</version>
+    </dependency>
     <!-- Graal Polyglot Framework -->
     <dependency>
       <groupId>org.openhab.osgiify</groupId>

--- a/bundles/org.openhab.automation.pythonscripting/src/main/feature/feature.xml
+++ b/bundles/org.openhab.automation.pythonscripting/src/main/feature/feature.xml
@@ -4,25 +4,10 @@
 
 	<feature name="openhab-automation-pythonscripting" description="Python Scripting" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
-		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.sdk.collections/${graalvm.version}</bundle>
-		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.sdk.jniutils/${graalvm.version}</bundle>
-		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.sdk.nativeimage/${graalvm.version}</bundle>
-		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.sdk.word/${graalvm.version}</bundle>
-		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.shadowed.icu4j/${graalvm.version}</bundle>
-		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.llvm.llvm-api/${graalvm.version}</bundle>
-		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.shadowed.json/${graalvm.version}</bundle>
-		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.shadowed.xz/${graalvm.version}</bundle>
-		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.polyglot.polyglot/${graalvm.version}</bundle>
-		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.truffle.truffle-runtime/${graalvm.version}</bundle>
-		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.truffle.truffle-compiler/${graalvm.version}</bundle>
-		<bundle dependency="true" start-level="78">mvn:org.openhab.osgiify/org.graalvm.regex.regex/${graalvm.version}</bundle>
-		<bundle dependency="true" start-level="78">mvn:org.openhab.osgiify/org.graalvm.tools.chromeinspector-tool/${graalvm.version}</bundle>
-		<bundle dependency="true" start-level="78">mvn:org.openhab.osgiify/org.graalvm.tools.profiler-tool/${graalvm.version}</bundle>
-		<bundle dependency="true" start-level="78">mvn:org.openhab.osgiify/org.graalvm.python.python-resources/${graalvm.version}</bundle>
-		<bundle dependency="true" start-level="78">mvn:org.openhab.osgiify/org.graalvm.python.python-language/${graalvm.version}</bundle>
-		<bundle dependency="true" start-level="78">mvn:org.openhab.osgiify/org.graalvm.truffle.truffle-nfi/${graalvm.version}</bundle>
-		<bundle dependency="true" start-level="78">mvn:org.openhab.osgiify/org.graalvm.truffle.truffle-nfi-libffi/${graalvm.version}</bundle>
-		<bundle dependency="true" start-level="79">mvn:org.openhab.osgiify/org.graalvm.truffle.truffle-api/${graalvm.version}</bundle>
+
+		<requirement>openhab.tp;filter:="(feature=graal-python)"</requirement>
+		<feature dependency="true">openhab.tp-graal-python</feature>
+
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.automation.pythonscripting/${project.version}</bundle>
 	</feature>
 </features>

--- a/bundles/org.openhab.automation.pythonscripting/src/main/java/org/openhab/automation/pythonscripting/internal/PythonScriptEngineFactory.java
+++ b/bundles/org.openhab.automation.pythonscripting/src/main/java/org/openhab/automation/pythonscripting/internal/PythonScriptEngineFactory.java
@@ -27,9 +27,11 @@ import org.graalvm.polyglot.Language;
 import org.openhab.automation.pythonscripting.internal.fs.PythonDependencyTracker;
 import org.openhab.automation.pythonscripting.internal.scriptengine.graal.GraalPythonScriptEngine;
 import org.openhab.automation.pythonscripting.internal.scriptengine.graal.GraalPythonScriptEngine.ScriptEngineProvider;
+import org.openhab.automation.pythonscripting.internal.scriptengine.graal.GraalPythonScriptEngineFactory;
 import org.openhab.core.automation.module.script.ScriptDependencyTracker;
 import org.openhab.core.automation.module.script.ScriptEngineFactory;
 import org.openhab.core.config.core.ConfigurableService;
+import org.openhab.core.graal.GraalUtil;
 import org.openhab.core.i18n.TimeZoneProvider;
 import org.osgi.framework.Constants;
 import org.osgi.service.component.annotations.Activate;
@@ -37,6 +39,8 @@ import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Modified;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -58,7 +62,7 @@ public class PythonScriptEngineFactory implements ScriptEngineFactory, ScriptEng
     public static final String SCRIPT_TYPE = "application/x-python3";
 
     private final List<String> scriptTypes = List.of("py", SCRIPT_TYPE);
-    private final PythonDependencyTracker pythonDependencyTracker;
+    private volatile @Nullable PythonDependencyTracker pythonDependencyTracker;
     private final PythonScriptEngineConfiguration configuration;
 
     private static final String PYTHON_OPTION_ENGINE_WARNINTERPRETERONLY = "engine.WarnInterpreterOnly";
@@ -66,11 +70,10 @@ public class PythonScriptEngineFactory implements ScriptEngineFactory, ScriptEng
     /**
      * Shared Polyglot {@link Engine} instance to be used by all instances of {@link PythonScriptEngine}.
      */
-    private final Engine engine;
+    private final @Nullable Engine engine;
 
     @Activate
-    public PythonScriptEngineFactory(final @Reference PythonDependencyTracker pythonDependencyTracker,
-            final @Reference TimeZoneProvider timeZoneProvider, Map<String, Object> config) {
+    public PythonScriptEngineFactory(@Reference TimeZoneProvider timeZoneProvider, Map<String, Object> config) {
         logger.debug("Loading PythonScriptEngineFactory");
 
         String defaultTimezone = ZoneId.systemDefault().getId();
@@ -81,39 +84,62 @@ public class PythonScriptEngineFactory implements ScriptEngineFactory, ScriptEng
                     defaultTimezone, providerTimezone, defaultTimezone);
         }
 
-        this.pythonDependencyTracker = pythonDependencyTracker;
         this.configuration = new PythonScriptEngineConfiguration(config);
 
-        Engine.Builder engineBuilder = createEngineBuilder();
-        if (configuration.isDebuggerEnabled()) {
-            engineBuilder //
-                    .option("inspect", "0.0.0.0:" + configuration.getDebuggerPort()) //
-                    .option("inspect.Suspend", "false") // Don't pause at startup waiting for debugger to attach
-                    .option("inspect.WaitAttached", "false") // Don't block code execution waiting for debugger to
-                                                             // attach
-                    .option("inspect.Secure", "false"); // Disable TLS
-
-            Engine engine;
-            try {
-                engine = engineBuilder.build();
-                logger.info("Debugger support is enabled for Python Scripting on port {}",
-                        configuration.getDebuggerPort());
-            } catch (RuntimeException e) {
-                logger.error(
-                        "Failed to initialize Graal Python engine with debugger support. Continuing without debugger support.",
-                        e);
-                engine = createEngineBuilder().build();
-            }
-            this.engine = engine;
-        } else {
-            this.engine = createEngineBuilder().build();
+        Engine engine;
+        try {
+            engine = createEngine();
+            logger.debug("GraalPy engine created; language resolution deferred to first use");
+        } catch (Exception e) {
+            logger.error("Failed to create GraalPy engine", e);
+            engine = null;
         }
-
+        this.engine = engine;
         this.configuration.init(this);
+    }
 
-        if (getLanguage() == null) {
-            logger.error(
-                    "Graal Python language not initialized. Restart openHAB to initialize available Graal languages properly.");
+    @Deactivate
+    public void dispose() {
+        Engine engine = this.engine;
+        if (engine != null) {
+            engine.close();
+        }
+        GraalUtil.clearCache();
+    }
+
+    private Engine createEngine() {
+        Thread thread = Thread.currentThread();
+
+        // The classloader is swapped during creation to make sure the engine can "see" what it needs
+        ClassLoader original = thread.getContextClassLoader();
+        try {
+            thread.setContextClassLoader(GraalPythonScriptEngineFactory.class.getClassLoader());
+            Engine.Builder engineBuilder = createEngineBuilder();
+            if (configuration.isDebuggerEnabled()) {
+                engineBuilder //
+                        .option("inspect", "0.0.0.0:" + configuration.getDebuggerPort()) //
+                        .option("inspect.Suspend", "false") // Don't pause at startup waiting for debugger to attach
+                        .option("inspect.WaitAttached", "false") // Don't block code execution waiting for debugger to
+                                                                 // attach
+                        .option("inspect.Secure", "false"); // Disable TLS
+
+                Engine engine;
+                try {
+                    engine = engineBuilder.build();
+                    logger.info("Debugger support is enabled for Python Scripting on port {}",
+                            configuration.getDebuggerPort());
+                } catch (RuntimeException e) {
+                    logger.error(
+                            "Failed to initialize Graal Python engine with debugger support. Continuing without debugger support.",
+                            e);
+                    engine = createEngineBuilder().build();
+                }
+                return engine;
+            } else {
+                return createEngineBuilder().build();
+            }
+        } finally {
+            thread.setContextClassLoader(original);
         }
     }
 
@@ -130,6 +156,17 @@ public class PythonScriptEngineFactory implements ScriptEngineFactory, ScriptEng
     @Modified
     protected void modified(Map<String, Object> config) {
         this.configuration.modified(config, this);
+    }
+
+    @Reference(cardinality = ReferenceCardinality.OPTIONAL, policy = ReferencePolicy.DYNAMIC)
+    protected void setPythonDependencyTracker(PythonDependencyTracker tracker) {
+        this.pythonDependencyTracker = tracker;
+    }
+
+    protected void unsetPythonDependencyTracker(PythonDependencyTracker tracker) {
+        if (this.pythonDependencyTracker == tracker) {
+            this.pythonDependencyTracker = null;
+        }
     }
 
     @Override
@@ -163,9 +200,19 @@ public class PythonScriptEngineFactory implements ScriptEngineFactory, ScriptEng
 
     @Override
     public @Nullable ScriptEngine createScriptEngine() {
-        if (getLanguage() == null) {
+        if (engine == null) {
+            logger.error("Graal engine not initialized");
             return null;
         }
+
+        // Use the common lock to safely get the language
+        Language language = GraalUtil.getLanguage(engine, GraalPythonScriptEngine.LANGUAGE_ID);
+        if (language == null) {
+            logger.error(
+                    "Graal Python language not initialized. Restart openHAB to initialize available Graal languages properly.");
+            return null;
+        }
+
         return new PythonScriptEngine(configuration, engine, this);
     }
 
@@ -184,6 +231,11 @@ public class PythonScriptEngineFactory implements ScriptEngineFactory, ScriptEng
      * @return the Graal language of {@link PythonScriptEngine} or {@code null} if not available
      */
     public @Nullable Language getLanguage() {
-        return engine.getLanguages().get(GraalPythonScriptEngine.LANGUAGE_ID);
+        return GraalUtil.getLanguage(engine, GraalPythonScriptEngine.LANGUAGE_ID);
+    }
+
+    @Override
+    public boolean isReady() {
+        return GraalUtil.getLanguage(engine, GraalPythonScriptEngine.LANGUAGE_ID) != null;
     }
 }


### PR DESCRIPTION
This is a companion PR of https://github.com/openhab/openhab-core/pull/5787. The build will fail because the changes from https://github.com/openhab/openhab-core/pull/5787 aren't in core.

I've done multiple things to make Graal initialization work. I'm hopeful that this will also make it possible to install and uninstall Graal based add-ons without restarting.

The steps are:

* Swapping the classloader while creating the engine
* Using the core `GraalUtil` for thread-safe language resolution
* Implementing `isReady()` to indicate when initialization is complete
* Breaking the cyclic dependency caused by the dependency trackers

Together these things make this seem dead stable to me. I can't say for sure that every measure is required; I've just worked to solve the problems I've met along the way. Maybe some aren't ultimately necessary, but I've included it all. Some things might be "better" even if they weren't the direct cause of the initialization problems.

I'm creating this as a draft, because both this and the core PR need further evaluation/discussion/testing.
