### PR TITLE
[amazonechocontrol] Buffer push stream data until a message is complete

### DIFF
--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/push/PushStreamAdapter.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/push/PushStreamAdapter.java
@@ -18,9 +18,9 @@ import java.io.ByteArrayOutputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Objects;
-import java.util.regex.Pattern;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http2.api.Session;
 import org.eclipse.jetty.http2.api.Stream;
@@ -28,6 +28,7 @@ import org.eclipse.jetty.http2.frames.DataFrame;
 import org.eclipse.jetty.http2.frames.HeadersFrame;
 import org.eclipse.jetty.http2.frames.PingFrame;
 import org.eclipse.jetty.util.Callback;
+import org.eclipse.jetty.util.QuotedStringTokenizer;
 import org.openhab.binding.amazonechocontrol.internal.dto.push.PushMessageTO;
 import org.openhab.binding.amazonechocontrol.internal.util.HttpUtil;
 import org.slf4j.Logger;
@@ -45,7 +46,6 @@ import com.google.gson.Gson;
 public class PushStreamAdapter extends Stream.Listener.Adapter {
     // real messages are a few KiB, the limit is only reached if the boundary never arrives
     static final int MAX_BUFFER_SIZE = 512 * 1024;
-    private static final Pattern DASHES_ONLY = Pattern.compile("-+");
 
     private final Logger logger = LoggerFactory.getLogger(PushStreamAdapter.class);
     private final Gson gson;
@@ -75,14 +75,24 @@ public class PushStreamAdapter extends Stream.Listener.Adapter {
             logger.warn("Headers of HTTP/2 stream don't contain content-type");
             return;
         }
-        int boundaryStart = contentType.indexOf("boundary=");
-        if (boundaryStart == -1) {
+        String boundaryParameter = boundaryParameterOf(contentType);
+        if (boundaryParameter.isEmpty()) {
             logger.warn("Content-type of HTTP/2 stream doesn't contain a boundary: {}", contentType);
             return;
         }
-        int boundaryEnd = contentType.indexOf(";", boundaryStart);
-        boundary = contentType.substring(boundaryStart + 9, boundaryEnd == -1 ? contentType.length() : boundaryEnd);
+        boundary = boundaryParameter;
         boundaryBytes = boundary.getBytes(StandardCharsets.UTF_8);
+    }
+
+    /** RFC 2046 permits (and sometimes requires) a quoted boundary parameter, so the quotes are not part of it. */
+    static String boundaryParameterOf(String contentType) {
+        for (String parameter : contentType.split(";")) {
+            String trimmed = parameter.trim();
+            if (trimmed.regionMatches(true, 0, "boundary=", 0, 9)) {
+                return QuotedStringTokenizer.unquote(trimmed.substring(9).trim());
+            }
+        }
+        return "";
     }
 
     @Override
@@ -120,12 +130,12 @@ public class PushStreamAdapter extends Stream.Listener.Adapter {
     private void processBuffer(int bytesCarriedOver) {
         byte[] data = buffer.toByteArray();
         int consumed = 0;
-        int boundaryPos;
         boolean firstCompletedPart = true;
-        while ((boundaryPos = indexOf(data, boundaryBytes, consumed)) != -1) {
-            String part = new String(data, consumed, boundaryPos - consumed, StandardCharsets.UTF_8);
+        int[] delimiterLine;
+        while ((delimiterLine = nextDelimiterLine(data, consumed)) != null) {
+            String part = new String(data, consumed, delimiterLine[0] - consumed, StandardCharsets.UTF_8);
             // the part counts as consumed even if it fails, a bad message must not wedge the stream
-            consumed = boundaryPos + boundaryBytes.length;
+            consumed = delimiterLine[1];
             if (spannedFrames(firstCompletedPart, bytesCarriedOver)) {
                 logger.debug("Completed a message of {} characters that arrived split over several frames",
                         part.length());
@@ -150,10 +160,7 @@ public class PushStreamAdapter extends Stream.Listener.Adapter {
     }
 
     private void handlePart(String part) {
-        // the delimiter on the wire may be the boundary parameter itself or "--" + parameter (RFC 2046),
-        // splitting at the parameter leaves the extra dashes behind as a line of their own
-        List<String> content = part.lines()
-                .filter(line -> !line.isBlank() && !DASHES_ONLY.matcher(line.strip()).matches()).toList();
+        List<String> content = part.lines().filter(line -> !line.isBlank()).toList();
         if (content.isEmpty()) {
             // a bare boundary is a keep-alive that requires a PING response
             logger.debug("Sending ping");
@@ -179,6 +186,42 @@ public class PushStreamAdapter extends Stream.Listener.Adapter {
             logger.warn(message, arguments);
             failureLogged = true;
         }
+    }
+
+    /**
+     * Finds the next complete delimiter line (optional dashes plus the boundary, alone on a line - anywhere
+     * else the value is payload, RFC 2046) as line start and end, or null while the line is still incomplete.
+     */
+    private int @Nullable [] nextDelimiterLine(byte[] data, int fromIndex) {
+        int position = fromIndex;
+        while ((position = indexOf(data, boundaryBytes, position)) != -1) {
+            int lineStart = position;
+            while (lineStart > fromIndex && data[lineStart - 1] == '-') {
+                lineStart--;
+            }
+            boolean atLineStart = lineStart == 0 || data[lineStart - 1] == '\n';
+            int afterBoundary = position + boundaryBytes.length;
+            if (atLineStart && afterBoundary >= data.length) {
+                return null;
+            }
+            if (atLineStart && data[afterBoundary] == '\n') {
+                return new int[] { lineStart, afterBoundary + 1 };
+            }
+            if (atLineStart && data[afterBoundary] == '\r') {
+                if (afterBoundary + 1 >= data.length) {
+                    return null;
+                }
+                if (data[afterBoundary + 1] == '\n') {
+                    return new int[] { lineStart, afterBoundary + 2 };
+                }
+            }
+            position = position + 1;
+        }
+        return null;
+    }
+
+    int bufferedByteCount() {
+        return buffer.size();
     }
 
     private static int indexOf(byte[] data, byte[] pattern, int fromIndex) {

--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/push/PushStreamAdapter.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/push/PushStreamAdapter.java
@@ -14,10 +14,11 @@ package org.openhab.binding.amazonechocontrol.internal.push;
 
 import static org.eclipse.jetty.http.HttpHeader.CONTENT_TYPE;
 
-import java.io.BufferedReader;
-import java.io.StringReader;
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Objects;
+import java.util.regex.Pattern;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jetty.http.HttpFields;
@@ -38,14 +39,24 @@ import com.google.gson.Gson;
  * The {@link PushStreamAdapter} handles the HTTP/2 push stream
  *
  * @author Jan N. Klug - Initial contribution
+ * @author Martin Littkovsky - Buffer stream data until a message is complete
  */
 @NonNullByDefault
 public class PushStreamAdapter extends Stream.Listener.Adapter {
+    // real messages are a few KiB, the limit is only reached if the boundary never arrives
+    static final int MAX_BUFFER_SIZE = 512 * 1024;
+    private static final Pattern DASHES_ONLY = Pattern.compile("-+");
+
     private final Logger logger = LoggerFactory.getLogger(PushStreamAdapter.class);
     private final Gson gson;
     private final Session session;
     private final Listener listener;
+    // all mutable state is confined to the stream's serialized listener invocations
+    private final ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+
     private String boundary = "";
+    private byte[] boundaryBytes = new byte[0];
+    private boolean failureLogged = false;
 
     public PushStreamAdapter(Gson gson, Session session, Listener listener) {
         this.gson = gson;
@@ -65,50 +76,110 @@ public class PushStreamAdapter extends Stream.Listener.Adapter {
             return;
         }
         int boundaryStart = contentType.indexOf("boundary=");
+        if (boundaryStart == -1) {
+            logger.warn("Content-type of HTTP/2 stream doesn't contain a boundary: {}", contentType);
+            return;
+        }
         int boundaryEnd = contentType.indexOf(";", boundaryStart);
-        boundary = contentType.substring(boundaryStart + 9, boundaryEnd);
+        boundary = contentType.substring(boundaryStart + 9, boundaryEnd == -1 ? contentType.length() : boundaryEnd);
+        boundaryBytes = boundary.getBytes(StandardCharsets.UTF_8);
     }
 
     @Override
     public void onData(@NonNullByDefault({}) Stream stream, @NonNullByDefault({}) DataFrame frame,
             @NonNullByDefault({}) Callback callback) {
-        byte[] contentBuffer = new byte[frame.remaining()];
-        frame.getData().get(contentBuffer);
-        String contentString = new String(contentBuffer);
-        logger.trace("Received raw data {}", contentString);
-
-        // process
         try {
+            byte[] contentBuffer = new byte[frame.remaining()];
+            frame.getData().get(contentBuffer);
+            if (logger.isTraceEnabled()) {
+                logger.trace("Received raw data {}", new String(contentBuffer, StandardCharsets.UTF_8));
+            }
             if (boundary.isBlank()) {
-                logger.debug("Discarding message because boundary is not set");
+                logger.debug("Discarding data because boundary is not set");
                 return;
             }
-            BufferedReader contentReader = new BufferedReader(new StringReader(contentString));
-            List<String> content = contentReader.lines().filter(line -> !line.isBlank()).toList();
-
-            if (content.isEmpty()) {
-                return;
-            }
-
-            if (!content.get(content.size() - 1).endsWith(boundary)) {
-                logger.debug("Discarding incomplete message, boundary not found");
-            }
-
-            if (content.size() == 1) {
-                // only boundary requires a PING response
-                logger.debug("Sending ping");
-                session.ping(new PingFrame(false), Callback.NOOP);
-            } else if (content.get(0).equals("Content-Type: application/json")) {
-                // parse the message
-                PushMessageTO parsedMessage = Objects
-                        .requireNonNullElse(gson.fromJson(content.get(1), PushMessageTO.class), new PushMessageTO());
-                parsedMessage.directive.payload.renderingUpdates.forEach(listener::onPushMessageReceived);
-            } else {
-                logger.warn("Don't know how to handle frame starting with {}", content.get(0));
-            }
+            // a message can be split over several DATA frames and a frame can contain several messages,
+            // so bytes are collected until the trailing boundary marker completes a part
+            buffer.write(contentBuffer, 0, contentBuffer.length);
+            processBuffer();
         } catch (RuntimeException e) {
             logger.warn("Exception while processing message", e);
+        } finally {
+            // completing the callback replenishes the HTTP/2 flow control window,
+            // without that the server can't send further data on this long-lived stream
+            callback.succeeded();
         }
+    }
+
+    private void processBuffer() {
+        byte[] data = buffer.toByteArray();
+        int consumed = 0;
+        int boundaryPos;
+        while ((boundaryPos = indexOf(data, boundaryBytes, consumed)) != -1) {
+            String part = new String(data, consumed, boundaryPos - consumed, StandardCharsets.UTF_8);
+            // the part counts as consumed even if it fails, a bad message must not wedge the stream
+            consumed = boundaryPos + boundaryBytes.length;
+            try {
+                handlePart(part);
+            } catch (RuntimeException e) {
+                // the content was already logged at TRACE when the frame arrived
+                logFailure("Failed to process a message part of {} characters: {}", part.length(), e.toString());
+                logger.debug("Processing failure", e);
+            }
+        }
+        if (consumed > 0) {
+            buffer.reset();
+            buffer.write(data, consumed, data.length - consumed);
+        }
+        if (buffer.size() > MAX_BUFFER_SIZE) {
+            logger.warn("Discarding {} bytes of buffered data that don't contain a message boundary", buffer.size());
+            buffer.reset();
+        }
+    }
+
+    private void handlePart(String part) {
+        // the delimiter on the wire may be the boundary parameter itself or "--" + parameter (RFC 2046),
+        // splitting at the parameter leaves the extra dashes behind as a line of their own
+        List<String> content = part.lines()
+                .filter(line -> !line.isBlank() && !DASHES_ONLY.matcher(line.strip()).matches()).toList();
+        if (content.isEmpty()) {
+            // a bare boundary is a keep-alive that requires a PING response
+            logger.debug("Sending ping");
+            session.ping(new PingFrame(false), Callback.NOOP);
+            return;
+        }
+        if (content.get(0).equals("Content-Type: application/json")) {
+            String json = String.join("", content.subList(1, content.size()));
+            PushMessageTO parsedMessage = Objects.requireNonNullElse(gson.fromJson(json, PushMessageTO.class),
+                    new PushMessageTO());
+            parsedMessage.directive.payload.renderingUpdates.forEach(listener::onPushMessageReceived);
+            failureLogged = false;
+        } else {
+            logFailure("Don't know how to handle a message part of {} characters", part.length());
+        }
+    }
+
+    // the first failure of a streak is a WARN, repetitions only DEBUG to keep a format change from flooding the log
+    private void logFailure(String message, Object... arguments) {
+        if (failureLogged) {
+            logger.debug(message, arguments);
+        } else {
+            logger.warn(message, arguments);
+            failureLogged = true;
+        }
+    }
+
+    private static int indexOf(byte[] data, byte[] pattern, int fromIndex) {
+        for (int i = fromIndex; i <= data.length - pattern.length; i++) {
+            int j = 0;
+            while (j < pattern.length && data[i + j] == pattern[j]) {
+                j++;
+            }
+            if (j == pattern.length) {
+                return i;
+            }
+        }
+        return -1;
     }
 
     public interface Listener {

--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/push/PushStreamAdapter.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/push/PushStreamAdapter.java
@@ -100,8 +100,9 @@ public class PushStreamAdapter extends Stream.Listener.Adapter {
             }
             // a message can be split over several DATA frames and a frame can contain several messages,
             // so bytes are collected until the trailing boundary marker completes a part
+            int bytesCarriedOver = buffer.size();
             buffer.write(contentBuffer, 0, contentBuffer.length);
-            processBuffer();
+            processBuffer(bytesCarriedOver);
         } catch (RuntimeException e) {
             logger.warn("Exception while processing message", e);
         } finally {
@@ -111,14 +112,25 @@ public class PushStreamAdapter extends Stream.Listener.Adapter {
         }
     }
 
-    private void processBuffer() {
+    /** A completed part spanned frames when it used bytes an earlier frame had left in the buffer. */
+    static boolean spannedFrames(boolean firstCompletedPart, int bytesCarriedOver) {
+        return firstCompletedPart && bytesCarriedOver > 0;
+    }
+
+    private void processBuffer(int bytesCarriedOver) {
         byte[] data = buffer.toByteArray();
         int consumed = 0;
         int boundaryPos;
+        boolean firstCompletedPart = true;
         while ((boundaryPos = indexOf(data, boundaryBytes, consumed)) != -1) {
             String part = new String(data, consumed, boundaryPos - consumed, StandardCharsets.UTF_8);
             // the part counts as consumed even if it fails, a bad message must not wedge the stream
             consumed = boundaryPos + boundaryBytes.length;
+            if (spannedFrames(firstCompletedPart, bytesCarriedOver)) {
+                logger.debug("Completed a message of {} characters that arrived split over several frames",
+                        part.length());
+            }
+            firstCompletedPart = false;
             try {
                 handlePart(part);
             } catch (RuntimeException e) {

--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/push/PushStreamAdapter.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/push/PushStreamAdapter.java
@@ -159,7 +159,7 @@ public class PushStreamAdapter extends Stream.Listener.Adapter {
         }
     }
 
-    // the first failure of a streak is a WARN, repetitions only DEBUG to keep a format change from flooding the log
+    /** The first failure of a streak is a WARN, repetitions only DEBUG: a format change must not flood the log. */
     private void logFailure(String message, Object... arguments) {
         if (failureLogged) {
             logger.debug(message, arguments);

--- a/bundles/org.openhab.binding.amazonechocontrol/src/test/java/org/openhab/binding/amazonechocontrol/internal/push/PushStreamAdapterTest.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/test/java/org/openhab/binding/amazonechocontrol/internal/push/PushStreamAdapterTest.java
@@ -1,0 +1,302 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.amazonechocontrol.internal.push;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jetty.http.HttpFields;
+import org.eclipse.jetty.http.HttpHeader;
+import org.eclipse.jetty.http.HttpVersion;
+import org.eclipse.jetty.http.MetaData;
+import org.eclipse.jetty.http2.api.Session;
+import org.eclipse.jetty.http2.api.Stream;
+import org.eclipse.jetty.http2.frames.DataFrame;
+import org.eclipse.jetty.http2.frames.HeadersFrame;
+import org.eclipse.jetty.http2.frames.PingFrame;
+import org.eclipse.jetty.util.Callback;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.openhab.binding.amazonechocontrol.internal.dto.push.PushMessageTO;
+import org.openhab.binding.amazonechocontrol.internal.util.NonNullListTypeAdapterFactory;
+import org.openhab.binding.amazonechocontrol.internal.util.SerializeNullTypeAdapterFactory;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+
+/**
+ * The {@link PushStreamAdapterTest} contains tests for re-assembling push messages from HTTP/2 DATA frames
+ *
+ * @author Martin Littkovsky - Initial contribution
+ */
+@NonNullByDefault
+public class PushStreamAdapterTest {
+    private static final String BOUNDARY = "------abcde13";
+    private static final String CONTENT_TYPE = "multipart/related; boundary=" + BOUNDARY + "; type=application/json";
+    private static final String MESSAGE_JSON = buildMessageJson();
+    private static final String MESSAGE_PART = "Content-Type: application/json\r\n\r\n" + MESSAGE_JSON + "\r\n"
+            + BOUNDARY + "\r\n";
+
+    private final Gson gson = new GsonBuilder().registerTypeAdapterFactory(new NonNullListTypeAdapterFactory())
+            .registerTypeAdapterFactory(new SerializeNullTypeAdapterFactory()).create();
+    private final Session session = mock(Session.class);
+    private final Stream stream = mock(Stream.class);
+    private final List<PushMessageTO.RenderingUpdateTO> receivedUpdates = new ArrayList<>();
+    private final AtomicInteger succeededCallbacks = new AtomicInteger();
+
+    private PushStreamAdapter adapter = new PushStreamAdapter(gson, session, receivedUpdates::add);
+
+    @BeforeEach
+    public void setUp() {
+        adapter = new PushStreamAdapter(gson, session, receivedUpdates::add);
+        adapter.onHeaders(stream, headersFrame(CONTENT_TYPE));
+    }
+
+    @Test
+    public void completeMessageInSingleFrameIsProcessed() {
+        sendData(MESSAGE_PART);
+
+        assertThat(receivedUpdates, hasSize(1));
+        assertThat(receivedUpdates.get(0).route, is("DeeAppMessage"));
+        assertThat(succeededCallbacks.get(), is(1));
+    }
+
+    @Test
+    public void messageSplitAcrossFramesIsReassembled() {
+        // the reported failure: the first frame ends inside the resourceMetadata string
+        int cut = MESSAGE_PART.indexOf("volumeSetting");
+        sendData(MESSAGE_PART.substring(0, cut));
+        assertThat(receivedUpdates, hasSize(0));
+
+        sendData(MESSAGE_PART.substring(cut));
+        assertThat(receivedUpdates, hasSize(1));
+        assertThat(succeededCallbacks.get(), is(2));
+    }
+
+    @Test
+    public void messageSplitInsideMultiByteCharacterIsReassembled() {
+        String part = MESSAGE_PART.replace("\"route\":\"DeeAppMessage\"", "\"route\":\"Küchen-Echo\"");
+        byte[] bytes = part.getBytes(StandardCharsets.UTF_8);
+        // cut between the two UTF-8 bytes of the 'ü'
+        int cut = indexOf(bytes, "K".getBytes(StandardCharsets.UTF_8)) + 2;
+
+        sendData(slice(bytes, 0, cut));
+        sendData(slice(bytes, cut, bytes.length));
+
+        assertThat(receivedUpdates, hasSize(1));
+        assertThat(receivedUpdates.get(0).route, is("Küchen-Echo"));
+    }
+
+    @Test
+    public void boundarySplitAcrossFramesIsReassembled() {
+        int cut = MESSAGE_PART.lastIndexOf(BOUNDARY) + 4;
+        sendData(MESSAGE_PART.substring(0, cut));
+        assertThat(receivedUpdates, hasSize(0));
+
+        sendData(MESSAGE_PART.substring(cut));
+        assertThat(receivedUpdates, hasSize(1));
+    }
+
+    @Test
+    public void multipleMessagesInOneFrameAreAllProcessed() {
+        sendData(MESSAGE_PART + MESSAGE_PART);
+
+        assertThat(receivedUpdates, hasSize(2));
+    }
+
+    @Test
+    public void bareBoundaryTriggersPing() {
+        sendData(BOUNDARY + "\r\n");
+
+        ArgumentCaptor<PingFrame> pingCaptor = ArgumentCaptor.forClass(PingFrame.class);
+        verify(session, times(1)).ping(pingCaptor.capture(), any(Callback.class));
+        assertThat(pingCaptor.getValue().isReply(), is(false));
+        assertThat(receivedUpdates, hasSize(0));
+    }
+
+    @Test
+    public void consumedPartsAreNotDeliveredAgain() {
+        sendData(MESSAGE_PART);
+        sendData(BOUNDARY + "\r\n");
+        sendData(MESSAGE_PART);
+
+        assertThat(receivedUpdates, hasSize(2));
+        verify(session, times(1)).ping(any(PingFrame.class), any(Callback.class));
+    }
+
+    @Test
+    public void unprocessablePartDoesNotWedgeTheStream() {
+        // the explicit null overwrites the field initializer and the dispatch throws
+        sendData("Content-Type: application/json\r\n\r\n{\"directive\":null}\r\n" + BOUNDARY + "\r\n");
+        sendData(MESSAGE_PART);
+
+        assertThat(receivedUpdates, hasSize(1));
+        assertThat(succeededCallbacks.get(), is(2));
+    }
+
+    @Test
+    public void rfc2046DelimiterWithDashPrefixIsAccepted() {
+        String delimiter = "--" + BOUNDARY;
+        sendData("Content-Type: application/json\r\n\r\n" + MESSAGE_JSON + "\r\n" + delimiter + "\r\n");
+        sendData(delimiter + "\r\n");
+
+        assertThat(receivedUpdates, hasSize(1));
+        verify(session, times(1)).ping(any(PingFrame.class), any(Callback.class));
+    }
+
+    @Test
+    public void jsonSpreadOverSeveralLinesIsJoined() {
+        sendData(MESSAGE_PART.replace("\"renderingUpdates\":", "\"renderingUpdates\":\r\n"));
+
+        assertThat(receivedUpdates, hasSize(1));
+    }
+
+    @Test
+    public void nonJsonPartWithParseableBodyIsIgnored() {
+        sendData("Content-Type: text/plain\r\n\r\n" + MESSAGE_JSON + "\r\n" + BOUNDARY + "\r\n");
+
+        assertThat(receivedUpdates, hasSize(0));
+    }
+
+    @Test
+    public void messageReassemblesAtEverySplitPosition() {
+        byte[] bytes = MESSAGE_PART.getBytes(StandardCharsets.UTF_8);
+        for (int cut = 1; cut < bytes.length; cut++) {
+            receivedUpdates.clear();
+            adapter = new PushStreamAdapter(gson, session, receivedUpdates::add);
+            adapter.onHeaders(stream, headersFrame(CONTENT_TYPE));
+            sendData(slice(bytes, 0, cut));
+            sendData(slice(bytes, cut, bytes.length));
+            assertThat("split at byte " + cut, receivedUpdates, hasSize(1));
+        }
+    }
+
+    @Test
+    public void keepAliveAndMessageInOneFrameAreBothProcessed() {
+        sendData(BOUNDARY + "\r\n" + MESSAGE_PART);
+
+        verify(session, times(1)).ping(any(PingFrame.class), any(Callback.class));
+        assertThat(receivedUpdates, hasSize(1));
+    }
+
+    @Test
+    public void dataWithoutBoundaryHeaderIsDiscarded() {
+        adapter = new PushStreamAdapter(gson, session, receivedUpdates::add);
+        sendData(MESSAGE_PART);
+
+        assertThat(receivedUpdates, hasSize(0));
+        assertThat(succeededCallbacks.get(), is(1));
+    }
+
+    @Test
+    public void boundaryAsLastContentTypeParameterIsAccepted() {
+        adapter = new PushStreamAdapter(gson, session, receivedUpdates::add);
+        adapter.onHeaders(stream, headersFrame("multipart/related; type=application/json; boundary=" + BOUNDARY));
+        sendData(MESSAGE_PART);
+
+        assertThat(receivedUpdates, hasSize(1));
+    }
+
+    @Test
+    public void malformedJsonInCompletePartDoesNotBreakFollowingMessages() {
+        sendData("Content-Type: application/json\r\n\r\n{\"directive\":{\"header\":[]}}\r\n" + BOUNDARY + "\r\n");
+        sendData(MESSAGE_PART);
+
+        assertThat(receivedUpdates, hasSize(1));
+    }
+
+    @Test
+    public void unknownPartTypeIsIgnored() {
+        sendData("Content-Type: text/plain\r\n\r\nsomething\r\n" + BOUNDARY + "\r\n");
+
+        assertThat(receivedUpdates, hasSize(0));
+        verify(session, never()).ping(any(PingFrame.class), any(Callback.class));
+    }
+
+    @Test
+    public void overlongDataWithoutBoundaryIsDiscarded() {
+        byte[] filler = new byte[PushStreamAdapter.MAX_BUFFER_SIZE + 1];
+        sendData(filler);
+        sendData(MESSAGE_PART.getBytes(StandardCharsets.UTF_8));
+
+        // without the discard the part would start with half a megabyte of filler and not parse
+        assertThat(receivedUpdates, hasSize(1));
+    }
+
+    private void sendData(String content) {
+        sendData(content.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private void sendData(byte[] content) {
+        adapter.onData(stream, new DataFrame(1, ByteBuffer.wrap(content), false), new Callback() {
+            @Override
+            public void succeeded() {
+                succeededCallbacks.incrementAndGet();
+            }
+        });
+    }
+
+    private HeadersFrame headersFrame(String contentType) {
+        HttpFields fields = new HttpFields();
+        fields.put(HttpHeader.CONTENT_TYPE, contentType);
+        return new HeadersFrame(new MetaData(HttpVersion.HTTP_2, fields), null, false);
+    }
+
+    // reconstructed from the log in openhab/openhab-addons#21426 with all ids replaced; the doubly nested
+    // escaping (a JSON document inside resourceMetadata, another one inside its payload) is built with Gson
+    // because exactly this long escaped string is where the reported frame split happened
+    private static String buildMessageJson() {
+        String innerPayload = "{\"destinationUserId\":\"A1PY8QQU9P0FJP\",\"dsn\":\"G000AA0000000000\","
+                + "\"volumeSetting\":48000}";
+        String resourceMetadata = "{\"command\":\"PUSH_VOLUME_CHANGE\",\"payload\":" + new Gson().toJson(innerPayload)
+                + ",\"error\":false,\"errorMessage\":null,"
+                + "\"mediaReferenceId\":\"aca2df8c-c1b8-4a3a-904b-7f4842cefecb:1\"}";
+        return "{\"directive\":{\"header\":{\"namespace\":\"DeeAppMessagingGateway\",\"name\":\"ProcessNotification\","
+                + "\"messageId\":\"11111111-2222-3333-4444-555555555555\"},\"payload\":{\"renderingUpdates\":"
+                + "[{\"route\":\"DeeAppMessage\",\"resourceId\":\"resource-id\",\"resourceMetadata\":"
+                + new Gson().toJson(resourceMetadata) + "}]}}}";
+    }
+
+    private static byte[] slice(byte[] data, int from, int to) {
+        byte[] result = new byte[to - from];
+        System.arraycopy(data, from, result, 0, result.length);
+        return result;
+    }
+
+    private static int indexOf(byte[] data, byte[] pattern) {
+        for (int i = 0; i <= data.length - pattern.length; i++) {
+            int j = 0;
+            while (j < pattern.length && data[i + j] == pattern[j]) {
+                j++;
+            }
+            if (j == pattern.length) {
+                return i;
+            }
+        }
+        return -1;
+    }
+}

--- a/bundles/org.openhab.binding.amazonechocontrol/src/test/java/org/openhab/binding/amazonechocontrol/internal/push/PushStreamAdapterTest.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/test/java/org/openhab/binding/amazonechocontrol/internal/push/PushStreamAdapterTest.java
@@ -297,6 +297,35 @@ public class PushStreamAdapterTest {
         assertThat(spannedFrames(true, 0), is(false));
     }
 
+    @Test
+    public void aQuotedBoundaryParameterIsAccepted() {
+        adapter.onHeaders(stream,
+                headersFrame("multipart/related; boundary=\"" + BOUNDARY + "\"; type=application/json"));
+
+        sendData(MESSAGE_PART);
+
+        assertThat(receivedUpdates, hasSize(1));
+    }
+
+    @Test
+    public void aLineWrapRightAfterTheBoundaryValueDoesNotSplitTheMessage() {
+        // the dangerous shape: a payload line ending exactly with the boundary value, newline and all
+        String json = MESSAGE_JSON.replace("resource-id", "wrap at " + BOUNDARY + "\r\n continues");
+        sendData("Content-Type: application/json\r\n\r\n" + json + "\r\n" + BOUNDARY + "\r\n");
+
+        assertThat(receivedUpdates, hasSize(1));
+        assertThat(receivedUpdates.get(0).route, is("DeeAppMessage"));
+    }
+
+    @Test
+    public void aCompleteMessageLeavesNothingInTheBuffer() {
+        sendData(MESSAGE_PART);
+        assertThat(adapter.bufferedByteCount(), is(0));
+
+        sendData(MESSAGE_PART);
+        assertThat(receivedUpdates, hasSize(2));
+    }
+
     private static byte[] slice(byte[] data, int from, int to) {
         byte[] result = new byte[to - from];
         System.arraycopy(data, from, result, 0, result.length);

--- a/bundles/org.openhab.binding.amazonechocontrol/src/test/java/org/openhab/binding/amazonechocontrol/internal/push/PushStreamAdapterTest.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/test/java/org/openhab/binding/amazonechocontrol/internal/push/PushStreamAdapterTest.java
@@ -20,6 +20,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.openhab.binding.amazonechocontrol.internal.push.PushStreamAdapter.spannedFrames;
 
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
@@ -279,6 +280,21 @@ public class PushStreamAdapterTest {
                 + "\"messageId\":\"11111111-2222-3333-4444-555555555555\"},\"payload\":{\"renderingUpdates\":"
                 + "[{\"route\":\"DeeAppMessage\",\"resourceId\":\"resource-id\",\"resourceMetadata\":"
                 + new Gson().toJson(resourceMetadata) + "}]}}}";
+    }
+
+    @Test
+    public void aPartUsingBytesFromAnEarlierFrameCountsAsSpanningFrames() {
+        assertThat(spannedFrames(true, 42), is(true));
+    }
+
+    @Test
+    public void aPartAfterTheFirstOneOfAFrameNeverCountsAsSpanningFrames() {
+        assertThat(spannedFrames(false, 42), is(false));
+    }
+
+    @Test
+    public void aPartFromAnEmptyBufferDoesNotCountAsSpanningFrames() {
+        assertThat(spannedFrames(true, 0), is(false));
     }
 
     private static byte[] slice(byte[] data, int from, int to) {


### PR DESCRIPTION
# Description

Since ~2026-08-17 Amazon delivers push messages split over several HTTP/2 DATA frames. `PushStreamAdapter` parses each frame as a complete multipart part, so every affected message produces two WARNs (`MalformedJsonException: Unterminated string` for the first fragment, `Don't know how to handle frame starting with ...` for the rest) and the message is lost.

The adapter now buffers the raw bytes and processes a part only once its trailing boundary marker has arrived; one frame carrying several parts is handled as well. Fixed in the same path because the new code depends on it:

- an incomplete part was logged as discarded but processed anyway (missing `return`)
- frame content was decoded with the platform default charset before re-assembly; parts are now decoded as UTF-8 and only when complete, so a multi-byte character split across frames survives
- the DATA frame callback was never completed, so consumed bytes were never returned to the HTTP/2 flow control window (Jetty replenishes it in `DataCallback.succeeded`) — a busy long-lived stream would stall for good once the initial window is exhausted
- a parse failure of a *complete* part (a real format change, not fragmentation) logs one WARN per streak and resynchronizes at the next boundary, so a future API evolution cannot flood the log again

Fixes #21426.

One detail was captured live because no log in the issue shows it: the wire delimiter is `--` + the boundary parameter (RFC 2046), e.g. header `boundary=------abcde123` vs. `--------abcde123` on the wire. The previous line-based code tolerated that by suffix-matching; the buffered parser accepts both forms and strips the leftover dashes.

# Testing

18 new unit tests re-assemble fixtures reconstructed from the reported log: an exhaustive sweep splitting the message at every single byte position, the split inside the escaped `resourceMetadata` string exactly as reported, a split inside a multi-byte character, a split boundary marker, several messages per frame, both delimiter forms, keep-alive ping, unprocessable-part recovery and buffer-overflow discard. Full bundle suite green (138 tests). Verified on a production system: stream connect, the captured RFC 2046 keep-alive recognized and answered with PING (the account had no push traffic during the observation window; the message path is covered by the sweep fixtures).

**Transparency:** this patch was developed with AI assistance (Claude); every commit carries an `AI-assisted-by` trailer. All changes were built, tested and verified on a production system by the author.
