### PR TITLE
[mqtt] Expose read-only trigger channels

### DIFF
--- a/bundles/org.openhab.binding.mqtt/README.md
+++ b/bundles/org.openhab.binding.mqtt/README.md
@@ -155,6 +155,7 @@ You can add the following channels:
 - **image**: This channel handles binary images in common java supported formats (bmp,jpg,png).
 - **datetime**: This channel handles date/time values.
 - **rollershutter**: This channel is for rollershutters.
+- **trigger**: This channel emits the received MQTT payload as a channel event without updating an Item state.
 
 ## Channel Configuration
 
@@ -168,7 +169,22 @@ You can add the following channels:
   You usually need this to be `true` if your item is also linked to another channel, say a KNX actor, and you want a received MQTT payload to command that KNX actor.
 - **retained**: The value will be published to the command topic as retained message. A retained value stays on the broker and can even be seen by MQTT clients that are subscribing at a later point in time.
 - **qos**: QoS of this channel. Overrides the connection QoS (defined in broker connection).
-- **trigger**: If `true`, the state topic will not update a state, but trigger a channel instead.
+- **trigger**: If `true`, a received MQTT value that is valid for the selected channel type triggers a channel event instead of updating a state.
+  This typed trigger behavior remains supported, but for untyped trigger events the dedicated `trigger` channel type is preferred.
+  If a `commandTopic` is also configured, the channel retains state-channel metadata so linked Item commands can continue to be published to MQTT.
+
+### Trigger Channels
+
+The trigger channel emits every successfully transformed payload received on `stateTopic` as a channel event.
+It does not validate the payload as one of the state channel types and does not update an Item state.
+
+In a `.things` file, use the MQTT trigger channel type:
+
+```java
+Type trigger : alarm [ stateTopic="sensors/alarm" ]
+```
+
+The generic `Trigger String` and `Trigger Switch` forms do not select an MQTT channel type and are not supported by this binding.
 
 ### Channel Type "string"
 

--- a/bundles/org.openhab.binding.mqtt/README.md
+++ b/bundles/org.openhab.binding.mqtt/README.md
@@ -171,6 +171,7 @@ You can add the following channels:
 - **qos**: QoS of this channel. Overrides the connection QoS (defined in broker connection).
 - **trigger**: If `true`, a received MQTT value that is valid for the selected channel type triggers a channel event instead of updating a state.
   This typed trigger behavior remains supported, but for untyped trigger events the dedicated `trigger` channel type is preferred.
+  Image channels always remain state channels because their payload is binary.
   If a `commandTopic` is also configured, the channel retains state-channel metadata so linked Item commands can continue to be published to MQTT.
 
 ### Trigger Channels

--- a/bundles/org.openhab.binding.mqtt/src/main/java/org/openhab/binding/mqtt/generic/ChannelState.java
+++ b/bundles/org.openhab.binding.mqtt/src/main/java/org/openhab/binding/mqtt/generic/ChannelState.java
@@ -421,7 +421,7 @@ public class ChannelState implements MqttMessageSubscriber {
         } else {
             commandTopic = config.commandTopic;
         }
-        return connection.publish(commandTopic, commandString.getBytes(), qos, config.retained);
+        return connection.publish(commandTopic, commandString.getBytes(StandardCharsets.UTF_8), qos, config.retained);
     }
 
     /**

--- a/bundles/org.openhab.binding.mqtt/src/main/java/org/openhab/binding/mqtt/generic/internal/handler/GenericMQTTThingHandler.java
+++ b/bundles/org.openhab.binding.mqtt/src/main/java/org/openhab/binding/mqtt/generic/internal/handler/GenericMQTTThingHandler.java
@@ -178,14 +178,11 @@ public class GenericMQTTThingHandler extends AbstractMQTTThingHandler implements
             boolean shouldBeTrigger = MqttBindingConstants.TRIGGER.equals(channelTypeId) || (channelConfig.trigger
                     && channelConfig.commandTopic.isBlank() && !MqttBindingConstants.IMAGE.equals(channelTypeId));
             ChannelKind expectedKind = shouldBeTrigger ? ChannelKind.TRIGGER : ChannelKind.STATE;
-            if (channel.getKind() != expectedKind) {
-                if (channelBuilder == null) {
-                    channelBuilder = ChannelBuilder.create(channel);
-                }
-                channelBuilder.withKind(expectedKind);
+            if (channelBuilder == null && channel.getKind() != expectedKind) {
+                channelBuilder = ChannelBuilder.create(channel);
             }
-
             if (channelBuilder != null) {
+                channelBuilder.withKind(expectedKind);
                 thingBuilder.withoutChannel(channel.getUID());
                 thingBuilder.withChannel(channelBuilder.build());
                 modified = true;

--- a/bundles/org.openhab.binding.mqtt/src/main/java/org/openhab/binding/mqtt/generic/internal/handler/GenericMQTTThingHandler.java
+++ b/bundles/org.openhab.binding.mqtt/src/main/java/org/openhab/binding/mqtt/generic/internal/handler/GenericMQTTThingHandler.java
@@ -174,13 +174,15 @@ public class GenericMQTTThingHandler extends AbstractMQTTThingHandler implements
                 }
             }
 
-            if (channelConfig.trigger && channelConfig.commandTopic.isBlank()
-                    && !MqttBindingConstants.IMAGE.equals(channelTypeUID.getId())
-                    && channel.getKind() != ChannelKind.TRIGGER) {
+            String channelTypeId = channelTypeUID.getId();
+            boolean shouldBeTrigger = MqttBindingConstants.TRIGGER.equals(channelTypeId) || (channelConfig.trigger
+                    && channelConfig.commandTopic.isBlank() && !MqttBindingConstants.IMAGE.equals(channelTypeId));
+            ChannelKind expectedKind = shouldBeTrigger ? ChannelKind.TRIGGER : ChannelKind.STATE;
+            if (channel.getKind() != expectedKind) {
                 if (channelBuilder == null) {
                     channelBuilder = ChannelBuilder.create(channel);
                 }
-                channelBuilder.withKind(ChannelKind.TRIGGER);
+                channelBuilder.withKind(expectedKind);
             }
 
             if (channelBuilder != null) {

--- a/bundles/org.openhab.binding.mqtt/src/main/java/org/openhab/binding/mqtt/generic/internal/handler/GenericMQTTThingHandler.java
+++ b/bundles/org.openhab.binding.mqtt/src/main/java/org/openhab/binding/mqtt/generic/internal/handler/GenericMQTTThingHandler.java
@@ -43,6 +43,7 @@ import org.openhab.core.thing.binding.ThingHandlerCallback;
 import org.openhab.core.thing.binding.builder.ChannelBuilder;
 import org.openhab.core.thing.binding.builder.ThingBuilder;
 import org.openhab.core.thing.binding.generic.ChannelTransformation;
+import org.openhab.core.thing.type.ChannelKind;
 import org.openhab.core.thing.type.ChannelTypeUID;
 import org.openhab.core.types.StateDescription;
 import org.openhab.core.types.util.UnitUtils;
@@ -150,6 +151,7 @@ public class GenericMQTTThingHandler extends AbstractMQTTThingHandler implements
                 continue;
             }
             final ChannelConfig channelConfig = channel.getConfiguration().as(ChannelConfig.class);
+            ChannelBuilder channelBuilder = null;
 
             if (channelTypeUID
                     .equals(new ChannelTypeUID(MqttBindingConstants.BINDING_ID, MqttBindingConstants.NUMBER))) {
@@ -159,7 +161,7 @@ public class GenericMQTTThingHandler extends AbstractMQTTThingHandler implements
                 // Number
                 String actualItemType = channel.getAcceptedItemType();
                 if (!expectedItemType.equals(actualItemType)) {
-                    ChannelBuilder channelBuilder = callback.createChannelBuilder(channel.getUID(), channelTypeUID)
+                    channelBuilder = callback.createChannelBuilder(channel.getUID(), channelTypeUID)
                             .withAcceptedItemType(expectedItemType).withConfiguration(channel.getConfiguration());
                     String label = channel.getLabel();
                     if (label != null) {
@@ -169,10 +171,21 @@ public class GenericMQTTThingHandler extends AbstractMQTTThingHandler implements
                     if (description != null) {
                         channelBuilder.withDescription(description);
                     }
-                    thingBuilder.withoutChannel(channel.getUID());
-                    thingBuilder.withChannel(channelBuilder.build());
-                    modified = true;
                 }
+            }
+
+            if (channelConfig.trigger && channelConfig.commandTopic.isBlank()
+                    && channel.getKind() != ChannelKind.TRIGGER) {
+                if (channelBuilder == null) {
+                    channelBuilder = ChannelBuilder.create(channel);
+                }
+                channelBuilder.withKind(ChannelKind.TRIGGER);
+            }
+
+            if (channelBuilder != null) {
+                thingBuilder.withoutChannel(channel.getUID());
+                thingBuilder.withChannel(channelBuilder.build());
+                modified = true;
             }
 
             try {

--- a/bundles/org.openhab.binding.mqtt/src/main/java/org/openhab/binding/mqtt/generic/internal/handler/GenericMQTTThingHandler.java
+++ b/bundles/org.openhab.binding.mqtt/src/main/java/org/openhab/binding/mqtt/generic/internal/handler/GenericMQTTThingHandler.java
@@ -175,6 +175,7 @@ public class GenericMQTTThingHandler extends AbstractMQTTThingHandler implements
             }
 
             if (channelConfig.trigger && channelConfig.commandTopic.isBlank()
+                    && !MqttBindingConstants.IMAGE.equals(channelTypeUID.getId())
                     && channel.getKind() != ChannelKind.TRIGGER) {
                 if (channelBuilder == null) {
                     channelBuilder = ChannelBuilder.create(channel);

--- a/bundles/org.openhab.binding.mqtt/src/main/java/org/openhab/binding/mqtt/handler/BrokerHandler.java
+++ b/bundles/org.openhab.binding.mqtt/src/main/java/org/openhab/binding/mqtt/handler/BrokerHandler.java
@@ -12,6 +12,7 @@
  */
 package org.openhab.binding.mqtt.handler;
 
+import java.nio.charset.StandardCharsets;
 import java.security.NoSuchAlgorithmException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -218,8 +219,8 @@ public class BrokerHandler extends AbstractBrokerHandler implements PinnedCallba
         final String topic = config.lwtTopic;
         if (topic != null) {
             final String msg = config.lwtMessage;
-            MqttWillAndTestament will = new MqttWillAndTestament(topic, msg != null ? msg.getBytes() : null,
-                    config.lwtQos, config.lwtRetain);
+            MqttWillAndTestament will = new MqttWillAndTestament(topic,
+                    msg != null ? msg.getBytes(StandardCharsets.UTF_8) : null, config.lwtQos, config.lwtRetain);
             connection.setLastWill(will);
         }
 
@@ -256,6 +257,6 @@ public class BrokerHandler extends AbstractBrokerHandler implements PinnedCallba
             return CompletableFuture.completedFuture(true);
         }
         String nonNullMessage = message != null ? message : "";
-        return connection.publish(topic, nonNullMessage.getBytes(), connection.getQos(), retain);
+        return connection.publish(topic, nonNullMessage.getBytes(StandardCharsets.UTF_8), connection.getQos(), retain);
     }
 }

--- a/bundles/org.openhab.binding.mqtt/src/main/java/org/openhab/binding/mqtt/internal/action/MQTTActions.java
+++ b/bundles/org.openhab.binding.mqtt/src/main/java/org/openhab/binding/mqtt/internal/action/MQTTActions.java
@@ -12,6 +12,8 @@
  */
 package org.openhab.binding.mqtt.internal.action;
 
+import java.nio.charset.StandardCharsets;
+
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.mqtt.handler.AbstractBrokerHandler;
@@ -64,7 +66,7 @@ public class MQTTActions implements ThingActions {
             logger.debug("skipping MQTT publishing to topic '{}' due to null value.", topic);
             return;
         }
-        publishMQTT(topic, value.getBytes(), retain);
+        publishMQTT(topic, value.getBytes(StandardCharsets.UTF_8), retain);
     }
 
     @RuleAction(label = "@text/actionLabel", description = "@text/actionDesc")

--- a/bundles/org.openhab.binding.mqtt/src/test/java/org/openhab/binding/mqtt/generic/ChannelStateTests.java
+++ b/bundles/org.openhab.binding.mqtt/src/test/java/org/openhab/binding/mqtt/generic/ChannelStateTests.java
@@ -21,6 +21,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
@@ -122,18 +123,18 @@ public class ChannelStateTests {
         verify(connectionMock).subscribe(eq("state"), eq(c));
 
         c.publishValue(new StringType("UPDATE")).get();
-        verify(connectionMock).publish(eq("command"), argThat(p -> Arrays.equals(p, "UPDATE".getBytes())), anyInt(),
-                eq(false));
+        verify(connectionMock).publish(eq("command"),
+                argThat(p -> Arrays.equals(p, "UPDATE".getBytes(StandardCharsets.UTF_8))), anyInt(), eq(false));
 
         c.config.formatBeforePublish = "prefix%s";
         c.publishValue(new StringType("UPDATE")).get();
-        verify(connectionMock).publish(eq("command"), argThat(p -> Arrays.equals(p, "prefixUPDATE".getBytes())),
-                anyInt(), eq(false));
+        verify(connectionMock).publish(eq("command"),
+                argThat(p -> Arrays.equals(p, "prefixUPDATE".getBytes(StandardCharsets.UTF_8))), anyInt(), eq(false));
 
         c.config.formatBeforePublish = "%1$s-%1$s";
         c.publishValue(new StringType("UPDATE")).get();
-        verify(connectionMock).publish(eq("command"), argThat(p -> Arrays.equals(p, "UPDATE-UPDATE".getBytes())),
-                anyInt(), eq(false));
+        verify(connectionMock).publish(eq("command"),
+                argThat(p -> Arrays.equals(p, "UPDATE-UPDATE".getBytes(StandardCharsets.UTF_8))), anyInt(), eq(false));
 
         c.config.formatBeforePublish = "%s";
         c.config.retained = true;
@@ -154,8 +155,8 @@ public class ChannelStateTests {
         verify(connectionMock).subscribe(eq("state"), eq(c));
 
         c.publishValue(StopMoveType.STOP).get();
-        verify(connectionMock).publish(eq("command"), argThat(p -> Arrays.equals(p, "STOP".getBytes())), anyInt(),
-                eq(false));
+        verify(connectionMock).publish(eq("command"),
+                argThat(p -> Arrays.equals(p, "STOP".getBytes(StandardCharsets.UTF_8))), anyInt(), eq(false));
 
         c.stop().get();
         verify(connectionMock).unsubscribe(eq("state"), eq(c));
@@ -172,8 +173,8 @@ public class ChannelStateTests {
         verify(connectionMock).subscribe(eq("state"), eq(c));
 
         c.publishValue(StopMoveType.STOP).get();
-        verify(connectionMock).publish(eq("stopCommand"), argThat(p -> Arrays.equals(p, "STOP".getBytes())), anyInt(),
-                eq(false));
+        verify(connectionMock).publish(eq("stopCommand"),
+                argThat(p -> Arrays.equals(p, "STOP".getBytes(StandardCharsets.UTF_8))), anyInt(), eq(false));
 
         c.stop().get();
         verify(connectionMock).unsubscribe(eq("state"), eq(c));
@@ -185,7 +186,7 @@ public class ChannelStateTests {
                 channelUIDMock, textValue, channelStateUpdateListenerMock));
 
         CompletableFuture<@Nullable Void> future = c.start(connectionMock, scheduler, 100);
-        c.processMessage("state/bla/topic", "A TEST".getBytes());
+        c.processMessage("state/bla/topic", "A TEST".getBytes(StandardCharsets.UTF_8));
         future.get(300, TimeUnit.MILLISECONDS);
 
         assertThat(textValue.getChannelState().toString(), is("A TEST"));
@@ -197,7 +198,7 @@ public class ChannelStateTests {
         ChannelState c = spy(new ChannelState(config, channelUIDMock, textValue, channelStateUpdateListenerMock));
 
         CompletableFuture<@Nullable Void> future = c.start(connectionMock, scheduler, 100);
-        c.processMessage("state", "A TEST".getBytes());
+        c.processMessage("state", "A TEST".getBytes(StandardCharsets.UTF_8));
         future.get(300, TimeUnit.MILLISECONDS);
 
         assertThat(textValue.getChannelState().toString(), is("A TEST"));
@@ -210,8 +211,8 @@ public class ChannelStateTests {
         ChannelState channelState = new ChannelState(triggerConfig, channelUIDMock, new OnOffValue("ON", "OFF"),
                 channelStateUpdateListenerMock);
 
-        channelState.processMessage("state", "ON".getBytes());
-        channelState.processMessage("state", "INVALID".getBytes());
+        channelState.processMessage("state", "ON".getBytes(StandardCharsets.UTF_8));
+        channelState.processMessage("state", "INVALID".getBytes(StandardCharsets.UTF_8));
 
         verify(channelStateUpdateListenerMock).triggerChannel(channelUIDMock, "ON");
         verify(channelStateUpdateListenerMock, times(1)).triggerChannel(any(), any());
@@ -224,13 +225,13 @@ public class ChannelStateTests {
         ChannelState c = spy(new ChannelState(config, channelUIDMock, value, channelStateUpdateListenerMock));
         c.start(connectionMock, mock(ScheduledExecutorService.class), 100);
 
-        c.processMessage("state", "15".getBytes());
+        c.processMessage("state", "15".getBytes(StandardCharsets.UTF_8));
         assertThat(value.getChannelState().toString(), is("15"));
 
-        c.processMessage("state", "INCREASE".getBytes());
+        c.processMessage("state", "INCREASE".getBytes(StandardCharsets.UTF_8));
         assertThat(value.getChannelState().toString(), is("25"));
 
-        c.processMessage("state", "DECREASE".getBytes());
+        c.processMessage("state", "DECREASE".getBytes(StandardCharsets.UTF_8));
         assertThat(value.getChannelState().toString(), is("15"));
 
         verify(channelStateUpdateListenerMock, times(3)).updateChannelState(eq(channelUIDMock), any());
@@ -242,10 +243,10 @@ public class ChannelStateTests {
         ChannelState c = spy(new ChannelState(config, channelUIDMock, value, channelStateUpdateListenerMock));
         c.start(connectionMock, mock(ScheduledExecutorService.class), 100);
 
-        c.processMessage("state", "5.5".getBytes());
+        c.processMessage("state", "5.5".getBytes(StandardCharsets.UTF_8));
         assertThat(value.getChannelState().toString(), is("5.5"));
 
-        c.processMessage("state", "INCREASE".getBytes());
+        c.processMessage("state", "INCREASE".getBytes(StandardCharsets.UTF_8));
         assertThat(value.getChannelState().toString(), is("16.0"));
     }
 
@@ -255,13 +256,13 @@ public class ChannelStateTests {
         ChannelState c = spy(new ChannelState(config, channelUIDMock, value, channelStateUpdateListenerMock));
         c.start(connectionMock, mock(ScheduledExecutorService.class), 100);
 
-        c.processMessage("state", "15".getBytes());
+        c.processMessage("state", "15".getBytes(StandardCharsets.UTF_8));
         assertThat(value.getChannelState().toString(), is("15 W"));
 
-        c.processMessage("state", "INCREASE".getBytes());
+        c.processMessage("state", "INCREASE".getBytes(StandardCharsets.UTF_8));
         assertThat(value.getChannelState().toString(), is("25 W"));
 
-        c.processMessage("state", "DECREASE".getBytes());
+        c.processMessage("state", "DECREASE".getBytes(StandardCharsets.UTF_8));
         assertThat(value.getChannelState().toString(), is("15 W"));
 
         verify(channelStateUpdateListenerMock, times(3)).updateChannelState(eq(channelUIDMock), any());
@@ -273,7 +274,7 @@ public class ChannelStateTests {
         ChannelState c = spy(new ChannelState(config, channelUIDMock, value, channelStateUpdateListenerMock));
         c.start(connectionMock, mock(ScheduledExecutorService.class), 100);
 
-        c.processMessage("state", "63.7".getBytes());
+        c.processMessage("state", "63.7".getBytes(StandardCharsets.UTF_8));
         assertThat(value.getChannelState().toString(), is("63.7 %"));
 
         verify(channelStateUpdateListenerMock, times(1)).updateChannelState(eq(channelUIDMock), any());
@@ -286,16 +287,16 @@ public class ChannelStateTests {
         ChannelState c = spy(new ChannelState(config, channelUIDMock, value, channelStateUpdateListenerMock));
         c.start(connectionMock, mock(ScheduledExecutorService.class), 100);
 
-        c.processMessage("state", "-100".getBytes()); // 0%
+        c.processMessage("state", "-100".getBytes(StandardCharsets.UTF_8)); // 0%
         assertThat(value.getChannelState().toString(), is("0"));
 
-        c.processMessage("state", "100".getBytes()); // 100%
+        c.processMessage("state", "100".getBytes(StandardCharsets.UTF_8)); // 100%
         assertThat(value.getChannelState().toString(), is("100"));
 
-        c.processMessage("state", "0".getBytes()); // 50%
+        c.processMessage("state", "0".getBytes(StandardCharsets.UTF_8)); // 50%
         assertThat(value.getChannelState().toString(), is("50"));
 
-        c.processMessage("state", "INCREASE".getBytes());
+        c.processMessage("state", "INCREASE".getBytes(StandardCharsets.UTF_8));
         assertThat(value.getChannelState().toString(), is("55"));
         assertThat(value.getMQTTpublishValue((Command) value.getChannelState(), null), is("10"));
         assertThat(value.getMQTTpublishValue((Command) value.getChannelState(), "%03.0f"), is("010"));
@@ -307,21 +308,21 @@ public class ChannelStateTests {
         ChannelState c = spy(new ChannelState(config, channelUIDMock, value, channelStateUpdateListenerMock));
         c.start(connectionMock, mock(ScheduledExecutorService.class), 100);
 
-        c.processMessage("state", "ON".getBytes()); // Normal on state
+        c.processMessage("state", "ON".getBytes(StandardCharsets.UTF_8)); // Normal on state
         assertThat(value.getChannelState().toString(), is("0,0,10"));
         assertThat(value.getMQTTpublishValue((Command) value.getChannelState(), null), is("26,26,26"));
 
-        c.processMessage("state", "FOFF".getBytes()); // Custom off state
+        c.processMessage("state", "FOFF".getBytes(StandardCharsets.UTF_8)); // Custom off state
         assertThat(value.getChannelState().toString(), is("0,0,0"));
         assertThat(value.getMQTTpublishValue((Command) value.getChannelState(), null), is("0,0,0"));
 
-        c.processMessage("state", "10".getBytes()); // Brightness only
+        c.processMessage("state", "10".getBytes(StandardCharsets.UTF_8)); // Brightness only
         assertThat(value.getChannelState().toString(), is("0,0,10"));
         assertThat(value.getMQTTpublishValue((Command) value.getChannelState(), null), is("26,26,26"));
 
         HSBType t = HSBType.fromRGB(12, 18, 231);
 
-        c.processMessage("state", "12,18,231".getBytes());
+        c.processMessage("state", "12,18,231".getBytes(StandardCharsets.UTF_8));
         assertThat(value.getChannelState(), is(t)); // HSB
         assertThat(value.getMQTTpublishValue((Command) value.getChannelState(), null), is("12,18,231"));
         assertThat(value.getMQTTpublishValue((Command) value.getChannelState(), "%3$d,%2$d,%1$d"), is("231,18,12"));
@@ -333,19 +334,19 @@ public class ChannelStateTests {
         ChannelState c = spy(new ChannelState(config, channelUIDMock, value, channelStateUpdateListenerMock));
         c.start(connectionMock, mock(ScheduledExecutorService.class), 100);
 
-        c.processMessage("state", "ON".getBytes()); // Normal on state
+        c.processMessage("state", "ON".getBytes(StandardCharsets.UTF_8)); // Normal on state
         assertThat(value.getChannelState().toString(), is("0,0,10"));
         assertThat(value.getMQTTpublishValue((Command) value.getChannelState(), null), is("0,0,10"));
 
-        c.processMessage("state", "FOFF".getBytes()); // Custom off state
+        c.processMessage("state", "FOFF".getBytes(StandardCharsets.UTF_8)); // Custom off state
         assertThat(value.getChannelState().toString(), is("0,0,0"));
         assertThat(value.getMQTTpublishValue((Command) value.getChannelState(), null), is("0,0,0"));
 
-        c.processMessage("state", "10".getBytes()); // Brightness only
+        c.processMessage("state", "10".getBytes(StandardCharsets.UTF_8)); // Brightness only
         assertThat(value.getChannelState().toString(), is("0,0,10"));
         assertThat(value.getMQTTpublishValue((Command) value.getChannelState(), null), is("0,0,10"));
 
-        c.processMessage("state", "12,18,100".getBytes());
+        c.processMessage("state", "12,18,100".getBytes(StandardCharsets.UTF_8));
         assertThat(value.getChannelState().toString(), is("12,18,100"));
         assertThat(value.getMQTTpublishValue((Command) value.getChannelState(), null), is("12,18,100"));
     }
@@ -357,18 +358,18 @@ public class ChannelStateTests {
         c.start(connectionMock, mock(ScheduledExecutorService.class), 100);
 
         // incoming messages
-        c.processMessage("state", "ON".getBytes()); // Normal on state
+        c.processMessage("state", "ON".getBytes(StandardCharsets.UTF_8)); // Normal on state
         assertThat(value.getChannelState().toString(), is("0,0,10"));
 
-        c.processMessage("state", "FOFF".getBytes()); // Custom off state
+        c.processMessage("state", "FOFF".getBytes(StandardCharsets.UTF_8)); // Custom off state
         // note we don't care what color value is currently stored, just that brightness is off
         assertThat(((HSBType) value.getChannelState()).getBrightness(), is(PercentType.ZERO));
 
-        c.processMessage("state", "10".getBytes()); // Brightness only
+        c.processMessage("state", "10".getBytes(StandardCharsets.UTF_8)); // Brightness only
         assertThat(value.getChannelState().toString(), is("0,0,10"));
 
         HSBType t = ColorUtil.xyToHsb(new double[] { 0.3f, 0.6f });
-        c.processMessage("state", "0.3,0.6,100".getBytes());
+        c.processMessage("state", "0.3,0.6,100".getBytes(StandardCharsets.UTF_8));
         assertTrue(((HSBType) value.getChannelState()).closeTo(t, 0.001)); // HSB
 
         // outgoing messages
@@ -397,7 +398,7 @@ public class ChannelStateTests {
         ChannelState c = spy(new ChannelState(config, channelUIDMock, value, channelStateUpdateListenerMock));
         c.start(connectionMock, mock(ScheduledExecutorService.class), 100);
 
-        c.processMessage("state", "46.833974, 7.108433".getBytes());
+        c.processMessage("state", "46.833974, 7.108433".getBytes(StandardCharsets.UTF_8));
         assertThat(value.getChannelState().toString(), is("46.833974,7.108433"));
         assertThat(value.getMQTTpublishValue((Command) value.getChannelState(), null), is("46.833974,7.108433"));
     }
@@ -411,7 +412,7 @@ public class ChannelStateTests {
         ZonedDateTime zd = ZonedDateTime.now();
         String datetime = zd.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME);
 
-        subject.processMessage("state", datetime.getBytes());
+        subject.processMessage("state", datetime.getBytes(StandardCharsets.UTF_8));
 
         String channelState = value.getChannelState().toString();
         assertTrue(channelState.startsWith(datetime),
@@ -479,7 +480,7 @@ public class ChannelStateTests {
             ChannelState c = spy(new ChannelState(config, channelUIDMock, textValue, channelStateUpdateListenerMock));
 
             CompletableFuture<@Nullable Void> future = c.start(connectionMock, scheduler, 100);
-            c.processMessage("state", T1_INPUT.getBytes());
+            c.processMessage("state", T1_INPUT.getBytes(StandardCharsets.UTF_8));
             future.get(300, TimeUnit.MILLISECONDS);
 
             assertThat(textValue.getChannelState().toString(), is(T1_RESULT));
@@ -494,7 +495,7 @@ public class ChannelStateTests {
 
             // First, test with an input that doesn't get transformed to null
             CompletableFuture<@Nullable Void> future = c.start(connectionMock, scheduler, 100);
-            c.processMessage("state", T1_INPUT.getBytes());
+            c.processMessage("state", T1_INPUT.getBytes(StandardCharsets.UTF_8));
             future.get(300, TimeUnit.MILLISECONDS);
 
             assertThat(textValue.getChannelState().toString(), is(T1_RESULT));
@@ -504,7 +505,7 @@ public class ChannelStateTests {
 
             // now test with an input that gets transformed to null
             future = c.start(connectionMock, scheduler, 100);
-            c.processMessage("state", NULL_INPUT.getBytes());
+            c.processMessage("state", NULL_INPUT.getBytes(StandardCharsets.UTF_8));
             future.get(300, TimeUnit.MILLISECONDS);
 
             // textValue should not have been updated
@@ -522,8 +523,8 @@ public class ChannelStateTests {
             verify(connectionMock).subscribe(eq("state"), eq(c));
 
             c.publishValue(new StringType(T1_INPUT)).get();
-            verify(connectionMock).publish(eq("command"), argThat(p -> Arrays.equals(p, T1_RESULT.getBytes())),
-                    anyInt(), eq(false));
+            verify(connectionMock).publish(eq("command"),
+                    argThat(p -> Arrays.equals(p, T1_RESULT.getBytes(StandardCharsets.UTF_8))), anyInt(), eq(false));
         }
     }
 }

--- a/bundles/org.openhab.binding.mqtt/src/test/java/org/openhab/binding/mqtt/generic/ChannelStateTests.java
+++ b/bundles/org.openhab.binding.mqtt/src/test/java/org/openhab/binding/mqtt/generic/ChannelStateTests.java
@@ -49,6 +49,7 @@ import org.openhab.binding.mqtt.generic.values.DateTimeValue;
 import org.openhab.binding.mqtt.generic.values.ImageValue;
 import org.openhab.binding.mqtt.generic.values.LocationValue;
 import org.openhab.binding.mqtt.generic.values.NumberValue;
+import org.openhab.binding.mqtt.generic.values.OnOffValue;
 import org.openhab.binding.mqtt.generic.values.PercentageValue;
 import org.openhab.binding.mqtt.generic.values.TextValue;
 import org.openhab.core.io.transport.mqtt.MqttBrokerConnection;
@@ -201,6 +202,20 @@ public class ChannelStateTests {
 
         assertThat(textValue.getChannelState().toString(), is("A TEST"));
         verify(channelStateUpdateListenerMock).updateChannelState(eq(channelUIDMock), any());
+    }
+
+    @Test
+    public void typedTriggerOnlyEmitsEventsForValidValues() {
+        ChannelConfig triggerConfig = ChannelConfigBuilder.create("state", "").makeTrigger(true).build();
+        ChannelState channelState = new ChannelState(triggerConfig, channelUIDMock, new OnOffValue("ON", "OFF"),
+                channelStateUpdateListenerMock);
+
+        channelState.processMessage("state", "ON".getBytes());
+        channelState.processMessage("state", "INVALID".getBytes());
+
+        verify(channelStateUpdateListenerMock).triggerChannel(channelUIDMock, "ON");
+        verify(channelStateUpdateListenerMock, times(1)).triggerChannel(any(), any());
+        verify(channelStateUpdateListenerMock, never()).updateChannelState(any(), any());
     }
 
     @Test

--- a/bundles/org.openhab.binding.mqtt/src/test/java/org/openhab/binding/mqtt/generic/ChannelStateTests.java
+++ b/bundles/org.openhab.binding.mqtt/src/test/java/org/openhab/binding/mqtt/generic/ChannelStateTests.java
@@ -421,14 +421,17 @@ public class ChannelStateTests {
 
     @Test
     public void receiveImageTest() {
+        ChannelConfig triggerConfig = ChannelConfigBuilder.create("state", "").makeTrigger(true).build();
         ImageValue value = new ImageValue();
-        ChannelState c = spy(new ChannelState(config, channelUIDMock, value, channelStateUpdateListenerMock));
+        ChannelState c = spy(new ChannelState(triggerConfig, channelUIDMock, value, channelStateUpdateListenerMock));
         c.start(connectionMock, mock(ScheduledExecutorService.class), 100);
 
         byte[] payload = { (byte) 0xFF, (byte) 0xD8, 0x01, 0x02, (byte) 0xFF, (byte) 0xD9 };
         c.processMessage("state", payload);
         assertThat(value.getChannelState(), is(instanceOf(RawType.class)));
         assertThat(((RawType) value.getChannelState()).getMimeType(), is("image/jpeg"));
+        verify(channelStateUpdateListenerMock).updateChannelState(channelUIDMock, value.getChannelState());
+        verify(channelStateUpdateListenerMock, never()).triggerChannel(any(), any());
     }
 
     @Nested

--- a/bundles/org.openhab.binding.mqtt/src/test/java/org/openhab/binding/mqtt/generic/internal/handler/GenericThingHandlerTests.java
+++ b/bundles/org.openhab.binding.mqtt/src/test/java/org/openhab/binding/mqtt/generic/internal/handler/GenericThingHandlerTests.java
@@ -162,6 +162,18 @@ public class GenericThingHandlerTests {
     }
 
     @Test
+    public void initializeKeepsReadOnlyImageTriggerAsStateChannel() {
+        Configuration configuration = new Configuration(Map.of("stateTopic", "test/state", "trigger", true));
+        Channel imageChannel = cb("image", "Image", configuration, IMAGE_CHANNEL);
+        when(thingMock.getChannels()).thenReturn(List.of(imageChannel));
+
+        thingHandler.initialize();
+
+        verify(callbackMock, never()).thingUpdated(any());
+        assertThat(imageChannel.getKind(), is(ChannelKind.STATE));
+    }
+
+    @Test
     public void handleCommandRefresh() {
         TextValue value = spy(new TextValue());
         value.update(new StringType("DEMOVALUE"));

--- a/bundles/org.openhab.binding.mqtt/src/test/java/org/openhab/binding/mqtt/generic/internal/handler/GenericThingHandlerTests.java
+++ b/bundles/org.openhab.binding.mqtt/src/test/java/org/openhab/binding/mqtt/generic/internal/handler/GenericThingHandlerTests.java
@@ -17,8 +17,11 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
+import static org.openhab.binding.mqtt.generic.internal.MqttBindingConstants.GENERIC_MQTT_THING;
 import static org.openhab.binding.mqtt.generic.internal.handler.ThingChannelConstants.*;
 
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -26,6 +29,7 @@ import org.eclipse.jdt.annotation.Nullable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
@@ -42,12 +46,14 @@ import org.openhab.binding.mqtt.handler.AbstractBrokerHandler;
 import org.openhab.core.config.core.Configuration;
 import org.openhab.core.io.transport.mqtt.MqttBrokerConnection;
 import org.openhab.core.library.types.StringType;
+import org.openhab.core.thing.Channel;
 import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.Thing;
 import org.openhab.core.thing.ThingStatus;
 import org.openhab.core.thing.ThingStatusDetail;
 import org.openhab.core.thing.ThingStatusInfo;
 import org.openhab.core.thing.binding.ThingHandlerCallback;
+import org.openhab.core.thing.type.ChannelKind;
 import org.openhab.core.types.RefreshType;
 import org.openhab.core.types.UnDefType;
 
@@ -73,6 +79,7 @@ public class GenericThingHandlerTests {
         ThingStatusInfo thingStatus = new ThingStatusInfo(ThingStatus.ONLINE, ThingStatusDetail.NONE, null);
 
         // Mock the thing: We need the thingUID and the bridgeUID
+        when(thingMock.getThingTypeUID()).thenReturn(GENERIC_MQTT_THING);
         when(thingMock.getUID()).thenReturn(TEST_GENERIC_THING);
         when(thingMock.getChannels()).thenReturn(THING_CHANNEL_LIST);
         when(thingMock.getStatusInfo()).thenReturn(thingStatus);
@@ -123,6 +130,35 @@ public class GenericThingHandlerTests {
 
         verify(callbackMock).statusUpdated(eq(thingMock), argThat(arg -> ThingStatus.ONLINE.equals(arg.getStatus())
                 && ThingStatusDetail.NONE.equals(arg.getStatusDetail())));
+    }
+
+    @Test
+    public void initializeMarksReadOnlyTypedTriggerAsTriggerChannel() {
+        Configuration configuration = new Configuration(Map.of("stateTopic", "test/state", "trigger", true));
+        Channel triggerChannel = cb("onoff", "Switch", configuration, ON_OFF_CHANNEL);
+        when(thingMock.getChannels()).thenReturn(List.of(triggerChannel));
+
+        thingHandler.initialize();
+
+        ArgumentCaptor<Thing> thingCaptor = ArgumentCaptor.forClass(Thing.class);
+        verify(callbackMock).thingUpdated(thingCaptor.capture());
+        Channel updatedChannel = thingCaptor.getValue().getChannel(triggerChannel.getUID());
+        assertThat(updatedChannel.getKind(), is(ChannelKind.TRIGGER));
+        assertThat(updatedChannel.getChannelTypeUID(), is(ON_OFF_CHANNEL));
+        assertThat(updatedChannel.getAcceptedItemType(), is("Switch"));
+    }
+
+    @Test
+    public void initializeKeepsCommandCapableTypedTriggerAsStateChannel() {
+        Configuration configuration = new Configuration(
+                Map.of("stateTopic", "test/state", "commandTopic", "test/command", "trigger", true));
+        Channel triggerChannel = cb("onoff", "Switch", configuration, ON_OFF_CHANNEL);
+        when(thingMock.getChannels()).thenReturn(List.of(triggerChannel));
+
+        thingHandler.initialize();
+
+        verify(callbackMock, never()).thingUpdated(any());
+        assertThat(triggerChannel.getKind(), is(ChannelKind.STATE));
     }
 
     @Test

--- a/bundles/org.openhab.binding.mqtt/src/test/java/org/openhab/binding/mqtt/generic/internal/handler/GenericThingHandlerTests.java
+++ b/bundles/org.openhab.binding.mqtt/src/test/java/org/openhab/binding/mqtt/generic/internal/handler/GenericThingHandlerTests.java
@@ -151,6 +151,26 @@ public class GenericThingHandlerTests {
     }
 
     @Test
+    public void initializeKeepsNumberTriggerKindWhenUpdatingAcceptedItemType() {
+        Configuration configuration = new Configuration(
+                Map.of("stateTopic", "test/state", "trigger", true, "unit", "W"));
+        Channel triggerChannel = ChannelBuilder.create(cb("number", "Number", configuration, NUMBER_CHANNEL))
+                .withKind(ChannelKind.TRIGGER).build();
+        ChannelBuilder replacementBuilder = ChannelBuilder.create(triggerChannel.getUID(), "Number")
+                .withType(NUMBER_CHANNEL);
+        when(callbackMock.createChannelBuilder(triggerChannel.getUID(), NUMBER_CHANNEL)).thenReturn(replacementBuilder);
+        when(thingMock.getChannels()).thenReturn(List.of(triggerChannel));
+
+        thingHandler.initialize();
+
+        ArgumentCaptor<Thing> thingCaptor = ArgumentCaptor.forClass(Thing.class);
+        verify(callbackMock).thingUpdated(thingCaptor.capture());
+        Channel updatedChannel = thingCaptor.getValue().getChannel(triggerChannel.getUID());
+        assertThat(updatedChannel.getKind(), is(ChannelKind.TRIGGER));
+        assertThat(updatedChannel.getAcceptedItemType(), is("Number:Power"));
+    }
+
+    @Test
     public void initializeRestoresCommandCapableTypedTriggerAsStateChannel() {
         Configuration configuration = new Configuration(
                 Map.of("stateTopic", "test/state", "commandTopic", "test/command", "trigger", true));

--- a/bundles/org.openhab.binding.mqtt/src/test/java/org/openhab/binding/mqtt/generic/internal/handler/GenericThingHandlerTests.java
+++ b/bundles/org.openhab.binding.mqtt/src/test/java/org/openhab/binding/mqtt/generic/internal/handler/GenericThingHandlerTests.java
@@ -20,6 +20,7 @@ import static org.mockito.Mockito.*;
 import static org.openhab.binding.mqtt.generic.internal.MqttBindingConstants.GENERIC_MQTT_THING;
 import static org.openhab.binding.mqtt.generic.internal.handler.ThingChannelConstants.*;
 
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -53,6 +54,7 @@ import org.openhab.core.thing.ThingStatus;
 import org.openhab.core.thing.ThingStatusDetail;
 import org.openhab.core.thing.ThingStatusInfo;
 import org.openhab.core.thing.binding.ThingHandlerCallback;
+import org.openhab.core.thing.binding.builder.ChannelBuilder;
 import org.openhab.core.thing.type.ChannelKind;
 import org.openhab.core.types.RefreshType;
 import org.openhab.core.types.UnDefType;
@@ -149,28 +151,62 @@ public class GenericThingHandlerTests {
     }
 
     @Test
-    public void initializeKeepsCommandCapableTypedTriggerAsStateChannel() {
+    public void initializeRestoresCommandCapableTypedTriggerAsStateChannel() {
         Configuration configuration = new Configuration(
                 Map.of("stateTopic", "test/state", "commandTopic", "test/command", "trigger", true));
-        Channel triggerChannel = cb("onoff", "Switch", configuration, ON_OFF_CHANNEL);
+        Channel triggerChannel = ChannelBuilder.create(cb("onoff", "Switch", configuration, ON_OFF_CHANNEL))
+                .withKind(ChannelKind.TRIGGER).build();
+        when(thingMock.getChannels()).thenReturn(List.of(triggerChannel));
+
+        thingHandler.initialize();
+
+        ArgumentCaptor<Thing> thingCaptor = ArgumentCaptor.forClass(Thing.class);
+        verify(callbackMock).thingUpdated(thingCaptor.capture());
+        Channel updatedChannel = thingCaptor.getValue().getChannel(triggerChannel.getUID());
+        assertThat(updatedChannel.getKind(), is(ChannelKind.STATE));
+    }
+
+    @Test
+    public void initializeRestoresDisabledTypedTriggerAsStateChannel() {
+        Configuration configuration = new Configuration(Map.of("stateTopic", "test/state"));
+        Channel triggerChannel = ChannelBuilder.create(cb("onoff", "Switch", configuration, ON_OFF_CHANNEL))
+                .withKind(ChannelKind.TRIGGER).build();
+        when(thingMock.getChannels()).thenReturn(List.of(triggerChannel));
+
+        thingHandler.initialize();
+
+        ArgumentCaptor<Thing> thingCaptor = ArgumentCaptor.forClass(Thing.class);
+        verify(callbackMock).thingUpdated(thingCaptor.capture());
+        Channel updatedChannel = thingCaptor.getValue().getChannel(triggerChannel.getUID());
+        assertThat(updatedChannel.getKind(), is(ChannelKind.STATE));
+    }
+
+    @Test
+    public void initializeRestoresReadOnlyImageTriggerAsStateChannel() {
+        Configuration configuration = new Configuration(Map.of("stateTopic", "test/state", "trigger", true));
+        Channel imageChannel = ChannelBuilder.create(cb("image", "Image", configuration, IMAGE_CHANNEL))
+                .withKind(ChannelKind.TRIGGER).build();
+        when(thingMock.getChannels()).thenReturn(List.of(imageChannel));
+
+        thingHandler.initialize();
+
+        ArgumentCaptor<Thing> thingCaptor = ArgumentCaptor.forClass(Thing.class);
+        verify(callbackMock).thingUpdated(thingCaptor.capture());
+        Channel updatedChannel = thingCaptor.getValue().getChannel(imageChannel.getUID());
+        assertThat(updatedChannel.getKind(), is(ChannelKind.STATE));
+    }
+
+    @Test
+    public void initializeKeepsDedicatedTriggerChannelAsTriggerChannel() {
+        Configuration configuration = new Configuration(Map.of("stateTopic", "test/state"));
+        Channel triggerChannel = ChannelBuilder.create(cb("trigger", "String", configuration, TRIGGER_CHANNEL))
+                .withKind(ChannelKind.TRIGGER).build();
         when(thingMock.getChannels()).thenReturn(List.of(triggerChannel));
 
         thingHandler.initialize();
 
         verify(callbackMock, never()).thingUpdated(any());
-        assertThat(triggerChannel.getKind(), is(ChannelKind.STATE));
-    }
-
-    @Test
-    public void initializeKeepsReadOnlyImageTriggerAsStateChannel() {
-        Configuration configuration = new Configuration(Map.of("stateTopic", "test/state", "trigger", true));
-        Channel imageChannel = cb("image", "Image", configuration, IMAGE_CHANNEL);
-        when(thingMock.getChannels()).thenReturn(List.of(imageChannel));
-
-        thingHandler.initialize();
-
-        verify(callbackMock, never()).thingUpdated(any());
-        assertThat(imageChannel.getKind(), is(ChannelKind.STATE));
+        assertThat(triggerChannel.getKind(), is(ChannelKind.TRIGGER));
     }
 
     @Test
@@ -232,7 +268,7 @@ public class GenericThingHandlerTests {
                         textValue, thingHandler));
         doReturn(channelConfig).when(thingHandler).createChannelState(any(), any(), any());
         thingHandler.initialize();
-        byte[] payload = "UPDATE".getBytes();
+        byte[] payload = "UPDATE".getBytes(StandardCharsets.UTF_8);
         // Test process message
         channelConfig.processMessage("test/state", payload);
 

--- a/bundles/org.openhab.binding.mqtt/src/test/java/org/openhab/binding/mqtt/generic/internal/handler/ThingChannelConstants.java
+++ b/bundles/org.openhab.binding.mqtt/src/test/java/org/openhab/binding/mqtt/generic/internal/handler/ThingChannelConstants.java
@@ -45,6 +45,7 @@ public class ThingChannelConstants {
     public static final ChannelTypeUID ON_OFF_CHANNEL = new ChannelTypeUID(BINDING_ID, MqttBindingConstants.SWITCH);
     public static final ChannelTypeUID NUMBER_CHANNEL = new ChannelTypeUID(BINDING_ID, MqttBindingConstants.NUMBER);
     public static final ChannelTypeUID PERCENTAGE_CHANNEL = new ChannelTypeUID(BINDING_ID, MqttBindingConstants.DIMMER);
+    public static final ChannelTypeUID IMAGE_CHANNEL = new ChannelTypeUID(BINDING_ID, MqttBindingConstants.IMAGE);
     public static final ChannelTypeUID UNKNOWN_CHANNEL = new ChannelTypeUID(BINDING_ID, "unknown");
 
     public static final ChannelUID TEXT_CHANNEL_UID = new ChannelUID(TEST_GENERIC_THING, "mytext");

--- a/bundles/org.openhab.binding.mqtt/src/test/java/org/openhab/binding/mqtt/generic/internal/handler/ThingChannelConstants.java
+++ b/bundles/org.openhab.binding.mqtt/src/test/java/org/openhab/binding/mqtt/generic/internal/handler/ThingChannelConstants.java
@@ -46,6 +46,7 @@ public class ThingChannelConstants {
     public static final ChannelTypeUID NUMBER_CHANNEL = new ChannelTypeUID(BINDING_ID, MqttBindingConstants.NUMBER);
     public static final ChannelTypeUID PERCENTAGE_CHANNEL = new ChannelTypeUID(BINDING_ID, MqttBindingConstants.DIMMER);
     public static final ChannelTypeUID IMAGE_CHANNEL = new ChannelTypeUID(BINDING_ID, MqttBindingConstants.IMAGE);
+    public static final ChannelTypeUID TRIGGER_CHANNEL = new ChannelTypeUID(BINDING_ID, MqttBindingConstants.TRIGGER);
     public static final ChannelTypeUID UNKNOWN_CHANNEL = new ChannelTypeUID(BINDING_ID, "unknown");
 
     public static final ChannelUID TEXT_CHANNEL_UID = new ChannelUID(TEST_GENERIC_THING, "mytext");

--- a/bundles/org.openhab.binding.mqtt/src/test/java/org/openhab/binding/mqtt/generic/mapping/MqttTopicClassMapperTests.java
+++ b/bundles/org.openhab.binding.mqtt/src/test/java/org/openhab/binding/mqtt/generic/mapping/MqttTopicClassMapperTests.java
@@ -24,6 +24,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.lang.reflect.Field;
 import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledExecutorService;
@@ -184,7 +185,7 @@ public class MqttTopicClassMapperTests {
             verify(f).subscribeAndReceive(any(), anyInt());
 
             // Simulate a received MQTT value and use the annotation data as input.
-            f.processMessage(f.topic, annotation.value().getBytes());
+            f.processMessage(f.topic, annotation.value().getBytes(StandardCharsets.UTF_8));
             verify(fieldChangedObserverMock, times(++loopCounter)).attributeChanged(any(), any(), any(), any(),
                     anyBoolean());
 
@@ -223,7 +224,7 @@ public class MqttTopicClassMapperTests {
 
         SubscribeFieldToMQTTtopic field = attributes.subscriptions.stream()
                 .filter(f -> "state".equals(f.field.getName())).findFirst().get();
-        field.processMessage(field.topic, "garbage".getBytes());
+        field.processMessage(field.topic, "garbage".getBytes(StandardCharsets.UTF_8));
         verify(fieldChangedObserverMock, times(0)).attributeChanged(any(), any(), any(), any(), anyBoolean());
         assertThat(attributes.state.toString(), is("unknown"));
     }

--- a/bundles/org.openhab.binding.mqtt/src/test/java/org/openhab/binding/mqtt/generic/mapping/SubscribeFieldToMQTTtopicTests.java
+++ b/bundles/org.openhab.binding.mqtt/src/test/java/org/openhab/binding/mqtt/generic/mapping/SubscribeFieldToMQTTtopicTests.java
@@ -24,6 +24,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.lang.reflect.Field;
 import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
@@ -145,7 +146,7 @@ public class SubscribeFieldToMQTTtopicTests {
         CompletableFuture<@Nullable Void> future = subscriber.subscribeAndReceive(connectionMock, 1000);
 
         // Simulate a received MQTT message
-        subscriber.processMessage("ignored", "10".getBytes());
+        subscriber.processMessage("ignored", "10".getBytes(StandardCharsets.UTF_8));
         // No timeout should happen
         future.get(50, TimeUnit.MILLISECONDS);
         assertThat(attributes.aInt, is(10));

--- a/bundles/org.openhab.binding.mqtt/src/test/java/org/openhab/binding/mqtt/internal/MQTTTopicDiscoveryServiceTest.java
+++ b/bundles/org.openhab.binding.mqtt/src/test/java/org/openhab/binding/mqtt/internal/MQTTTopicDiscoveryServiceTest.java
@@ -17,6 +17,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 
@@ -91,7 +92,7 @@ public class MQTTTopicDiscoveryServiceTest {
         subject.createdHandler(handler);
         assertThat(subject.discoveryTopics.get("topic"), hasItem(listenerMock));
         // Simulate receiving
-        final byte[] bytes = "TEST".getBytes();
+        final byte[] bytes = "TEST".getBytes(StandardCharsets.UTF_8);
         connection.getSubscribers().get("topic").messageArrived("topic", bytes, false);
         verify(listenerMock).receivedMessage(eq(thingMock.getUID()), eq(connection), eq("topic"), eq(bytes));
     }
@@ -106,7 +107,7 @@ public class MQTTTopicDiscoveryServiceTest {
         assertThat(subject.discoveryTopics.get("topic"), hasItem(listenerMock));
 
         // Simulate receiving
-        final byte[] bytes = "TEST".getBytes();
+        final byte[] bytes = "TEST".getBytes(StandardCharsets.UTF_8);
         connection.getSubscribers().get("topic").messageArrived("topic", bytes, false);
         verify(listenerMock).receivedMessage(eq(thingMock.getUID()), eq(connection), eq("topic"), eq(bytes));
     }
@@ -122,7 +123,7 @@ public class MQTTTopicDiscoveryServiceTest {
         BrokerHandlerEx.verifyCreateBrokerConnection(handler, 1);
 
         // Simulate receiving
-        final byte[] bytes = "TEST".getBytes();
+        final byte[] bytes = "TEST".getBytes(StandardCharsets.UTF_8);
         connection.getSubscribers().get("topic").messageArrived("topic", bytes, false);
         verify(listenerMock).receivedMessage(eq(thingMock.getUID()), eq(connection), eq("topic"), eq(bytes));
     }
@@ -137,7 +138,7 @@ public class MQTTTopicDiscoveryServiceTest {
         assertThat(subject.discoveryTopics.get("topic"), hasItem(listenerMock));
 
         // Simulate receiving
-        final byte[] bytes = "".getBytes();
+        final byte[] bytes = "".getBytes(StandardCharsets.UTF_8);
         connection.getSubscribers().get("topic").messageArrived("topic", bytes, false);
         verify(listenerMock).topicVanished(eq(thingMock.getUID()), eq(connection), eq("topic"));
     }


### PR DESCRIPTION
Typed channels configured with `trigger=true` and without a `commandTopic` are now exposed as trigger channels. This allows framework consumers such as Main UI to distinguish them from state channels.

Typed trigger behavior remains backward compatible: incoming payloads are validated using the configured channel type before emitting a trigger event. Channels that also define a `commandTopic` retain state-channel metadata so linked Item commands can still be published to MQTT.

Adapted docs to:

- Recommend `Type trigger` for untyped MQTT trigger events.
- Explain the typed `trigger=true` behavior.
- Document the command-capable hybrid case.
- Clarify that `Trigger String` and `Trigger Switch` do not select an MQTT channel type and are unsupported.

Fixes: https://github.com/openhab/openhab-addons/issues/19583

_Disclaimer: tests and documentation created here with assistence from codex, supervised and reviewed by me, runtime code by me_