### PR TITLE
[mqtt] Improve configuration validation

### DIFF
--- a/bundles/org.openhab.binding.mqtt/src/main/java/org/openhab/binding/mqtt/generic/internal/handler/GenericMQTTThingHandler.java
+++ b/bundles/org.openhab.binding.mqtt/src/main/java/org/openhab/binding/mqtt/generic/internal/handler/GenericMQTTThingHandler.java
@@ -153,6 +153,15 @@ public class GenericMQTTThingHandler extends AbstractMQTTThingHandler implements
             final ChannelConfig channelConfig = channel.getConfiguration().as(ChannelConfig.class);
             ChannelBuilder channelBuilder = null;
 
+            boolean triggerChannel = channelConfig.trigger
+                    || MqttBindingConstants.TRIGGER.equals(channelTypeUID.getId());
+            if (channelConfig.stateTopic.isBlank() && (triggerChannel || channelConfig.commandTopic.isBlank())) {
+                String requiredTopics = triggerChannel ? "stateTopic" : "stateTopic or commandTopic";
+                logger.warn("Channel '{}' must define {}", channel.getUID(), requiredTopics);
+                configErrors.add(channel.getUID());
+                continue;
+            }
+
             if (channelTypeUID
                     .equals(new ChannelTypeUID(MqttBindingConstants.BINDING_ID, MqttBindingConstants.NUMBER))) {
                 Unit<?> unit = UnitUtils.parseUnit(channelConfig.unit);
@@ -210,7 +219,7 @@ public class GenericMQTTThingHandler extends AbstractMQTTThingHandler implements
         // If some channels could not start up, put the entire thing offline and display the channels
         // in question to the user.
         if (!configErrors.isEmpty()) {
-            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, "Remove and recreate: "
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, "Invalid channel configuration: "
                     + configErrors.stream().map(ChannelUID::getAsString).collect(Collectors.joining(",")));
             return;
         }

--- a/bundles/org.openhab.binding.mqtt/src/test/java/org/openhab/binding/mqtt/generic/internal/handler/GenericThingHandlerTests.java
+++ b/bundles/org.openhab.binding.mqtt/src/test/java/org/openhab/binding/mqtt/generic/internal/handler/GenericThingHandlerTests.java
@@ -135,6 +135,55 @@ public class GenericThingHandlerTests {
     }
 
     @Test
+    public void initializeWithStateOnlyChannel() {
+        Channel channel = cb("stateOnly", "String", new Configuration(Map.of("stateTopic", "test/state")),
+                TEXT_CHANNEL);
+        when(thingMock.getChannels()).thenReturn(List.of(channel));
+
+        thingHandler.initialize();
+
+        assertThat(thingHandler.channelStateByChannelUID.containsKey(channel.getUID()), is(true));
+        verify(connectionMock).subscribe(eq("test/state"), any());
+    }
+
+    @Test
+    public void initializeWithCommandOnlyChannel() {
+        Channel channel = cb("commandOnly", "String", new Configuration(Map.of("commandTopic", "test/command")),
+                TEXT_CHANNEL);
+        when(thingMock.getChannels()).thenReturn(List.of(channel));
+
+        thingHandler.initialize();
+
+        assertThat(thingHandler.channelStateByChannelUID.containsKey(channel.getUID()), is(true));
+        verify(connectionMock, never()).subscribe(any(), any());
+    }
+
+    @Test
+    public void initializeRejectsChannelWithUnknownPropertiesInsteadOfTopics() {
+        Channel channel = cb("invalid", "String",
+                new Configuration(Map.of("status", "test/state", "trans", "JSONPATH:$.value")), TEXT_CHANNEL);
+
+        assertConfigurationError(channel);
+    }
+
+    @Test
+    public void initializeRejectsTypedTriggerWithoutStateTopic() {
+        Channel channel = cb("invalidTypedTrigger", "String",
+                new Configuration(Map.of("commandTopic", "test/command", "trigger", true)), TEXT_CHANNEL);
+
+        assertConfigurationError(channel);
+    }
+
+    @Test
+    public void initializeRejectsTriggerWithoutStateTopic() {
+        ChannelUID channelUID = new ChannelUID(TEST_GENERIC_THING, "invalidTrigger");
+        Channel channel = ChannelBuilder.create(channelUID).withType(TRIGGER_CHANNEL).withKind(ChannelKind.TRIGGER)
+                .withConfiguration(new Configuration(Map.of("commandTopic", "test/command"))).build();
+
+        assertConfigurationError(channel);
+    }
+
+    @Test
     public void initializeMarksReadOnlyTypedTriggerAsTriggerChannel() {
         Configuration configuration = new Configuration(Map.of("stateTopic", "test/state", "trigger", true));
         Channel triggerChannel = cb("onoff", "Switch", configuration, ON_OFF_CHANNEL);
@@ -309,5 +358,18 @@ public class GenericThingHandlerTests {
                 .bridgeStatusChanged(new ThingStatusInfo(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE, null));
         thingHandler.bridgeStatusChanged(new ThingStatusInfo(ThingStatus.ONLINE, ThingStatusDetail.NONE, null));
         verify(connectionMock, times(2)).subscribe(eq("test/LWT"), any());
+    }
+
+    private void assertConfigurationError(Channel channel) {
+        when(thingMock.getChannels()).thenReturn(List.of(channel));
+
+        thingHandler.initialize();
+
+        assertThat(thingHandler.channelStateByChannelUID.containsKey(channel.getUID()), is(false));
+        verify(thingHandler, never()).start(any());
+        verify(callbackMock).statusUpdated(eq(thingMock),
+                argThat(arg -> ThingStatus.OFFLINE.equals(arg.getStatus())
+                        && ThingStatusDetail.CONFIGURATION_ERROR.equals(arg.getStatusDetail())
+                        && ("Invalid channel configuration: " + channel.getUID()).equals(arg.getDescription())));
     }
 }


### PR DESCRIPTION
This bug fix validates MQTT channel topic configuration during Thing initialization.

This change:
- Requires state channels to define at least one of `stateTopic` or `commandTopic`.
- Requires dedicated trigger channels and channels configured with `trigger=true` to define `stateTopic`.
- Sets the Thing to `OFFLINE` with `CONFIGURATION_ERROR` and identifies invalid channels.

Depends on #21449 for the related typed-trigger channel handling.

Fixes: https://github.com/openhab/openhab-addons/issues/20100

_Disclaimer: tests and documentation created here with assistence from codex, supervised and reviewed by me, runtime code by me_