### PR TITLE
[whisperstt] Fix vad endless loop

### DIFF
--- a/bundles/org.openhab.voice.whisperstt/src/main/java/org/openhab/voice/whisperstt/internal/WhisperSTTService.java
+++ b/bundles/org.openhab.voice.whisperstt/src/main/java/org/openhab/voice/whisperstt/internal/WhisperSTTService.java
@@ -422,6 +422,7 @@ public class WhisperSTTService implements STTService {
                         // run vad
                         if (nProcessedSamples + nSamplesStep > nSamplesMax - nSamplesStep) {
                             logger.debug("VAD: Skipping, max length reached");
+                            break;
                         } else {
                             VAD.@Nullable VADResult lastVADResult = vad.analyze(stepAudioSamples);
                             if (lastVADResult.isVoice()) {


### PR DESCRIPTION
During testing my voice assistent device, VAD detected the whole time a voice, which results in a endless loop. RecognitionStopEvent was never triggered. 

The problem related to the wrong VAD voice detection is not part of this pull request. This patch is just fixing the endless loop.

I guess that there is only a break missing. 

I say "guess" and not "sure", because I am only just beginning to explore and understand the "voice" code. ;-)