### PR TITLE
[zwavejs] Ignore problematic websocket messages

### DIFF
--- a/bundles/org.openhab.binding.zwavejs/src/main/java/org/openhab/binding/zwavejs/internal/api/ZWaveJSClient.java
+++ b/bundles/org.openhab.binding.zwavejs/src/main/java/org/openhab/binding/zwavejs/internal/api/ZWaveJSClient.java
@@ -43,6 +43,7 @@ import org.openhab.binding.zwavejs.internal.api.dto.messages.EventMessage;
 import org.openhab.binding.zwavejs.internal.api.dto.messages.ResultMessage;
 import org.openhab.binding.zwavejs.internal.api.dto.messages.VersionMessage;
 import org.openhab.binding.zwavejs.internal.api.exception.CommunicationException;
+import org.openhab.binding.zwavejs.internal.config.ZwaveJSBridgeConfiguration;
 import org.openhab.binding.zwavejs.internal.handler.ZwaveEventListener;
 import org.openhab.core.common.ThreadPoolManager;
 import org.slf4j.Logger;
@@ -91,7 +92,7 @@ public class ZWaveJSClient implements WebSocketListener {
     private final Object lifecycleLock = new Object();
     private final Object sendLock = new Object();
 
-    private volatile int bufferSize = 1048576 * 2; // 2 MiB
+    private volatile int bufferSize = ZwaveJSBridgeConfiguration.DEFAULT_MAX_MESSAGE_SIZE;
     private volatile @Nullable Session session;
     private @Nullable Future<?> sessionFuture;
     private @Nullable ScheduledFuture<?> keepAliveFuture;
@@ -299,14 +300,12 @@ public class ZWaveJSClient implements WebSocketListener {
         } catch (JsonParseException ex) {
             logger.warn("Failed to parse incoming WebSocket message: {}", ex.getMessage());
             logger.trace("RECV | {}", message);
-            notifyListenersOnError("Failed to parse message: " + ex.getMessage());
             return;
         }
 
         if (baseEvent == null || baseEvent.type == null) {
             logger.warn("Received event with unknown or null type.");
             logger.trace("RECV | {}", message);
-            notifyListenersOnError("Received event with unknown or null type.");
             return;
         }
 

--- a/bundles/org.openhab.binding.zwavejs/src/main/java/org/openhab/binding/zwavejs/internal/config/ZwaveJSBridgeConfiguration.java
+++ b/bundles/org.openhab.binding.zwavejs/src/main/java/org/openhab/binding/zwavejs/internal/config/ZwaveJSBridgeConfiguration.java
@@ -22,9 +22,11 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 @NonNullByDefault
 public class ZwaveJSBridgeConfiguration {
 
+    public static final int DEFAULT_MAX_MESSAGE_SIZE = 16 * 1024 * 1024;
+
     public String hostname = "";
     public int port = 3000;
-    public int maxMessageSize = 2097152;
+    public int maxMessageSize = DEFAULT_MAX_MESSAGE_SIZE;
     public boolean configurationChannels = false;
 
     public boolean isValid() {

--- a/bundles/org.openhab.binding.zwavejs/src/test/java/org/openhab/binding/zwavejs/internal/api/ZWaveJSClientTest.java
+++ b/bundles/org.openhab.binding.zwavejs/src/test/java/org/openhab/binding/zwavejs/internal/api/ZWaveJSClientTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.zwavejs.internal.api;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jetty.websocket.client.WebSocketClient;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.openhab.binding.zwavejs.internal.handler.ZwaveEventListener;
+
+@NonNullByDefault
+public class ZWaveJSClientTest {
+
+    private final WebSocketClient webSocketClient = mock(WebSocketClient.class);
+    private final ZWaveJSClient client = new ZWaveJSClient(webSocketClient);
+
+    @ParameterizedTest
+    @ValueSource(strings = { "not-json", "{\"type\":\"future-message\"}", "{}", "null" })
+    public void invalidMessageDoesNotReportConnectionError(String message) {
+        ZwaveEventListener listener = mock(ZwaveEventListener.class);
+        client.addEventListener(listener);
+
+        client.onWebSocketText(message);
+
+        verifyNoInteractions(listener);
+    }
+}


### PR DESCRIPTION
- Ignore malformed or unsupported individual messages without incorrectly marking the active connection offline.
- Align the client fallback message size with the documented 16 MiB default.
- Adds tests to connection handling