### PR TITLE
[chatgpt] Use max_completion_tokens for OpenAI requests

### DIFF
--- a/bundles/org.openhab.binding.chatgpt/src/main/java/org/openhab/binding/chatgpt/internal/api/dto/ChatRequestBody.java
+++ b/bundles/org.openhab.binding.chatgpt/src/main/java/org/openhab/binding/chatgpt/internal/api/dto/ChatRequestBody.java
@@ -28,7 +28,7 @@ public class ChatRequestBody {
     private Double temperature;
     @JsonProperty("top_p")
     private Double topP;
-    @JsonProperty("max_tokens")
+    @JsonProperty("max_completion_tokens")
     private Integer maxTokens;
     private String user;
     private List<ChatTools> tools;


### PR DESCRIPTION
Trying to use more recent (specifically reasoning) models from OpenAI, I get this error in my log:

```
Error response payload from [https://api.openai.com/v1/chat/completions](https://api.openai.com/v1/chat/completions) (POST): { "error" : { "message" : "Unsupported parameter: 'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead.", "type" : "invalid_request_error", "param" : "max_tokens", "code" : "unsupported_parameter" } }
```

`max_tokens` parameter is deprecated and not even allowed anymore for reasoning models. Instead, `max_completion_tokens` should be used.

This PR is keeping the existing maxTokens configuration key for backward compatibility while sending OpenAI-compatible chat completion payloads with max_completion_tokens.