### PR TITLE
[zwavejs] Fix Z-Wave JS channel and shutter handling

### DIFF
--- a/bundles/org.openhab.binding.zwavejs/README.md
+++ b/bundles/org.openhab.binding.zwavejs/README.md
@@ -74,7 +74,7 @@ The following devices and parameters support inversion:
 - **Switch, Contact, and Dimmer**: These channels have a single configuration parameter, `inverted`, which reverses the logical state.
 - **RollerShutter**: These channels have two configuration parameters:
   - `inverted`: Reverses the logical state, similar to the above.
-  - `isUpdownInverted`: Independently inverts the up and down directions.
+  - `isUpDownInverted`: Independently inverts the up and down directions.
 
 **note:** Without any inversion, the binding considers 100% fully open (up position) and 0% fully closed (down position).
 

--- a/bundles/org.openhab.binding.zwavejs/src/main/java/org/openhab/binding/zwavejs/internal/handler/ZwaveJSNodeHandler.java
+++ b/bundles/org.openhab.binding.zwavejs/src/main/java/org/openhab/binding/zwavejs/internal/handler/ZwaveJSNodeHandler.java
@@ -208,9 +208,11 @@ public class ZwaveJSNodeHandler extends BaseThingHandler implements ZwaveNodeLis
             }
             ChannelUID targetChannel = null;
             if (rollerShutterCapability.isMovingUp()) {
-                targetChannel = rollerShutterCapability.upChannel;
+                targetChannel = rollerShutterConfig.isUpDownInverted ? rollerShutterCapability.downChannel
+                        : rollerShutterCapability.upChannel;
             } else if (rollerShutterCapability.isMovingDown()) {
-                targetChannel = rollerShutterCapability.downChannel;
+                targetChannel = rollerShutterConfig.isUpDownInverted ? rollerShutterCapability.upChannel
+                        : rollerShutterCapability.downChannel;
             }
             if (targetChannel == null) {
                 logger.debug("Node {}. Cannot stop movement, no direction known", config.id);
@@ -226,14 +228,15 @@ public class ZwaveJSNodeHandler extends BaseThingHandler implements ZwaveNodeLis
 
         // Handle UpDownType: UP or DOWN, respect inversion
         if (command instanceof UpDownType upDownCommand) {
-            boolean isUpCommand = (UpDownType.UP.equals(upDownCommand) && !rollerShutterConfig.isUpDownInverted)
+            boolean usesUpChannel = (UpDownType.UP.equals(upDownCommand) && !rollerShutterConfig.isUpDownInverted)
                     || (UpDownType.DOWN.equals(upDownCommand) && rollerShutterConfig.isUpDownInverted);
-            ChannelUID targetChannel = isUpCommand ? rollerShutterCapability.upChannel
+            ChannelUID targetChannel = usesUpChannel ? rollerShutterCapability.upChannel
                     : rollerShutterCapability.downChannel;
             ZwaveJSChannelConfiguration targetChannelConfig = getChannelConfiguration(targetChannel);
             NodeSetValueCommand zwaveCommand = new NodeSetValueCommand(config.id, targetChannelConfig);
             zwaveCommand.value = true;
-            rollerShutterCapability.setDirection(isUpCommand, !isUpCommand);
+            boolean isMovingUp = UpDownType.UP.equals(upDownCommand);
+            rollerShutterCapability.setDirection(isMovingUp, !isMovingUp);
             bridgeHandler.sendCommand(zwaveCommand);
             return;
         }

--- a/bundles/org.openhab.binding.zwavejs/src/main/java/org/openhab/binding/zwavejs/internal/type/ZwaveJSTypeGeneratorImpl.java
+++ b/bundles/org.openhab.binding.zwavejs/src/main/java/org/openhab/binding/zwavejs/internal/type/ZwaveJSTypeGeneratorImpl.java
@@ -18,7 +18,6 @@ import static org.openhab.binding.zwavejs.internal.CommandClassConstants.COMMAND
 import static org.openhab.binding.zwavejs.internal.CommandClassConstants.COMMAND_CLASS_SWITCH_COLOR;
 
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
@@ -52,8 +51,6 @@ import org.openhab.core.semantics.model.DefaultSemanticTags.Property;
 import org.openhab.core.thing.Channel;
 import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.DefaultSystemChannelTypeProvider;
-import org.openhab.core.thing.Thing;
-import org.openhab.core.thing.ThingRegistry;
 import org.openhab.core.thing.ThingUID;
 import org.openhab.core.thing.binding.builder.ChannelBuilder;
 import org.openhab.core.thing.type.ChannelType;
@@ -76,7 +73,6 @@ import org.slf4j.LoggerFactory;
  * @see ChannelTypeBuilder
  * @see ChannelTypeUID
  * @see StateChannelTypeBuilder
- * @see ThingRegistry
  * @see ZwaveJSChannelTypeProvider
  * @see ZwaveJSConfigDescriptionProvider
  *
@@ -105,27 +101,14 @@ public class ZwaveJSTypeGeneratorImpl implements ZwaveJSTypeGenerator {
             "awning", "venetian", "drape", "roller", "screen", "covering", "rts");
 
     private final Logger logger = LoggerFactory.getLogger(ZwaveJSTypeGeneratorImpl.class);
-    private final ThingRegistry thingRegistry;
     private final ZwaveJSChannelTypeProvider channelTypeProvider;
     private final ZwaveJSConfigDescriptionProvider configDescriptionProvider;
 
     @Activate
     public ZwaveJSTypeGeneratorImpl(@Reference ZwaveJSChannelTypeProvider channelTypeProvider,
-            @Reference ZwaveJSConfigDescriptionProvider configDescriptionProvider,
-            @Reference ThingRegistry thingRegistry) {
+            @Reference ZwaveJSConfigDescriptionProvider configDescriptionProvider) {
         this.channelTypeProvider = channelTypeProvider;
         this.configDescriptionProvider = configDescriptionProvider;
-        this.thingRegistry = thingRegistry;
-    }
-
-    /**
-     * Retrieves a Thing by its UID.
-     *
-     * @param thingUID the UID of the Thing
-     * @return the Thing, or {@code null} if not found
-     */
-    public @Nullable Thing getThing(ThingUID thingUID) {
-        return thingRegistry.get(thingUID);
     }
 
     /**
@@ -140,7 +123,7 @@ public class ZwaveJSTypeGeneratorImpl implements ZwaveJSTypeGenerator {
     public ZwaveJSTypeGeneratorResult generate(ThingUID thingUID, Node node, boolean configurationAsChannels) {
         ZwaveJSTypeGeneratorResult result = new ZwaveJSTypeGeneratorResult();
         List<ConfigDescriptionParameter> configDescriptions = new ArrayList<>();
-        URI uri = Objects.requireNonNull(getConfigDescriptionURI(thingUID, node));
+        URI uri = URI.create("thing:" + thingUID);
 
         for (Value value : node.values) {
             if (!configurationAsChannels && CONFIGURATION_COMMAND_CLASSES.contains(value.commandClass)) {
@@ -499,27 +482,6 @@ public class ZwaveJSTypeGeneratorImpl implements ZwaveJSTypeGenerator {
         return builder.isAdvanced(details.isAdvanced).build();
     }
 
-    private @Nullable URI getConfigDescriptionURI(ThingUID thingUID, Node node) {
-        Thing thing = getThing(thingUID);
-        if (thing == null) {
-            logger.debug("Thing '{}'' not found in registry for getConfigDescriptionURI", thingUID);
-            return null;
-        }
-        ThingUID bridgeUID = thing.getBridgeUID();
-        if (bridgeUID == null) {
-            logger.debug("No bridgeUID found for Thing '{}'' in getConfigDescriptionURI", thingUID);
-            return null;
-        }
-
-        try {
-            return new URI(String.format("thing:%s:node:%s:node%s", BindingConstants.BINDING_ID, bridgeUID.getId(),
-                    node.nodeId));
-        } catch (URISyntaxException ex) {
-            logger.warn("Can't create configDescriptionURI for node {}", node.nodeId);
-            return null;
-        }
-    }
-
     /**
      * Matches the given list of keywords against the label and description of the provided
      * {@link ChannelMetadata}. This method delegates the matching logic to the overloaded
@@ -572,6 +534,7 @@ public class ZwaveJSTypeGeneratorImpl implements ZwaveJSTypeGenerator {
             case CoreItemFactory.COLOR:
                 point = details.writable ? Point.CONTROL : Point.STATUS;
                 property = Property.COLOR;
+                break;
             case CoreItemFactory.DIMMER:
                 point = Point.CONTROL;
                 break;

--- a/bundles/org.openhab.binding.zwavejs/src/main/java/org/openhab/binding/zwavejs/internal/type/capabilities/RollerShutterCapability.java
+++ b/bundles/org.openhab.binding.zwavejs/src/main/java/org/openhab/binding/zwavejs/internal/type/capabilities/RollerShutterCapability.java
@@ -122,8 +122,8 @@ public class RollerShutterCapability {
             this.isMovingDown = false;
             return;
         }
-        this.isMovingUp = isUpDownInverted ? position > cachedPosition : position < cachedPosition;
-        this.isMovingDown = isUpDownInverted ? position < cachedPosition : position > cachedPosition;
+        this.isMovingUp = isUpDownInverted ? position < cachedPosition : position > cachedPosition;
+        this.isMovingDown = isUpDownInverted ? position > cachedPosition : position < cachedPosition;
         this.cachedPosition = position;
     }
 

--- a/bundles/org.openhab.binding.zwavejs/src/test/java/org/openhab/binding/zwavejs/internal/handler/ZwaveJSNodeHandlerRollerShutterStateTest.java
+++ b/bundles/org.openhab.binding.zwavejs/src/test/java/org/openhab/binding/zwavejs/internal/handler/ZwaveJSNodeHandlerRollerShutterStateTest.java
@@ -88,8 +88,8 @@ public class ZwaveJSNodeHandlerRollerShutterStateTest {
         Event event = createRollerShutterDimmerEvent(capability.dimmerChannel.getId(), 80);
         handler.onNodeStateChanged(event);
         assertEquals(80, capability.getCachedPosition());
-        assertTrue(capability.isMovingDown());
-        assertFalse(capability.isMovingUp());
+        assertTrue(capability.isMovingUp());
+        assertFalse(capability.isMovingDown());
     }
 
     // Without any inversion, 100% is fully open (up position) and 0% is fully closed (down position).
@@ -125,9 +125,9 @@ public class ZwaveJSNodeHandlerRollerShutterStateTest {
 
         assertTrue(successfulHandling);
         assertEquals(80, capability.getCachedPosition());
-        // With inversion, increasing value means moving up
-        assertTrue(capability.isMovingUp());
-        assertFalse(capability.isMovingDown());
+        // With inversion, increasing value means moving down
+        assertTrue(capability.isMovingDown());
+        assertFalse(capability.isMovingUp());
     }
 
     @Test

--- a/bundles/org.openhab.binding.zwavejs/src/test/java/org/openhab/binding/zwavejs/internal/handler/ZwaveJSNodeHandlerTest.java
+++ b/bundles/org.openhab.binding.zwavejs/src/test/java/org/openhab/binding/zwavejs/internal/handler/ZwaveJSNodeHandlerTest.java
@@ -31,6 +31,7 @@ import org.openhab.binding.zwavejs.internal.api.dto.commands.NodeGetValueCommand
 import org.openhab.binding.zwavejs.internal.api.dto.commands.NodeSetValueCommand;
 import org.openhab.binding.zwavejs.internal.api.dto.messages.EventMessage;
 import org.openhab.binding.zwavejs.internal.handler.mock.ZwaveJSNodeHandlerMock;
+import org.openhab.binding.zwavejs.internal.type.capabilities.RollerShutterCapability;
 import org.openhab.core.config.core.Configuration;
 import org.openhab.core.library.CoreItemFactory;
 import org.openhab.core.library.types.DecimalType;
@@ -568,6 +569,42 @@ public class ZwaveJSNodeHandlerTest {
 
         assertEquals(39, sendCommand.nodeId);
         assertEquals(38, sendCommand.valueId.commandClass);
+        assertEquals("On", sendCommand.valueId.property);
+        assertEquals(false, sendCommand.value);
+    }
+
+    @Test
+    public void testRollershutterCommandStopAfterPositionIncrease() {
+        ZwaveJSNodeHandlerMock nodeHandler = arrangeHandleCommandTest(39);
+        RollerShutterCapability capability = nodeHandler.getRollerShutterCapabilities().values().stream().findFirst()
+                .orElseThrow();
+        capability.setPosition(80, false);
+
+        nodeHandler.handleCommand(new ChannelUID("zwavejs:test-bridge:test-thing:rollershutter-virtual"),
+                StopMoveType.STOP);
+
+        verify(nodeHandler.getBridgeHandler(), times(1)).sendCommand(any(NodeSetValueCommand.class));
+        NodeSetValueCommand sendCommand = captureCommand(nodeHandler, NodeSetValueCommand.class);
+
+        assertEquals("On", sendCommand.valueId.property);
+        assertEquals(false, sendCommand.value);
+    }
+
+    @Test
+    public void testRollershutterCommandStopAfterInvertedPositionIncrease() {
+        ZwaveJSNodeHandlerMock nodeHandler = arrangeHandleCommandTest(39);
+        RollerShutterCapability capability = nodeHandler.getRollerShutterCapabilities().values().stream().findFirst()
+                .orElseThrow();
+        nodeHandler.setRollerShutterInversion(capability, true);
+        ChannelUID channelUID = new ChannelUID("zwavejs:test-bridge:test-thing:rollershutter-virtual");
+
+        nodeHandler.handleCommand(channelUID, UpDownType.DOWN);
+        capability.setPosition(80, true);
+        nodeHandler.handleCommand(channelUID, StopMoveType.STOP);
+
+        verify(nodeHandler.getBridgeHandler(), times(2)).sendCommand(any(NodeSetValueCommand.class));
+        NodeSetValueCommand sendCommand = captureCommand(nodeHandler, NodeSetValueCommand.class);
+
         assertEquals("On", sendCommand.valueId.property);
         assertEquals(false, sendCommand.value);
     }

--- a/bundles/org.openhab.binding.zwavejs/src/test/java/org/openhab/binding/zwavejs/internal/handler/mock/ZwaveJSNodeHandlerMock.java
+++ b/bundles/org.openhab.binding.zwavejs/src/test/java/org/openhab/binding/zwavejs/internal/handler/mock/ZwaveJSNodeHandlerMock.java
@@ -40,7 +40,6 @@ import org.openhab.core.config.core.Configuration;
 import org.openhab.core.thing.Bridge;
 import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.Thing;
-import org.openhab.core.thing.ThingRegistry;
 import org.openhab.core.thing.ThingStatus;
 import org.openhab.core.thing.ThingUID;
 import org.openhab.core.thing.binding.ThingHandlerCallback;
@@ -93,10 +92,8 @@ public class ZwaveJSNodeHandlerMock extends ZwaveJSNodeHandler {
             final String filename, boolean configAsChannel) {
         ZwaveJSChannelTypeProvider channelTypeProvider = new ZwaveJSChannelTypeInMemmoryProvider();
         ZwaveJSConfigDescriptionProvider configDescriptionProvider = new ZwaveJSConfigDescriptionProviderImpl();
-        ThingRegistry thingRegistry = mock(ThingRegistry.class);
-        when(thingRegistry.get(any())).thenReturn(thing);
         ZwaveJSTypeGenerator typeGenerator = new ZwaveJSTypeGeneratorImpl(channelTypeProvider,
-                configDescriptionProvider, thingRegistry);
+                configDescriptionProvider);
 
         final ZwaveJSNodeHandlerMock handler = spy(
                 new ZwaveJSNodeHandlerMock(thing, typeGenerator, filename, configAsChannel));
@@ -175,7 +172,7 @@ public class ZwaveJSNodeHandlerMock extends ZwaveJSNodeHandler {
                     ZwaveJSChannelConfiguration config = channel.getConfiguration()
                             .as(ZwaveJSChannelConfiguration.class);
                     config.isUpDownInverted = isUpDownInverted;
-                    when(this.getChannelConfiguration(any())).thenReturn(config);
+                    doReturn(config).when(this).getChannelConfiguration(channel);
                 });
     }
 }

--- a/bundles/org.openhab.binding.zwavejs/src/test/java/org/openhab/binding/zwavejs/internal/type/ZwaveJSTypeGeneratorTest.java
+++ b/bundles/org.openhab.binding.zwavejs/src/test/java/org/openhab/binding/zwavejs/internal/type/ZwaveJSTypeGeneratorTest.java
@@ -13,15 +13,15 @@
 package org.openhab.binding.zwavejs.internal.type;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
 import static org.openhab.binding.zwavejs.internal.BindingConstants.BINDING_ID;
 
 import java.io.IOException;
 import java.math.BigDecimal;
+import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
@@ -29,14 +29,16 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openhab.binding.zwavejs.internal.BindingConstants;
 import org.openhab.binding.zwavejs.internal.DataUtil;
+import org.openhab.binding.zwavejs.internal.api.dto.MetadataType;
 import org.openhab.binding.zwavejs.internal.api.dto.Node;
+import org.openhab.binding.zwavejs.internal.api.dto.Value;
 import org.openhab.binding.zwavejs.internal.api.dto.messages.ResultMessage;
 import org.openhab.binding.zwavejs.internal.handler.mock.ZwaveJSChannelTypeInMemmoryProvider;
 import org.openhab.core.config.core.Configuration;
 import org.openhab.core.library.CoreItemFactory;
+import org.openhab.core.semantics.model.DefaultSemanticTags.Point;
+import org.openhab.core.semantics.model.DefaultSemanticTags.Property;
 import org.openhab.core.thing.Channel;
-import org.openhab.core.thing.Thing;
-import org.openhab.core.thing.ThingRegistry;
 import org.openhab.core.thing.ThingUID;
 import org.openhab.core.thing.type.ChannelType;
 import org.openhab.core.types.StateDescription;
@@ -54,12 +56,7 @@ public class ZwaveJSTypeGeneratorTest {
 
     @BeforeEach
     public void setup() {
-        ThingRegistry thingRegistry = mock(ThingRegistry.class);
-        Thing thing = mock(Thing.class);
-        when(thing.getUID()).thenReturn(new ThingUID(BindingConstants.BINDING_ID, "test-thing"));
-        when(thing.getBridgeUID()).thenReturn(new ThingUID(BindingConstants.BINDING_ID, "test-bridge"));
-        when(thingRegistry.get(any())).thenReturn(thing);
-        provider = new ZwaveJSTypeGeneratorImpl(channelTypeProvider, configDescriptionProvider, thingRegistry);
+        provider = new ZwaveJSTypeGeneratorImpl(channelTypeProvider, configDescriptionProvider);
     }
 
     private Channel getChannel(String store, int nodeId, String channelId) throws IOException {
@@ -73,6 +70,26 @@ public class ZwaveJSTypeGeneratorTest {
                 new ThingUID(BINDING_ID, "test-bridge", "test-thing"), Objects.requireNonNull(node),
                 configurationAsChannels);
         return Objects.requireNonNull(results.channels.get(channelId));
+    }
+
+    @Test
+    public void testConfigDescriptionUsesThingUID() throws IOException {
+        Node node = DataUtil.getNodeFromStore("store_4.json", 7);
+        ThingUID thingUID = new ThingUID(BINDING_ID, "node", "test-bridge", "kitchen");
+
+        Objects.requireNonNull(provider).generate(thingUID, Objects.requireNonNull(node), false);
+
+        assertNotNull(configDescriptionProvider.getConfigDescription(URI.create("thing:" + thingUID), null));
+    }
+
+    @Test
+    public void testConfigDescriptionUsesDefaultNodeThingUID() throws IOException {
+        Node node = DataUtil.getNodeFromStore("store_4.json", 7);
+        ThingUID thingUID = new ThingUID(BINDING_ID, "node", "test-bridge", "node7");
+
+        Objects.requireNonNull(provider).generate(thingUID, Objects.requireNonNull(node), false);
+
+        assertNotNull(configDescriptionProvider.getConfigDescription(URI.create("thing:" + thingUID), null));
     }
 
     @Test
@@ -322,6 +339,22 @@ public class ZwaveJSTypeGeneratorTest {
 
         assertNotNull(type);
         assertEquals("Color", type.getItemType());
+    }
+
+    @Test
+    public void testReadOnlyColorSemanticTags() throws IOException {
+        Node node = Objects.requireNonNull(DataUtil.getNodeFromStore("store_4.json", 44));
+        Value colorValue = node.values.stream().filter(value -> value.metadata.type == MetadataType.COLOR).findFirst()
+                .orElseThrow();
+        colorValue.metadata.writeable = false;
+
+        ZwaveJSTypeGeneratorResult results = Objects.requireNonNull(provider)
+                .generate(new ThingUID(BINDING_ID, "test-bridge", "test-thing"), node, false);
+        Channel channel = Objects.requireNonNull(results.channels.get("color-switch-hex-color"));
+        ChannelType type = Objects.requireNonNull(
+                channelTypeProvider.getChannelType(Objects.requireNonNull(channel.getChannelTypeUID()), null));
+
+        assertEquals(Set.of(Point.STATUS.getName(), Property.COLOR.getName()), type.getTags());
     }
 
     @Test

--- a/bundles/org.openhab.binding.zwavejs/src/test/java/org/openhab/binding/zwavejs/internal/type/capabilities/RollerShutterCapabilityTest.java
+++ b/bundles/org.openhab.binding.zwavejs/src/test/java/org/openhab/binding/zwavejs/internal/type/capabilities/RollerShutterCapabilityTest.java
@@ -78,26 +78,26 @@ public class RollerShutterCapabilityTest {
 
     @Test
     public void testSetPositionNormal() {
-        // Not inverted: position increases = moving down, decreases = moving up
-        capability.setPosition(10, false); // from 0 to 10: moving down
-        assertTrue(capability.isMovingDown());
-        assertFalse(capability.isMovingUp());
-        capability.setPosition(5, false); // from 10 to 5: moving up
+        // Not inverted: position increases = moving up, decreases = moving down
+        capability.setPosition(10, false); // from 0 to 10: moving up
         assertTrue(capability.isMovingUp());
         assertFalse(capability.isMovingDown());
+        capability.setPosition(5, false); // from 10 to 5: moving down
+        assertTrue(capability.isMovingDown());
+        assertFalse(capability.isMovingUp());
         capability.setPosition(5, false); // no change
         assertFalse(capability.isMoving());
     }
 
     @Test
     public void testSetPositionInverted() {
-        // Inverted: position increases = moving up, decreases = moving down
-        capability.setPosition(10, true); // from 0 to 10: moving up
-        assertTrue(capability.isMovingUp());
-        assertFalse(capability.isMovingDown());
-        capability.setPosition(5, true); // from 10 to 5: moving down
+        // Inverted: position increases = moving down, decreases = moving up
+        capability.setPosition(10, true); // from 0 to 10: moving down
         assertTrue(capability.isMovingDown());
         assertFalse(capability.isMovingUp());
+        capability.setPosition(5, true); // from 10 to 5: moving up
+        assertTrue(capability.isMovingUp());
+        assertFalse(capability.isMovingDown());
         capability.setPosition(5, true); // no change
         assertFalse(capability.isMoving());
     }


### PR DESCRIPTION
This fix corrects three issues in dynamic channel and rollershutter handling.

- Use the complete Thing UID for configuration-description URIs. This adds support for custom Thing IDs removes not needed `ThingRegistry` dependency.
- Prevent color channels from falling through to dimmer semantic handling, preserving the correct `Color` property and `Control` or `Status` point tag.
- Correct rollershutter movement detection and STOP handling. Movement direction is now represented logically.
- Added unit tests

No configuration or documentation changes are needed.
