### PR TITLE
[chatgpt] Fix ChatGPT binding tools with reasoning models

### DIFF
--- a/bundles/org.openhab.binding.chatgpt/src/main/java/org/openhab/binding/chatgpt/internal/api/ChatGPTApiClient.java
+++ b/bundles/org.openhab.binding.chatgpt/src/main/java/org/openhab/binding/chatgpt/internal/api/ChatGPTApiClient.java
@@ -22,6 +22,8 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Queue;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -72,6 +74,7 @@ public class ChatGPTApiClient {
     private final String apiKey;
     private final String baseUrl;
     private final ObjectMapper objectMapper;
+    private final Set<String> modelsRequiringReasoningEffort = ConcurrentHashMap.newKeySet();
 
     public ChatGPTApiClient(HttpClient httpClient, String apiKey, String baseUrl) {
         this.httpClient = httpClient;
@@ -310,15 +313,28 @@ public class ChatGPTApiClient {
             throw new ChatGPTApiException("Failed to serialize request body: " + e.getMessage(), e);
         }
 
-        return executeCompletionRequest(queryJson, timeoutSeconds);
+        // If we know this model requires reasoning_effort, use it preemptively
+        String reasoningEffort = modelsRequiringReasoningEffort.contains(model) ? "none" : null;
+        return executeCompletionRequest(queryJson, model, timeoutSeconds, reasoningEffort);
     }
 
-    private ChatResponse executeCompletionRequest(String queryJson, @Nullable Integer timeoutSeconds)
-            throws ChatGPTApiException {
+    private ChatResponse executeCompletionRequest(String queryJson, String model, @Nullable Integer timeoutSeconds,
+            @Nullable String reasoningEffort) throws ChatGPTApiException {
+        String finalJson = queryJson;
+        if (reasoningEffort != null) {
+            try {
+                JsonNode jsonNode = objectMapper.readTree(queryJson);
+                ((com.fasterxml.jackson.databind.node.ObjectNode) jsonNode).put("reasoning_effort", reasoningEffort);
+                finalJson = objectMapper.writeValueAsString(jsonNode);
+            } catch (IOException e) {
+                logger.debug("Failed to add reasoning_effort to request: {}", e.getMessage());
+            }
+        }
+
         Request request = httpClient.newRequest(baseUrl + PATH_CHAT_COMPLETIONS).method(HttpMethod.POST)
                 .timeout(timeoutSeconds != null ? timeoutSeconds : 10, TimeUnit.SECONDS)
                 .header(HttpHeader.CONTENT_TYPE, MimeTypes.Type.APPLICATION_JSON.asString())
-                .content(new StringContentProvider(queryJson, StandardCharsets.UTF_8));
+                .content(new StringContentProvider(finalJson, StandardCharsets.UTF_8));
         if (!apiKey.isBlank()) {
             request.header(HttpHeader.AUTHORIZATION, "Bearer " + apiKey);
         }
@@ -365,6 +381,12 @@ public class ChatGPTApiClient {
                 logger.debug("Error response from {} (POST): HTTP {} {}, payload size = {} bytes",
                         baseUrl + PATH_CHAT_COMPLETIONS, response.getStatus(), response.getReason(),
                         errorBody.getBytes(StandardCharsets.UTF_8).length);
+
+                if (response.getStatus() == HttpStatus.BAD_REQUEST_400 && errorBody.contains("reasoning_effort")) {
+                    logger.debug("Model {} requires reasoning_effort; caching and retrying", model);
+                    modelsRequiringReasoningEffort.add(model);
+                    return executeCompletionRequest(queryJson, model, timeoutSeconds, "none");
+                }
                 if (logger.isTraceEnabled()) {
                     try {
                         String prettyError = objectMapper.writerWithDefaultPrettyPrinter()
@@ -400,6 +422,7 @@ public class ChatGPTApiClient {
         if (!apiKey.isBlank()) {
             request.header(HttpHeader.AUTHORIZATION, "Bearer " + apiKey);
         }
+
         logger.debug("Request to {} (GET)", baseUrl + PATH_MODELS);
         try {
             ContentResponse response = request.send();

--- a/bundles/org.openhab.binding.chatgpt/src/main/java/org/openhab/binding/chatgpt/internal/api/ChatGPTApiClient.java
+++ b/bundles/org.openhab.binding.chatgpt/src/main/java/org/openhab/binding/chatgpt/internal/api/ChatGPTApiClient.java
@@ -313,13 +313,14 @@ public class ChatGPTApiClient {
             throw new ChatGPTApiException("Failed to serialize request body: " + e.getMessage(), e);
         }
 
-        // If we know this model requires reasoning_effort, use it preemptively
-        String reasoningEffort = modelsRequiringReasoningEffort.contains(model) ? "none" : null;
-        return executeCompletionRequest(queryJson, model, timeoutSeconds, reasoningEffort);
+        // If we know this model requires reasoning_effort for tool requests, use it preemptively
+        boolean hasTools = tools != null && !tools.isEmpty();
+        String reasoningEffort = hasTools && modelsRequiringReasoningEffort.contains(model) ? "none" : null;
+        return executeCompletionRequest(queryJson, model, hasTools, timeoutSeconds, reasoningEffort);
     }
 
-    private ChatResponse executeCompletionRequest(String queryJson, String model, @Nullable Integer timeoutSeconds,
-            @Nullable String reasoningEffort) throws ChatGPTApiException {
+    private ChatResponse executeCompletionRequest(String queryJson, String model, boolean hasTools,
+            @Nullable Integer timeoutSeconds, @Nullable String reasoningEffort) throws ChatGPTApiException {
         String finalJson = queryJson;
         if (reasoningEffort != null) {
             try {
@@ -382,10 +383,11 @@ public class ChatGPTApiClient {
                         baseUrl + PATH_CHAT_COMPLETIONS, response.getStatus(), response.getReason(),
                         errorBody.getBytes(StandardCharsets.UTF_8).length);
 
-                if (response.getStatus() == HttpStatus.BAD_REQUEST_400 && errorBody.contains("reasoning_effort")) {
+                if (reasoningEffort == null && hasTools && response.getStatus() == HttpStatus.BAD_REQUEST_400
+                        && errorBody.contains("reasoning_effort")) {
                     logger.debug("Model {} requires reasoning_effort; caching and retrying", model);
                     modelsRequiringReasoningEffort.add(model);
-                    return executeCompletionRequest(queryJson, model, timeoutSeconds, "none");
+                    return executeCompletionRequest(queryJson, model, hasTools, timeoutSeconds, "none");
                 }
                 if (logger.isTraceEnabled()) {
                     try {

--- a/bundles/org.openhab.binding.chatgpt/src/main/java/org/openhab/binding/chatgpt/internal/api/dto/ChatRequestBody.java
+++ b/bundles/org.openhab.binding.chatgpt/src/main/java/org/openhab/binding/chatgpt/internal/api/dto/ChatRequestBody.java
@@ -34,6 +34,8 @@ public class ChatRequestBody {
     private List<ChatTools> tools;
     @JsonProperty("tool_choice")
     private String toolChoice;
+    @JsonProperty("reasoning_effort")
+    private String reasoningEffort;
 
     public String getModel() {
         return model;
@@ -67,6 +69,10 @@ public class ChatRequestBody {
         return toolChoice;
     }
 
+    public String getReasoningEffort() {
+        return reasoningEffort;
+    }
+
     public void setModel(String model) {
         this.model = model;
     }
@@ -97,5 +103,9 @@ public class ChatRequestBody {
 
     public void setToolChoice(String toolChoice) {
         this.toolChoice = toolChoice;
+    }
+
+    public void setReasoningEffort(String reasoningEffort) {
+        this.reasoningEffort = reasoningEffort;
     }
 }


### PR DESCRIPTION
When using tools with reasoning-capable models (gpt-5.6-luna, gpt-5.6-terra) on /v1/chat/completions, OpenAI API rejects the request with an error about incompatible reasoning_effort. Other models like gpt-4o reject the parameter entirely if it's not supported - see https://community.openai.com/t/gpt-5-6-chat-completion-reasoning-effort-bug-behavior-change/1386454 for this annoying behavior.

Implement optimistic retry: first send request without reasoning_effort, and retry with reasoning_effort=none only if the specific OpenAI error indicates tool/reasoning incompatibility. This avoids errors on all models:
- Reasoning models work with the workaround
- Non-reasoning models work without the parameter
- No retry overhead when not needed

I know that this looks like an ugly workaround, which it essentially is. But afaik, there is no good way to tell which model is a reasoning model and which not. Also, they might behave differently when being used behind OpenRouter than directly from OpenAI. I didn't want to maintain a whitelist either, so this is the best I could come up with.

I've successfully tested both the "normal" ChatGPT feature of the Thing channels as well as the HLI feature both with gpt-4o and with gpt-5.6-luna.