### PR TITLE
[chatgpt] Bind ConfigOptionProvider to ThingHandler instance

### DIFF
--- a/bundles/org.openhab.binding.chatgpt/src/main/java/org/openhab/binding/chatgpt/internal/ChatGPTModelOptionProvider.java
+++ b/bundles/org.openhab.binding.chatgpt/src/main/java/org/openhab/binding/chatgpt/internal/ChatGPTModelOptionProvider.java
@@ -31,7 +31,7 @@ import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.ServiceScope;
 
 /**
- * The {@link ChatGPTModelOptionProvider} provides the available models from a OpenAI API-compatible service as options
+ * The {@link ChatGPTModelOptionProvider} provides the available models from an OpenAI API-compatible service as options
  * for the model configuration.
  *
  * @author Kai Kreuzer - Initial contribution

--- a/bundles/org.openhab.binding.chatgpt/src/main/java/org/openhab/binding/chatgpt/internal/ChatGPTModelOptionProvider.java
+++ b/bundles/org.openhab.binding.chatgpt/src/main/java/org/openhab/binding/chatgpt/internal/ChatGPTModelOptionProvider.java
@@ -12,12 +12,10 @@
  */
 package org.openhab.binding.chatgpt.internal;
 
-import static org.openhab.binding.chatgpt.internal.ChatGPTBindingConstants.CHANNEL_TYPE_UID_CHAT;
-import static org.openhab.binding.chatgpt.internal.ChatGPTBindingConstants.THING_TYPE_ACCOUNT;
-
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 
@@ -25,18 +23,20 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.config.core.ConfigOptionProvider;
 import org.openhab.core.config.core.ParameterOption;
+import org.openhab.core.thing.ChannelUID;
+import org.openhab.core.thing.ThingUID;
 import org.openhab.core.thing.binding.ThingHandler;
 import org.openhab.core.thing.binding.ThingHandlerService;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.ServiceScope;
 
 /**
- * The {@link ChatGPTModelOptionProvider} provides the available models from OpenAI as options for the channel
- * configuration.
+ * The {@link ChatGPTModelOptionProvider} provides the available models from a OpenAI API-compatible service as options
+ * for the model configuration.
  *
  * @author Kai Kreuzer - Initial contribution
  */
-@Component(scope = ServiceScope.PROTOTYPE, service = { ChatGPTModelOptionProvider.class, ConfigOptionProvider.class })
+@Component(scope = ServiceScope.PROTOTYPE, service = ChatGPTModelOptionProvider.class)
 @NonNullByDefault
 public class ChatGPTModelOptionProvider implements ThingHandlerService, ConfigOptionProvider {
     private @Nullable ThingHandler thingHandler;
@@ -44,17 +44,45 @@ public class ChatGPTModelOptionProvider implements ThingHandlerService, ConfigOp
     @Override
     public @Nullable Collection<ParameterOption> getParameterOptions(URI uri, String param, @Nullable String context,
             @Nullable Locale locale) {
-        if (CHANNEL_TYPE_UID_CHAT.getAsString().equals(uri.getSchemeSpecificPart())
-                || THING_TYPE_ACCOUNT.getAsString().equals(uri.getSchemeSpecificPart())) {
-            if ("model".equals(param)) {
-                List<ParameterOption> options = new ArrayList<>();
-                if (thingHandler instanceof ChatGPTHandler chatGPTHandler) {
-                    chatGPTHandler.getModels().forEach(model -> options.add(new ParameterOption(model, model)));
+        if (!"model".equals(param)) {
+            return null;
+        }
+
+        String scheme = uri.getScheme();
+        String ssp = uri.getSchemeSpecificPart();
+        ThingHandler localHandler = thingHandler;
+
+        if (localHandler != null) {
+            ThingUID thingUID = localHandler.getThing().getUID();
+            if ("thing".equals(scheme) && thingUID.getAsString().equals(ssp)) {
+                // URI matches the Thing this instance is bound to
+                return getModelOptions();
+            } else if ("channel".equals(scheme)) {
+                try {
+                    ChannelUID channelUID = new ChannelUID(ssp);
+                    if (channelUID.getThingUID().equals(thingUID)) {
+                        // URI matches a Channel of the Thing this instance is bound to
+                        return getModelOptions();
+                    }
+                } catch (IllegalArgumentException e) {
+                    // ignore IAE due to invalid channel UID
                 }
+            }
+        }
+
+        return null;
+    }
+
+    private Collection<ParameterOption> getModelOptions() {
+        if (thingHandler instanceof ChatGPTHandler chatGPTHandler) {
+            List<String> models = chatGPTHandler.getModels();
+            if (!models.isEmpty()) {
+                List<ParameterOption> options = new ArrayList<>();
+                models.forEach(model -> options.add(new ParameterOption(model, model)));
                 return options;
             }
         }
-        return null;
+        return Collections.emptyList();
     }
 
     @Override
@@ -65,9 +93,5 @@ public class ChatGPTModelOptionProvider implements ThingHandlerService, ConfigOp
     @Override
     public @Nullable ThingHandler getThingHandler() {
         return thingHandler;
-    }
-
-    @Override
-    public void activate() {
     }
 }


### PR DESCRIPTION
With each Thing possibly connecting to a different AI service, each service can offer different models. Previously, ChatGPTModelOptionProvider did not check for which Thing instance ConfigOptions were requested, causing options from Thing B to be also shown for Thing A and vice-versa.