### PR TITLE
[rrd4j] Fix failing CI tests

### DIFF
--- a/bundles/org.openhab.persistence.rrd4j/src/main/java/org/openhab/persistence/rrd4j/internal/RRD4jPersistenceService.java
+++ b/bundles/org.openhab.persistence.rrd4j/src/main/java/org/openhab/persistence/rrd4j/internal/RRD4jPersistenceService.java
@@ -126,12 +126,12 @@ public class RRD4jPersistenceService implements QueryablePersistenceService {
     private static final Set<String> SUPPORTED_TYPES = Set.of(CoreItemFactory.SWITCH, CoreItemFactory.CONTACT,
             CoreItemFactory.DIMMER, CoreItemFactory.NUMBER, CoreItemFactory.ROLLERSHUTTER, CoreItemFactory.COLOR);
 
-    private final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1,
-            new NamedThreadFactory("RRD4j"));
+    private final ScheduledExecutorService scheduler;
 
     private final Map<String, RrdDefConfig> rrdDefs = new ConcurrentHashMap<>();
 
     private final ConcurrentSkipListMap<Key, Double> storageMap = new ConcurrentSkipListMap<>(Key::compareTo);
+    private final Object flushLock = new Object();
 
     private static final String DATASOURCE_STATE = "state";
 
@@ -160,8 +160,14 @@ public class RRD4jPersistenceService implements QueryablePersistenceService {
     }
 
     RRD4jPersistenceService(ItemRegistry itemRegistry, Map<String, Object> config, Clock clock) {
+        this(itemRegistry, config, clock, Executors.newScheduledThreadPool(1, new NamedThreadFactory("RRD4j")));
+    }
+
+    RRD4jPersistenceService(ItemRegistry itemRegistry, Map<String, Object> config, Clock clock,
+            ScheduledExecutorService scheduler) {
         this.itemRegistry = itemRegistry;
         this.clock = clock;
+        this.scheduler = scheduler;
         storeJob = scheduler.scheduleWithFixedDelay(() -> doStore(false), 1, 1, TimeUnit.SECONDS);
         modified(config);
         active = true;
@@ -279,6 +285,7 @@ public class RRD4jPersistenceService implements QueryablePersistenceService {
     protected void deactivate() {
         active = false;
         storeJob.cancel(false);
+        scheduler.shutdown();
 
         // make sure we really store everything
         doStore(true);
@@ -348,16 +355,19 @@ public class RRD4jPersistenceService implements QueryablePersistenceService {
     }
 
     private void doStore(boolean force) {
-        long now = clock.instant().getEpochSecond();
-        while (!storageMap.isEmpty()) {
-            Key key = storageMap.firstKey();
-            if (now > key.timestamp || force) {
-                // no new elements can be added for this timestamp because we are already past that time or the service
-                // requires forced storing
-                Double value = storageMap.pollFirstEntry().getValue();
-                writePointToDatabase(key.name, value, key.timestamp);
-            } else {
-                return;
+        synchronized (flushLock) {
+            long now = clock.instant().getEpochSecond();
+            while (!storageMap.isEmpty()) {
+                Key key = storageMap.firstKey();
+                if (now > key.timestamp || force) {
+                    // no new elements can be added for this timestamp because we are already past that time or the
+                    // service
+                    // requires forced storing
+                    Double value = storageMap.pollFirstEntry().getValue();
+                    writePointToDatabase(key.name, value, key.timestamp);
+                } else {
+                    return;
+                }
             }
         }
     }

--- a/bundles/org.openhab.persistence.rrd4j/src/main/java/org/openhab/persistence/rrd4j/internal/RRD4jPersistenceService.java
+++ b/bundles/org.openhab.persistence.rrd4j/src/main/java/org/openhab/persistence/rrd4j/internal/RRD4jPersistenceService.java
@@ -15,6 +15,7 @@ package org.openhab.persistence.rrd4j.internal;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneId;
@@ -140,6 +141,7 @@ public class RRD4jPersistenceService implements QueryablePersistenceService {
 
     private final Logger logger = LoggerFactory.getLogger(RRD4jPersistenceService.class);
     private final ItemRegistry itemRegistry;
+    private final Clock clock;
     private boolean active = false;
 
     public static Path getDatabasePath(String name) {
@@ -154,7 +156,12 @@ public class RRD4jPersistenceService implements QueryablePersistenceService {
 
     @Activate
     public RRD4jPersistenceService(final @Reference ItemRegistry itemRegistry, Map<String, Object> config) {
+        this(itemRegistry, config, Clock.systemUTC());
+    }
+
+    RRD4jPersistenceService(ItemRegistry itemRegistry, Map<String, Object> config, Clock clock) {
         this.itemRegistry = itemRegistry;
+        this.clock = clock;
         storeJob = scheduler.scheduleWithFixedDelay(() -> doStore(false), 1, 1, TimeUnit.SECONDS);
         modified(config);
         active = true;
@@ -331,7 +338,7 @@ public class RRD4jPersistenceService implements QueryablePersistenceService {
             return;
         }
 
-        long now = System.currentTimeMillis() / 1000;
+        long now = clock.instant().getEpochSecond();
         Double oldValue = storageMap.put(new Key(now, name), value);
         if (oldValue != null && !oldValue.equals(value)) {
             logger.debug(
@@ -341,7 +348,7 @@ public class RRD4jPersistenceService implements QueryablePersistenceService {
     }
 
     private void doStore(boolean force) {
-        long now = System.currentTimeMillis() / 1000;
+        long now = clock.instant().getEpochSecond();
         while (!storageMap.isEmpty()) {
             Key key = storageMap.firstKey();
             if (now > key.timestamp || force) {
@@ -358,7 +365,7 @@ public class RRD4jPersistenceService implements QueryablePersistenceService {
     private synchronized void writePointToDatabase(String name, double value, long timestamp) {
         RrdDb db = null;
         try {
-            db = getDB(name, true);
+            db = getOrCreateDB(name, timestamp);
         } catch (Exception e) {
             logger.warn("Failed to open rrd4j database '{}' to store data ({})", name, e.toString());
         }
@@ -436,7 +443,7 @@ public class RRD4jPersistenceService implements QueryablePersistenceService {
         String localAlias = alias != null ? alias : itemName;
         RrdDb db = null;
         try {
-            db = getDB(localAlias, false);
+            db = getDB(localAlias);
         } catch (Exception e) {
             logger.warn("Failed to open rrd4j database '{}' for querying ({})", itemName, e.toString());
             return List.of();
@@ -580,7 +587,7 @@ public class RRD4jPersistenceService implements QueryablePersistenceService {
 
         RrdDb db = null;
         try {
-            db = getDB(localAlias, false);
+            db = getDB(localAlias);
         } catch (Exception e) {
             logger.warn("Failed to open rrd4j database '{}' for querying ({})", itemName, e.toString());
             return null;
@@ -694,7 +701,15 @@ public class RRD4jPersistenceService implements QueryablePersistenceService {
         };
     }
 
-    protected synchronized @Nullable RrdDb getDB(String alias, boolean createFileIfAbsent) {
+    private @Nullable RrdDb getDB(String alias) {
+        return openDatabase(alias, null);
+    }
+
+    private @Nullable RrdDb getOrCreateDB(String alias, long firstSampleTimestamp) {
+        return openDatabase(alias, firstSampleTimestamp);
+    }
+
+    private synchronized @Nullable RrdDb openDatabase(String alias, @Nullable Long firstSampleTimestamp) {
         RrdDb db = null;
         Path path = getDatabasePath(alias);
         try {
@@ -705,11 +720,11 @@ public class RRD4jPersistenceService implements QueryablePersistenceService {
                 // recreate the RrdDb instance from the file
                 builder.setPath(path.toString());
                 db = builder.build();
-            } else if (createFileIfAbsent) {
+            } else if (firstSampleTimestamp != null) {
                 if (!Files.exists(DB_FOLDER)) {
                     Files.createDirectories(DB_FOLDER);
                 }
-                RrdDef rrdDef = getRrdDef(alias, path);
+                RrdDef rrdDef = getRrdDef(alias, path, firstSampleTimestamp);
                 if (rrdDef != null) {
                     // create a new database file
                     builder.setRrdDef(rrdDef);
@@ -760,12 +775,13 @@ public class RRD4jPersistenceService implements QueryablePersistenceService {
         return useRdc;
     }
 
-    private @Nullable RrdDef getRrdDef(String itemName, Path path) {
+    private @Nullable RrdDef getRrdDef(String itemName, Path path, long firstSampleTimestamp) {
         RrdDef rrdDef = new RrdDef(path.toString());
         RrdDefConfig useRdc = getRrdDefConfig(itemName);
         if (useRdc != null) {
             rrdDef.setStep(useRdc.step);
-            rrdDef.setStartTime(System.currentTimeMillis() / 1000 - useRdc.step);
+            // Ensure the first sample crosses an RRD step boundary even if database creation is delayed.
+            rrdDef.setStartTime(firstSampleTimestamp - useRdc.step);
             rrdDef.addDatasource(DATASOURCE_STATE, useRdc.dsType, useRdc.heartbeat, useRdc.min, useRdc.max);
             for (RrdArchiveDef rad : useRdc.archives) {
                 rrdDef.addArchive(rad.fcn, rad.xff, rad.steps, rad.rows);

--- a/bundles/org.openhab.persistence.rrd4j/src/test/java/org/openhab/persistence/rrd4j/internal/RRD4jPersistenceServiceTest.java
+++ b/bundles/org.openhab.persistence.rrd4j/src/test/java/org/openhab/persistence/rrd4j/internal/RRD4jPersistenceServiceTest.java
@@ -26,6 +26,9 @@ import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.Map;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -254,6 +257,17 @@ class RRD4jPersistenceServiceTest {
     }
 
     @Test
+    void deactivationTerminatesScheduler() throws InterruptedException {
+        service.deactivate();
+        ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
+        service = new RRD4jPersistenceService(itemRegistry, Map.of(), Clock.systemUTC(), scheduler);
+
+        service.deactivate();
+
+        assertTrue(scheduler.awaitTermination(5, TimeUnit.SECONDS));
+    }
+
+    @Test
     void serviceIdIsCorrect() throws Exception {
         RRD4jPersistenceService simpleService = new RRD4jPersistenceService(itemRegistry, Map.of());
         try {
@@ -277,6 +291,7 @@ class RRD4jPersistenceServiceTest {
     @ParameterizedTest
     @ValueSource(booleans = { true, false })
     void storeAndRetrieveWithInvalidDBConfig(boolean reloadAfterStore) throws Exception {
+        service.deactivate();
         service = new RRD4jPersistenceService(itemRegistry, Map.of("something.invalid", "invalid/path/to/db"));
 
         configureNumberItem(reloadAfterStore ? "_PERSISTED" : "_MEMORY");

--- a/bundles/org.openhab.persistence.rrd4j/src/test/java/org/openhab/persistence/rrd4j/internal/RRD4jPersistenceServiceTest.java
+++ b/bundles/org.openhab.persistence.rrd4j/src/test/java/org/openhab/persistence/rrd4j/internal/RRD4jPersistenceServiceTest.java
@@ -20,7 +20,10 @@ import static org.mockito.Mockito.when;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Clock;
+import java.time.Instant;
 import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.Map;
 
@@ -225,6 +228,29 @@ class RRD4jPersistenceServiceTest {
 
         // Verify we got at least one result
         assertTrue(results.iterator().hasNext());
+    }
+
+    @Test
+    void firstSampleIsImmediatelyQueryableFromArchive() throws Exception {
+        long sampleTimestamp = 58;
+        service.deactivate();
+        service = new RRD4jPersistenceService(itemRegistry, Map.of(),
+                Clock.fixed(Instant.ofEpochSecond(sampleTimestamp), ZoneOffset.UTC));
+        configureNumberItem("_INITIAL");
+        deleteDatabaseFile(numberItem.getName());
+
+        service.store(numberItem);
+        service.deactivate();
+
+        FilterCriteria criteria = new FilterCriteria();
+        criteria.setItemName(numberItem.getName());
+        criteria.setBeginDate(ZonedDateTime.ofInstant(Instant.EPOCH, ZoneId.systemDefault()));
+        criteria.setEndDate(ZonedDateTime.ofInstant(Instant.ofEpochSecond(100), ZoneId.systemDefault()));
+        criteria.setOrdering(FilterCriteria.Ordering.ASCENDING);
+
+        Iterable<HistoricItem> results = service.query(criteria);
+        assertTrue(results.iterator().hasNext());
+        assertEquals(new DecimalType(42.5), results.iterator().next().getState());
     }
 
     @Test


### PR DESCRIPTION
Fixes CI RRD4j unit test persistence failures when database creation crosses a RRD step boundary.
- Initialize new databases relative to the first sample timestamp.
- Separate opening an existing database from creating one.
- Add an injectable clock for deterministic testing.
- Test the complete store() and flush path.

When fixing the above, the codex agent also found this resource leak where `deactivate()` cancels the scheduled job, but never shutsdown its executor. This is also fixed and made testable.

Fixes: #21482