### PR TITLE
[whisperstt] Use libfvad-jni from jvoice-project instead of givimad

### DIFF
--- a/bundles/org.openhab.voice.whisperstt/pom.xml
+++ b/bundles/org.openhab.voice.whisperstt/pom.xml
@@ -13,17 +13,17 @@
   <artifactId>org.openhab.voice.whisperstt</artifactId>
 
   <name>openHAB Add-ons :: Bundles :: Voice :: Whisper Speech-to-Text</name>
+
   <dependencies>
-    <!--Deps -->
     <dependency>
       <groupId>io.github.givimad</groupId>
       <artifactId>whisper-jni</artifactId>
       <version>1.6.1</version>
     </dependency>
     <dependency>
-      <groupId>io.github.givimad</groupId>
+      <groupId>io.github.jvoice-project</groupId>
       <artifactId>libfvad-jni</artifactId>
-      <version>1.0.0-1</version>
+      <version>1.0.0-997e9dc</version>
     </dependency>
   </dependencies>
 </project>

--- a/bundles/org.openhab.voice.whisperstt/src/main/java/org/openhab/voice/whisperstt/internal/WhisperSTTConfiguration.java
+++ b/bundles/org.openhab.voice.whisperstt/src/main/java/org/openhab/voice/whisperstt/internal/WhisperSTTConfiguration.java
@@ -16,7 +16,7 @@ import java.util.List;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 
-import io.github.givimad.libfvadjni.VoiceActivityDetector;
+import io.github.jvoiceproject.libfvadjni.VoiceActivityDetector;
 
 /**
  * The {@link WhisperSTTConfiguration} class contains fields mapping thing configuration parameters.

--- a/bundles/org.openhab.voice.whisperstt/src/main/java/org/openhab/voice/whisperstt/internal/WhisperSTTService.java
+++ b/bundles/org.openhab.voice.whisperstt/src/main/java/org/openhab/voice/whisperstt/internal/WhisperSTTService.java
@@ -76,7 +76,6 @@ import org.osgi.service.component.annotations.Reference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import io.github.givimad.libfvadjni.VoiceActivityDetector;
 import io.github.givimad.whisperjni.WhisperContext;
 import io.github.givimad.whisperjni.WhisperContextParams;
 import io.github.givimad.whisperjni.WhisperFullParams;
@@ -84,6 +83,7 @@ import io.github.givimad.whisperjni.WhisperGrammar;
 import io.github.givimad.whisperjni.WhisperJNI;
 import io.github.givimad.whisperjni.WhisperSamplingStrategy;
 import io.github.givimad.whisperjni.WhisperState;
+import io.github.jvoiceproject.libfvadjni.VoiceActivityDetector;
 
 /**
  * The {@link WhisperSTTService} class is a service implementation to use whisper.cpp for Speech-to-Text.

--- a/bundles/org.openhab.voice.whisperstt/src/main/java/org/openhab/voice/whisperstt/internal/utils/VAD.java
+++ b/bundles/org.openhab.voice.whisperstt/src/main/java/org/openhab/voice/whisperstt/internal/utils/VAD.java
@@ -18,7 +18,7 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import io.github.givimad.libfvadjni.VoiceActivityDetector;
+import io.github.jvoiceproject.libfvadjni.VoiceActivityDetector;
 
 /**
  * The {@link VAD} class is a voice activity detector implementation over libfvad-jni.


### PR DESCRIPTION
jvoice-project is an effort of @GiviMAD and me to move his fantastic work on piper-jni, libfvad-jni and in the future whisper-jni likely as well to a GitHub org so it is easier to maintain them as a team.
Since I haven't heard from Miguel for a while now, I went ahead forking and modernizing the libfvad-jni repository under the jvoice-project org.

Functionally, the jvoice-project version is 100% identical with his original one, just a new group name.

FTR: https://github.com/jvoice-project/libfvad-jni