### PR TITLE
[yamlcomposer] Add ARGS special variable to capture immediate arguments for includes and templates

### DIFF
--- a/bundles/org.openhab.io.yamlcomposer/doc/include.md
+++ b/bundles/org.openhab.io.yamlcomposer/doc/include.md
@@ -86,7 +86,16 @@ Variables provided in the `vars` section of an `!include` directive are visible 
 Local variables defined inside an include file can act as default values when they are not provided in the `!include` directive.
 This allows include files to be reused with different parameters while keeping sensible defaults inside the file itself.
 
-**Example:**
+### Strict Isolation with `ARGS`
+
+Explicitly passed variables are merged into the normal evaluation context, but they are also exposed separately through a predefined map named **`ARGS`**.
+
+`ARGS` contains **only** the variables provided at the include call site (via `vars:` or URL query parameters).
+It does **not** include global variables, inherited variables, or local defaults inside the include file.
+
+This allows include files to inspect exactly what the caller passed, without any inherited or default values.
+
+#### Example
 
 `main.yaml`:
 
@@ -106,7 +115,7 @@ things:
     vars:
       label: Bedroom Window
       id: bedroom-window
-      broker: mqtt:broker:external # override the global broker variable
+      broker: mqtt:broker:external
 ```
 
 `mqtt_contact.inc.yaml`:
@@ -118,9 +127,12 @@ config:
   availabilityTopic: ${id}/availability
   payloadAvailable: online
   payloadNotAvailable: offline
+
+debug:
+  args: ${ARGS}
 ```
 
-Resulting configuration:
+Result:
 
 ```yaml
 things:
@@ -131,6 +143,10 @@ things:
       availabilityTopic: livingroom-window/availability
       payloadAvailable: online
       payloadNotAvailable: offline
+    debug:
+      args:
+        label: Living Room Window
+        id: livingroom-window
 
   mqtt:topic:bedroom-window:
     bridge: mqtt:broker:external
@@ -139,6 +155,11 @@ things:
       availabilityTopic: bedroom-window/availability
       payloadAvailable: online
       payloadNotAvailable: offline
+    debug:
+      args:
+        label: Bedroom Window
+        id: bedroom-window
+        broker: mqtt:broker:external
 ```
 
 ## File Naming & Reload Behavior

--- a/bundles/org.openhab.io.yamlcomposer/doc/include.md
+++ b/bundles/org.openhab.io.yamlcomposer/doc/include.md
@@ -100,66 +100,44 @@ This allows include files to inspect exactly what the caller passed, without any
 `main.yaml`:
 
 ```yaml
-variables:
-  broker: mqtt:broker:main
-
 things:
-  mqtt:topic:livingroom-window: !include
-    file: mqtt_contact.inc.yaml
+  exec:command:apc: !include
+    file: exec.inc.yaml
     vars:
-      label: Living Room Window
-      id: livingroom-window
+      command: /usr/local/bin/apcaccess status
 
-  mqtt:topic:bedroom-window: !include
-    file: mqtt_contact.inc.yaml
+  exec:command:myscript: !include
+    file: exec.inc.yaml
     vars:
-      label: Bedroom Window
-      id: bedroom-window
-      broker: mqtt:broker:external
+      command: "php ./configurations/scripts/script.php %2$s"
+      transform: "REGEX((.*?))"
 ```
 
-`mqtt_contact.inc.yaml`:
+`exec.inc.yaml`:
 
 ```yaml
-bridge: ${broker}
-label: ${label}
 config:
-  availabilityTopic: ${id}/availability
-  payloadAvailable: online
-  payloadNotAvailable: offline
-
-debug:
-  args: ${ARGS}
+  autorun: false
+  timeout: 10
+  <<: ${ARGS}
 ```
 
 Result:
 
 ```yaml
 things:
-  mqtt:topic:livingroom-window:
-    bridge: mqtt:broker:main
-    label: Living Room Window
+  exec:command:apc:
     config:
-      availabilityTopic: livingroom-window/availability
-      payloadAvailable: online
-      payloadNotAvailable: offline
-    debug:
-      args:
-        label: Living Room Window
-        id: livingroom-window
+      autorun: false
+      timeout: 10
+      command: /usr/local/bin/apcaccess status
 
-  mqtt:topic:bedroom-window:
-    bridge: mqtt:broker:external
-    label: Bedroom Window
+  exec:command:myscript:
     config:
-      availabilityTopic: bedroom-window/availability
-      payloadAvailable: online
-      payloadNotAvailable: offline
-    debug:
-      args:
-        label: Bedroom Window
-        id: bedroom-window
-        broker: mqtt:broker:external
+      autorun: false
+      timeout: 10
+      command: php ./configurations/scripts/script.php %2$s
+      transform: REGEX((.*?))
 ```
 
 ## File Naming & Reload Behavior

--- a/bundles/org.openhab.io.yamlcomposer/doc/templates.md
+++ b/bundles/org.openhab.io.yamlcomposer/doc/templates.md
@@ -169,6 +169,47 @@ Inside a template:
 - `${var}` resolves using the combined variable context described above.
 - Each `!insert` call is isolated — variables from one invocation do not leak into another.
 
+### Strict Isolation with `ARGS`
+
+Just like `!include`, each `!insert` call exposes a predefined map named **`ARGS`** containing **only** the variables explicitly passed to that invocation (via `vars:` or URL query parameters).
+
+`ARGS` does **not** include:
+
+- variables defined elsewhere in the file
+- variables inherited from parent includes
+- local defaults inside the template
+
+Normal variable substitution uses the merged context, but `ARGS` shows only what the caller actually passed.
+
+#### Example
+
+```yaml
+templates:
+  greeting:
+    message: "Hello, ${name}!"
+    debug: ${ARGS}
+
+welcome:
+  user1: !insert { template: greeting, vars: { name: Alice } }
+  user2: !insert greeting?name=Bob&lang=en
+```
+
+Result:
+
+```yaml
+welcome:
+  user1:
+    message: "Hello, Alice!"
+    debug:
+      name: Alice
+
+  user2:
+    message: "Hello, Bob!"
+    debug:
+      name: Bob
+      lang: true
+```
+
 ## Limitations
 
 - Templates must be defined under the top‑level `templates:` section.

--- a/bundles/org.openhab.io.yamlcomposer/doc/variables.md
+++ b/bundles/org.openhab.io.yamlcomposer/doc/variables.md
@@ -474,19 +474,30 @@ If the list item must remain a scalar, declare the variable in the parent mappin
 The Composer injects environmental and file-system context automatically.
 These variables can be interpolated just like regular ones and are helpful when constructing paths for directives.
 
-| Variable           | Description                                                             |
-|:-------------------|:------------------------------------------------------------------------|
-| `OPENHAB_CONF`     | Absolute path to openHAB's main configuration directory.                |
-| `OPENHAB_USERDATA` | Absolute path to openHAB's userdata directory.                          |
-| `__FILE__`         | Absolute path to the current file.                                      |
-| `__FILE_NAME__`    | Filename portion without the extension or leading path.                 |
-| `__FILE_EXT__`     | File extension portion of the current file name.                        |
-| `__DIRECTORY__`    | Directory portion of the current file.                                  |
-| `__DIR__`          | Alias for `__DIRECTORY__`.                                              |
-| `package_id`       | Automatically resolved to the Package ID within included package files. |
+| Variable           | Description                                                          |
+|:-------------------|:---------------------------------------------------------------------|
+| `OPENHAB_CONF`     | Absolute path to openHAB's main configuration directory.             |
+| `OPENHAB_USERDATA` | Absolute path to openHAB's userdata directory.                       |
+| `__FILE__`         | Absolute path to the current file.                                   |
+| `__FILE_NAME__`    | Filename portion without the extension or leading path.              |
+| `__FILE_EXT__`     | File extension portion of the current file name.                     |
+| `__DIRECTORY__`    | Directory portion of the current file.                               |
+| `__DIR__`          | Alias for `__DIRECTORY__`.                                           |
+| `VARS`             | Map containing all variables currently visible in the current scope. |
 
-::: warning System Variable Protection
-System variables (`OPENHAB_CONF`, `__FILE__`, etc.) cannot be overridden or redefined by `!var` directives or `variables:` blocks. Attempting to redefine a system variable logs a warning and leaves the system value intact.
+#### Contextual / Special Variables
+
+These variables are dynamically populated based on the current execution context and are not always present.
+
+| Variable     | Description                                                                                                                                                          |
+|:-------------|:---------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `ARGS`       | Map containing only variables explicitly injected at the immediate `!include`/`!insert` call site (excludes global variables and those injected by parent includes). |
+| `package_id` | Automatically resolved to the Package ID within included package context.                                                                                            |
+
+::: warning Predefined Variable Protection
+With the exception of `package_id`, all predefined and contextual variables listed above are reserved by the Composer.
+They cannot be overridden or redefined by `!var` directives or `variables:` blocks.
+Attempting to redefine any of these protected variables logs a warning and leaves the system value intact.
 :::
 
 ### Handling Reserved Keywords

--- a/bundles/org.openhab.io.yamlcomposer/src/main/java/org/openhab/io/yamlcomposer/internal/core/VariableLoader.java
+++ b/bundles/org.openhab.io.yamlcomposer/src/main/java/org/openhab/io/yamlcomposer/internal/core/VariableLoader.java
@@ -36,7 +36,7 @@ import org.openhab.io.yamlcomposer.internal.placeholders.MergeKeyPlaceholder;
 public class VariableLoader {
 
     public static final Set<String> SPECIAL_VARIABLES = Set.of("OPENHAB_CONF", "OPENHAB_USERDATA", "__FILE__",
-            "__FILE_NAME__", "__FILE_EXT__", "__DIRECTORY__", "__DIR__");
+            "__FILE_NAME__", "__FILE_EXT__", "__DIRECTORY__", "__DIR__", "ENV", "VARS", "ARGS");
 
     private final Map<String, @Nullable Object> variables;
     private final Path absolutePath;

--- a/bundles/org.openhab.io.yamlcomposer/src/main/java/org/openhab/io/yamlcomposer/internal/processors/IncludeProcessor.java
+++ b/bundles/org.openhab.io.yamlcomposer/src/main/java/org/openhab/io/yamlcomposer/internal/processors/IncludeProcessor.java
@@ -103,7 +103,7 @@ public class IncludeProcessor implements PlaceholderProcessor<IncludePlaceholder
         // Handle parameters and variables
         Map<String, @Nullable Object> includeVariables = new HashMap<>(recursiveTransformer.getVariables());
         includeVariables.putAll(params.varsMap()); // params override current variables
-        includeVariables.put("ARGS", params.varsMap()); // injected vars
+        includeVariables.put("ARGS", params.varsMap());
 
         try {
             YamlComposer includeComposer = new YamlComposer(includePath, includeVariables, includeStack,

--- a/bundles/org.openhab.io.yamlcomposer/src/main/java/org/openhab/io/yamlcomposer/internal/processors/IncludeProcessor.java
+++ b/bundles/org.openhab.io.yamlcomposer/src/main/java/org/openhab/io/yamlcomposer/internal/processors/IncludeProcessor.java
@@ -103,6 +103,7 @@ public class IncludeProcessor implements PlaceholderProcessor<IncludePlaceholder
         // Handle parameters and variables
         Map<String, @Nullable Object> includeVariables = new HashMap<>(recursiveTransformer.getVariables());
         includeVariables.putAll(params.varsMap()); // params override current variables
+        includeVariables.put("ARGS", params.varsMap()); // injected vars
 
         try {
             YamlComposer includeComposer = new YamlComposer(includePath, includeVariables, includeStack,

--- a/bundles/org.openhab.io.yamlcomposer/src/main/java/org/openhab/io/yamlcomposer/internal/processors/InsertProcessor.java
+++ b/bundles/org.openhab.io.yamlcomposer/src/main/java/org/openhab/io/yamlcomposer/internal/processors/InsertProcessor.java
@@ -12,6 +12,7 @@
  */
 package org.openhab.io.yamlcomposer.internal.processors;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -76,7 +77,8 @@ public class InsertProcessor implements PlaceholderProcessor<InsertPlaceholder> 
 
         // The substitution placeholders in the template are resolved using the templateVariables context
         // unlike any other processing which uses the main variables map
-        Map<String, @Nullable Object> templateVariables = params.varsMap();
+        Map<String, @Nullable Object> templateVariables = new HashMap<>(params.varsMap());
+        templateVariables.put("ARGS", params.varsMap());
         RecursiveTransformer localTransformer = recursiveTransformer.withOverrideVariables(templateVariables);
         // Keep package override placeholders (!remove/!replace) intact so they are only
         // applied in the dedicated PACKAGE_OVERRIDES phase.

--- a/bundles/org.openhab.io.yamlcomposer/src/test/java/org/openhab/io/yamlcomposer/internal/YamlComposerIncludeTagTest.java
+++ b/bundles/org.openhab.io.yamlcomposer/src/test/java/org/openhab/io/yamlcomposer/internal/YamlComposerIncludeTagTest.java
@@ -259,8 +259,6 @@ class YamlComposerIncludeTagTest extends AbstractYamlComposerTest {
                         injected_var: "injected"
                     """);
 
-            // The included file has a local variable block, inherits the global variable,
-            // and receives the injected variable. We test that ARGS only sees the injected one.
             writeFixture("included.inc.yaml", """
                     variables:
                       local_var: "local"
@@ -307,7 +305,6 @@ class YamlComposerIncludeTagTest extends AbstractYamlComposerTest {
 
             Map<Object, @Nullable Object> data = loadFixture(main);
 
-            // ARGS isolation strictly prevents inheritance from parent includes
             assertThat("ARGS MUST contain explicitly injected variables for this specific include",
                     getNestedValue(data, "data", "level2_data", "args_l2"), equalTo("val2"));
 

--- a/bundles/org.openhab.io.yamlcomposer/src/test/java/org/openhab/io/yamlcomposer/internal/YamlComposerIncludeTagTest.java
+++ b/bundles/org.openhab.io.yamlcomposer/src/test/java/org/openhab/io/yamlcomposer/internal/YamlComposerIncludeTagTest.java
@@ -246,6 +246,74 @@ class YamlComposerIncludeTagTest extends AbstractYamlComposerTest {
             assertThat(getNestedValue(data, "data", "var2"), equalTo("value2"));
             assertThat(getNestedValue(data, "data", "var3"), equalTo("local_value"));
         }
+
+        @Test
+        @DisplayName("ARGS exists in the included file context and contains ONLY the variables explicitly passed to the include")
+        void argsKeywordReferencesOnlyInjectedVariableSet() throws IOException {
+            Path main = writeFixture("main.yaml", """
+                    variables:
+                      global_var: "global"
+                    data: !include
+                      file: included.inc.yaml
+                      vars:
+                        injected_var: "injected"
+                    """);
+
+            // The included file has a local variable block, inherits the global variable,
+            // and receives the injected variable. We test that ARGS only sees the injected one.
+            writeFixture("included.inc.yaml", """
+                    variables:
+                      local_var: "local"
+
+                    # Verify ARGS strictly isolates the injected variables
+                    args_global: ${ARGS.global_var | default('missing')}
+                    args_injected: ${ARGS.injected_var | default('missing')}
+                    args_local: ${ARGS.local_var | default('missing')}
+                    """);
+
+            Map<Object, @Nullable Object> data = loadFixture(main);
+
+            assertThat("ARGS MUST contain explicitly injected variables", getNestedValue(data, "data", "args_injected"),
+                    equalTo("injected"));
+
+            assertThat("ARGS should NOT contain inherited global variables",
+                    getNestedValue(data, "data", "args_global"), equalTo("missing"));
+
+            assertThat("ARGS should NOT contain variables defined locally in the include",
+                    getNestedValue(data, "data", "args_local"), equalTo("missing"));
+        }
+
+        @Test
+        @DisplayName("ARGS in nested includes isolates variables to the immediate call site, excluding parent explicitly passed vars")
+        void argsKeywordStrictlyIsolatesNestedIncludes() throws IOException {
+            Path main = writeFixture("main.yaml", """
+                    data: !include
+                      file: level1.inc.yaml
+                      vars:
+                        level1_var: "val1"
+                    """);
+
+            writeFixture("level1.inc.yaml", """
+                    level2_data: !include
+                      file: level2.inc.yaml
+                      vars:
+                        level2_var: "val2"
+                    """);
+
+            writeFixture("level2.inc.yaml", """
+                    args_l1: ${ARGS.level1_var | default('missing')}
+                    args_l2: ${ARGS.level2_var | default('missing')}
+                    """);
+
+            Map<Object, @Nullable Object> data = loadFixture(main);
+
+            // ARGS isolation strictly prevents inheritance from parent includes
+            assertThat("ARGS MUST contain explicitly injected variables for this specific include",
+                    getNestedValue(data, "data", "level2_data", "args_l2"), equalTo("val2"));
+
+            assertThat("ARGS should NOT contain variables injected by the parent include",
+                    getNestedValue(data, "data", "level2_data", "args_l1"), equalTo("missing"));
+        }
     }
 
     @Nested

--- a/bundles/org.openhab.io.yamlcomposer/src/test/java/org/openhab/io/yamlcomposer/internal/YamlComposerInsertTagTest.java
+++ b/bundles/org.openhab.io.yamlcomposer/src/test/java/org/openhab/io/yamlcomposer/internal/YamlComposerInsertTagTest.java
@@ -249,5 +249,107 @@ class YamlComposerInsertTagTest extends AbstractYamlComposerTest {
 
             assertThat(logSession.getTrackedWarnings(), hasItem(containsString("template not found")));
         }
+
+        @Test
+        @DisplayName("ARGS exists in the template context and contains ONLY the variables explicitly passed to the insert")
+        void argsKeywordReferencesOnlyInjectedVariableSet() throws IOException {
+            String yaml = """
+                    variables:
+                      global_var: "global_value"
+
+                    templates:
+                      mytpl:
+                        # ARGS isolated access
+                        args_global: ${ARGS.global_var | default('missing')}
+                        args_injected: ${ARGS.injected_var | default('missing')}
+
+                    target: !insert
+                      template: mytpl
+                      vars:
+                        injected_var: "injected_value"
+                    """;
+
+            Map<Object, @Nullable Object> data = loadYaml(yaml);
+
+            // ARGS isolation works
+            assertThat("ARGS MUST contain explicitly injected variables",
+                    getNestedValue(data, "target", "args_injected"), equalTo("injected_value"));
+
+            assertThat("ARGS should NOT contain variables inherited from the parent file",
+                    getNestedValue(data, "target", "args_global"), equalTo("missing"));
+        }
+
+        @Test
+        @DisplayName("ARGS in nested inserts isolates variables to the immediate call site, excluding parent explicitly passed vars")
+        void argsKeywordStrictlyIsolatesNestedInserts() throws IOException {
+            String yaml = """
+                    templates:
+                      level1_tpl:
+                        level2_data: !insert
+                          template: level2_tpl
+                          vars:
+                            level2_var: "val2"
+
+                      level2_tpl:
+                        args_l1: ${ARGS.level1_var | default('missing')}
+                        args_l2: ${ARGS.level2_var | default('missing')}
+
+                    target: !insert
+                      template: level1_tpl
+                      vars:
+                        level1_var: "val1"
+                    """;
+
+            Map<Object, @Nullable Object> data = loadYaml(yaml);
+
+            // ARGS isolation strictly prevents inheritance from parent inserts
+            assertThat("ARGS MUST contain explicitly injected variables for this specific insert",
+                    getNestedValue(data, "target", "level2_data", "args_l2"), equalTo("val2"));
+
+            assertThat("ARGS should NOT contain variables injected by the parent insert",
+                    getNestedValue(data, "target", "level2_data", "args_l1"), equalTo("missing"));
+        }
+
+        @Test
+        @DisplayName("ARGS inside templates strictly isolates to insert-level vars and excludes parent include-level args")
+        void templateInsideIncludeIsolatesArgsExcludingIncludeArgs() throws IOException {
+            Path main = writeFixture("main.yaml", """
+                    data: !include
+                      file: child.inc.yaml
+                      vars:
+                        shared_key: "value_from_include"
+                    """);
+
+            writeFixture("child.inc.yaml", """
+                    # Outside template: ARGS at the include level *does* contain shared_key
+                    include_level_args_check: ${ARGS.shared_key}
+
+                    templates:
+                      mytpl:
+                        # Inside template: ARGS should NOT see the include's 'shared_key'
+                        args_shared: ${ARGS.shared_key | default('missing')}
+                        # Inside template: ARGS must see its own insert-level arg
+                        args_insert: ${ARGS.insert_only | default('missing')}
+
+                    result: !insert
+                      template: mytpl
+                      vars:
+                        insert_only: "value_from_insert"
+                    """);
+
+            Map<Object, @Nullable Object> data = loadFixture(main);
+
+            // Contrast check: ARGS at the include level has it
+            assertThat("ARGS at the include level contains the variable",
+                    getNestedValue(data, "data", "include_level_args_check"), equalTo("value_from_include"));
+
+            // Isolation check: ARGS inside the template does NOT have it
+            assertThat("ARGS inside template should NOT contain parent include-level arguments",
+                    getNestedValue(data, "data", "result", "args_shared"), equalTo("missing"));
+
+            // Local check: ARGS inside the template has its own arg
+            assertThat("ARGS inside template must contain its own immediate insert-level arguments",
+                    getNestedValue(data, "data", "result", "args_insert"), equalTo("value_from_insert"));
+        }
     }
 }

--- a/bundles/org.openhab.io.yamlcomposer/src/test/java/org/openhab/io/yamlcomposer/internal/YamlComposerInsertTagTest.java
+++ b/bundles/org.openhab.io.yamlcomposer/src/test/java/org/openhab/io/yamlcomposer/internal/YamlComposerInsertTagTest.java
@@ -271,7 +271,6 @@ class YamlComposerInsertTagTest extends AbstractYamlComposerTest {
 
             Map<Object, @Nullable Object> data = loadYaml(yaml);
 
-            // ARGS isolation works
             assertThat("ARGS MUST contain explicitly injected variables",
                     getNestedValue(data, "target", "args_injected"), equalTo("injected_value"));
 
@@ -302,7 +301,6 @@ class YamlComposerInsertTagTest extends AbstractYamlComposerTest {
 
             Map<Object, @Nullable Object> data = loadYaml(yaml);
 
-            // ARGS isolation strictly prevents inheritance from parent inserts
             assertThat("ARGS MUST contain explicitly injected variables for this specific insert",
                     getNestedValue(data, "target", "level2_data", "args_l2"), equalTo("val2"));
 
@@ -339,15 +337,12 @@ class YamlComposerInsertTagTest extends AbstractYamlComposerTest {
 
             Map<Object, @Nullable Object> data = loadFixture(main);
 
-            // Contrast check: ARGS at the include level has it
             assertThat("ARGS at the include level contains the variable",
                     getNestedValue(data, "data", "include_level_args_check"), equalTo("value_from_include"));
 
-            // Isolation check: ARGS inside the template does NOT have it
             assertThat("ARGS inside template should NOT contain parent include-level arguments",
                     getNestedValue(data, "data", "result", "args_shared"), equalTo("missing"));
 
-            // Local check: ARGS inside the template has its own arg
             assertThat("ARGS inside template must contain its own immediate insert-level arguments",
                     getNestedValue(data, "data", "result", "args_insert"), equalTo("value_from_insert"));
         }

--- a/bundles/org.openhab.io.yamlcomposer/src/test/java/org/openhab/io/yamlcomposer/internal/YamlComposerVariablesAndSubstitutionsTest.java
+++ b/bundles/org.openhab.io.yamlcomposer/src/test/java/org/openhab/io/yamlcomposer/internal/YamlComposerVariablesAndSubstitutionsTest.java
@@ -145,6 +145,47 @@ class YamlComposerVariablesAndSubstitutionsTest extends AbstractYamlComposerTest
                     getNestedValue(data, "include", "filename"), is("predefinedVarsOverride.inc"));
         }
 
+        @ParameterizedTest
+        // We specifically allow package_id to be overridden, so it is not included in this test
+        @ValueSource(strings = { "OPENHAB_CONF", "OPENHAB_USERDATA", "__FILE__", "__FILE_NAME__", "__FILE_EXT__",
+                "__DIRECTORY__", "__DIR__", "ENV", "VARS", "ARGS" })
+        @DisplayName("Logs a warning when attempting to override predefined variables")
+        void logsWarningWhenOverridingPredefinedVariables(String varName) throws IOException {
+            String assertionMessage = "Attempting to override a predefined variable %s within a variables: block should log a warning"
+                    .formatted(varName);
+
+            // 1. Test top-level variables block
+            Path mainFile = writeFixture("predefinedVarsOverride.yaml", """
+                    variables:
+                      %s: "invalid"
+
+                    foo: ${%s}
+                    """.formatted(varName, varName));
+            Map<Object, @Nullable Object> result = loadFixture(mainFile);
+
+            assertThat(assertionMessage, logSession.getTrackedWarnings(),
+                    hasItem(containsString("Cannot redefine special variable")));
+
+            assertThat(getNestedValue(result, "foo"), is(not("invalid")));
+
+            // Clear the log session to ensure the next assertion is testing the new composition
+            logSession.flush();
+
+            // 2. Test inline !var directive
+            mainFile = writeFixture("predefinedVarsInlineOverride.yaml", """
+                    !var %s: "invalid"
+                    foo: ${%s}
+                    """.formatted(varName, varName));
+            result = loadFixture(mainFile);
+
+            assertionMessage = "Attempting to override a predefined variable %s with !var should log a warning"
+                    .formatted(varName);
+            assertThat(assertionMessage, logSession.getTrackedWarnings(),
+                    hasItem(containsString("Cannot redefine special variable")));
+
+            assertThat(getNestedValue(result, "foo"), is(not("invalid")));
+        }
+
         @Test
         @DisplayName("Loads entire variables block from an !include file")
         void loadsEntireVariablesBlockFromInclude() throws IOException {


### PR DESCRIPTION
- Adds the special `ARGS` variable to capture immediate arguments for both `!include` and `!insert` calls.
- Ensures `ARGS` remains strictly scoped to its immediate invocation layer (preventing parent arguments from leaking into inner `ARGS`).

