### PR TITLE
[gpio] Add discovery method

### DIFF
--- a/bundles/org.openhab.binding.gpio/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.binding.gpio/src/main/resources/OH-INF/addon/addon.xml
@@ -8,4 +8,16 @@
 	<description>Adds GPIO support to openHAB.</description>
 	<connection>local</connection>
 
+	<discovery-methods>
+		<discovery-method>
+			<service-type>process</service-type>
+			<match-properties>
+				<match-property>
+					<name>command</name>
+					<regex>(?i).*[/\\](pigpiod)(\.exe)?$</regex>
+				</match-property>
+			</match-properties>
+		</discovery-method>
+	</discovery-methods>
+
 </addon:addon>


### PR DESCRIPTION
Add a discovery-method so the add-on finder can suggest this binding when the `pigpiod` daemon is running on the host machine.