### PR TITLE
[linkplay] Fix discovery method

### DIFF
--- a/bundles/org.openhab.binding.linkplay/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.binding.linkplay/src/main/resources/OH-INF/addon/addon.xml
@@ -5,11 +5,17 @@
 
 	<type>binding</type>
 	<name>LinkPlay Binding</name>
-	<description>This is the binding for LinkPlay.</description>
+	<description>This is the binding for audio devices based on the LinkPlay platform.</description>
 	<connection>local</connection>
 	<discovery-methods>
 		<discovery-method>
 			<service-type>upnp</service-type>
+			<match-properties>
+				<match-property>
+					<name>manufacturer</name>
+					<regex>(?i)Linkplay.*</regex>
+				</match-property>
+			</match-properties>
 		</discovery-method>
 	</discovery-methods>
 </addon:addon>

--- a/bundles/org.openhab.binding.linkplay/src/main/resources/OH-INF/i18n/linkplay.properties
+++ b/bundles/org.openhab.binding.linkplay/src/main/resources/OH-INF/i18n/linkplay.properties
@@ -1,7 +1,7 @@
 # add-on
 
 addon.linkplay.name = LinkPlay Binding
-addon.linkplay.description = This is the binding for LinkPlay.
+addon.linkplay.description = This is the binding for audio devices based on the LinkPlay platform.
 
 # thing types
 


### PR DESCRIPTION
Fix the discovery method for the LinkPlay binding. Right now LinkPlay is always a suggested add-on. Here is a capture of the UPNP information for reference:

<img width="506" height="380" alt="image" src="https://github.com/user-attachments/assets/3d993d95-8d65-4645-afe5-ff21274caadf" />
