### PR TITLE
[amazonechocontrol] Use one logger for requests and responses

### DIFF
--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/util/HttpRequestBuilder.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/util/HttpRequestBuilder.java
@@ -324,7 +324,6 @@ public class HttpRequestBuilder {
         private static final int MAX_REDIRECTS = 30;
         private static final int MAX_RETRIES = 3;
 
-        private final Logger logger = LoggerFactory.getLogger(HttpResponseListener.class);
         private final CompletableFuture<HttpResponse> httpResponse;
         private final RequestParams params;
         private final boolean autoRedirect;


### PR DESCRIPTION
`HttpResponseListener` declared its own logger. As a nested class that name is `HttpRequestBuilder$HttpResponseListener`, and log4j2 splits the logger hierarchy at dots rather than at the dollar sign — so raising `org.openhab.binding.amazonechocontrol.internal.util.HttpRequestBuilder`, which is the obvious thing to do when tracing HTTP traffic, showed every request and no response at all. The only line carrying a status code and a response body lives in that class.

The class is not static, so removing the field lets its calls resolve to the enclosing one. Nothing else changes.

Measured on a production system, with only `...util.HttpRequestBuilder` raised to DEBUG and its parent left at INFO:

| | requests logged | responses logged |
|---|---|---|
| before | dozens | 0 |
| after | 35 | 35 |

All 21 other loggers in this binding belong to top-level classes and follow the same `getLogger(ThisClass.class)` form; this was the only nested one.

**Transparency:** this patch was developed with AI assistance (Claude); every commit carries an `AI-assisted-by` trailer. All changes were built, tested and verified on a production system by the author.
