### PR TITLE
AGENTS.md: Add PR repository guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -310,3 +310,5 @@ When creating a pull request, read and follow `.github/PULL_REQUEST_TEMPLATE.md`
 - Treat HTML-commented template text as instructions and write visible Markdown that addresses the applicable requirements; do not copy the comment delimiters or leave the PR description hidden inside an HTML comment.
 - Before creating or updating a pull request, verify that its title and description still match the current diff and scope, especially after follow-up changes.
 - Treat the template as the source of truth for the remaining pull-request requirements rather than duplicating them here.
+
+When working on a pull request, unless stated otherwise, assume the PR references the openhab/openhab-addons repository (`upstream` Git remote).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -311,4 +311,4 @@ When creating a pull request, read and follow `.github/PULL_REQUEST_TEMPLATE.md`
 - Before creating or updating a pull request, verify that its title and description still match the current diff and scope, especially after follow-up changes.
 - Treat the template as the source of truth for the remaining pull-request requirements rather than duplicating them here.
 
-When working on a pull request, unless stated otherwise, assume the PR references the openhab/openhab-addons repository (`upstream` Git remote).
+When working on a pull request, unless stated otherwise, assume the PR references the `openhab/openhab-addons` repository.


### PR DESCRIPTION
When having AI agents work on PRs (e.g. review), over and over again they asked me or tried to find out themselves which repository to look at. By adding this guidance, they finally get it right directly and without intervention.