### PR TITLE
[chatgpt] Update keywords with additional AI services supported

### DIFF
--- a/bundles/org.openhab.binding.chatgpt/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.binding.chatgpt/src/main/resources/OH-INF/addon/addon.xml
@@ -6,7 +6,7 @@
 	<type>binding</type>
 	<name>ChatGPT Binding</name>
 	<description>Integrates with OpenAI API-compatible AI services for AI-powered chat and smart home control.</description>
-	<keywords>ChatGPT,OpenAI,OpenRouter,Mistral,Ollama,human language interpreter</keywords>
+	<keywords>Anthropic,ChatGPT,Claude,DeepSeek,Mistral,Ollama,OpenAI,OpenRouter,SpaceXAI,human language interpreter</keywords>
 	<connection>cloud</connection>
 
 </addon:addon>


### PR DESCRIPTION
This allows to find the ChatGPT binding through these keywords in the add-on store.