### PR TITLE
[gemini] Add HLI keyword to addon.xml

### DIFF
--- a/bundles/org.openhab.binding.gemini/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.binding.gemini/src/main/resources/OH-INF/addon/addon.xml
@@ -6,6 +6,7 @@
 	<type>binding</type>
 	<name>Gemini Binding</name>
 	<description>Integrates with the Google Gemini API for AI-powered chat and smart home control.</description>
+	<keywords>human language interpreter</keywords>
 	<connection>cloud</connection>
 
 </addon:addon>


### PR DESCRIPTION
Backports #21466 for Gemini.
Required to backport https://github.com/openhab/openhab-webui/pull/4460.