### PR TITLE
[metrics] Document the new rule execution duration metric

### DIFF
--- a/bundles/org.openhab.io.metrics/README.md
+++ b/bundles/org.openhab.io.metrics/README.md
@@ -13,6 +13,7 @@ Currently, the following metrics are provided:
 - openHAB bundle states
 - openHAB thing states
 - openHAB rule runs (per rule)
+- openHAB rule execution duration (per rule)
 - openHAB thread pool stats (per scheduler)
 - JVM stats including metrics of:
   - Class loader


### PR DESCRIPTION
## Description   

Documentation-only change (Improvement).                                                                                                                                                                                                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
  openHAB core gained a new metric for the execution duration of rules (see openhab/openhab-core#5358).                                                                                                                                                                                                                                                                                                                                                                             
  Next to the existing `openhab.rule.runs` counter, the Metrics service now also exposes                                                                                                                                                                                                                                                                                                                                                                                            
  `openhab.rule.duration`, a timer that records how long each rule run took, tagged per rule                                                                                                                                                                                                                                                                                                                                                                                        
  (`rule` = rule ID, `rulename` = rule name).                                                                                                                                                                                                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
  This PR adds the new metric to the "Provided Metrics" list in the add-on README, so the                                                                                                                                                                                                                                                                                                                                                                                           
  documentation matches what the service actually exports.                                                                                                                                                                                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
  Depends on openhab/openhab-core#5358 — this PR should only be merged once the core change is in.                                                                                                                                                                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
  ## Testing                                                                                                                                                                                                                                                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
  No functional change, documentation only. The rendered README can be reviewed in the diff.  