### PR TITLE
[oppo] Consolidate player model information

### DIFF
--- a/bundles/org.openhab.binding.oppo/README.md
+++ b/bundles/org.openhab.binding.oppo/README.md
@@ -103,7 +103,7 @@ The following channels are available:
 | control           | Player      | Simulate pressing the transport control buttons on the remote control (play/pause/next/previous/rew/ffwd)                             |
 | time-mode         | String      | Sets the time information display mode on the player (T= Title Elapsed, X= Title Remaining, C= Chapter Elapsed, K= Chapter Remaining) |
 | time-display      | Number:Time | Indicates the time information that matches the display on the player for the current `time mode` setting (Read-only)                 |
-| current_title     | Number      | The current title or track number playing (Read-only)                                                                                 |
+| current-title     | Number      | The current title or track number playing (Read-only)                                                                                 |
 | total-title       | Number      | The total number of titles or tracks on the disc (Read-only)                                                                          |
 | current-chapter   | Number      | The current chapter number (Read-only)                                                                                                |
 | total-chapter     | Number      | The total number of chapters in the current title (Read-only)                                                                         |

--- a/bundles/org.openhab.binding.oppo/src/main/java/org/openhab/binding/oppo/internal/OppoBindingConstants.java
+++ b/bundles/org.openhab.binding.oppo/src/main/java/org/openhab/binding/oppo/internal/OppoBindingConstants.java
@@ -12,7 +12,6 @@
  */
 package org.openhab.binding.oppo.internal;
 
-import java.util.Map;
 import java.util.Set;
 
 import javax.measure.Unit;
@@ -44,17 +43,6 @@ public class OppoBindingConstants {
 
     public static final Unit<Time> API_SECONDS_UNIT = Units.SECOND;
     public static final Unit<Dimensionless> API_PERCENT_UNIT = Units.PERCENT;
-
-    public static final int MODEL83 = 83;
-    public static final int MODEL93 = 93;
-    public static final int MODEL103 = 103;
-    public static final int MODEL105 = 105;
-    public static final int MODEL203 = 203;
-    public static final int MODEL205 = 205;
-
-    public static final Map<ThingTypeUID, Integer> THING_TYPE_TO_MODEL = Map.of(THING_TYPE_BDP83, MODEL83,
-            THING_TYPE_BDP93, MODEL93, THING_TYPE_BDP103, MODEL103, THING_TYPE_BDP105, MODEL105, THING_TYPE_UDP203,
-            MODEL203, THING_TYPE_UDP205, MODEL205);
 
     public static final Integer BDP83_PORT = 19999;
     public static final Integer BDP10X_PORT = 48360;

--- a/bundles/org.openhab.binding.oppo/src/main/java/org/openhab/binding/oppo/internal/OppoBindingConstants.java
+++ b/bundles/org.openhab.binding.oppo/src/main/java/org/openhab/binding/oppo/internal/OppoBindingConstants.java
@@ -44,6 +44,13 @@ public class OppoBindingConstants {
     public static final Unit<Time> API_SECONDS_UNIT = Units.SECOND;
     public static final Unit<Dimensionless> API_PERCENT_UNIT = Units.PERCENT;
 
+    public static final Set<String> BDPXX_HDMI_MODES = Set.of("AUTO", "SRC", "1080P", "1080I", "720P", "SDP", "SDI");
+    public static final Set<String> BDP10X_HDMI_MODES = Set.of("AUTO", "SRC", "4K2K", "1080P", "1080I", "720P", "SDP",
+            "SDI");
+    public static final Set<String> UDP20X_HDMI_MODES = Set.of("AUTO", "SRC", "UHD_AUTO", "UHD24", "UHD50", "UHD60",
+            "1080P_AUTO", "1080P24", "1080P50", "1080P60", "1080I50", "1080I60", "720P50", "720P60", "576P", "576I",
+            "480P", "480I");
+
     public static final Integer BDP83_PORT = 19999;
     public static final Integer BDP10X_PORT = 48360;
     public static final Integer UDP20X_PORT = 23;

--- a/bundles/org.openhab.binding.oppo/src/main/java/org/openhab/binding/oppo/internal/OppoPlayerModel.java
+++ b/bundles/org.openhab.binding.oppo/src/main/java/org/openhab/binding/oppo/internal/OppoPlayerModel.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.oppo.internal;
+
+import static org.openhab.binding.oppo.internal.OppoBindingConstants.*;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.binding.oppo.internal.communication.OppoCommand;
+import org.openhab.core.thing.ThingTypeUID;
+
+/**
+ * The {@link OppoPlayerModel} enumeration defines the supported Oppo player models.
+ *
+ * @author Jacob Laursen - Initial contribution
+ */
+@NonNullByDefault
+public enum OppoPlayerModel {
+    /**
+     * OPPO BDP-83 Blu-ray player
+     */
+    BDP83(83, THING_TYPE_BDP83, BDP83_PORT, OppoCommand.QUERY_COMMANDS_83, true),
+    /**
+     * OPPO BDP-93/95 Blu-ray Player
+     */
+    BDP93(93, THING_TYPE_BDP93, BDP10X_PORT, OppoCommand.QUERY_COMMANDS_83, true),
+    /**
+     * OPPO BDP-103/103D Blu-ray Player
+     */
+    BDP103(103, THING_TYPE_BDP103, BDP10X_PORT, OppoCommand.QUERY_COMMANDS_10X, true),
+    /**
+     * OPPO BDP-105/105D Blu-ray Player
+     */
+    BDP105(105, THING_TYPE_BDP105, BDP10X_PORT, OppoCommand.QUERY_COMMANDS_10X, true),
+    /**
+     * OPPO UDP-203 Ultra HD Blu-ray Player
+     */
+    UDP203(203, THING_TYPE_UDP203, UDP20X_PORT, OppoCommand.QUERY_COMMANDS_20X, false),
+    /**
+     * OPPO UDP-205 Ultra HD Blu-ray Player
+     */
+    UDP205(205, THING_TYPE_UDP205, UDP20X_PORT, OppoCommand.QUERY_COMMANDS_20X, false);
+
+    private final int modelNumber;
+    private final ThingTypeUID thingTypeUID;
+    private final int port;
+    private final Set<OppoCommand> queryCommands;
+    private final boolean needsHdmiModeWorkaround;
+
+    OppoPlayerModel(int model, ThingTypeUID thingTypeUID, int port, Set<OppoCommand> queryCommands,
+            boolean needsHdmiModeWorkaround) {
+        this.modelNumber = model;
+        this.thingTypeUID = thingTypeUID;
+        this.port = port;
+        this.queryCommands = queryCommands;
+        this.needsHdmiModeWorkaround = needsHdmiModeWorkaround;
+    }
+
+    public int getModelNumber() {
+        return modelNumber;
+    }
+
+    public String getModelNumberAsString() {
+        return Integer.toString(modelNumber);
+    }
+
+    public ThingTypeUID getThingTypeUID() {
+        return thingTypeUID;
+    }
+
+    public int getPort() {
+        return port;
+    }
+
+    public Set<OppoCommand> getQueryCommands() {
+        return queryCommands;
+    }
+
+    public boolean needsHdmiModeWorkaround() {
+        return needsHdmiModeWorkaround;
+    }
+
+    private static final Map<Integer, OppoPlayerModel> BY_MODEL_NUMBER = Arrays.stream(values())
+            .collect(Collectors.toUnmodifiableMap(playerModel -> playerModel.modelNumber, playerModel -> playerModel));
+
+    private static final Map<ThingTypeUID, OppoPlayerModel> BY_THING_TYPE_UID = Arrays.stream(values())
+            .collect(Collectors.toUnmodifiableMap(playerModel -> playerModel.thingTypeUID, playerModel -> playerModel));
+
+    public static OppoPlayerModel fromModelNumber(int modelNumber) {
+        OppoPlayerModel playerModel = BY_MODEL_NUMBER.get(modelNumber);
+        if (playerModel == null) {
+            throw new IllegalArgumentException("Unknown OPPO model: " + modelNumber);
+        }
+        return playerModel;
+    }
+
+    public static OppoPlayerModel fromThingTypeUID(ThingTypeUID thingTypeUID) {
+        OppoPlayerModel playerModel = BY_THING_TYPE_UID.get(thingTypeUID);
+        if (playerModel == null) {
+            throw new IllegalArgumentException("Unknown OPPO ThingTypeUID: " + thingTypeUID);
+        }
+        return playerModel;
+    }
+}

--- a/bundles/org.openhab.binding.oppo/src/main/java/org/openhab/binding/oppo/internal/OppoPlayerModel.java
+++ b/bundles/org.openhab.binding.oppo/src/main/java/org/openhab/binding/oppo/internal/OppoPlayerModel.java
@@ -33,40 +33,42 @@ public enum OppoPlayerModel {
     /**
      * OPPO BDP-83 Blu-ray player
      */
-    BDP83(83, THING_TYPE_BDP83, BDP83_PORT, OppoCommand.QUERY_COMMANDS_83, true),
+    BDP83(83, THING_TYPE_BDP83, BDP83_PORT, OppoCommand.QUERY_COMMANDS_83, BDPXX_HDMI_MODES, true),
     /**
      * OPPO BDP-93/95 Blu-ray Player
      */
-    BDP93(93, THING_TYPE_BDP93, BDP10X_PORT, OppoCommand.QUERY_COMMANDS_83, true),
+    BDP93(93, THING_TYPE_BDP93, BDP10X_PORT, OppoCommand.QUERY_COMMANDS_83, BDPXX_HDMI_MODES, true),
     /**
      * OPPO BDP-103/103D Blu-ray Player
      */
-    BDP103(103, THING_TYPE_BDP103, BDP10X_PORT, OppoCommand.QUERY_COMMANDS_10X, true),
+    BDP103(103, THING_TYPE_BDP103, BDP10X_PORT, OppoCommand.QUERY_COMMANDS_10X, BDP10X_HDMI_MODES, true),
     /**
      * OPPO BDP-105/105D Blu-ray Player
      */
-    BDP105(105, THING_TYPE_BDP105, BDP10X_PORT, OppoCommand.QUERY_COMMANDS_10X, true),
+    BDP105(105, THING_TYPE_BDP105, BDP10X_PORT, OppoCommand.QUERY_COMMANDS_10X, BDP10X_HDMI_MODES, true),
     /**
      * OPPO UDP-203 Ultra HD Blu-ray Player
      */
-    UDP203(203, THING_TYPE_UDP203, UDP20X_PORT, OppoCommand.QUERY_COMMANDS_20X, false),
+    UDP203(203, THING_TYPE_UDP203, UDP20X_PORT, OppoCommand.QUERY_COMMANDS_20X, UDP20X_HDMI_MODES, false),
     /**
      * OPPO UDP-205 Ultra HD Blu-ray Player
      */
-    UDP205(205, THING_TYPE_UDP205, UDP20X_PORT, OppoCommand.QUERY_COMMANDS_20X, false);
+    UDP205(205, THING_TYPE_UDP205, UDP20X_PORT, OppoCommand.QUERY_COMMANDS_20X, UDP20X_HDMI_MODES, false);
 
     private final int modelNumber;
     private final ThingTypeUID thingTypeUID;
     private final int port;
     private final Set<OppoCommand> queryCommands;
+    private final Set<String> hdmiModes;
     private final boolean needsHdmiModeWorkaround;
 
     OppoPlayerModel(int model, ThingTypeUID thingTypeUID, int port, Set<OppoCommand> queryCommands,
-            boolean needsHdmiModeWorkaround) {
+            Set<String> hdmiModes, boolean needsHdmiModeWorkaround) {
         this.modelNumber = model;
         this.thingTypeUID = thingTypeUID;
         this.port = port;
         this.queryCommands = queryCommands;
+        this.hdmiModes = hdmiModes;
         this.needsHdmiModeWorkaround = needsHdmiModeWorkaround;
     }
 
@@ -88,6 +90,10 @@ public enum OppoPlayerModel {
 
     public Set<OppoCommand> getQueryCommands() {
         return queryCommands;
+    }
+
+    public Set<String> getHdmiModes() {
+        return hdmiModes;
     }
 
     public boolean needsHdmiModeWorkaround() {

--- a/bundles/org.openhab.binding.oppo/src/main/java/org/openhab/binding/oppo/internal/discovery/OppoDiscoveryService.java
+++ b/bundles/org.openhab.binding.oppo/src/main/java/org/openhab/binding/oppo/internal/discovery/OppoDiscoveryService.java
@@ -31,6 +31,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.oppo.internal.OppoPlayerModel;
 import org.openhab.core.config.discovery.AbstractDiscoveryService;
 import org.openhab.core.config.discovery.DiscoveryResult;
 import org.openhab.core.config.discovery.DiscoveryResultBuilder;
@@ -246,9 +247,10 @@ public class OppoDiscoveryService extends AbstractDiscoveryService {
                     displayName = DISPLAY_NAME_93;
                 }
             } else if (UDP20X_PORT.toString().equals(port)) {
-                if (displayName != null && displayName.contains(Integer.toString(MODEL203))) {
+                if (displayName != null && displayName.contains(OppoPlayerModel.UDP203.getModelNumberAsString())) {
                     thingTypeUID = THING_TYPE_UDP203;
-                } else if (displayName != null && displayName.contains(Integer.toString(MODEL205))) {
+                } else if (displayName != null
+                        && displayName.contains(OppoPlayerModel.UDP205.getModelNumberAsString())) {
                     thingTypeUID = THING_TYPE_UDP205;
                 } else {
                     thingTypeUID = THING_TYPE_UDP203;

--- a/bundles/org.openhab.binding.oppo/src/main/java/org/openhab/binding/oppo/internal/handler/OppoHandler.java
+++ b/bundles/org.openhab.binding.oppo/src/main/java/org/openhab/binding/oppo/internal/handler/OppoHandler.java
@@ -21,7 +21,6 @@ import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
-import java.util.Set;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
@@ -30,6 +29,7 @@ import java.util.regex.Pattern;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.oppo.internal.OppoException;
+import org.openhab.binding.oppo.internal.OppoPlayerModel;
 import org.openhab.binding.oppo.internal.OppoStateDescriptionOptionProvider;
 import org.openhab.binding.oppo.internal.communication.OppoCommand;
 import org.openhab.binding.oppo.internal.communication.OppoConnector;
@@ -98,7 +98,6 @@ public class OppoHandler extends BaseThingHandler implements OppoMessageEventLis
 
     private List<StateOption> inputSourceOptions = new ArrayList<>();
     private List<StateOption> hdmiModeOptions = new ArrayList<>();
-    private Set<OppoCommand> queryCommands = OppoCommand.QUERY_COMMANDS_20X;
 
     private long lastEventReceived = System.currentTimeMillis();
     private String verboseMode = VERBOSE_2;
@@ -113,7 +112,7 @@ public class OppoHandler extends BaseThingHandler implements OppoMessageEventLis
     private volatile boolean powerCmdDebounce = false;
     private volatile boolean srcCmdDebounce = false;
     private volatile boolean isStopped = true;
-    private boolean isUDP20X = false;
+    private OppoPlayerModel model = OppoPlayerModel.BDP83;
     private boolean isBdpIP = false;
     private volatile boolean isVbModeSet = false;
     private volatile boolean isInitialQuery = false;
@@ -138,18 +137,9 @@ public class OppoHandler extends BaseThingHandler implements OppoMessageEventLis
     public void initialize() {
         final OppoThingConfiguration config = getConfigAs(OppoThingConfiguration.class);
 
-        final int model;
-        if (THING_TYPE_PLAYER.equals(thing.getThingTypeUID())) {
-            model = config.model;
-        } else {
-            model = THING_TYPE_TO_MODEL.getOrDefault(thing.getThingTypeUID(), 0);
-        }
-
-        if (model == 0) {
-            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, "@text/error.player-model");
-            return;
-        }
-        this.isUDP20X = (model == MODEL203 || model == MODEL205);
+        model = THING_TYPE_PLAYER.equals(thing.getThingTypeUID()) //
+                ? OppoPlayerModel.fromModelNumber(config.model)
+                : OppoPlayerModel.fromThingTypeUID(thing.getThingTypeUID());
 
         final String serialPort = config.serialPort;
         final String host = config.host;
@@ -165,22 +155,12 @@ public class OppoHandler extends BaseThingHandler implements OppoMessageEventLis
         } else {
             isBdpIP = false;
             if (port == null) {
-                port = switch (model) {
-                    case MODEL83 -> BDP83_PORT;
-                    case MODEL93, MODEL103, MODEL105 -> BDP10X_PORT;
-                    default -> UDP20X_PORT;
-                };
+                port = model.getPort();
                 isBdpIP = port != UDP20X_PORT;
             } else if (port <= 0) {
                 configError = "@text/error.invalid-port";
             }
         }
-
-        queryCommands = switch (model) {
-            case MODEL83, MODEL93 -> OppoCommand.QUERY_COMMANDS_83;
-            case MODEL103, MODEL105 -> OppoCommand.QUERY_COMMANDS_10X;
-            default -> OppoCommand.QUERY_COMMANDS_20X;
-        };
 
         this.verboseMode = config.verboseMode && !isBdpIP ? VERBOSE_3 : VERBOSE_2;
 
@@ -677,11 +657,8 @@ public class OppoHandler extends BaseThingHandler implements OppoMessageEventLis
                         updateChannelState(CHANNEL_OSD_POSITION, updateData);
                         break;
                     case QHD:
-                        if (this.isUDP20X) {
-                            updateChannelState(CHANNEL_HDMI_MODE, updateData);
-                        } else {
-                            handleHdmiModeUpdate(updateData);
-                        }
+                        updateChannelState(CHANNEL_HDMI_MODE,
+                                model.needsHdmiModeWorkaround() ? translateHdmiMode(updateData) : updateData);
                         break;
                     case QHR: // 203 & 205 only
                         updateChannelState(CHANNEL_HDR_MODE, updateData);
@@ -847,14 +824,14 @@ public class OppoHandler extends BaseThingHandler implements OppoMessageEventLis
                                 }
 
                                 isInitialQuery = true;
-                                queryCommands.forEach(cmd -> {
+                                for (OppoCommand cmd : model.getQueryCommands()) {
                                     try {
                                         connector.sendCommand(cmd);
                                         Thread.sleep(SLEEP_BETWEEN_CMD_MS);
                                     } catch (OppoException | InterruptedException e) {
                                         logger.debug("Exception sending polling commands: {}", e.getMessage());
                                     }
-                                });
+                                }
                             }
 
                             // for Verbose mode 2 get the current play back time if we are playing
@@ -1037,40 +1014,13 @@ public class OppoHandler extends BaseThingHandler implements OppoMessageEventLis
         }
     }
 
-    private void buildStateOptionLists(int model) {
+    private void buildStateOptionLists(OppoPlayerModel model) {
         hdmiModeOptions.clear();
         inputSourceOptions.clear();
 
-        if (!isUDP20X) {
-            hdmiModeOptions.add(new StateOption("AUTO", getString("auto", "Auto")));
-            hdmiModeOptions.add(new StateOption("SRC", getString("direct", "Source Direct")));
-            if (model == MODEL103 || model == MODEL105) {
-                hdmiModeOptions.add(new StateOption("4K2K", "4K*2K"));
-            }
-            hdmiModeOptions.add(new StateOption("1080P", "1080P"));
-            hdmiModeOptions.add(new StateOption("1080I", "1080I"));
-            hdmiModeOptions.add(new StateOption("720P", "720P"));
-            hdmiModeOptions.add(new StateOption("SDP", "480P"));
-            hdmiModeOptions.add(new StateOption("SDI", "480I"));
-        }
-
-        if (model == MODEL103 || model == MODEL105) {
-            inputSourceOptions.add(new StateOption("0", getString("blu_ray", "Blu-ray Player")));
-            inputSourceOptions.add(new StateOption("1", getString("hdmi_in_front", "HDMI In-Front")));
-            inputSourceOptions.add(new StateOption("2", getString("hdmi_in_back", "HDMI In-Back")));
-            inputSourceOptions.add(new StateOption("3", getString("arc1", "ARC HDMI Out 1")));
-            inputSourceOptions.add(new StateOption("4", getString("arc2", "ARC HDMI Out 2")));
-
-            if (model == MODEL105) {
-                inputSourceOptions.add(new StateOption("5", getString("optical", "Optical In")));
-                inputSourceOptions.add(new StateOption("6", getString("coaxial", "Coaxial In")));
-                inputSourceOptions.add(new StateOption("7", getString("usb", "USB Audio In")));
-            }
-        }
-
-        if (isUDP20X) {
-            hdmiModeOptions.add(new StateOption("AUTO", getString("auto", "Auto")));
-            hdmiModeOptions.add(new StateOption("SRC", getString("direct", "Source Direct")));
+        hdmiModeOptions.add(new StateOption("AUTO", getString("auto", "Auto")));
+        hdmiModeOptions.add(new StateOption("SRC", getString("direct", "Source Direct")));
+        if (model == OppoPlayerModel.UDP203 || model == OppoPlayerModel.UDP205) {
             hdmiModeOptions.add(new StateOption("UHD_AUTO", getString("auto_uhd", "UHD Auto")));
             hdmiModeOptions.add(new StateOption("UHD24", "UHD24"));
             hdmiModeOptions.add(new StateOption("UHD50", "UHD50"));
@@ -1087,12 +1037,35 @@ public class OppoHandler extends BaseThingHandler implements OppoMessageEventLis
             hdmiModeOptions.add(new StateOption("576I", "567I"));
             hdmiModeOptions.add(new StateOption("480P", "480P"));
             hdmiModeOptions.add(new StateOption("480I", "480I"));
+        } else {
+            if (model == OppoPlayerModel.BDP103 || model == OppoPlayerModel.BDP105) {
+                hdmiModeOptions.add(new StateOption("4K2K", "4K*2K"));
+            }
+            hdmiModeOptions.add(new StateOption("1080P", "1080P"));
+            hdmiModeOptions.add(new StateOption("1080I", "1080I"));
+            hdmiModeOptions.add(new StateOption("720P", "720P"));
+            hdmiModeOptions.add(new StateOption("SDP", "480P"));
+            hdmiModeOptions.add(new StateOption("SDI", "480I"));
+        }
 
+        if (model == OppoPlayerModel.BDP103 || model == OppoPlayerModel.BDP105) {
+            inputSourceOptions.add(new StateOption("0", getString("blu_ray", "Blu-ray Player")));
+            inputSourceOptions.add(new StateOption("1", getString("hdmi_in_front", "HDMI In-Front")));
+            inputSourceOptions.add(new StateOption("2", getString("hdmi_in_back", "HDMI In-Back")));
+            inputSourceOptions.add(new StateOption("3", getString("arc1", "ARC HDMI Out 1")));
+            inputSourceOptions.add(new StateOption("4", getString("arc2", "ARC HDMI Out 2")));
+
+            if (model == OppoPlayerModel.BDP105) {
+                inputSourceOptions.add(new StateOption("5", getString("optical", "Optical In")));
+                inputSourceOptions.add(new StateOption("6", getString("coaxial", "Coaxial In")));
+                inputSourceOptions.add(new StateOption("7", getString("usb", "USB Audio In")));
+            }
+        } else if (model == OppoPlayerModel.UDP203 || model == OppoPlayerModel.UDP205) {
             inputSourceOptions.add(new StateOption("0", getString("blu_ray", "Blu-ray Player")));
             inputSourceOptions.add(new StateOption("1", getString("hdmi_in", "HDMI In")));
             inputSourceOptions.add(new StateOption("2", getString("arc", "ARC HDMI Out")));
 
-            if (model == MODEL205) {
+            if (model == OppoPlayerModel.UDP205) {
                 inputSourceOptions.add(new StateOption("3", getString("optical", "Optical In")));
                 inputSourceOptions.add(new StateOption("4", getString("coaxial", "Coaxial In")));
                 inputSourceOptions.add(new StateOption("5", getString("usb", "USB Audio In")));
@@ -1104,17 +1077,14 @@ public class OppoHandler extends BaseThingHandler implements OppoMessageEventLis
         return translationProvider.getText(bundle, "option." + i18nKey, defaultStr, localeProvider.getLocale());
     }
 
-    private void handleHdmiModeUpdate(String updateData) {
+    private String translateHdmiMode(String hdmiMode) {
         // ugly... a couple of the query hdmi mode response codes on the earlier models don't match the code to set it
         // some of this protocol is weird like that...
-        if ("480I".equals(updateData)) {
-            updateChannelState(CHANNEL_HDMI_MODE, "SDI");
-        } else if ("480P".equals(updateData)) {
-            updateChannelState(CHANNEL_HDMI_MODE, "SDP");
-        } else if ("4K*2K".equals(updateData)) {
-            updateChannelState(CHANNEL_HDMI_MODE, "4K2K");
-        } else {
-            updateChannelState(CHANNEL_HDMI_MODE, updateData);
-        }
+        return switch (hdmiMode) {
+            case "480I" -> "SDI";
+            case "480P" -> "SDP";
+            case "4K*2K" -> "4K2K";
+            default -> hdmiMode;
+        };
     }
 }

--- a/bundles/org.openhab.binding.oppo/src/main/java/org/openhab/binding/oppo/internal/handler/OppoHandler.java
+++ b/bundles/org.openhab.binding.oppo/src/main/java/org/openhab/binding/oppo/internal/handler/OppoHandler.java
@@ -21,6 +21,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.Set;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
@@ -85,6 +86,8 @@ public class OppoHandler extends BaseThingHandler implements OppoMessageEventLis
 
     private final Logger logger = LoggerFactory.getLogger(OppoHandler.class);
 
+    private final List<StateOption> allHdmiModeStateOptions;
+
     private @Nullable ScheduledFuture<?> reconnectJob;
     private @Nullable ScheduledFuture<?> pollingJob;
 
@@ -95,9 +98,6 @@ public class OppoHandler extends BaseThingHandler implements OppoMessageEventLis
     private final TranslationProvider translationProvider;
     private final LocaleProvider localeProvider;
     private final @Nullable Bundle bundle;
-
-    private List<StateOption> inputSourceOptions = new ArrayList<>();
-    private List<StateOption> hdmiModeOptions = new ArrayList<>();
 
     private long lastEventReceived = System.currentTimeMillis();
     private String verboseMode = VERBOSE_2;
@@ -130,7 +130,8 @@ public class OppoHandler extends BaseThingHandler implements OppoMessageEventLis
         this.serialPortManager = serialPortManager;
         this.translationProvider = translationProvider;
         this.localeProvider = localeProvider;
-        this.bundle = FrameworkUtil.getBundle(OppoHandler.class);
+        bundle = FrameworkUtil.getBundle(OppoHandler.class);
+        allHdmiModeStateOptions = createAllHdmiModeStateOptions();
     }
 
     @Override
@@ -178,13 +179,13 @@ public class OppoHandler extends BaseThingHandler implements OppoMessageEventLis
             return;
         }
 
-        buildStateOptionLists(model);
-        if (!inputSourceOptions.isEmpty()) {
+        List<StateOption> inputSourceStateOptions = buildInputSourceStateOptions(model);
+        if (!inputSourceStateOptions.isEmpty()) {
             stateDescriptionProvider.setStateOptions(new ChannelUID(getThing().getUID(), CHANNEL_SOURCE),
-                    inputSourceOptions);
+                    inputSourceStateOptions);
         }
         stateDescriptionProvider.setStateOptions(new ChannelUID(getThing().getUID(), CHANNEL_HDMI_MODE),
-                hdmiModeOptions);
+                buildHdmiModeStateOptions(model));
 
         scheduleReconnectJob();
         schedulePollingJob();
@@ -1014,63 +1015,82 @@ public class OppoHandler extends BaseThingHandler implements OppoMessageEventLis
         }
     }
 
-    private void buildStateOptionLists(OppoPlayerModel model) {
-        hdmiModeOptions.clear();
-        inputSourceOptions.clear();
+    private List<StateOption> buildInputSourceStateOptions(OppoPlayerModel model) {
+        return switch (model) {
+            case BDP103 -> buildBdpInputSourceStateOptions(false);
+            case BDP105 -> buildBdpInputSourceStateOptions(true);
+            case UDP203 -> buildUdpInputSourceStateOptions(false);
+            case UDP205 -> buildUdpInputSourceStateOptions(true);
+            default -> List.of();
+        };
+    }
 
-        hdmiModeOptions.add(new StateOption("AUTO", getString("auto", "Auto")));
-        hdmiModeOptions.add(new StateOption("SRC", getString("direct", "Source Direct")));
-        if (model == OppoPlayerModel.UDP203 || model == OppoPlayerModel.UDP205) {
-            hdmiModeOptions.add(new StateOption("UHD_AUTO", getString("auto_uhd", "UHD Auto")));
-            hdmiModeOptions.add(new StateOption("UHD24", "UHD24"));
-            hdmiModeOptions.add(new StateOption("UHD50", "UHD50"));
-            hdmiModeOptions.add(new StateOption("UHD60", "UHD60"));
-            hdmiModeOptions.add(new StateOption("1080P_AUTO", getString("auto_1080p", "1080P Auto")));
-            hdmiModeOptions.add(new StateOption("1080P24", "1080P24"));
-            hdmiModeOptions.add(new StateOption("1080P50", "1080P50"));
-            hdmiModeOptions.add(new StateOption("1080P60", "1080P60"));
-            hdmiModeOptions.add(new StateOption("1080I50", "1080I50"));
-            hdmiModeOptions.add(new StateOption("1080I60", "1080I60"));
-            hdmiModeOptions.add(new StateOption("720P50", "720P50"));
-            hdmiModeOptions.add(new StateOption("720P60", "720P60"));
-            hdmiModeOptions.add(new StateOption("576P", "576P"));
-            hdmiModeOptions.add(new StateOption("576I", "576I"));
-            hdmiModeOptions.add(new StateOption("480P", "480P"));
-            hdmiModeOptions.add(new StateOption("480I", "480I"));
-        } else {
-            if (model == OppoPlayerModel.BDP103 || model == OppoPlayerModel.BDP105) {
-                hdmiModeOptions.add(new StateOption("4K2K", "4K*2K"));
-            }
-            hdmiModeOptions.add(new StateOption("1080P", "1080P"));
-            hdmiModeOptions.add(new StateOption("1080I", "1080I"));
-            hdmiModeOptions.add(new StateOption("720P", "720P"));
-            hdmiModeOptions.add(new StateOption("SDP", "480P"));
-            hdmiModeOptions.add(new StateOption("SDI", "480I"));
+    private List<StateOption> buildBdpInputSourceStateOptions(boolean includeAudioInputs) {
+        List<StateOption> options = new ArrayList<>(8);
+
+        options.add(new StateOption("0", getString("blu_ray", "Blu-ray Player")));
+        options.add(new StateOption("1", getString("hdmi_in_front", "HDMI In-Front")));
+        options.add(new StateOption("2", getString("hdmi_in_back", "HDMI In-Back")));
+        options.add(new StateOption("3", getString("arc1", "ARC HDMI Out 1")));
+        options.add(new StateOption("4", getString("arc2", "ARC HDMI Out 2")));
+
+        if (includeAudioInputs) {
+            options.add(new StateOption("5", getString("optical", "Optical In")));
+            options.add(new StateOption("6", getString("coaxial", "Coaxial In")));
+            options.add(new StateOption("7", getString("usb", "USB Audio In")));
         }
 
-        if (model == OppoPlayerModel.BDP103 || model == OppoPlayerModel.BDP105) {
-            inputSourceOptions.add(new StateOption("0", getString("blu_ray", "Blu-ray Player")));
-            inputSourceOptions.add(new StateOption("1", getString("hdmi_in_front", "HDMI In-Front")));
-            inputSourceOptions.add(new StateOption("2", getString("hdmi_in_back", "HDMI In-Back")));
-            inputSourceOptions.add(new StateOption("3", getString("arc1", "ARC HDMI Out 1")));
-            inputSourceOptions.add(new StateOption("4", getString("arc2", "ARC HDMI Out 2")));
+        return options;
+    }
 
-            if (model == OppoPlayerModel.BDP105) {
-                inputSourceOptions.add(new StateOption("5", getString("optical", "Optical In")));
-                inputSourceOptions.add(new StateOption("6", getString("coaxial", "Coaxial In")));
-                inputSourceOptions.add(new StateOption("7", getString("usb", "USB Audio In")));
-            }
-        } else if (model == OppoPlayerModel.UDP203 || model == OppoPlayerModel.UDP205) {
-            inputSourceOptions.add(new StateOption("0", getString("blu_ray", "Blu-ray Player")));
-            inputSourceOptions.add(new StateOption("1", getString("hdmi_in", "HDMI In")));
-            inputSourceOptions.add(new StateOption("2", getString("arc", "ARC HDMI Out")));
+    private List<StateOption> buildUdpInputSourceStateOptions(boolean includeAudioInputs) {
+        List<StateOption> options = new ArrayList<>(6);
 
-            if (model == OppoPlayerModel.UDP205) {
-                inputSourceOptions.add(new StateOption("3", getString("optical", "Optical In")));
-                inputSourceOptions.add(new StateOption("4", getString("coaxial", "Coaxial In")));
-                inputSourceOptions.add(new StateOption("5", getString("usb", "USB Audio In")));
-            }
+        options.add(new StateOption("0", getString("blu_ray", "Blu-ray Player")));
+        options.add(new StateOption("1", getString("hdmi_in", "HDMI In")));
+        options.add(new StateOption("2", getString("arc", "ARC HDMI Out")));
+
+        if (includeAudioInputs) {
+            options.add(new StateOption("3", getString("optical", "Optical In")));
+            options.add(new StateOption("4", getString("coaxial", "Coaxial In")));
+            options.add(new StateOption("5", getString("usb", "USB Audio In")));
         }
+
+        return options;
+    }
+
+    private List<StateOption> buildHdmiModeStateOptions(OppoPlayerModel model) {
+        Set<String> supportedModes = model.getHdmiModes();
+
+        return allHdmiModeStateOptions.stream().filter(option -> supportedModes.contains(option.getValue())).toList();
+    }
+
+    private List<StateOption> createAllHdmiModeStateOptions() {
+        return List.of( //
+                new StateOption("AUTO", getString("auto", "Auto")), //
+                new StateOption("SRC", getString("direct", "Source Direct")), //
+                new StateOption("UHD_AUTO", getString("auto_uhd", "UHD Auto")), //
+                new StateOption("4K2K", "4K*2K"), //
+                new StateOption("UHD24", "UHD24"), //
+                new StateOption("UHD50", "UHD50"), //
+                new StateOption("UHD60", "UHD60"), //
+                new StateOption("1080P_AUTO", getString("auto_1080p", "1080P Auto")), //
+                new StateOption("1080P24", "1080P24"), //
+                new StateOption("1080P50", "1080P50"), //
+                new StateOption("1080P60", "1080P60"), //
+                new StateOption("1080P", "1080P"), //
+                new StateOption("1080I50", "1080I50"), //
+                new StateOption("1080I60", "1080I60"), //
+                new StateOption("1080I", "1080I"), //
+                new StateOption("720P50", "720P50"), //
+                new StateOption("720P60", "720P60"), //
+                new StateOption("720P", "720P"), //
+                new StateOption("576P", "576P"), //
+                new StateOption("576I", "576I"), //
+                new StateOption("480P", "480P"), //
+                new StateOption("SDP", "480P"), //
+                new StateOption("480I", "480I"), //
+                new StateOption("SDI", "480I"));
     }
 
     private @Nullable String getString(String i18nKey, String defaultStr) {

--- a/bundles/org.openhab.binding.oppo/src/main/java/org/openhab/binding/oppo/internal/handler/OppoHandler.java
+++ b/bundles/org.openhab.binding.oppo/src/main/java/org/openhab/binding/oppo/internal/handler/OppoHandler.java
@@ -1033,8 +1033,8 @@ public class OppoHandler extends BaseThingHandler implements OppoMessageEventLis
             hdmiModeOptions.add(new StateOption("1080I60", "1080I60"));
             hdmiModeOptions.add(new StateOption("720P50", "720P50"));
             hdmiModeOptions.add(new StateOption("720P60", "720P60"));
-            hdmiModeOptions.add(new StateOption("576P", "567P"));
-            hdmiModeOptions.add(new StateOption("576I", "567I"));
+            hdmiModeOptions.add(new StateOption("576P", "576P"));
+            hdmiModeOptions.add(new StateOption("576I", "576I"));
             hdmiModeOptions.add(new StateOption("480P", "480P"));
             hdmiModeOptions.add(new StateOption("480I", "480I"));
         } else {

--- a/bundles/org.openhab.binding.oppo/src/main/resources/OH-INF/i18n/oppo.properties
+++ b/bundles/org.openhab.binding.oppo/src/main/resources/OH-INF/i18n/oppo.properties
@@ -442,7 +442,6 @@ option.usb = USB Audio In
 
 # configuration error messages
 
-error.player-model = Player model must be specified
 error.port-select = Undefined serialPort and host configuration settings; please set one of them
 error.rfc2217 = Use host and port configuration settings for a serial over IP connection
 error.invalid-port = Invalid port configuration setting


### PR DESCRIPTION
This makes `OppoPlayerModel` the single source of truth for supported player models and their associated configuration.

Also fix typos in HDMI mode state option labels and a Channel ID in the documentation which was missed in #21445