### PR TITLE
[fineoffsetweatherstation] Update README. Battery level  only available via HTTP API for WS85 sensor and similar models

### DIFF
--- a/bundles/org.openhab.binding.fineoffsetweatherstation/README.md
+++ b/bundles/org.openhab.binding.fineoffsetweatherstation/README.md
@@ -114,6 +114,7 @@ This binding support discovery of Fine Offset gateway devices by sending a broad
 Discovery probes the HTTP API first and falls back to the TCP protocols.
 Values reported by the HTTP API in the unit configured on the gateway (e.g. °F, inHg, mph) are normalized to the binding's units, so the channels are identical regardless of the transport or the gateway's display settings.
 A few channels are only available via the HTTP API and therefore only appear on gateways using the `HTTP_ECOWITT` protocol: `temperature-feels-like`, `vapor-pressure-deficit`, `irradiation-solar`, `piezo-rain-state`, `rain-24-hours` and `piezo-rain-24-hours`.
+As far as WS85 sensor type and similar models, like WS80 and WH90, the `batteryLevel` channel is only available via the HTTP API.
 
 ### `sensor` Thing Configuration
 


### PR DESCRIPTION

# Description

Update README to aware the user  that, as far as WS85 sensor and similar models like WS80 and WH90, the battery level channel is only available via the HTTP API  
