### PR TITLE
[deutschebahn] Fix timezone issue

### DIFF
--- a/bundles/org.openhab.binding.deutschebahn/src/main/java/org/openhab/binding/deutschebahn/internal/DeutscheBahnHandlerFactory.java
+++ b/bundles/org.openhab.binding.deutschebahn/src/main/java/org/openhab/binding/deutschebahn/internal/DeutscheBahnHandlerFactory.java
@@ -20,14 +20,18 @@ import java.util.Set;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.deutschebahn.internal.timetable.TimetableTimeConverter;
 import org.openhab.binding.deutschebahn.internal.timetable.TimetablesV1Impl;
+import org.openhab.core.i18n.TimeZoneProvider;
 import org.openhab.core.thing.Bridge;
 import org.openhab.core.thing.Thing;
 import org.openhab.core.thing.ThingTypeUID;
 import org.openhab.core.thing.binding.BaseThingHandlerFactory;
 import org.openhab.core.thing.binding.ThingHandler;
 import org.openhab.core.thing.binding.ThingHandlerFactory;
+import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * The {@link DeutscheBahnHandlerFactory} is responsible for creating things and thing handlers.
@@ -40,6 +44,13 @@ public class DeutscheBahnHandlerFactory extends BaseThingHandlerFactory {
 
     private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Set.of(TIMETABLE_TYPE, TRAIN_TYPE);
 
+    private final TimeZoneProvider timeZoneProvider;
+
+    @Activate
+    public DeutscheBahnHandlerFactory(final @Reference TimeZoneProvider timeZoneProvider) {
+        this.timeZoneProvider = timeZoneProvider;
+    }
+
     @Override
     public boolean supportsThingType(final ThingTypeUID thingTypeUID) {
         return SUPPORTED_THING_TYPES_UIDS.contains(thingTypeUID);
@@ -48,11 +59,13 @@ public class DeutscheBahnHandlerFactory extends BaseThingHandlerFactory {
     @Override
     protected @Nullable ThingHandler createHandler(final Thing thing) {
         final ThingTypeUID thingTypeUID = thing.getThingTypeUID();
+        final TimetableTimeConverter timeConverter = new TimetableTimeConverter(timeZoneProvider.getTimeZone());
 
         if (TIMETABLE_TYPE.equals(thingTypeUID)) {
-            return new DeutscheBahnTimetableHandler((Bridge) thing, TimetablesV1Impl::new, Date::new, null);
+            return new DeutscheBahnTimetableHandler((Bridge) thing, TimetablesV1Impl::new, Date::new, timeConverter,
+                    null);
         } else if (TRAIN_TYPE.equals(thingTypeUID)) {
-            return new DeutscheBahnTrainHandler(thing);
+            return new DeutscheBahnTrainHandler(thing, timeConverter);
         }
 
         return null;

--- a/bundles/org.openhab.binding.deutschebahn/src/main/java/org/openhab/binding/deutschebahn/internal/DeutscheBahnTimetableConfiguration.java
+++ b/bundles/org.openhab.binding.deutschebahn/src/main/java/org/openhab/binding/deutschebahn/internal/DeutscheBahnTimetableConfiguration.java
@@ -22,6 +22,7 @@ import org.openhab.binding.deutschebahn.internal.filter.FilterScanner;
 import org.openhab.binding.deutschebahn.internal.filter.FilterScannerException;
 import org.openhab.binding.deutschebahn.internal.filter.FilterToken;
 import org.openhab.binding.deutschebahn.internal.filter.TimetableStopPredicate;
+import org.openhab.binding.deutschebahn.internal.timetable.TimetableTimeConverter;
 
 /**
  * The {@link DeutscheBahnTimetableConfiguration} for the Timetable bridge-type.
@@ -66,13 +67,14 @@ public class DeutscheBahnTimetableConfiguration {
     /**
      * Returns the additional configured {@link TimetableStopPredicate} or <code>null</code> if not specified.
      */
-    public @Nullable TimetableStopPredicate getAdditionalFilter() throws FilterScannerException, FilterParserException {
+    public @Nullable TimetableStopPredicate getAdditionalFilter(TimetableTimeConverter timeConverter)
+            throws FilterScannerException, FilterParserException {
         if (additionalFilter.isBlank()) {
             return null;
         } else {
             final FilterScanner scanner = new FilterScanner();
             final List<FilterToken> filterTokens = scanner.processInput(additionalFilter);
-            return FilterParser.parse(filterTokens);
+            return FilterParser.parse(filterTokens, timeConverter);
         }
     }
 }

--- a/bundles/org.openhab.binding.deutschebahn/src/main/java/org/openhab/binding/deutschebahn/internal/DeutscheBahnTimetableHandler.java
+++ b/bundles/org.openhab.binding.deutschebahn/src/main/java/org/openhab/binding/deutschebahn/internal/DeutscheBahnTimetableHandler.java
@@ -35,6 +35,7 @@ import org.openhab.binding.deutschebahn.internal.filter.FilterParserException;
 import org.openhab.binding.deutschebahn.internal.filter.FilterScannerException;
 import org.openhab.binding.deutschebahn.internal.filter.TimetableStopPredicate;
 import org.openhab.binding.deutschebahn.internal.timetable.TimetableLoader;
+import org.openhab.binding.deutschebahn.internal.timetable.TimetableTimeConverter;
 import org.openhab.binding.deutschebahn.internal.timetable.TimetablesV1Api;
 import org.openhab.binding.deutschebahn.internal.timetable.TimetablesV1ApiFactory;
 import org.openhab.binding.deutschebahn.internal.timetable.dto.TimetableStop;
@@ -119,6 +120,7 @@ public class DeutscheBahnTimetableHandler extends BaseBridgeHandler {
     private final TimetablesV1ApiFactory timetablesV1ApiFactory;
 
     private final Supplier<Date> currentTimeProvider;
+    private final TimetableTimeConverter timeConverter;
 
     private final ScheduledExecutorService executorService;
 
@@ -129,10 +131,12 @@ public class DeutscheBahnTimetableHandler extends BaseBridgeHandler {
             final Bridge bridge, //
             final TimetablesV1ApiFactory timetablesV1ApiFactory, //
             final Supplier<Date> currentTimeProvider, //
+            final TimetableTimeConverter timeConverter, //
             @Nullable final ScheduledExecutorService executorService) {
         super(bridge);
         this.timetablesV1ApiFactory = timetablesV1ApiFactory;
         this.currentTimeProvider = currentTimeProvider;
+        this.timeConverter = timeConverter;
         this.executorService = executorService == null ? this.scheduler : executorService;
     }
 
@@ -162,11 +166,12 @@ public class DeutscheBahnTimetableHandler extends BaseBridgeHandler {
             final TimetablesV1Api api = this.timetablesV1ApiFactory.create( //
                     config.clientId, //
                     config.clientSecret, //
-                    HttpUtil::executeUrl //
+                    HttpUtil::executeUrl, //
+                    timeConverter //
             );
 
             final TimetableStopFilter stopFilter = config.getTrainFilterFilter();
-            final TimetableStopPredicate additionalFilter = config.getAdditionalFilter();
+            final TimetableStopPredicate additionalFilter = config.getAdditionalFilter(timeConverter);
 
             final TimetableStopPredicate combinedFilter;
             if (additionalFilter == null) {
@@ -183,6 +188,7 @@ public class DeutscheBahnTimetableHandler extends BaseBridgeHandler {
                     combinedFilter, //
                     eventSelection, //
                     currentTimeProvider, //
+                    timeConverter, //
                     config.evaNo, //
                     1); // will be updated on first call
 

--- a/bundles/org.openhab.binding.deutschebahn/src/main/java/org/openhab/binding/deutschebahn/internal/DeutscheBahnTrainHandler.java
+++ b/bundles/org.openhab.binding.deutschebahn/src/main/java/org/openhab/binding/deutschebahn/internal/DeutscheBahnTrainHandler.java
@@ -17,6 +17,7 @@ import java.util.List;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.deutschebahn.internal.timetable.TimetableTimeConverter;
 import org.openhab.binding.deutschebahn.internal.timetable.dto.TimetableStop;
 import org.openhab.core.thing.Channel;
 import org.openhab.core.thing.ChannelUID;
@@ -86,12 +87,14 @@ public class DeutscheBahnTrainHandler extends BaseThingHandler {
 
     private final Logger logger = LoggerFactory.getLogger(DeutscheBahnTrainHandler.class);
     private final List<ChannelWithConfig> configuredChannels = new ArrayList<>();
+    private final TimetableTimeConverter timeConverter;
 
     /**
      * Creates a new {@link DeutscheBahnTrainHandler}.
      */
-    public DeutscheBahnTrainHandler(Thing thing) {
+    public DeutscheBahnTrainHandler(Thing thing, TimetableTimeConverter timeConverter) {
         super(thing);
+        this.timeConverter = timeConverter;
     }
 
     @Override
@@ -159,7 +162,7 @@ public class DeutscheBahnTrainHandler extends BaseThingHandler {
         }
         final ChannelWithConfig channelWithConfig = new ChannelWithConfig( //
                 channelUid, //
-                new EventAttributeSelection(eventType, attribute));
+                new EventAttributeSelection(eventType, attribute, timeConverter));
         this.configuredChannels.add(channelWithConfig);
     }
 

--- a/bundles/org.openhab.binding.deutschebahn/src/main/java/org/openhab/binding/deutschebahn/internal/EventAttribute.java
+++ b/bundles/org.openhab.binding.deutschebahn/src/main/java/org/openhab/binding/deutschebahn/internal/EventAttribute.java
@@ -12,18 +12,18 @@
  */
 package org.openhab.binding.deutschebahn.internal;
 
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.deutschebahn.internal.timetable.TimetableTimeConverter;
 import org.openhab.binding.deutschebahn.internal.timetable.dto.Event;
 import org.openhab.binding.deutschebahn.internal.timetable.dto.EventStatus;
 import org.openhab.binding.deutschebahn.internal.timetable.dto.Message;
@@ -41,13 +41,19 @@ import org.openhab.core.types.State;
  * @see <a href="https://developers.deutschebahn.com/db-api-marketplace/apis/product/timetables">DB API Marketplace</a>
  *
  * @author Sönke Küper - initial contribution
+ * @author Leo Siepel - Add explicit time-zone handling
  *
  * @param <VALUE_TYPE> type of value in Bean.
  * @param <STATE_TYPE> type of state.
  */
 @NonNullByDefault
-public final class EventAttribute<VALUE_TYPE, STATE_TYPE extends State>
-        extends AbstractDtoAttributeSelector<Event, @Nullable VALUE_TYPE, STATE_TYPE> {
+public final class EventAttribute<VALUE_TYPE, STATE_TYPE extends State> {
+
+    @FunctionalInterface
+    private interface TimetableValueSetter<VALUE_TYPE> {
+
+        void accept(Event event, VALUE_TYPE value, TimetableTimeConverter timeConverter);
+    }
 
     /**
      * Planned Path.
@@ -73,15 +79,13 @@ public final class EventAttribute<VALUE_TYPE, STATE_TYPE extends State>
     /**
      * Planned time.
      */
-    public static final EventAttribute<Date, DateTimeType> PT = new EventAttribute<>("planned-time",
-            getDate(Event::getPt), setDate(Event::setPt), EventAttribute::createDateTimeType,
-            EventAttribute::mapDateToStringList, DateTimeType.class);
+    public static final EventAttribute<Date, DateTimeType> PT = createDateAttribute("planned-time", Event::getPt,
+            Event::setPt);
     /**
      * Changed time.
      */
-    public static final EventAttribute<Date, DateTimeType> CT = new EventAttribute<>("changed-time",
-            getDate(Event::getCt), setDate(Event::setCt), EventAttribute::createDateTimeType,
-            EventAttribute::mapDateToStringList, DateTimeType.class);
+    public static final EventAttribute<Date, DateTimeType> CT = createDateAttribute("changed-time", Event::getCt,
+            Event::setCt);
     /**
      * Planned status.
      */
@@ -102,9 +106,8 @@ public final class EventAttribute<VALUE_TYPE, STATE_TYPE extends State>
     /**
      * Cancellation time.
      */
-    public static final EventAttribute<Date, DateTimeType> CLT = new EventAttribute<>("cancellation-time",
-            getDate(Event::getClt), setDate(Event::setClt), EventAttribute::createDateTimeType,
-            EventAttribute::mapDateToStringList, DateTimeType.class);
+    public static final EventAttribute<Date, DateTimeType> CLT = createDateAttribute("cancellation-time", Event::getClt,
+            Event::setClt);
     /**
      * Wing.
      */
@@ -209,7 +212,12 @@ public final class EventAttribute<VALUE_TYPE, STATE_TYPE extends State>
     public static final List<EventAttribute<?, ?>> ALL_ATTRIBUTES = Arrays.asList(PPTH, CPTH, PP, CP, PT, CT, PS, CS,
             HI, CLT, WINGS, TRA, PDE, CDE, DC, L, MESSAGES);
 
-    private static final SimpleDateFormat DATETIME_FORMAT = new SimpleDateFormat("yyMMddHHmm");
+    private final BiFunction<Event, TimetableTimeConverter, @Nullable VALUE_TYPE> getter;
+    private final TimetableValueSetter<VALUE_TYPE> setter;
+    private final BiFunction<VALUE_TYPE, TimetableTimeConverter, @Nullable STATE_TYPE> getState;
+    private final String channelTypeName;
+    private final Class<STATE_TYPE> stateType;
+    private final BiFunction<VALUE_TYPE, TimetableTimeConverter, List<String>> valueToList;
 
     /**
      * Creates a new {@link EventAttribute}.
@@ -224,7 +232,75 @@ public final class EventAttribute<VALUE_TYPE, STATE_TYPE extends State>
             final Function<VALUE_TYPE, @Nullable STATE_TYPE> getState, //
             final Function<VALUE_TYPE, List<String>> valueToList, //
             final Class<STATE_TYPE> stateType) {
-        super(channelTypeName, getter, setter, getState, valueToList, stateType);
+        this(channelTypeName, (event, timeConverter) -> getter.apply(event),
+                (event, value, timeConverter) -> setter.accept(event, value),
+                (value, timeConverter) -> getState.apply(value), (value, timeConverter) -> valueToList.apply(value),
+                stateType);
+    }
+
+    private EventAttribute(final String channelTypeName,
+            final BiFunction<Event, TimetableTimeConverter, @Nullable VALUE_TYPE> getter,
+            final TimetableValueSetter<VALUE_TYPE> setter,
+            final BiFunction<VALUE_TYPE, TimetableTimeConverter, @Nullable STATE_TYPE> getState,
+            final BiFunction<VALUE_TYPE, TimetableTimeConverter, List<String>> valueToList,
+            final Class<STATE_TYPE> stateType) {
+        this.channelTypeName = channelTypeName;
+        this.getter = getter;
+        this.setter = setter;
+        this.getState = getState;
+        this.valueToList = valueToList;
+        this.stateType = stateType;
+    }
+
+    private static EventAttribute<Date, DateTimeType> createDateAttribute(final String channelTypeName,
+            final Function<Event, @Nullable String> getter, final BiConsumer<Event, String> setter) {
+        return new EventAttribute<>(channelTypeName, getDate(getter), setDate(setter),
+                (value, timeConverter) -> createDateTimeType(value),
+                (value, timeConverter) -> mapDateToStringList(value, timeConverter), DateTimeType.class);
+    }
+
+    /**
+     * Returns the type of the state value.
+     */
+    public Class<STATE_TYPE> getStateType() {
+        return stateType;
+    }
+
+    /**
+     * Returns the name of the corresponding channel type.
+     */
+    public String getChannelTypeName() {
+        return channelTypeName;
+    }
+
+    /**
+     * Returns the state for the selected attribute, using the supplied time zone for date values.
+     */
+    public @Nullable STATE_TYPE getState(final Event event, final TimetableTimeConverter timeConverter) {
+        final @Nullable VALUE_TYPE value = getValue(event, timeConverter);
+        return value == null ? null : getState.apply(value, timeConverter);
+    }
+
+    /**
+     * Returns the selected attribute value, using the supplied time zone for date values.
+     */
+    public @Nullable VALUE_TYPE getValue(final Event event, final TimetableTimeConverter timeConverter) {
+        return getter.apply(event, timeConverter);
+    }
+
+    /**
+     * Returns the selected attribute as strings, using the supplied time zone for date values.
+     */
+    @SuppressWarnings("null")
+    public List<String> getStringValues(final Event event, final TimetableTimeConverter timeConverter) {
+        return valueToList.apply(getValue(event, timeConverter), timeConverter);
+    }
+
+    /**
+     * Sets the selected attribute, using the supplied time zone for date values.
+     */
+    public void setValue(final Event event, final VALUE_TYPE value, final TimetableTimeConverter timeConverter) {
+        setter.accept(event, value, timeConverter);
     }
 
     private static StringType fromEventStatus(final EventStatus value) {
@@ -258,36 +334,18 @@ public final class EventAttribute<VALUE_TYPE, STATE_TYPE extends State>
         return OnOffType.from(value != null && value == 1);
     }
 
-    private static Function<Event, @Nullable Date> getDate(final Function<Event, @Nullable String> getValue) {
-        return (final Event event) -> parseDate(getValue.apply(event));
+    private static BiFunction<Event, TimetableTimeConverter, @Nullable Date> getDate(
+            final Function<Event, @Nullable String> getValue) {
+        return (event, timeConverter) -> timeConverter.parseEventTime(getValue.apply(event));
     }
 
-    private static BiConsumer<Event, Date> setDate(final BiConsumer<Event, String> setter) {
-        return (final Event event, final Date value) -> {
-            synchronized (DATETIME_FORMAT) {
-                String formattedDate = DATETIME_FORMAT.format(value);
-                setter.accept(event, formattedDate);
-            }
-        };
+    private static TimetableValueSetter<Date> setDate(final BiConsumer<Event, String> setter) {
+        return (event, value, timeConverter) -> setter.accept(event, timeConverter.formatEventTime(value));
     }
 
     private static void setMessages(Event event, List<Message> messages) {
         event.getM().clear();
         event.getM().addAll(messages);
-    }
-
-    @Nullable
-    private static synchronized Date parseDate(@Nullable final String dateValue) {
-        if ((dateValue == null) || dateValue.isEmpty()) {
-            return null;
-        }
-        try {
-            synchronized (DATETIME_FORMAT) {
-                return DATETIME_FORMAT.parse(dateValue);
-            }
-        } catch (final ParseException e) {
-            return null;
-        }
     }
 
     @Nullable
@@ -360,13 +418,11 @@ public final class EventAttribute<VALUE_TYPE, STATE_TYPE extends State>
         }
     }
 
-    private static List<String> mapDateToStringList(@Nullable Date value) {
+    private static List<String> mapDateToStringList(@Nullable Date value, TimetableTimeConverter timeConverter) {
         if (value == null) {
             return List.of();
         } else {
-            synchronized (DATETIME_FORMAT) {
-                return List.of(DATETIME_FORMAT.format(value));
-            }
+            return List.of(timeConverter.formatEventTime(value));
         }
     }
 

--- a/bundles/org.openhab.binding.deutschebahn/src/main/java/org/openhab/binding/deutschebahn/internal/EventAttributeSelection.java
+++ b/bundles/org.openhab.binding.deutschebahn/src/main/java/org/openhab/binding/deutschebahn/internal/EventAttributeSelection.java
@@ -18,6 +18,7 @@ import java.util.Objects;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.deutschebahn.internal.timetable.TimetableTimeConverter;
 import org.openhab.binding.deutschebahn.internal.timetable.dto.Event;
 import org.openhab.binding.deutschebahn.internal.timetable.dto.TimetableStop;
 import org.openhab.core.types.State;
@@ -34,13 +35,16 @@ public final class EventAttributeSelection implements AttributeSelection {
 
     private final EventType eventType;
     private final EventAttribute<?, ?> eventAttribute;
+    private final TimetableTimeConverter timeConverter;
 
     /**
      * Creates a new {@link EventAttributeSelection}.
      */
-    public EventAttributeSelection(EventType eventType, EventAttribute<?, ?> eventAttribute) {
+    public EventAttributeSelection(EventType eventType, EventAttribute<?, ?> eventAttribute,
+            TimetableTimeConverter timeConverter) {
         this.eventType = eventType;
         this.eventAttribute = eventAttribute;
+        this.timeConverter = timeConverter;
     }
 
     @Nullable
@@ -50,7 +54,7 @@ public final class EventAttributeSelection implements AttributeSelection {
         if (event == null) {
             return UnDefType.UNDEF;
         } else {
-            return this.eventAttribute.getState(event);
+            return this.eventAttribute.getState(event, timeConverter);
         }
     }
 
@@ -60,7 +64,7 @@ public final class EventAttributeSelection implements AttributeSelection {
         if (event == null) {
             return UnDefType.UNDEF;
         } else {
-            return this.eventAttribute.getValue(event);
+            return this.eventAttribute.getValue(event, timeConverter);
         }
     }
 
@@ -70,7 +74,7 @@ public final class EventAttributeSelection implements AttributeSelection {
         if (event == null) {
             return Collections.emptyList();
         } else {
-            return this.eventAttribute.getStringValues(event);
+            return this.eventAttribute.getStringValues(event, timeConverter);
         }
     }
 

--- a/bundles/org.openhab.binding.deutschebahn/src/main/java/org/openhab/binding/deutschebahn/internal/filter/ChannelNameEquals.java
+++ b/bundles/org.openhab.binding.deutschebahn/src/main/java/org/openhab/binding/deutschebahn/internal/filter/ChannelNameEquals.java
@@ -20,6 +20,7 @@ import org.openhab.binding.deutschebahn.internal.EventAttribute;
 import org.openhab.binding.deutschebahn.internal.EventAttributeSelection;
 import org.openhab.binding.deutschebahn.internal.EventType;
 import org.openhab.binding.deutschebahn.internal.TripLabelAttribute;
+import org.openhab.binding.deutschebahn.internal.timetable.TimetableTimeConverter;
 
 /**
  * Token representing an attribute filter.
@@ -77,11 +78,13 @@ public final class ChannelNameEquals extends FilterToken {
     /**
      * Maps this into a {@link TimetableStopByStringEventAttributeFilter}.
      */
-    public TimetableStopByStringEventAttributeFilter mapToPredicate() throws FilterParserException {
-        return new TimetableStopByStringEventAttributeFilter(mapAttributeSelection(), filterValue);
+    public TimetableStopByStringEventAttributeFilter mapToPredicate(TimetableTimeConverter timeConverter)
+            throws FilterParserException {
+        return new TimetableStopByStringEventAttributeFilter(mapAttributeSelection(timeConverter), filterValue);
     }
 
-    private AttributeSelection mapAttributeSelection() throws FilterParserException {
+    private AttributeSelection mapAttributeSelection(TimetableTimeConverter timeConverter)
+            throws FilterParserException {
         switch (this.channelGroup) {
             case "trip":
                 final TripLabelAttribute<?, ?> tripAttribute = TripLabelAttribute.getByChannelName(this.channelName);
@@ -97,7 +100,7 @@ public final class ChannelNameEquals extends FilterToken {
                 if (departureAttribute == null) {
                     throw new FilterParserException("Invalid departure channel: " + channelName);
                 }
-                return new EventAttributeSelection(eventTypeDeparture, departureAttribute);
+                return new EventAttributeSelection(eventTypeDeparture, departureAttribute, timeConverter);
 
             case "arrival":
                 final EventType eventTypeArrival = EventType.ARRIVAL;
@@ -106,7 +109,7 @@ public final class ChannelNameEquals extends FilterToken {
                 if (arrivalAttribute == null) {
                     throw new FilterParserException("Invalid arrival channel: " + channelName);
                 }
-                return new EventAttributeSelection(eventTypeArrival, arrivalAttribute);
+                return new EventAttributeSelection(eventTypeArrival, arrivalAttribute, timeConverter);
             default:
                 throw new FilterParserException("Unknown channel group: " + channelGroup);
         }

--- a/bundles/org.openhab.binding.deutschebahn/src/main/java/org/openhab/binding/deutschebahn/internal/filter/FilterParser.java
+++ b/bundles/org.openhab.binding.deutschebahn/src/main/java/org/openhab/binding/deutschebahn/internal/filter/FilterParser.java
@@ -16,6 +16,7 @@ import java.util.List;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.deutschebahn.internal.timetable.TimetableTimeConverter;
 
 /**
  * Parses a {@link FilterToken}-Sequence into a {@link TimetableStopPredicate}.
@@ -32,9 +33,11 @@ public final class FilterParser {
 
         @Nullable
         private final State previousState;
+        protected final TimetableTimeConverter timeConverter;
 
-        public State(@Nullable State previousState) {
+        public State(@Nullable State previousState, TimetableTimeConverter timeConverter) {
             this.previousState = previousState;
+            this.timeConverter = timeConverter;
         }
 
         private final State handle(FilterToken token) throws FilterParserException {
@@ -45,7 +48,7 @@ public final class FilterParser {
 
         @Override
         public final State handle(ChannelNameEquals channelEquals) throws FilterParserException {
-            final TimetableStopByStringEventAttributeFilter predicate = channelEquals.mapToPredicate();
+            final TimetableStopByStringEventAttributeFilter predicate = channelEquals.mapToPredicate(timeConverter);
             return this.handleChildResult(predicate);
         }
 
@@ -76,8 +79,8 @@ public final class FilterParser {
         @Nullable
         private TimetableStopPredicate result;
 
-        public InitialState() {
-            super(null);
+        public InitialState(TimetableTimeConverter timeConverter) {
+            super(null, timeConverter);
         }
 
         @Override
@@ -88,7 +91,7 @@ public final class FilterParser {
                 throw new FilterParserException(
                         "Invalid filter: first argument missing for '|' at " + operator.getPosition());
             }
-            return new OrState(this, currentResult);
+            return new OrState(this, currentResult, timeConverter);
         }
 
         @Override
@@ -99,13 +102,13 @@ public final class FilterParser {
                 throw new FilterParserException(
                         "Invalid filter: first argument missing for '&' at " + operator.getPosition());
             }
-            return new AndState(this, currentResult);
+            return new AndState(this, currentResult, timeConverter);
         }
 
         @Override
         public State handle(BracketOpenToken token) throws FilterParserException {
             this.result = null;
-            return new SubQueryState(this);
+            return new SubQueryState(this, timeConverter);
         }
 
         @Override
@@ -140,8 +143,8 @@ public final class FilterParser {
 
         private final TimetableStopPredicate first;
 
-        public AndState(State previousState, final TimetableStopPredicate first) {
-            super(previousState);
+        public AndState(State previousState, final TimetableStopPredicate first, TimetableTimeConverter timeConverter) {
+            super(previousState, timeConverter);
             this.first = first;
         }
 
@@ -159,7 +162,7 @@ public final class FilterParser {
 
         @Override
         public State handle(BracketOpenToken token) throws FilterParserException {
-            return new SubQueryState(this);
+            return new SubQueryState(this, timeConverter);
         }
 
         @Override
@@ -186,8 +189,8 @@ public final class FilterParser {
 
         private final TimetableStopPredicate first;
 
-        public OrState(State previousState, final TimetableStopPredicate first) {
-            super(previousState);
+        public OrState(State previousState, final TimetableStopPredicate first, TimetableTimeConverter timeConverter) {
+            super(previousState, timeConverter);
             this.first = first;
         }
 
@@ -205,7 +208,7 @@ public final class FilterParser {
 
         @Override
         public State handle(BracketOpenToken token) throws FilterParserException {
-            return new SubQueryState(this);
+            return new SubQueryState(this, timeConverter);
         }
 
         @Override
@@ -233,8 +236,8 @@ public final class FilterParser {
         @Nullable
         private TimetableStopPredicate currentResult;
 
-        public SubQueryState(State previousState) {
-            super(previousState);
+        public SubQueryState(State previousState, TimetableTimeConverter timeConverter) {
+            super(previousState, timeConverter);
         }
 
         @Override
@@ -244,7 +247,7 @@ public final class FilterParser {
                 throw new FilterParserException(
                         "Operator '|' at " + operator.getPosition() + " must not be first element in subquery.");
             }
-            return new OrState(this, result);
+            return new OrState(this, result, timeConverter);
         }
 
         @Override
@@ -254,12 +257,12 @@ public final class FilterParser {
                 throw new FilterParserException(
                         "Operator '&' at" + operator.getPosition() + " must not be first element in subquery.");
             }
-            return new AndState(this, result);
+            return new AndState(this, result, timeConverter);
         }
 
         @Override
         public State handle(BracketOpenToken token) throws FilterParserException {
-            return new SubQueryState(this);
+            return new SubQueryState(this, timeConverter);
         }
 
         @Override
@@ -289,8 +292,9 @@ public final class FilterParser {
     /**
      * Parses the given {@link FilterToken} into a {@link TimetableStopPredicate}.
      */
-    public static TimetableStopPredicate parse(final List<FilterToken> tokens) throws FilterParserException {
-        State state = new InitialState();
+    public static TimetableStopPredicate parse(final List<FilterToken> tokens, TimetableTimeConverter timeConverter)
+            throws FilterParserException {
+        State state = new InitialState(timeConverter);
         for (FilterToken token : tokens) {
             state = state.handle(token);
         }

--- a/bundles/org.openhab.binding.deutschebahn/src/main/java/org/openhab/binding/deutschebahn/internal/timetable/TimetableLoader.java
+++ b/bundles/org.openhab.binding.deutschebahn/src/main/java/org/openhab/binding/deutschebahn/internal/timetable/TimetableLoader.java
@@ -13,12 +13,11 @@
 package org.openhab.binding.deutschebahn.internal.timetable;
 
 import java.io.IOException;
+import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
-import java.util.Calendar;
 import java.util.Collections;
 import java.util.Date;
-import java.util.GregorianCalendar;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -42,6 +41,7 @@ import org.openhab.core.library.types.DateTimeType;
  * This consists of a series of calls.
  *
  * @author Sönke Küper - initial contribution
+ * @author Leo Siepel - Add explicit time-zone handling
  */
 @NonNullByDefault
 public final class TimetableLoader {
@@ -63,12 +63,13 @@ public final class TimetableLoader {
     private final TimetableStopPredicate stopPredicate;
     private final TimetableStopComparator comparator;
     private final Supplier<Date> currentTimeProvider;
+    private final TimetableTimeConverter timeConverter;
     private int stopCount;
 
     private final String evaNo;
 
     @Nullable
-    private Date lastRequestedPlan;
+    private LocalDateTime lastRequestedPlan;
     @Nullable
     private Date lastRequestedChanges;
 
@@ -79,16 +80,18 @@ public final class TimetableLoader {
      * @param stopPredicate Filter for selection of loaded {@link TimetableStop}.
      * @param requestedStopCount Count of stops to be loaded on each call.
      * @param currentTimeProvider {@link Supplier} for the current time.
+     * @param timeConverter converter for the local timetable time zone.
      */
     public TimetableLoader(final TimetablesV1Api api, final TimetableStopPredicate stopPredicate,
-            final EventType eventToSort, final Supplier<Date> currentTimeProvider, final String evaNo,
-            final int requestedStopCount) {
+            final EventType eventToSort, final Supplier<Date> currentTimeProvider,
+            final TimetableTimeConverter timeConverter, final String evaNo, final int requestedStopCount) {
         this.api = api;
         this.stopPredicate = stopPredicate;
         this.currentTimeProvider = currentTimeProvider;
+        this.timeConverter = timeConverter;
         this.evaNo = evaNo;
         this.stopCount = requestedStopCount;
-        this.comparator = new TimetableStopComparator(eventToSort);
+        this.comparator = new TimetableStopComparator(eventToSort, timeConverter);
         this.cachedStopsPerId = new HashMap<>();
         this.cachedChanges = new HashMap<>();
         this.lastRequestedChanges = null;
@@ -148,11 +151,11 @@ public final class TimetableLoader {
     /**
      * Returns <code>true</code> if the planned and changed time from arrival and departure are in the past.
      */
-    private static boolean isInPast(TimetableStop stop, Date currentTime) {
+    private boolean isInPast(TimetableStop stop, Date currentTime) {
         return isBefore(EventAttribute.PT, stop.getAr(), currentTime) //
                 && isBefore(EventAttribute.CT, stop.getAr(), currentTime) //
                 && isBefore(EventAttribute.PT, stop.getDp(), currentTime) //
-                && isBefore(EventAttribute.PT, stop.getDp(), currentTime);
+                && isBefore(EventAttribute.CT, stop.getDp(), currentTime);
     }
 
     /**
@@ -160,14 +163,14 @@ public final class TimetableLoader {
      * the given compareTime.
      * If the {@link Event} is <code>null</code> it will return <code>true</code>.
      */
-    private static boolean isBefore( //
+    private boolean isBefore( //
             final EventAttribute<Date, DateTimeType> attribute, //
             final @Nullable Event event, //
             final Date toCompare) {
         if (event == null) {
             return true;
         }
-        final Date value = attribute.getValue(event);
+        final Date value = attribute.getValue(event, timeConverter);
         if (value == null) {
             return true;
         } else {
@@ -185,23 +188,21 @@ public final class TimetableLoader {
         }
 
         // start requesting at last request time.
-        final GregorianCalendar requestTime = new GregorianCalendar();
-        if (this.lastRequestedPlan != null) {
-            requestTime.setTime(this.lastRequestedPlan);
-            requestTime.set(Calendar.HOUR_OF_DAY, requestTime.get(Calendar.HOUR_OF_DAY) + 1);
-        } else {
-            requestTime.setTime(currentTime);
-        }
+        final LocalDateTime localCurrentTime = LocalDateTime.ofInstant(currentTime.toInstant(),
+                timeConverter.getTimeZone());
+        final LocalDateTime lastRequestedPlan = this.lastRequestedPlan;
+        LocalDateTime requestTime = lastRequestedPlan == null ? localCurrentTime : lastRequestedPlan.plusHours(1);
 
         // Determine the max. time for which a plan is available
-        final GregorianCalendar maxRequestTime = new GregorianCalendar();
-        maxRequestTime.setTime(currentTime);
-        maxRequestTime.set(Calendar.HOUR_OF_DAY, maxRequestTime.get(Calendar.HOUR_OF_DAY) + MAX_ADVANCE_HOUR);
+        final LocalDateTime maxRequestTime = localCurrentTime.plusHours(MAX_ADVANCE_HOUR);
 
         // load until required amount of stops is present or no more data is available.
-        while ((this.cachedStopsPerId.size() < this.stopCount) && requestTime.before(maxRequestTime)) {
-            final Timetable timetable = this.api.getPlan(this.evaNo, requestTime.getTime());
-            this.lastRequestedPlan = requestTime.getTime();
+        while ((this.cachedStopsPerId.size() < this.stopCount) && requestTime.isBefore(maxRequestTime)) {
+            // Resolve daylight-saving gaps before retaining and advancing the local plan hour.
+            requestTime = requestTime.atZone(timeConverter.getTimeZone()).toLocalDateTime();
+            final Date apiRequestTime = Date.from(requestTime.atZone(timeConverter.getTimeZone()).toInstant());
+            final Timetable timetable = this.api.getPlan(this.evaNo, apiRequestTime);
+            this.lastRequestedPlan = requestTime;
 
             // Filter only stops that are selected by given filter
             final List<TimetableStop> stops = timetable //
@@ -214,7 +215,7 @@ public final class TimetableLoader {
             this.processLoadedPlan(stops, currentTime);
 
             // Move request time one hour ahead.
-            requestTime.set(Calendar.HOUR_OF_DAY, requestTime.get(Calendar.HOUR_OF_DAY) + 1);
+            requestTime = requestTime.plusHours(1);
         }
     }
 
@@ -228,7 +229,7 @@ public final class TimetableLoader {
             // Check if a change for the stop was cached and apply it
             final TimetableStop change = this.cachedChanges.remove(stop.getId());
             if (change != null) {
-                TimetableStopMerger.merge(stop, change);
+                TimetableStopMerger.merge(stop, change, timeConverter);
             }
 
             // Check if stop is in past after applying changes and put
@@ -256,7 +257,7 @@ public final class TimetableLoader {
 
             final TimetableStop existingEntry = this.cachedStopsPerId.get(change.getId());
             if (existingEntry != null) {
-                TimetableStopMerger.merge(existingEntry, change);
+                TimetableStopMerger.merge(existingEntry, change, timeConverter);
             } else {
                 this.cachedChanges.put(change.getId(), change);
             }

--- a/bundles/org.openhab.binding.deutschebahn/src/main/java/org/openhab/binding/deutschebahn/internal/timetable/TimetableStopComparator.java
+++ b/bundles/org.openhab.binding.deutschebahn/src/main/java/org/openhab/binding/deutschebahn/internal/timetable/TimetableStopComparator.java
@@ -30,13 +30,15 @@ import org.openhab.binding.deutschebahn.internal.timetable.dto.TimetableStop;
 public class TimetableStopComparator implements Comparator<TimetableStop> {
 
     private final EventType eventSelection;
+    private final TimetableTimeConverter timeConverter;
 
     /**
      * Creates a new {@link TimetableStopComparator} that sorts {@link TimetableStop} according the Event selected
      * selected by the given {@link EventType}.
      */
-    public TimetableStopComparator(EventType eventSelection) {
+    public TimetableStopComparator(EventType eventSelection, TimetableTimeConverter timeConverter) {
         this.eventSelection = eventSelection;
+        this.timeConverter = timeConverter;
     }
 
     @Override
@@ -49,7 +51,7 @@ public class TimetableStopComparator implements Comparator<TimetableStop> {
      * The time will be returned from the {@link Event} selected by the given {@link EventType}.
      * If the {@link TimetableStop} has no according {@link Event} the other Event will be used.
      */
-    private static Date determinePlannedDate(TimetableStop stop, EventType eventSelection) {
+    private Date determinePlannedDate(TimetableStop stop, EventType eventSelection) {
         Event selectedEvent = eventSelection.getEvent(stop);
         if (selectedEvent == null) {
             selectedEvent = eventSelection.getOppositeEvent(stop);
@@ -57,7 +59,7 @@ public class TimetableStopComparator implements Comparator<TimetableStop> {
         if (selectedEvent == null) {
             throw new AssertionError("one event is always present");
         }
-        final Date value = EventAttribute.PT.getValue(selectedEvent);
+        final Date value = EventAttribute.PT.getValue(selectedEvent, timeConverter);
         if (value == null) {
             throw new AssertionError("planned time cannot be null");
         }

--- a/bundles/org.openhab.binding.deutschebahn/src/main/java/org/openhab/binding/deutschebahn/internal/timetable/TimetableStopMerger.java
+++ b/bundles/org.openhab.binding.deutschebahn/src/main/java/org/openhab/binding/deutschebahn/internal/timetable/TimetableStopMerger.java
@@ -31,28 +31,31 @@ final class TimetableStopMerger {
     /**
      * Merges the {@link TimetableStop} inplace to the first TimetableStop.
      */
-    public static void merge(final TimetableStop first, final TimetableStop second) {
-        mergeStopAttributes(first, second);
+    public static void merge(final TimetableStop first, final TimetableStop second,
+            TimetableTimeConverter timeConverter) {
+        mergeStopAttributes(first, second, timeConverter);
     }
 
     /**
      * Updates all values from the second {@link TimetableStop} into the first one.
      */
-    private static void mergeStopAttributes(final TimetableStop first, final TimetableStop second) {
-        mergeEventAttributes(first.getAr(), second.getAr());
-        mergeEventAttributes(first.getDp(), second.getDp());
+    private static void mergeStopAttributes(final TimetableStop first, final TimetableStop second,
+            TimetableTimeConverter timeConverter) {
+        mergeEventAttributes(first.getAr(), second.getAr(), timeConverter);
+        mergeEventAttributes(first.getDp(), second.getDp(), timeConverter);
     }
 
     /**
      * Updates all values from the second Event into the first one.
      */
-    private static void mergeEventAttributes(@Nullable final Event first, @Nullable final Event second) {
+    private static void mergeEventAttributes(@Nullable final Event first, @Nullable final Event second,
+            TimetableTimeConverter timeConverter) {
         if ((first == null) || (second == null)) {
             return;
         }
 
         for (final EventAttribute<?, ?> attribute : EventAttribute.ALL_ATTRIBUTES) {
-            updateAttribute(attribute, first, second);
+            updateAttribute(attribute, first, second, timeConverter);
         }
     }
 
@@ -61,10 +64,10 @@ final class TimetableStopMerger {
      * <code>null</code>.
      */
     private static <VALUE_TYPE> void updateAttribute(final EventAttribute<VALUE_TYPE, ?> attribute, final Event first,
-            final Event second) {
-        final @Nullable VALUE_TYPE value = attribute.getValue(second);
+            final Event second, TimetableTimeConverter timeConverter) {
+        final @Nullable VALUE_TYPE value = attribute.getValue(second, timeConverter);
         if (value != null) {
-            attribute.setValue(first, value);
+            attribute.setValue(first, value, timeConverter);
         }
     }
 }

--- a/bundles/org.openhab.binding.deutschebahn/src/main/java/org/openhab/binding/deutschebahn/internal/timetable/TimetableTimeConverter.java
+++ b/bundles/org.openhab.binding.deutschebahn/src/main/java/org/openhab/binding/deutschebahn/internal/timetable/TimetableTimeConverter.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.deutschebahn.internal.timetable;
+
+import java.time.DateTimeException;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.format.ResolverStyle;
+import java.util.Date;
+import java.util.Locale;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
+/**
+ * Converts between instants and the local date/time representations used by the Timetables API.
+ *
+ * @author Leo Siepel - Initial contribution
+ */
+@NonNullByDefault
+public final class TimetableTimeConverter {
+
+    private static final DateTimeFormatter PLAN_DATE_FORMAT = DateTimeFormatter.ofPattern("yyMMdd", Locale.ROOT);
+    private static final DateTimeFormatter PLAN_HOUR_FORMAT = DateTimeFormatter.ofPattern("HH", Locale.ROOT);
+    private static final DateTimeFormatter EVENT_TIME_FORMAT = DateTimeFormatter.ofPattern("uuMMddHHmm", Locale.ROOT)
+            .withResolverStyle(ResolverStyle.STRICT);
+
+    private final ZoneId timeZone;
+
+    /**
+     * Creates a converter for the given timetable time zone.
+     */
+    public TimetableTimeConverter(ZoneId timeZone) {
+        this.timeZone = timeZone;
+    }
+
+    /**
+     * Returns the time zone used by this converter.
+     */
+    public ZoneId getTimeZone() {
+        return timeZone;
+    }
+
+    /**
+     * Formats the local date used by a plan request.
+     */
+    public String formatPlanDate(Date time) {
+        return PLAN_DATE_FORMAT.format(time.toInstant().atZone(timeZone));
+    }
+
+    /**
+     * Formats the local hour used by a plan request.
+     */
+    public String formatPlanHour(Date time) {
+        return PLAN_HOUR_FORMAT.format(time.toInstant().atZone(timeZone));
+    }
+
+    /**
+     * Formats an instant as a local timetable event time.
+     */
+    public String formatEventTime(Date time) {
+        return EVENT_TIME_FORMAT.format(time.toInstant().atZone(timeZone));
+    }
+
+    /**
+     * Parses a local timetable event time into an instant.
+     */
+    public @Nullable Date parseEventTime(@Nullable String value) {
+        if (value == null || value.isEmpty()) {
+            return null;
+        }
+        try {
+            final Instant instant = LocalDateTime.parse(value, EVENT_TIME_FORMAT).atZone(timeZone).toInstant();
+            return Date.from(instant);
+        } catch (DateTimeException e) {
+            return null;
+        }
+    }
+}

--- a/bundles/org.openhab.binding.deutschebahn/src/main/java/org/openhab/binding/deutschebahn/internal/timetable/TimetablesV1ApiFactory.java
+++ b/bundles/org.openhab.binding.deutschebahn/src/main/java/org/openhab/binding/deutschebahn/internal/timetable/TimetablesV1ApiFactory.java
@@ -28,6 +28,6 @@ public interface TimetablesV1ApiFactory {
     /**
      * Creates a new instance of the {@link TimetablesV1Api}.
      */
-    TimetablesV1Api create(final String clientId, final String clientSecret, final HttpCallable httpCallable)
-            throws JAXBException;
+    TimetablesV1Api create(final String clientId, final String clientSecret, final HttpCallable httpCallable,
+            final TimetableTimeConverter timeConverter) throws JAXBException;
 }

--- a/bundles/org.openhab.binding.deutschebahn/src/main/java/org/openhab/binding/deutschebahn/internal/timetable/TimetablesV1Impl.java
+++ b/bundles/org.openhab.binding.deutschebahn/src/main/java/org/openhab/binding/deutschebahn/internal/timetable/TimetablesV1Impl.java
@@ -15,7 +15,6 @@ package org.openhab.binding.deutschebahn.internal.timetable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringReader;
-import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
@@ -75,12 +74,10 @@ public final class TimetablesV1Impl implements TimetablesV1Api {
     private static final String DB_CLIENT_SECRET_HEADER_NAME = "DB-Api-Key";
 
     private static final int REQUEST_TIMEOUT_MS = (int) TimeUnit.SECONDS.toMillis(30);
-    private static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyMMdd");
-    private static final SimpleDateFormat HOUR_FORMAT = new SimpleDateFormat("HH");
-
     private final String clientId;
     private final String clientSecret;
     private final HttpCallable httpCallable;
+    private final TimetableTimeConverter timeConverter;
 
     private final Logger logger = LoggerFactory.getLogger(TimetablesV1Impl.class);
     private final JAXBContext jaxbContext;
@@ -94,10 +91,12 @@ public final class TimetablesV1Impl implements TimetablesV1Api {
     public TimetablesV1Impl( //
             final String clientId, //
             final String clientSecret, //
-            final HttpCallable httpCallable) throws JAXBException {
+            final HttpCallable httpCallable, //
+            final TimetableTimeConverter timeConverter) throws JAXBException {
         this.clientId = clientId;
         this.clientSecret = clientSecret;
         this.httpCallable = httpCallable;
+        this.timeConverter = timeConverter;
 
         // The results from webservice does not conform to the schema provided. The triplabel-Element (tl) is expected
         // to occour as
@@ -193,17 +192,14 @@ public final class TimetablesV1Impl implements TimetablesV1Api {
     /**
      * Build rest endpoint URL for request the planned timetable.
      */
-    @SuppressWarnings("PMD.UnsynchronizedStaticFormatter")
     private String buildPlanRequestURL(final String evaNr, final Date date) {
-        synchronized (this) {
-            final String dateParam = DATE_FORMAT.format(date);
-            final String hourParam = HOUR_FORMAT.format(date);
+        final String dateParam = timeConverter.formatPlanDate(date);
+        final String hourParam = timeConverter.formatPlanHour(date);
 
-            return PLAN_URL //
-                    .replace("%evaNo%", evaNr) //
-                    .replace("%date%", dateParam) //
-                    .replace("%hour%", hourParam);
-        }
+        return PLAN_URL //
+                .replace("%evaNo%", evaNr) //
+                .replace("%date%", dateParam) //
+                .replace("%hour%", hourParam);
     }
 
     /**

--- a/bundles/org.openhab.binding.deutschebahn/src/test/java/org/openhab/binding/deutschebahn/internal/DeutscheBahnTimetableHandlerTest.java
+++ b/bundles/org.openhab.binding.deutschebahn/src/test/java/org/openhab/binding/deutschebahn/internal/DeutscheBahnTimetableHandlerTest.java
@@ -21,8 +21,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
-import java.util.Calendar;
-import java.util.GregorianCalendar;
 import java.util.List;
 import java.util.concurrent.ScheduledExecutorService;
 
@@ -31,6 +29,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.openhab.binding.deutschebahn.internal.timetable.TimeproviderStub;
+import org.openhab.binding.deutschebahn.internal.timetable.TimetableTimeConverter;
 import org.openhab.binding.deutschebahn.internal.timetable.TimetablesV1ApiFactory;
 import org.openhab.binding.deutschebahn.internal.timetable.TimetablesV1ApiStub;
 import org.openhab.binding.deutschebahn.internal.timetable.TimetablesV1Impl.HttpCallable;
@@ -106,7 +105,7 @@ public class DeutscheBahnTimetableHandlerTest implements TimetablesV1ImplTestHel
             final Bridge bridge, //
             final TimetablesV1ApiFactory apiFactory) { //
         final TimeproviderStub timeProvider = new TimeproviderStub();
-        timeProvider.time = new GregorianCalendar(2021, Calendar.AUGUST, 16, 9, 30);
+        timeProvider.time = createCalendar(2021, 8, 16, 9, 30);
 
         final ScheduledExecutorService executorStub = Mockito.mock(ScheduledExecutorService.class);
         doAnswer((InvocationOnMock invocation) -> {
@@ -115,7 +114,7 @@ public class DeutscheBahnTimetableHandlerTest implements TimetablesV1ImplTestHel
         }).when(executorStub).execute(any(Runnable.class));
 
         final DeutscheBahnTimetableHandler handler = new DeutscheBahnTimetableHandler(bridge, apiFactory, timeProvider,
-                executorStub);
+                TIME_CONVERTER, executorStub);
         handler.setCallback(callback);
         handler.initialize();
         return handler;
@@ -191,8 +190,8 @@ public class DeutscheBahnTimetableHandlerTest implements TimetablesV1ImplTestHel
 
         final TimetablesV1ApiStub stubWithError = TimetablesV1ApiStub.createWithException();
 
-        final DeutscheBahnTimetableHandler handler = createAndInitHandler(callback, bridge,
-                (String clientId, String clientSecret, HttpCallable httpCallable) -> stubWithError);
+        final DeutscheBahnTimetableHandler handler = createAndInitHandler(callback, bridge, (String clientId,
+                String clientSecret, HttpCallable httpCallable, TimetableTimeConverter timeConverter) -> stubWithError);
 
         try {
             verify(callback).statusUpdated(eq(bridge), argThat(arg -> arg.getStatus().equals(ThingStatus.UNKNOWN)));
@@ -230,8 +229,8 @@ public class DeutscheBahnTimetableHandlerTest implements TimetablesV1ImplTestHel
 
         final TimetablesV1ApiStub stubWithData = TimetablesV1ApiStub.createWithResult(timetable);
 
-        final DeutscheBahnTimetableHandler handler = createAndInitHandler(callback, bridge,
-                (String clientId, String clientSecret, HttpCallable httpCallable) -> stubWithData);
+        final DeutscheBahnTimetableHandler handler = createAndInitHandler(callback, bridge, (String clientId,
+                String clientSecret, HttpCallable httpCallable, TimetableTimeConverter timeConverter) -> stubWithData);
 
         try {
             verify(callback).statusUpdated(eq(bridge), argThat(arg -> arg.getStatus().equals(ThingStatus.UNKNOWN)));

--- a/bundles/org.openhab.binding.deutschebahn/src/test/java/org/openhab/binding/deutschebahn/internal/DeutscheBahnTrainHandlerTest.java
+++ b/bundles/org.openhab.binding.deutschebahn/src/test/java/org/openhab/binding/deutschebahn/internal/DeutscheBahnTrainHandlerTest.java
@@ -15,13 +15,15 @@ package org.openhab.binding.deutschebahn.internal;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.Arrays;
 import java.util.Date;
-import java.util.GregorianCalendar;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+import org.openhab.binding.deutschebahn.internal.timetable.TimetableTimeConverter;
 import org.openhab.binding.deutschebahn.internal.timetable.dto.Event;
 import org.openhab.binding.deutschebahn.internal.timetable.dto.TimetableStop;
 import org.openhab.binding.deutschebahn.internal.timetable.dto.TripLabel;
@@ -47,6 +49,7 @@ import org.openhab.core.types.UnDefType;
 public class DeutscheBahnTrainHandlerTest {
 
     private static final String SAMPLE_PATH = "Bielefeld Hbf|Herford|Löhne(Westf)|Bad Oeynhausen|Porta Westfalica|Minden(Westf)|Bückeburg|Stadthagen|Haste|Wunstorf|Hannover Hbf|Lehrte";
+    private static final TimetableTimeConverter TIME_CONVERTER = new TimetableTimeConverter(ZoneId.of("Europe/Berlin"));
 
     private static Configuration createConfig(int position) {
         final Configuration config = new Configuration();
@@ -93,7 +96,7 @@ public class DeutscheBahnTrainHandlerTest {
 
     private static DeutscheBahnTrainHandler createAndInitHandler(final ThingHandlerCallback callback,
             final Thing thing) {
-        final DeutscheBahnTrainHandler handler = new DeutscheBahnTrainHandler(thing);
+        final DeutscheBahnTrainHandler handler = new DeutscheBahnTrainHandler(thing, TIME_CONVERTER);
         handler.setCallback(callback);
         handler.initialize();
         return handler;
@@ -101,6 +104,11 @@ public class DeutscheBahnTrainHandlerTest {
 
     private static State getDateTime(final Date day) {
         return new DateTimeType(day.toInstant());
+    }
+
+    private static Date createDate(int year, int month, int dayOfMonth, int hour, int minute) {
+        return Date.from(LocalDateTime.of(year, month, dayOfMonth, hour, minute).atZone(TIME_CONVERTER.getTimeZone())
+                .toInstant());
     }
 
     @Test
@@ -136,8 +144,8 @@ public class DeutscheBahnTrainHandlerTest {
 
             handler.updateChannels(stop);
 
-            final Date arrivalTime = new GregorianCalendar(2021, 7, 16, 14, 34).getTime();
-            final Date departureTime = new GregorianCalendar(2021, 7, 16, 14, 35).getTime();
+            final Date arrivalTime = createDate(2021, 8, 16, 14, 34);
+            final Date departureTime = createDate(2021, 8, 16, 14, 35);
 
             verify(callback, timeout(1000)).stateUpdated(new ChannelUID(thing.getUID(), "trip#category"),
                     new StringType("WFB"));
@@ -182,7 +190,7 @@ public class DeutscheBahnTrainHandlerTest {
 
             handler.updateChannels(stop);
 
-            final Date arrivalTime = new GregorianCalendar(2021, 7, 16, 14, 34).getTime();
+            final Date arrivalTime = createDate(2021, 8, 16, 14, 34);
 
             verify(callback, timeout(1000)).stateUpdated(new ChannelUID(thing.getUID(), "trip#category"),
                     UnDefType.UNDEF);

--- a/bundles/org.openhab.binding.deutschebahn/src/test/java/org/openhab/binding/deutschebahn/internal/EventAttributeTest.java
+++ b/bundles/org.openhab.binding.deutschebahn/src/test/java/org/openhab/binding/deutschebahn/internal/EventAttributeTest.java
@@ -15,15 +15,19 @@ package org.openhab.binding.deutschebahn.internal;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.GregorianCalendar;
+import java.util.Date;
 import java.util.List;
 import java.util.function.Consumer;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.junit.jupiter.api.Test;
+import org.openhab.binding.deutschebahn.internal.timetable.TimetableTimeConverter;
 import org.openhab.binding.deutschebahn.internal.timetable.dto.Event;
 import org.openhab.binding.deutschebahn.internal.timetable.dto.EventStatus;
 import org.openhab.binding.deutschebahn.internal.timetable.dto.Message;
@@ -43,6 +47,7 @@ import org.openhab.core.types.State;
 public class EventAttributeTest {
 
     private static final String SAMPLE_PATH = "Bielefeld Hbf|Herford|Löhne(Westf)|Bad Oeynhausen|Porta Westfalica|Minden(Westf)|Bückeburg|Stadthagen|Haste|Wunstorf|Hannover Hbf|Lehrte";
+    private static final TimetableTimeConverter TIME_CONVERTER = new TimetableTimeConverter(ZoneId.of("Europe/Berlin"));
 
     private <VALUE_TYPE, STATE_TYPE extends State> void doTestEventAttribute( //
             String channelName, //
@@ -56,22 +61,22 @@ public class EventAttributeTest {
                 .getByChannelName(channelName, eventType);
         assertThat(attribute, is(not(nullValue())));
         assertThat(attribute.getChannelTypeName(), is(expectedChannelName == null ? channelName : expectedChannelName));
-        assertThat(attribute.getValue(new Event()), is(nullValue()));
-        assertThat(attribute.getState(new Event()), is(nullValue()));
+        assertThat(attribute.getValue(new Event(), TIME_CONVERTER), is(nullValue()));
+        assertThat(attribute.getState(new Event(), TIME_CONVERTER), is(nullValue()));
 
         // Create an event and set the attribute value.
         final Event eventWithValueSet = new Event();
         setValue.accept(eventWithValueSet);
 
         // then try get value and state.
-        assertThat(attribute.getValue(eventWithValueSet), is(expectedValue));
-        assertThat(attribute.getState(eventWithValueSet), is(expectedState));
+        assertThat(attribute.getValue(eventWithValueSet, TIME_CONVERTER), is(expectedValue));
+        assertThat(attribute.getState(eventWithValueSet, TIME_CONVERTER), is(expectedState));
 
         // Try set Value in new Event
         final Event copyTarget = new Event();
-        attribute.setValue(copyTarget, expectedValue);
+        attribute.setValue(copyTarget, expectedValue, TIME_CONVERTER);
         if (performSetterTest) {
-            assertThat(attribute.getValue(copyTarget), is(expectedValue));
+            assertThat(attribute.getValue(copyTarget, TIME_CONVERTER), is(expectedValue));
         }
     }
 
@@ -144,28 +149,37 @@ public class EventAttributeTest {
     @Test
     public void testPlannedTime() {
         String time = "2109111825";
-        GregorianCalendar expectedValue = new GregorianCalendar(2021, 8, 11, 18, 25, 0);
+        Date expectedValue = createDate(2021, 9, 11, 18, 25);
         DateTimeType expectedState = new DateTimeType(expectedValue.toInstant());
-        doTestEventAttribute("planned-time", null, (Event e) -> e.setPt(time), expectedValue.getTime(), expectedState,
+        doTestEventAttribute("planned-time", null, (Event e) -> e.setPt(time), expectedValue, expectedState,
                 EventType.DEPARTURE, true);
+    }
+
+    @Test
+    public void testPlannedTimeUsesConfiguredTimeZoneInWinter() {
+        Event event = new Event();
+        event.setPt("2202231430");
+
+        assertThat(EventAttribute.PT.getState(event, TIME_CONVERTER),
+                is(new DateTimeType(Instant.parse("2022-02-23T13:30:00Z"))));
     }
 
     @Test
     public void testChangedTime() {
         String time = "2109111825";
-        GregorianCalendar expectedValue = new GregorianCalendar(2021, 8, 11, 18, 25, 0);
+        Date expectedValue = createDate(2021, 9, 11, 18, 25);
         DateTimeType expectedState = new DateTimeType(expectedValue.toInstant());
-        doTestEventAttribute("changed-time", null, (Event e) -> e.setCt(time), expectedValue.getTime(), expectedState,
+        doTestEventAttribute("changed-time", null, (Event e) -> e.setCt(time), expectedValue, expectedState,
                 EventType.DEPARTURE, true);
     }
 
     @Test
     public void testCancellationTime() {
         String time = "2109111825";
-        GregorianCalendar expectedValue = new GregorianCalendar(2021, 8, 11, 18, 25, 0);
+        Date expectedValue = createDate(2021, 9, 11, 18, 25);
         DateTimeType expectedState = new DateTimeType(expectedValue.toInstant());
-        doTestEventAttribute("cancellation-time", null, (Event e) -> e.setClt(time), expectedValue.getTime(),
-                expectedState, EventType.DEPARTURE, true);
+        doTestEventAttribute("cancellation-time", null, (Event e) -> e.setClt(time), expectedValue, expectedState,
+                EventType.DEPARTURE, true);
     }
 
     @Test
@@ -282,5 +296,10 @@ public class EventAttributeTest {
 
         doTestEventAttribute("messages", null, (Event e) -> e.getM().addAll(messages), messages,
                 new StringType(expectedOneMessage), EventType.DEPARTURE, true);
+    }
+
+    private static Date createDate(int year, int month, int dayOfMonth, int hour, int minute) {
+        return Date.from(LocalDateTime.of(year, month, dayOfMonth, hour, minute).atZone(TIME_CONVERTER.getTimeZone())
+                .toInstant());
     }
 }

--- a/bundles/org.openhab.binding.deutschebahn/src/test/java/org/openhab/binding/deutschebahn/internal/filter/FilterParserTest.java
+++ b/bundles/org.openhab.binding.deutschebahn/src/test/java/org/openhab/binding/deutschebahn/internal/filter/FilterParserTest.java
@@ -16,6 +16,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.junit.jupiter.api.Assertions.fail;
 
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -29,6 +30,7 @@ import org.openhab.binding.deutschebahn.internal.EventAttribute;
 import org.openhab.binding.deutschebahn.internal.EventAttributeSelection;
 import org.openhab.binding.deutschebahn.internal.EventType;
 import org.openhab.binding.deutschebahn.internal.TripLabelAttribute;
+import org.openhab.binding.deutschebahn.internal.timetable.TimetableTimeConverter;
 
 /**
  * Tests for {@link FilterParser}
@@ -37,6 +39,8 @@ import org.openhab.binding.deutschebahn.internal.TripLabelAttribute;
  */
 @NonNullByDefault
 public class FilterParserTest {
+
+    private static final TimetableTimeConverter TIME_CONVERTER = new TimetableTimeConverter(ZoneId.of("Europe/Berlin"));
 
     private static final class FilterTokenSequenceBuilder {
 
@@ -91,7 +95,8 @@ public class FilterParserTest {
 
     private static void checkAttributeFilter(TimetableStopPredicate predicate, ChannelNameEquals channelEquals,
             EventType eventType, EventAttribute<?, ?> eventAttribute) {
-        checkAttributeFilter(predicate, channelEquals, new EventAttributeSelection(eventType, eventAttribute));
+        checkAttributeFilter(predicate, channelEquals,
+                new EventAttributeSelection(eventType, eventAttribute, TIME_CONVERTER));
     }
 
     private static void checkAttributeFilter(TimetableStopPredicate predicate, ChannelNameEquals channelEquals,
@@ -112,12 +117,16 @@ public class FilterParserTest {
         return (AndPredicate) predicate;
     }
 
+    private static TimetableStopPredicate parse(List<FilterToken> tokens) throws FilterParserException {
+        return FilterParser.parse(tokens, TIME_CONVERTER);
+    }
+
     @Test
     public void testParseSimple() throws FilterParserException {
         final List<FilterToken> input = new ArrayList<>();
         ChannelNameEquals channelEquals = new ChannelNameEquals(1, "trip", "number", Pattern.compile("20"));
         input.add(channelEquals);
-        final TimetableStopPredicate result = FilterParser.parse(input);
+        final TimetableStopPredicate result = parse(input);
         checkAttributeFilter(result, channelEquals, TripLabelAttribute.N);
     }
 
@@ -127,7 +136,7 @@ public class FilterParserTest {
         final ChannelNameEquals channelEquals01 = b.channelFilter("trip", "number", "20");
         b.and();
         final ChannelNameEquals channelEquals02 = b.channelFilter("trip", "number", "30");
-        final TimetableStopPredicate result = FilterParser.parse(b.build());
+        final TimetableStopPredicate result = parse(b.build());
         final AndPredicate andPredicate = assertAnd(result);
 
         checkAttributeFilter(andPredicate.getFirst(), channelEquals01, TripLabelAttribute.N);
@@ -140,7 +149,7 @@ public class FilterParserTest {
         final ChannelNameEquals channelEquals01 = b.channelFilter("trip", "number", "20");
         b.or();
         final ChannelNameEquals channelEquals02 = b.channelFilter("trip", "number", "30");
-        final TimetableStopPredicate result = FilterParser.parse(b.build());
+        final TimetableStopPredicate result = parse(b.build());
         final OrPredicate orPredicate = assertOr(result);
 
         checkAttributeFilter(orPredicate.getFirst(), channelEquals01, TripLabelAttribute.N);
@@ -159,7 +168,7 @@ public class FilterParserTest {
         b.bracketClose();
         final List<FilterToken> input = b.build();
 
-        final TimetableStopPredicate result = FilterParser.parse(input);
+        final TimetableStopPredicate result = parse(input);
         final AndPredicate andPredicate = assertAnd(result);
 
         checkAttributeFilter(andPredicate.getFirst(), channelEquals01, TripLabelAttribute.N);
@@ -188,7 +197,7 @@ public class FilterParserTest {
 
         final List<FilterToken> input = b.build();
 
-        final TimetableStopPredicate result = FilterParser.parse(input);
+        final TimetableStopPredicate result = parse(input);
         final OrPredicate orPredicate = assertOr(result);
 
         final AndPredicate firstAnd = assertAnd(orPredicate.getFirst());
@@ -204,79 +213,79 @@ public class FilterParserTest {
     public void testParseErrors() {
         final ChannelNameEquals channelEquals = new ChannelNameEquals(1, "trip", "number", Pattern.compile("20"));
         try {
-            FilterParser.parse(Collections.emptyList());
+            parse(Collections.emptyList());
             fail();
         } catch (FilterParserException e) {
         }
 
         try {
-            FilterParser.parse(builder().and().build());
+            parse(builder().and().build());
             fail();
         } catch (FilterParserException e) {
         }
 
         try {
-            FilterParser.parse(builder().or().build());
+            parse(builder().or().build());
             fail();
         } catch (FilterParserException e) {
         }
         try {
-            FilterParser.parse(builder().bracketOpen().build());
+            parse(builder().bracketOpen().build());
             fail();
         } catch (FilterParserException e) {
         }
         try {
-            FilterParser.parse(builder().bracketClose().build());
+            parse(builder().bracketClose().build());
             fail();
         } catch (FilterParserException e) {
         }
         try {
-            FilterParser.parse(builder().bracketOpen().bracketClose().build());
+            parse(builder().bracketOpen().bracketClose().build());
             fail();
         } catch (FilterParserException e) {
         }
         try {
-            FilterParser.parse(builder().bracketOpen().and().build());
+            parse(builder().bracketOpen().and().build());
             fail();
         } catch (FilterParserException e) {
         }
         try {
-            FilterParser.parse(builder().bracketOpen().and().build());
+            parse(builder().bracketOpen().and().build());
             fail();
         } catch (FilterParserException e) {
         }
         try {
-            FilterParser.parse(builder().channelFilter(channelEquals).and().bracketOpen().build());
+            parse(builder().channelFilter(channelEquals).and().bracketOpen().build());
             fail();
         } catch (FilterParserException e) {
         }
         try {
-            FilterParser.parse(builder().channelFilter(channelEquals).and().bracketClose().build());
+            parse(builder().channelFilter(channelEquals).and().bracketClose().build());
             fail();
         } catch (FilterParserException e) {
         }
         try {
-            FilterParser.parse(builder().channelFilter(channelEquals).or().bracketOpen().build());
+            parse(builder().channelFilter(channelEquals).or().bracketOpen().build());
             fail();
         } catch (FilterParserException e) {
         }
         try {
-            FilterParser.parse(builder().channelFilter(channelEquals).or().bracketClose().build());
+            parse(builder().channelFilter(channelEquals).or().bracketClose().build());
             fail();
         } catch (FilterParserException e) {
         }
         try {
-            FilterParser.parse(builder().channelFilter(channelEquals).and().build());
+            parse(builder().channelFilter(channelEquals).and().build());
             fail();
         } catch (FilterParserException e) {
         }
         try {
-            FilterParser.parse(builder().channelFilter(channelEquals).or().build());
+            parse(builder().channelFilter(channelEquals).or().build());
             fail();
         } catch (FilterParserException e) {
         }
         try {
-            FilterParser.parse(Arrays.asList(channelEquals, channelEquals));
+            parse(Arrays.asList(channelEquals, channelEquals));
             fail();
         } catch (FilterParserException e) {
         }

--- a/bundles/org.openhab.binding.deutschebahn/src/test/java/org/openhab/binding/deutschebahn/internal/filter/TimetableByStringEventAttributeFilterTest.java
+++ b/bundles/org.openhab.binding.deutschebahn/src/test/java/org/openhab/binding/deutschebahn/internal/filter/TimetableByStringEventAttributeFilterTest.java
@@ -14,6 +14,7 @@ package org.openhab.binding.deutschebahn.internal.filter;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.time.ZoneId;
 import java.util.regex.Pattern;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -22,6 +23,7 @@ import org.openhab.binding.deutschebahn.internal.EventAttribute;
 import org.openhab.binding.deutschebahn.internal.EventAttributeSelection;
 import org.openhab.binding.deutschebahn.internal.EventType;
 import org.openhab.binding.deutschebahn.internal.TripLabelAttribute;
+import org.openhab.binding.deutschebahn.internal.timetable.TimetableTimeConverter;
 import org.openhab.binding.deutschebahn.internal.timetable.dto.Event;
 import org.openhab.binding.deutschebahn.internal.timetable.dto.TimetableStop;
 import org.openhab.binding.deutschebahn.internal.timetable.dto.TripLabel;
@@ -33,6 +35,8 @@ import org.openhab.binding.deutschebahn.internal.timetable.dto.TripLabel;
  */
 @NonNullByDefault
 public final class TimetableByStringEventAttributeFilterTest {
+
+    private static final TimetableTimeConverter TIME_CONVERTER = new TimetableTimeConverter(ZoneId.of("Europe/Berlin"));
 
     @Test
     public void testFilterTripLabelAttribute() {
@@ -61,7 +65,7 @@ public final class TimetableByStringEventAttributeFilterTest {
     @Test
     public void testFilterEventAttribute() {
         final EventAttributeSelection eventAttribute = new EventAttributeSelection(EventType.DEPARTURE,
-                EventAttribute.L);
+                EventAttribute.L, TIME_CONVERTER);
         final TimetableStopByStringEventAttributeFilter filter = new TimetableStopByStringEventAttributeFilter(
                 eventAttribute, Pattern.compile("RE.*"));
         final TimetableStop stop = new TimetableStop();
@@ -92,7 +96,7 @@ public final class TimetableByStringEventAttributeFilterTest {
     @Test
     public void testFilterEventAttributeList() {
         final EventAttributeSelection eventAttribute = new EventAttributeSelection(EventType.DEPARTURE,
-                EventAttribute.PPTH);
+                EventAttribute.PPTH, TIME_CONVERTER);
         final TimetableStopByStringEventAttributeFilter filter = new TimetableStopByStringEventAttributeFilter(
                 eventAttribute, Pattern.compile("Hannover.*"));
         final TimetableStop stop = new TimetableStop();

--- a/bundles/org.openhab.binding.deutschebahn/src/test/java/org/openhab/binding/deutschebahn/internal/timetable/TimetableLoaderTest.java
+++ b/bundles/org.openhab.binding.deutschebahn/src/test/java/org/openhab/binding/deutschebahn/internal/timetable/TimetableLoaderTest.java
@@ -16,14 +16,14 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.util.Calendar;
-import java.util.GregorianCalendar;
 import java.util.List;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.junit.jupiter.api.Test;
 import org.openhab.binding.deutschebahn.internal.EventType;
 import org.openhab.binding.deutschebahn.internal.TimetableStopFilter;
+import org.openhab.binding.deutschebahn.internal.timetable.dto.Event;
+import org.openhab.binding.deutschebahn.internal.timetable.dto.Timetable;
 import org.openhab.binding.deutschebahn.internal.timetable.dto.TimetableStop;
 
 /**
@@ -39,9 +39,9 @@ public class TimetableLoaderTest implements TimetablesV1ImplTestHelper {
         final TimetablesApiTestModule timeTableTestModule = this.createApiWithTestdata();
         final TimeproviderStub timeProvider = new TimeproviderStub();
         final TimetableLoader loader = new TimetableLoader(timeTableTestModule.getApi(), TimetableStopFilter.ALL,
-                EventType.DEPARTURE, timeProvider, EVA_LEHRTE, 20);
+                EventType.DEPARTURE, timeProvider, TIME_CONVERTER, EVA_LEHRTE, 20);
 
-        timeProvider.time = new GregorianCalendar(2021, Calendar.AUGUST, 16, 9, 30);
+        timeProvider.time = createCalendar(2021, 8, 16, 9, 30);
 
         final List<TimetableStop> stops = loader.getTimetableStops();
         assertThat(timeTableTestModule.getRequestedPlanUrls(),
@@ -69,9 +69,9 @@ public class TimetableLoaderTest implements TimetablesV1ImplTestHelper {
         final TimetablesApiTestModule timeTableTestModule = this.createApiWithTestdata();
         final TimeproviderStub timeProvider = new TimeproviderStub();
         final TimetableLoader loader = new TimetableLoader(timeTableTestModule.getApi(), TimetableStopFilter.ALL,
-                EventType.DEPARTURE, timeProvider, EVA_LEHRTE, 8);
+                EventType.DEPARTURE, timeProvider, TIME_CONVERTER, EVA_LEHRTE, 8);
 
-        timeProvider.time = new GregorianCalendar(2021, Calendar.AUGUST, 16, 9, 0);
+        timeProvider.time = createCalendar(2021, 8, 16, 9, 0);
 
         final List<TimetableStop> stops = loader.getTimetableStops();
         assertThat(timeTableTestModule.getRequestedPlanUrls(),
@@ -107,9 +107,9 @@ public class TimetableLoaderTest implements TimetablesV1ImplTestHelper {
         final TimetablesApiTestModule timeTableTestModule = this.createApiWithTestdata();
         final TimeproviderStub timeProvider = new TimeproviderStub();
         final TimetableLoader loader = new TimetableLoader(timeTableTestModule.getApi(), TimetableStopFilter.ALL,
-                EventType.DEPARTURE, timeProvider, EVA_LEHRTE, 1);
+                EventType.DEPARTURE, timeProvider, TIME_CONVERTER, EVA_LEHRTE, 1);
 
-        timeProvider.time = new GregorianCalendar(2021, Calendar.AUGUST, 16, 9, 30);
+        timeProvider.time = createCalendar(2021, 8, 16, 9, 30);
 
         // First call - plan and full changes are requested.
         loader.getTimetableStops();
@@ -168,13 +168,13 @@ public class TimetableLoaderTest implements TimetablesV1ImplTestHelper {
         final TimetablesApiTestModule timeTableTestModule = this.createApiWithTestdata();
         final TimeproviderStub timeProvider = new TimeproviderStub();
         final TimetableLoader loader = new TimetableLoader(timeTableTestModule.getApi(), TimetableStopFilter.ARRIVALS,
-                EventType.ARRIVAL, timeProvider, EVA_LEHRTE, 20);
+                EventType.ARRIVAL, timeProvider, TIME_CONVERTER, EVA_LEHRTE, 20);
 
         // Simulate that only one url is available
         timeTableTestModule.addAvailableUrl(
                 "https://apis.deutschebahn.com/db-api-marketplace/apis/timetables/v1/plan/8000226/210816/09");
 
-        timeProvider.time = new GregorianCalendar(2021, Calendar.AUGUST, 16, 9, 0);
+        timeProvider.time = createCalendar(2021, 8, 16, 9, 0);
 
         final List<TimetableStop> stops = loader.getTimetableStops();
 
@@ -189,13 +189,13 @@ public class TimetableLoaderTest implements TimetablesV1ImplTestHelper {
         final TimetablesApiTestModule timeTableTestModule = this.createApiWithTestdata();
         final TimeproviderStub timeProvider = new TimeproviderStub();
         final TimetableLoader loader = new TimetableLoader(timeTableTestModule.getApi(), TimetableStopFilter.DEPARTURES,
-                EventType.DEPARTURE, timeProvider, EVA_LEHRTE, 20);
+                EventType.DEPARTURE, timeProvider, TIME_CONVERTER, EVA_LEHRTE, 20);
 
         // Simulate that only one url is available
         timeTableTestModule.addAvailableUrl(
                 "https://apis.deutschebahn.com/db-api-marketplace/apis/timetables/v1/plan/8000226/210816/09");
 
-        timeProvider.time = new GregorianCalendar(2021, Calendar.AUGUST, 16, 9, 0);
+        timeProvider.time = createCalendar(2021, 8, 16, 9, 0);
 
         final List<TimetableStop> stops = loader.getTimetableStops();
 
@@ -210,9 +210,9 @@ public class TimetableLoaderTest implements TimetablesV1ImplTestHelper {
         final TimetablesApiTestModule timeTableTestModule = this.createApiWithTestdata();
         final TimeproviderStub timeProvider = new TimeproviderStub();
         final TimetableLoader loader = new TimetableLoader(timeTableTestModule.getApi(), TimetableStopFilter.DEPARTURES,
-                EventType.DEPARTURE, timeProvider, EVA_LEHRTE, 1);
+                EventType.DEPARTURE, timeProvider, TIME_CONVERTER, EVA_LEHRTE, 1);
 
-        timeProvider.time = new GregorianCalendar(2021, Calendar.AUGUST, 16, 9, 35);
+        timeProvider.time = createCalendar(2021, 8, 16, 9, 35);
 
         final List<TimetableStop> stops = loader.getTimetableStops();
         assertThat(timeTableTestModule.getRequestedPlanUrls(),
@@ -227,5 +227,24 @@ public class TimetableLoaderTest implements TimetablesV1ImplTestHelper {
         assertEquals("-5296516961807204721-2108160906-5", stops.get(0).getId());
         assertEquals("2108160942", stops.get(0).getDp().getCt());
         assertEquals("8681599812964340829-2108160955-1", stops.get(3).getId());
+    }
+
+    @Test
+    public void testKeepDepartureIfChangedTimeIsInFuture() throws Exception {
+        final Timetable timetable = new Timetable();
+        final TimetableStop stop = new TimetableStop();
+        stop.setId("delayed-departure");
+        final Event departure = new Event();
+        departure.setPt("2108160930");
+        departure.setCt("2108160940");
+        stop.setDp(departure);
+        timetable.getS().add(stop);
+
+        final TimeproviderStub timeProvider = new TimeproviderStub();
+        timeProvider.time = createCalendar(2021, 8, 16, 9, 35);
+        final TimetableLoader loader = new TimetableLoader(TimetablesV1ApiStub.createWithResult(timetable),
+                TimetableStopFilter.DEPARTURES, EventType.DEPARTURE, timeProvider, TIME_CONVERTER, EVA_LEHRTE, 1);
+
+        assertThat(loader.getTimetableStops(), contains(stop));
     }
 }

--- a/bundles/org.openhab.binding.deutschebahn/src/test/java/org/openhab/binding/deutschebahn/internal/timetable/TimetablesApiTestModule.java
+++ b/bundles/org.openhab.binding.deutschebahn/src/test/java/org/openhab/binding/deutschebahn/internal/timetable/TimetablesApiTestModule.java
@@ -55,6 +55,7 @@ public final class TimetablesApiTestModule {
     }
 
     public TimetablesV1ApiFactory getApiFactory() {
-        return (String clientId, String clientSecret, HttpCallable httpCallable) -> api;
+        return (String clientId, String clientSecret, HttpCallable httpCallable,
+                TimetableTimeConverter timeConverter) -> api;
     }
 }

--- a/bundles/org.openhab.binding.deutschebahn/src/test/java/org/openhab/binding/deutschebahn/internal/timetable/TimetablesV1ImplTest.java
+++ b/bundles/org.openhab.binding.deutschebahn/src/test/java/org/openhab/binding/deutschebahn/internal/timetable/TimetablesV1ImplTest.java
@@ -14,9 +14,9 @@ package org.openhab.binding.deutschebahn.internal.timetable;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import java.util.Calendar;
+import java.time.Instant;
 import java.util.Date;
-import java.util.GregorianCalendar;
+import java.util.List;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.junit.jupiter.api.Test;
@@ -34,7 +34,7 @@ public class TimetablesV1ImplTest implements TimetablesV1ImplTestHelper {
     public void testGetDataForLehrte() throws Exception {
         TimetablesV1Api timeTableApi = createApiWithTestdata().getApi();
 
-        Date time = new GregorianCalendar(2021, Calendar.AUGUST, 16, 9, 22).getTime();
+        Date time = createDate(2021, 8, 16, 9, 22);
 
         Timetable timeTable = timeTableApi.getPlan(EVA_LEHRTE, time);
         assertNotNull(timeTable);
@@ -45,7 +45,7 @@ public class TimetablesV1ImplTest implements TimetablesV1ImplTestHelper {
     public void testGetNonExistingData() throws Exception {
         TimetablesV1Api timeTableApi = createApiWithTestdata().getApi();
 
-        Date time = new GregorianCalendar(2021, Calendar.AUGUST, 16, 9, 22).getTime();
+        Date time = createDate(2021, 8, 16, 9, 22);
 
         Timetable timeTable = timeTableApi.getPlan("ABCDEF", time);
         assertNotNull(timeTable);
@@ -56,7 +56,7 @@ public class TimetablesV1ImplTest implements TimetablesV1ImplTestHelper {
     public void testGetDataForHannoverHBF() throws Exception {
         TimetablesV1Api timeTableApi = createApiWithTestdata().getApi();
 
-        Date time = new GregorianCalendar(2021, Calendar.OCTOBER, 14, 11, 0).getTime();
+        Date time = createDate(2021, 10, 14, 11, 0);
 
         Timetable timeTable = timeTableApi.getPlan(EVA_HANNOVER_HBF, time);
         assertNotNull(timeTable);
@@ -65,5 +65,31 @@ public class TimetablesV1ImplTest implements TimetablesV1ImplTestHelper {
         Timetable changes = timeTableApi.getFullChanges(EVA_HANNOVER_HBF);
         assertNotNull(changes);
         assertEquals(730, changes.getS().size());
+    }
+
+    @Test
+    public void testPlanRequestUsesConfiguredTimeZoneInWinter() throws Exception {
+        assertPlanUrl("2022-02-23T13:26:00Z",
+                "https://apis.deutschebahn.com/db-api-marketplace/apis/timetables/v1/plan/8000226/220223/14");
+    }
+
+    @Test
+    public void testPlanRequestUsesConfiguredTimeZoneInSummer() throws Exception {
+        assertPlanUrl("2022-08-23T12:26:00Z",
+                "https://apis.deutschebahn.com/db-api-marketplace/apis/timetables/v1/plan/8000226/220823/14");
+    }
+
+    @Test
+    public void testPlanRequestUsesLocalDateAtMidnight() throws Exception {
+        assertPlanUrl("2022-02-23T23:30:00Z",
+                "https://apis.deutschebahn.com/db-api-marketplace/apis/timetables/v1/plan/8000226/220224/00");
+    }
+
+    private void assertPlanUrl(String instant, String expectedUrl) throws Exception {
+        TimetablesApiTestModule testModule = createApiWithTestdata();
+
+        testModule.getApi().getPlan(EVA_LEHRTE, Date.from(Instant.parse(instant)));
+
+        assertEquals(List.of(expectedUrl), testModule.getRequestedPlanUrls());
     }
 }

--- a/bundles/org.openhab.binding.deutschebahn/src/test/java/org/openhab/binding/deutschebahn/internal/timetable/TimetablesV1ImplTestHelper.java
+++ b/bundles/org.openhab.binding.deutschebahn/src/test/java/org/openhab/binding/deutschebahn/internal/timetable/TimetablesV1ImplTestHelper.java
@@ -16,6 +16,10 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.File;
 import java.net.URL;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Date;
+import java.util.GregorianCalendar;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 
@@ -31,6 +35,16 @@ public interface TimetablesV1ImplTestHelper {
     static final String EVA_HANNOVER_HBF = "8000152";
     static final String CLIENT_ID = "bdwrpmxuo6157jrekftlbcc6ju9awo";
     static final String CLIENT_SECRET = "354c8161cd7fb0936c840240280c131e";
+    static final ZoneId TIME_ZONE = ZoneId.of("Europe/Berlin");
+    static final TimetableTimeConverter TIME_CONVERTER = new TimetableTimeConverter(TIME_ZONE);
+
+    default Date createDate(int year, int month, int dayOfMonth, int hour, int minute) {
+        return Date.from(LocalDateTime.of(year, month, dayOfMonth, hour, minute).atZone(TIME_ZONE).toInstant());
+    }
+
+    default GregorianCalendar createCalendar(int year, int month, int dayOfMonth, int hour, int minute) {
+        return GregorianCalendar.from(LocalDateTime.of(year, month, dayOfMonth, hour, minute).atZone(TIME_ZONE));
+    }
 
     /**
      * Creates a {@link TimetablesApiTestModule} that uses http response data from file system.
@@ -50,7 +64,7 @@ public interface TimetablesV1ImplTestHelper {
         assertNotNull(timetablesData);
         final File testDataDir = new File(timetablesData.toURI());
         final TimetableStubHttpCallable httpStub = new TimetableStubHttpCallable(testDataDir);
-        final TimetablesV1Impl timeTableApi = new TimetablesV1Impl(CLIENT_ID, CLIENT_SECRET, httpStub);
+        final TimetablesV1Impl timeTableApi = new TimetablesV1Impl(CLIENT_ID, CLIENT_SECRET, httpStub, TIME_CONVERTER);
         return new TimetablesApiTestModule(timeTableApi, httpStub);
     }
 }


### PR DESCRIPTION
- Uses TimeZoneProvider when creating handlers.
- Added explicit, thread-safe java.time conversion
- Applies the configured timezone consistently to API URLs, event timestamps, filters, sorting, merging, and past-event detection.
- Handles daylight-saving transitions without duplicate plan requests.
- Corrected the departure check to use changed time (CT) instead of checking planned time twice
- Added regression tests for winter/summer offsets, midnight date rollover, event parsing, and delayed departures.

openHAB 5.2.0 or later test jar: https://1drv.ms/u/c/70ea7ac46bc61c73/IQCeQAiR9bwtRomWnxPzlk1hAeO5CGNJew3snRGrcACBLN8?e=0kdjKV

Fixes: https://github.com/openhab/openhab-addons/issues/12354