### PR TITLE
[amazonechocontrol] Reach the voice history without push events

### DIFF
--- a/bundles/org.openhab.binding.amazonechocontrol/README.md
+++ b/bundles/org.openhab.binding.amazonechocontrol/README.md
@@ -130,13 +130,16 @@ See section _Smart Home Devices_ below for more information.
 | `discoverSmartHome`             | 0       | 0...No discover, 1...Discover direct connected, 2...Discover direct and Alexa skill devices, 3...Discover direct, Alexa and openHAB skill devices                                                                |
 | `pollingIntervalSmartHomeAlexa` | 30      | Defines the time in seconds for openHAB to pull the state of the Alexa connected devices. The minimum is 10 seconds.                                                                                             |
 | `pollingIntervalSmartSkills`    | 120     | Defines the time in seconds for openHAB to pull the state of the over a skill connected devices. The minimum is 60 seconds.                                                                                      |
-| `activityRequestDelay`          | 10      | The number of seconds between a voice command was detected and the received command is requested from the server. The minimum is 2 seconds. Lower values improve response time but may result in loss of events. |
+| `activityRequestDelay`          | 10      | The number of seconds the binding waits between the voice command event and the history request. The minimum is 2 seconds. Amazon needs a moment to write a spoken command into the history.                     |
+| `activityRequestWindow`         | 120     | The number of seconds of voice history a request covers, counted backwards from the request time. When polling, it must be at least as large as the polling interval. The recommended minimum is 60 seconds.     |
+| `activityPollingInterval`       | 0       | The number of seconds between automatic voice history requests, for accounts without push events. 0 disables polling. Each poll is one request to Amazon; below 60 seconds risks rate limiting.                  |
 
 ### Channels
 
-| Channel Type ID | Item Type | Access Mode | Thing Type | Description                                      |
-|-----------------|-----------|-------------|------------|--------------------------------------------------|
-| `sendMessage`   | String    | W           | account    | Write Only! Sends a message to the Echo devices. |
+| Channel Type ID   | Item Type | Access Mode | Thing Type | Description                                                                      |
+|-------------------|-----------|-------------|------------|----------------------------------------------------------------------------------|
+| `sendMessage`     | String    | W           | account    | Write Only! Sends a message to the Echo devices.                                 |
+| `refreshActivity` | Switch    | R/W         | account    | ON requests the voice history; the channel answers OFF when the request is done. |
 
 ### Thing Configuration
 

--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/AccountHandlerConfig.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/AccountHandlerConfig.java
@@ -26,4 +26,6 @@ public class AccountHandlerConfig {
     public int pollingIntervalSmartHomeAlexa = 60;
     public int pollingIntervalSmartSkills = 120;
     public int activityRequestDelay = 10;
+    public int activityRequestWindow = 120;
+    public int activityPollingInterval = 0;
 }

--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/connection/Connection.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/connection/Connection.java
@@ -628,7 +628,7 @@ public class Connection {
     public List<CustomerHistoryRecordTO> getActivities(long startTime, long endTime) {
         try {
             String url = getRetailUrl() + "/alexa-privacy/apd/rvh/customer-history-records?startTime=" + startTime
-                    + "&endTime=" + endTime + "&maxRecordSize=1";
+                    + "&endTime=" + endTime;
             CustomerHistoryRecordsTO customerHistoryRecords = requestBuilder.get(url)
                     .syncSend(CustomerHistoryRecordsTO.class);
             return customerHistoryRecords.customerHistoryRecords.stream()

--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/connection/Connection.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/connection/Connection.java
@@ -625,19 +625,14 @@ public class Connection {
         return List.of();
     }
 
-    public List<CustomerHistoryRecordTO> getActivities(long startTime, long endTime) {
-        try {
-            String url = getRetailUrl() + "/alexa-privacy/apd/rvh/customer-history-records?startTime=" + startTime
-                    + "&endTime=" + endTime;
-            CustomerHistoryRecordsTO customerHistoryRecords = requestBuilder.get(url)
-                    .syncSend(CustomerHistoryRecordsTO.class);
-            return customerHistoryRecords.customerHistoryRecords.stream()
-                    .filter(r -> !"DEVICE_ARBITRATION".equals(r.utteranceType))
-                    .sorted(Comparator.comparing(r -> r.timestamp)).toList();
-        } catch (ConnectionException e) {
-            logger.info("getting activities failed", e);
-        }
-        return List.of();
+    public List<CustomerHistoryRecordTO> getActivities(long startTime, long endTime) throws ConnectionException {
+        String url = getRetailUrl() + "/alexa-privacy/apd/rvh/customer-history-records?startTime=" + startTime
+                + "&endTime=" + endTime;
+        CustomerHistoryRecordsTO customerHistoryRecords = requestBuilder.get(url)
+                .syncSend(CustomerHistoryRecordsTO.class);
+        return customerHistoryRecords.customerHistoryRecords.stream()
+                .filter(r -> !"DEVICE_ARBITRATION".equals(r.utteranceType))
+                .sorted(Comparator.comparing(r -> r.timestamp)).toList();
     }
 
     public @Nullable NamedListsInfoTO getNamedListInfo(String listId) {

--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/handler/AccountHandler.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/handler/AccountHandler.java
@@ -37,6 +37,7 @@ import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -102,7 +103,6 @@ import com.google.gson.JsonSyntaxException;
  * @author Michael Geramb - Initial Contribution
  * @author Martin Littkovsky - Backoff for failed notification polls
  * @author Martin Littkovsky - Skip polls while no notification channel is linked
- * @author Martin Littkovsky - Configurable activity request window, optional voice history polling
  */
 @NonNullByDefault
 public class AccountHandler extends BaseBridgeHandler implements PushConnection.Listener {
@@ -138,6 +138,10 @@ public class AccountHandler extends BaseBridgeHandler implements PushConnection.
     // volatile: armed from the thread that creates a link, read by the scheduler
     private volatile long nextRefreshNotifications = 0;
     private final NotificationPollBackoff notificationPollBackoff = new NotificationPollBackoff();
+    // counts lifecycle edges (initialize, dispose, relogin), so a request that straddles one is discarded
+    private final AtomicInteger activityLifecycle = new AtomicInteger();
+    private int activityPollTicksToSkip = 0;
+    private int activityPollFailureStreak = 0;
     // Held while a poll result is accepted as one step: validate the attempt, publish it, record the
     // next due time. Split apart, setConnection() lands in between and the replaced session wins.
     private final Object notificationCommit = new Object();
@@ -164,6 +168,7 @@ public class AccountHandler extends BaseBridgeHandler implements PushConnection.
     @Override
     public void initialize() {
         disposing = false;
+        activityLifecycle.incrementAndGet();
         handlerConfig = getConfig().as(AccountHandlerConfig.class);
 
         updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_PENDING, "Wait for login");
@@ -322,6 +327,7 @@ public class AccountHandler extends BaseBridgeHandler implements PushConnection.
     }
 
     private void cleanup() {
+        activityLifecycle.incrementAndGet();
         logger.debug("cleanup {}", getThing().getUID().getAsString());
         ScheduledFuture<?> activityPollingJob = this.activityPollingJob;
         if (activityPollingJob != null) {
@@ -406,6 +412,7 @@ public class AccountHandler extends BaseBridgeHandler implements PushConnection.
     public void setConnection(Connection newConnection) {
         pushConnection.close();
         connection = newConnection;
+        activityLifecycle.incrementAndGet();
         storeSession();
 
         // force data check
@@ -804,31 +811,66 @@ public class AccountHandler extends BaseBridgeHandler implements PushConnection.
     }
 
     private void pollActivity() {
-        if (disposing) {
+        if (activityPollTicksToSkip > 0) {
+            activityPollTicksToSkip--;
             return;
         }
-        dispatchActivityRecords(false);
+        try {
+            dispatchActivityRecords(false);
+            if (activityPollFailureStreak > 0) {
+                activityPollFailureStreak = 0;
+                logger.info("Successfully polled the voice history again");
+            }
+        } catch (ConnectionException e) {
+            activityPollFailureStreak++;
+            activityPollTicksToSkip = failedPollTicksToSkip(activityPollFailureStreak,
+                    handlerConfig.activityPollingInterval);
+            long nextAttemptSeconds = (activityPollTicksToSkip + 1L) * handlerConfig.activityPollingInterval;
+            if (activityPollFailureStreak == 1) {
+                logger.warn("Voice history poll failed, next attempt in {} s: {}", nextAttemptSeconds, e.getMessage());
+            } else {
+                logger.debug("Voice history poll failed, next attempt in {} s: {}", nextAttemptSeconds, e.getMessage());
+            }
+        } catch (RuntimeException e) {
+            // an exception escaping a fixed-delay task silently ends all further polls
+            logger.warn("Voice history poll failed: {}", e.toString());
+            logger.debug("Voice history poll failure", e);
+        }
     }
 
-    private void dispatchActivityRecords(boolean replayHistory) {
+    /** Doubles the effective poll interval per consecutive failure, capped at the hourly data refresh. */
+    static int failedPollTicksToSkip(int failureStreak, int pollingIntervalSeconds) {
+        long doublingTicks = (1L << Math.min(failureStreak, 30)) - 1;
+        long hourlyCapTicks = Math.max(0, CHECK_DATA_INTERVAL / Math.max(1, pollingIntervalSeconds) - 1);
+        return (int) Math.min(doublingTicks, hourlyCapTicks);
+    }
+
+    private void dispatchActivityRecords(boolean replayHistory) throws ConnectionException {
+        int lifecycle = activityLifecycle.get();
         List<CustomerHistoryRecordTO> records = getCustomerActivity(null);
-        if (disposing) {
+        if (lifecycle != activityLifecycle.get()) {
+            logger.debug("Discarding {} activity record(s) fetched across a lifecycle change", records.size());
             return;
         }
         logger.debug("Activity request returned {} record(s), {} echo handler(s) registered", records.size(),
                 echoHandlers.size());
         for (CustomerHistoryRecordTO record : replayHistory ? newestRecordPerDevice(records) : records) {
             String serialNumber = deviceSerialOf(record);
-            EchoHandler echoHandler = echoHandlers.get(serialNumber);
+            EchoHandler echoHandler = serialNumber.isEmpty() ? null : echoHandlers.get(serialNumber);
             if (echoHandler == null) {
                 logger.debug("No echo handler for activity record of device ...{}",
                         serialNumber.substring(Math.max(0, serialNumber.length() - 6)));
                 continue;
             }
-            if (replayHistory) {
-                echoHandler.handleRequestedActivity(record);
-            } else {
-                echoHandler.handlePushActivity(record);
+            try {
+                if (replayHistory) {
+                    echoHandler.handleRequestedActivity(record);
+                } else {
+                    echoHandler.handlePushActivity(record);
+                }
+            } catch (RuntimeException e) {
+                // one malformed record must not cost the well-formed ones their delivery
+                logger.debug("Skipping an unreadable activity record: {}", e.toString());
             }
         }
     }
@@ -841,11 +883,11 @@ public class AccountHandler extends BaseBridgeHandler implements PushConnection.
     }
 
     private static String deviceSerialOf(CustomerHistoryRecordTO record) {
-        String[] keyParts = record.recordKey.split("#");
+        String[] keyParts = Objects.requireNonNullElse(record.recordKey, "").split("#");
         return keyParts[keyParts.length - 1];
     }
 
-    private List<CustomerHistoryRecordTO> getCustomerActivity(@Nullable Long timestamp) {
+    private List<CustomerHistoryRecordTO> getCustomerActivity(@Nullable Long timestamp) throws ConnectionException {
         if (!connection.isLoggedIn()) {
             return List.of();
         }
@@ -857,7 +899,13 @@ public class AccountHandler extends BaseBridgeHandler implements PushConnection.
     }
 
     private void handlePushActivity(@Nullable Long timestamp) {
-        List<CustomerHistoryRecordTO> activityRecords = getCustomerActivity(timestamp);
+        List<CustomerHistoryRecordTO> activityRecords;
+        try {
+            activityRecords = getCustomerActivity(timestamp);
+        } catch (ConnectionException e) {
+            logger.debug("Failed to get the voice history for a push activity: {}", e.getMessage());
+            activityRecords = List.of();
+        }
 
         while (!pushActivityProcessingQueue.isEmpty()) {
             String deviceSerialNumber = pushActivityProcessingQueue.poll();

--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/handler/AccountHandler.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/handler/AccountHandler.java
@@ -102,6 +102,7 @@ import com.google.gson.JsonSyntaxException;
  * @author Michael Geramb - Initial Contribution
  * @author Martin Littkovsky - Backoff for failed notification polls
  * @author Martin Littkovsky - Skip polls while no notification channel is linked
+ * @author Martin Littkovsky - Configurable activity request window, optional voice history polling
  */
 @NonNullByDefault
 public class AccountHandler extends BaseBridgeHandler implements PushConnection.Listener {
@@ -125,6 +126,7 @@ public class AccountHandler extends BaseBridgeHandler implements PushConnection.
     private @Nullable ScheduledFuture<?> checkDataJob;
     private @Nullable ScheduledFuture<?> updateSmartHomeStateJob;
     private @Nullable ScheduledFuture<?> refreshActivityJob;
+    private @Nullable ScheduledFuture<?> activityPollingJob;
     private @Nullable ScheduledFuture<?> refreshSmartHomeAfterCommandJob;
     private final Object synchronizeSmartHomeJobScheduler = new Object();
 
@@ -165,6 +167,7 @@ public class AccountHandler extends BaseBridgeHandler implements PushConnection.
         handlerConfig = getConfig().as(AccountHandlerConfig.class);
 
         updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_PENDING, "Wait for login");
+        updateState(CHANNEL_REFRESH_ACTIVITY, OnOffType.OFF);
 
         nextDataRefresh = 0;
         nextLoginCheck = 0;
@@ -178,6 +181,17 @@ public class AccountHandler extends BaseBridgeHandler implements PushConnection.
                 pollingIntervalSkills);
         updateSmartHomeStateJob = scheduler.scheduleWithFixedDelay(() -> updateSmartHomeState(null), 20, 10,
                 TimeUnit.SECONDS);
+
+        int pollingInterval = handlerConfig.activityPollingInterval;
+        if (pollingInterval > 0) {
+            if (handlerConfig.activityRequestWindow < pollingInterval) {
+                logger.warn(
+                        "activityRequestWindow ({}s) is smaller than activityPollingInterval ({}s) - commands between two polls will be missed",
+                        handlerConfig.activityRequestWindow, pollingInterval);
+            }
+            activityPollingJob = scheduler.scheduleWithFixedDelay(this::pollActivity, pollingInterval, pollingInterval,
+                    TimeUnit.SECONDS);
+        }
     }
 
     @Override
@@ -190,13 +204,15 @@ public class AccountHandler extends BaseBridgeHandler implements PushConnection.
             }
             String channelId = channelUID.getId();
             if (channelId.equals(CHANNEL_REFRESH_ACTIVITY) && command instanceof OnOffType) {
-                for (CustomerHistoryRecordTO record : getCustomerActivity(null)) {
-                    String[] keyParts = record.recordKey.split("#");
-                    String serialNumber = keyParts[keyParts.length - 1];
-                    EchoHandler echoHandler = echoHandlers.get(serialNumber);
-                    if (echoHandler != null) {
-                        echoHandler.handlePushActivity(record);
-                    }
+                if (command != OnOffType.ON) {
+                    updateState(CHANNEL_REFRESH_ACTIVITY, OnOffType.OFF);
+                    return;
+                }
+                updateState(CHANNEL_REFRESH_ACTIVITY, OnOffType.ON);
+                try {
+                    dispatchActivityRecords(true);
+                } finally {
+                    updateState(CHANNEL_REFRESH_ACTIVITY, OnOffType.OFF);
                 }
             } else if (channelId.equals(CHANNEL_SEND_MESSAGE) && command instanceof StringType) {
                 String commandValue = command.toFullString();
@@ -307,6 +323,11 @@ public class AccountHandler extends BaseBridgeHandler implements PushConnection.
 
     private void cleanup() {
         logger.debug("cleanup {}", getThing().getUID().getAsString());
+        ScheduledFuture<?> activityPollingJob = this.activityPollingJob;
+        if (activityPollingJob != null) {
+            activityPollingJob.cancel(true);
+            this.activityPollingJob = null;
+        }
         ScheduledFuture<?> updateSmartHomeStateJob = this.updateSmartHomeStateJob;
         if (updateSmartHomeStateJob != null) {
             updateSmartHomeStateJob.cancel(true);
@@ -782,12 +803,54 @@ public class AccountHandler extends BaseBridgeHandler implements PushConnection.
         }
     }
 
+    private void pollActivity() {
+        if (disposing) {
+            return;
+        }
+        dispatchActivityRecords(false);
+    }
+
+    private void dispatchActivityRecords(boolean replayHistory) {
+        List<CustomerHistoryRecordTO> records = getCustomerActivity(null);
+        if (disposing) {
+            return;
+        }
+        logger.debug("Activity request returned {} record(s), {} echo handler(s) registered", records.size(),
+                echoHandlers.size());
+        for (CustomerHistoryRecordTO record : replayHistory ? newestRecordPerDevice(records) : records) {
+            String serialNumber = deviceSerialOf(record);
+            EchoHandler echoHandler = echoHandlers.get(serialNumber);
+            if (echoHandler == null) {
+                logger.debug("No echo handler for activity record of device ...{}",
+                        serialNumber.substring(Math.max(0, serialNumber.length() - 6)));
+                continue;
+            }
+            if (replayHistory) {
+                echoHandler.handleRequestedActivity(record);
+            } else {
+                echoHandler.handlePushActivity(record);
+            }
+        }
+    }
+
+    private static Collection<CustomerHistoryRecordTO> newestRecordPerDevice(List<CustomerHistoryRecordTO> records) {
+        Map<String, CustomerHistoryRecordTO> newest = new HashMap<>();
+        records.forEach(record -> newest.merge(deviceSerialOf(record), record,
+                (known, candidate) -> known.timestamp >= candidate.timestamp ? known : candidate));
+        return newest.values();
+    }
+
+    private static String deviceSerialOf(CustomerHistoryRecordTO record) {
+        String[] keyParts = record.recordKey.split("#");
+        return keyParts[keyParts.length - 1];
+    }
+
     private List<CustomerHistoryRecordTO> getCustomerActivity(@Nullable Long timestamp) {
         if (!connection.isLoggedIn()) {
             return List.of();
         }
         long realTimestamp = Objects.requireNonNullElse(timestamp, System.currentTimeMillis());
-        long startTimestamp = realTimestamp - 120000;
+        long startTimestamp = realTimestamp - handlerConfig.activityRequestWindow * 1000L;
         long endTimestamp = realTimestamp + 30000;
 
         return connection.getActivities(startTimestamp, endTimestamp);

--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/handler/EchoHandler.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/handler/EchoHandler.java
@@ -99,7 +99,6 @@ import com.google.gson.JsonSyntaxException;
  *
  * @author Michael Geramb - Initial contribution
  * @author Martin Littkovsky - Report linked notification channels, so the account only polls for a consumer
- * @author Martin Littkovsky - Deliver requested activity from before the handler started
  */
 @NonNullByDefault
 public class EchoHandler extends BaseThingHandler {
@@ -118,7 +117,8 @@ public class EchoHandler extends BaseThingHandler {
     private final Object progressLock = new Object();
     private @Nullable String wakeWord;
     private @Nullable String lastKnownBluetoothMAC;
-    private long lastCustomerHistoryRecordTimestamp = System.currentTimeMillis();
+    private long handlerStartTimestamp = System.currentTimeMillis();
+    private long lastCustomerHistoryRecordTimestamp = 0;
     private String musicProviderId = "TUNEIN";
     private boolean isPlaying = false;
     private boolean isPaused = false;
@@ -156,7 +156,8 @@ public class EchoHandler extends BaseThingHandler {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_UNINITIALIZED, "Bridge handler not found.");
         }
 
-        lastCustomerHistoryRecordTimestamp = System.currentTimeMillis();
+        handlerStartTimestamp = System.currentTimeMillis();
+        lastCustomerHistoryRecordTimestamp = 0;
     }
 
     public boolean setDeviceAndUpdateThingStatus(DeviceTO device, @Nullable String wakeWord) {
@@ -967,18 +968,23 @@ public class EchoHandler extends BaseThingHandler {
     }
 
     /**
-     * An explicit refresh also delivers records from before the handler started, which the startup guard in
-     * {@link #handlePushActivity(CustomerHistoryRecordTO)} would otherwise drop.
+     * An explicit refresh also delivers records from before the handler started; a record at or behind one
+     * already delivered is dropped on both paths, so the channel never goes backward.
      */
     public synchronized void handleRequestedActivity(CustomerHistoryRecordTO customerHistoryRecord) {
-        lastCustomerHistoryRecordTimestamp = Math.min(lastCustomerHistoryRecordTimestamp,
-                customerHistoryRecord.timestamp - 1);
-        handlePushActivity(customerHistoryRecord);
+        handleActivity(customerHistoryRecord, true);
     }
 
     public synchronized void handlePushActivity(CustomerHistoryRecordTO customerHistoryRecord) {
+        handleActivity(customerHistoryRecord, false);
+    }
+
+    private void handleActivity(CustomerHistoryRecordTO customerHistoryRecord, boolean deliverRecordsFromBeforeStart) {
         long recordTimestamp = customerHistoryRecord.timestamp;
         if (recordTimestamp <= lastCustomerHistoryRecordTimestamp) {
+            return;
+        }
+        if (!deliverRecordsFromBeforeStart && recordTimestamp <= handlerStartTimestamp) {
             return;
         }
         lastCustomerHistoryRecordTimestamp = recordTimestamp;
@@ -987,7 +993,7 @@ public class EchoHandler extends BaseThingHandler {
             String recordItemType = voiceHistoryRecordItem.recordItemType;
             if ("CUSTOMER_TRANSCRIPT".equals(recordItemType) || "ASR_REPLACEMENT_TEXT".equals(recordItemType)) {
                 String customerTranscript = voiceHistoryRecordItem.transcriptText;
-                if (!customerTranscript.isEmpty()) {
+                if (customerTranscript != null && !customerTranscript.isEmpty()) {
                     // REMOVE WAKE WORD
                     String wakeWordPrefix = this.wakeWord;
                     if (wakeWordPrefix != null

--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/handler/EchoHandler.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/handler/EchoHandler.java
@@ -99,6 +99,7 @@ import com.google.gson.JsonSyntaxException;
  *
  * @author Michael Geramb - Initial contribution
  * @author Martin Littkovsky - Report linked notification channels, so the account only polls for a consumer
+ * @author Martin Littkovsky - Deliver requested activity from before the handler started
  */
 @NonNullByDefault
 public class EchoHandler extends BaseThingHandler {
@@ -963,6 +964,16 @@ public class EchoHandler extends BaseThingHandler {
                 }
             }
         }
+    }
+
+    /**
+     * An explicit refresh also delivers records from before the handler started, which the startup guard in
+     * {@link #handlePushActivity(CustomerHistoryRecordTO)} would otherwise drop.
+     */
+    public synchronized void handleRequestedActivity(CustomerHistoryRecordTO customerHistoryRecord) {
+        lastCustomerHistoryRecordTimestamp = Math.min(lastCustomerHistoryRecordTimestamp,
+                customerHistoryRecord.timestamp - 1);
+        handlePushActivity(customerHistoryRecord);
     }
 
     public synchronized void handlePushActivity(CustomerHistoryRecordTO customerHistoryRecord) {

--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/resources/OH-INF/i18n/amazonechocontrol.properties
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/resources/OH-INF/i18n/amazonechocontrol.properties
@@ -24,8 +24,12 @@ thing-type.amazonechocontrol.wha.description = Amazon Multiroom (Whole House Aud
 
 # thing types config
 
+thing-type.config.amazonechocontrol.account.activityPollingInterval.label = Activity Polling Interval
+thing-type.config.amazonechocontrol.account.activityPollingInterval.description = The number of seconds between automatic voice history requests. 0 (default) disables polling. Polling is meant for accounts that no longer receive push events, where lastVoiceCommand stays empty otherwise. Each poll sends one request to Amazon, so values below 60 seconds risk rate limiting. Commands arrive with a delay of up to one polling interval. Polling never replays commands from before openHAB started; the refreshActivity switch does.
 thing-type.config.amazonechocontrol.account.activityRequestDelay.label = Activity Request Delay
-thing-type.config.amazonechocontrol.account.activityRequestDelay.description = The number of seconds between a voice command was detected and the received command is requested from the server.
+thing-type.config.amazonechocontrol.account.activityRequestDelay.description = The number of seconds the binding waits between the event that indicates a voice command and the voice history request. Amazon needs a few seconds to write a spoken command into the history; a request that comes too early returns nothing and lastVoiceCommand stays empty. Increase this value if voice commands are missed although the connection works.
+thing-type.config.amazonechocontrol.account.activityRequestWindow.label = Activity Request Window
+thing-type.config.amazonechocontrol.account.activityRequestWindow.description = The number of seconds of voice history a request covers, counted backwards from the request time. The default of 120 seconds is sufficient when push events trigger the requests. When polling (via activityPollingInterval or a rule on refreshActivity), the window must be at least as large as the polling interval, otherwise commands spoken between two polls are missed. The recommended minimum is 60 seconds.
 thing-type.config.amazonechocontrol.account.discoverSmartHome.label = Device Discovery Mode
 thing-type.config.amazonechocontrol.account.discoverSmartHome.description = Defines which devices shall be discovered.
 thing-type.config.amazonechocontrol.account.discoverSmartHome.option.0 = No Discovery
@@ -123,7 +127,7 @@ channel-type.amazonechocontrol.powerState.label = Power State
 channel-type.amazonechocontrol.providerDisplayName.label = Provider Name
 channel-type.amazonechocontrol.providerDisplayName.description = Name of music provider
 channel-type.amazonechocontrol.refreshActivity.label = Refresh Activity
-channel-type.amazonechocontrol.refreshActivity.description = A command send to this channel refreshes the customer history activity (write-only)
+channel-type.amazonechocontrol.refreshActivity.description = ON requests the customer history activity; the channel answers OFF when the request is done
 channel-type.amazonechocontrol.relativeHumidity.label = Humidity
 channel-type.amazonechocontrol.remind.label = Remind
 channel-type.amazonechocontrol.remind.description = Speak the reminder and send a notification to the Alexa app

--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/resources/OH-INF/thing/thing-types.xml
@@ -45,9 +45,30 @@
 			</parameter>
 			<parameter name="activityRequestDelay" type="integer" min="2" unit="s">
 				<label>Activity Request Delay</label>
-				<description>The number of seconds between a voice command was detected and the received command is requested from
-					the server.</description>
+				<description>The number of seconds the binding waits between the event that indicates a voice command and the voice
+					history request. Amazon needs a few seconds to write a spoken command into the history; a request that comes too
+					early returns nothing and lastVoiceCommand stays empty. Increase this value if voice commands are missed although
+					the connection works.</description>
 				<default>10</default>
+			</parameter>
+			<parameter name="activityRequestWindow" type="integer" min="1" unit="s">
+				<label>Activity Request Window</label>
+				<description>The number of seconds of voice history a request covers, counted backwards from the request time. The
+					default of 120 seconds is sufficient when push events trigger the requests. When polling (via
+					activityPollingInterval or a rule on refreshActivity), the window must be at least as large as the polling
+					interval, otherwise commands spoken between two polls are missed. The recommended minimum is 60 seconds.</description>
+				<default>120</default>
+				<advanced>true</advanced>
+			</parameter>
+			<parameter name="activityPollingInterval" type="integer" min="0" unit="s">
+				<label>Activity Polling Interval</label>
+				<description>The number of seconds between automatic voice history requests. 0 (default) disables polling. Polling
+					is meant for accounts that no longer receive push events, where lastVoiceCommand stays empty otherwise. Each poll
+					sends one request to Amazon, so values below 60 seconds risk rate limiting. Commands arrive with a delay of up to
+					one polling interval. Polling never replays commands from before openHAB started; the refreshActivity switch
+					does.</description>
+				<default>0</default>
+				<advanced>true</advanced>
 			</parameter>
 		</config-description>
 	</bridge-type>
@@ -447,7 +468,8 @@
 	<channel-type id="refreshActivity">
 		<item-type>Switch</item-type>
 		<label>Refresh Activity</label>
-		<description>A command send to this channel refreshes the customer history activity (write-only)</description>
+		<description>ON requests the customer history activity; the channel answers OFF when the request is
+			done</description>
 		<tags>
 			<tag>Switch</tag>
 			<tag>Mode</tag>

--- a/bundles/org.openhab.binding.amazonechocontrol/src/test/java/org/openhab/binding/amazonechocontrol/internal/handler/AccountHandlerActivityDispatchTest.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/test/java/org/openhab/binding/amazonechocontrol/internal/handler/AccountHandlerActivityDispatchTest.java
@@ -1,0 +1,255 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.amazonechocontrol.internal.handler;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.after;
+import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.openhab.binding.amazonechocontrol.internal.AmazonEchoControlBindingConstants.CHANNEL_LAST_VOICE_COMMAND;
+import static org.openhab.binding.amazonechocontrol.internal.AmazonEchoControlBindingConstants.CHANNEL_REFRESH_ACTIVITY;
+import static org.openhab.binding.amazonechocontrol.internal.AmazonEchoControlBindingConstants.DEVICE_PROPERTY_SERIAL_NUMBER;
+import static org.openhab.binding.amazonechocontrol.internal.AmazonEchoControlBindingConstants.THING_TYPE_ACCOUNT;
+import static org.openhab.binding.amazonechocontrol.internal.AmazonEchoControlBindingConstants.THING_TYPE_ECHO;
+
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.http2.client.HTTP2Client;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
+import org.openhab.binding.amazonechocontrol.internal.AmazonEchoControlCommandDescriptionProvider;
+import org.openhab.binding.amazonechocontrol.internal.AmazonEchoControlStateDescriptionProvider;
+import org.openhab.binding.amazonechocontrol.internal.connection.Connection;
+import org.openhab.binding.amazonechocontrol.internal.connection.LoginData;
+import org.openhab.binding.amazonechocontrol.internal.dto.response.CustomerHistoryRecordTO;
+import org.openhab.binding.amazonechocontrol.internal.dto.response.CustomerHistoryRecordVoiceTO;
+import org.openhab.core.config.core.Configuration;
+import org.openhab.core.library.types.OnOffType;
+import org.openhab.core.library.types.StringType;
+import org.openhab.core.storage.Storage;
+import org.openhab.core.thing.Bridge;
+import org.openhab.core.thing.ChannelUID;
+import org.openhab.core.thing.Thing;
+import org.openhab.core.thing.ThingUID;
+import org.openhab.core.thing.binding.ThingHandlerCallback;
+
+import com.google.gson.Gson;
+
+/**
+ * The {@link AccountHandlerActivityDispatchTest} contains tests for the delivery of voice history records to the
+ * echo handlers: the startup guard on the push path, the history an explicit refresh delivers, the state the refresh
+ * switch shows while a request runs, and the optional polling for accounts without push.
+ *
+ * @author Martin Littkovsky - Initial contribution
+ */
+@NonNullByDefault
+public class AccountHandlerActivityDispatchTest {
+    private static final ThingUID ACCOUNT_UID = new ThingUID(THING_TYPE_ACCOUNT, "account1");
+    private static final ThingUID ECHO_UID = new ThingUID(THING_TYPE_ECHO, "account1", "echo1");
+    private static final String ECHO_SERIAL = "SERIAL_ECHO_1";
+    private static final ChannelUID REFRESH_CHANNEL = new ChannelUID(ACCOUNT_UID, CHANNEL_REFRESH_ACTIVITY);
+    private static final ChannelUID LAST_VOICE_CHANNEL = new ChannelUID(ECHO_UID, CHANNEL_LAST_VOICE_COMMAND);
+    private static final long ONE_HOUR_BEFORE_START = System.currentTimeMillis() - 3_600_000;
+    private static final long ONE_POLL_MILLIS = 1_000;
+
+    private @NonNullByDefault({}) AccountHandler accountHandler;
+    private @NonNullByDefault({}) EchoHandler echoHandler;
+    private @NonNullByDefault({}) Bridge bridge;
+    private @NonNullByDefault({}) Thing echoThing;
+    private @NonNullByDefault({}) Connection connection;
+    private @NonNullByDefault({}) ThingHandlerCallback accountCallback;
+    private @NonNullByDefault({}) ThingHandlerCallback echoCallback;
+
+    @BeforeEach
+    public void setUp() {
+        bridge = mock(Bridge.class);
+        when(bridge.getUID()).thenReturn(ACCOUNT_UID);
+        when(bridge.getConfiguration()).thenReturn(new Configuration());
+
+        @SuppressWarnings("unchecked")
+        Storage<String> storage = (Storage<String>) mock(Storage.class);
+        accountHandler = new AccountHandler(bridge, storage, new Gson(), mock(HttpClient.class),
+                mock(HTTP2Client.class), mock(AmazonEchoControlCommandDescriptionProvider.class));
+        accountCallback = mock(ThingHandlerCallback.class);
+        accountHandler.setCallback(accountCallback);
+        when(bridge.getHandler()).thenReturn(accountHandler);
+
+        connection = mock(Connection.class);
+        when(connection.isLoggedIn()).thenReturn(true);
+        LoginData loginData = mock(LoginData.class);
+        when(loginData.serializeLoginData()).thenReturn("");
+        when(connection.getLoginData()).thenReturn(loginData);
+        when(connection.getActivities(anyLong(), anyLong())).thenReturn(List.of());
+        accountHandler.setConnection(connection);
+
+        echoThing = mock(Thing.class);
+        when(echoThing.getUID()).thenReturn(ECHO_UID);
+        when(echoThing.getBridgeUID()).thenReturn(ACCOUNT_UID);
+        when(echoThing.getConfiguration())
+                .thenReturn(new Configuration(Map.of(DEVICE_PROPERTY_SERIAL_NUMBER, ECHO_SERIAL)));
+
+        echoCallback = mock(ThingHandlerCallback.class);
+        when(echoCallback.getBridge(ACCOUNT_UID)).thenReturn(bridge);
+        echoHandler = new EchoHandler(echoThing, new Gson(), mock(AmazonEchoControlStateDescriptionProvider.class));
+        echoHandler.setCallback(echoCallback);
+        echoHandler.initialize();
+        accountHandler.childHandlerInitialized(echoHandler, echoThing);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        accountHandler.dispose();
+    }
+
+    private void initializeWith(Map<String, Object> configuration) {
+        when(bridge.getConfiguration()).thenReturn(new Configuration(configuration));
+        accountHandler.initialize();
+        accountHandler.setConnection(connection);
+        clearInvocations(connection);
+    }
+
+    private static CustomerHistoryRecordTO record(String serialNumber, long timestamp, String transcript) {
+        CustomerHistoryRecordVoiceTO voiceItem = new CustomerHistoryRecordVoiceTO();
+        voiceItem.recordItemType = "CUSTOMER_TRANSCRIPT";
+        voiceItem.transcriptText = transcript;
+        CustomerHistoryRecordTO record = new CustomerHistoryRecordTO();
+        record.recordKey = "CUSTOMER#VOICE#x#" + serialNumber;
+        record.timestamp = timestamp;
+        record.utteranceType = "GENERAL";
+        record.voiceHistoryRecordItems = List.of(voiceItem);
+        return record;
+    }
+
+    @Test
+    public void testPushActivityDropsRecordsFromBeforeTheHandlerStarted() {
+        echoHandler.handlePushActivity(record(ECHO_SERIAL, ONE_HOUR_BEFORE_START, "turn on the light"));
+
+        verify(echoCallback, never()).stateUpdated(eq(LAST_VOICE_CHANNEL), any());
+    }
+
+    @Test
+    public void testRequestedActivityDeliversRecordsFromBeforeTheHandlerStarted() {
+        echoHandler.handleRequestedActivity(record(ECHO_SERIAL, ONE_HOUR_BEFORE_START, "turn on the light"));
+
+        verify(echoCallback).stateUpdated(LAST_VOICE_CHANNEL, new StringType("turn on the light"));
+    }
+
+    @Test
+    public void testPushActivityNeverGoesBackwards() {
+        long afterStart = System.currentTimeMillis() + 5_000;
+        echoHandler.handlePushActivity(record(ECHO_SERIAL, afterStart, "the newer command"));
+        echoHandler.handlePushActivity(record(ECHO_SERIAL, afterStart - 1_000, "the older command"));
+
+        verify(echoCallback, never()).stateUpdated(eq(LAST_VOICE_CHANNEL), eq(new StringType("the older command")));
+    }
+
+    @Test
+    public void testRefreshSwitchDeliversStoredHistoryToTheMatchingEcho() {
+        when(connection.getActivities(anyLong(), anyLong()))
+                .thenReturn(List.of(record("SERIAL_OF_NOBODY", ONE_HOUR_BEFORE_START, "for a stranger"),
+                        record(ECHO_SERIAL, ONE_HOUR_BEFORE_START + 1, "for this echo")));
+
+        accountHandler.handleCommand(REFRESH_CHANNEL, OnOffType.ON);
+
+        verify(echoCallback).stateUpdated(LAST_VOICE_CHANNEL, new StringType("for this echo"));
+        verify(echoCallback, never()).stateUpdated(eq(LAST_VOICE_CHANNEL), eq(new StringType("for a stranger")));
+    }
+
+    @Test
+    public void testRefreshSwitchDeliversOnlyTheNewestRecordOfADevice() {
+        when(connection.getActivities(anyLong(), anyLong()))
+                .thenReturn(List.of(record(ECHO_SERIAL, ONE_HOUR_BEFORE_START + 1_000, "the newest command"),
+                        record(ECHO_SERIAL, ONE_HOUR_BEFORE_START, "the older command")));
+
+        accountHandler.handleCommand(REFRESH_CHANNEL, OnOffType.ON);
+
+        verify(echoCallback).stateUpdated(LAST_VOICE_CHANNEL, new StringType("the newest command"));
+        verify(echoCallback, never()).stateUpdated(eq(LAST_VOICE_CHANNEL), eq(new StringType("the older command")));
+    }
+
+    @Test
+    public void testRefreshSwitchShowsOnWhileTheRequestRunsAndOffAfterwards() {
+        accountHandler.handleCommand(REFRESH_CHANNEL, OnOffType.ON);
+
+        InOrder order = inOrder(accountCallback, connection);
+        order.verify(accountCallback).stateUpdated(REFRESH_CHANNEL, OnOffType.ON);
+        order.verify(connection).getActivities(anyLong(), anyLong());
+        order.verify(accountCallback).stateUpdated(REFRESH_CHANNEL, OnOffType.OFF);
+    }
+
+    @Test
+    public void testOffCommandAnswersOffWithoutARequest() {
+        accountHandler.handleCommand(REFRESH_CHANNEL, OnOffType.OFF);
+
+        verify(accountCallback).stateUpdated(REFRESH_CHANNEL, OnOffType.OFF);
+        verify(connection, never()).getActivities(anyLong(), anyLong());
+    }
+
+    @Test
+    public void testActivityRequestUsesTheConfiguredWindow() {
+        initializeWith(Map.of("activityRequestWindow", 300));
+        long windowMillis = 300_000;
+        long futureCushionMillis = 30_000;
+
+        long before = System.currentTimeMillis();
+        accountHandler.handleCommand(REFRESH_CHANNEL, OnOffType.ON);
+        long after = System.currentTimeMillis();
+
+        ArgumentCaptor<Long> start = ArgumentCaptor.forClass(Long.class);
+        ArgumentCaptor<Long> end = ArgumentCaptor.forClass(Long.class);
+        verify(connection).getActivities(start.capture(), end.capture());
+        assertTrue(start.getValue() >= before - windowMillis && start.getValue() <= after - windowMillis,
+                "start is the request time minus the configured window");
+        assertTrue(end.getValue() >= before + futureCushionMillis && end.getValue() <= after + futureCushionMillis,
+                "end is the request time plus the cushion for clock drift");
+    }
+
+    @Test
+    public void testAConfiguredIntervalPollsTheVoiceHistory() {
+        initializeWith(Map.of("activityPollingInterval", 1));
+
+        verify(connection, timeout(5 * ONE_POLL_MILLIS).atLeastOnce()).getActivities(anyLong(), anyLong());
+    }
+
+    @Test
+    public void testWithoutAnIntervalNothingIsPolled() {
+        initializeWith(Map.of());
+
+        verify(connection, after(2 * ONE_POLL_MILLIS).never()).getActivities(anyLong(), anyLong());
+    }
+
+    @Test
+    public void testDisposeStopsThePolling() {
+        initializeWith(Map.of("activityPollingInterval", 1));
+        verify(connection, timeout(5 * ONE_POLL_MILLIS).atLeastOnce()).getActivities(anyLong(), anyLong());
+
+        accountHandler.dispose();
+        clearInvocations(connection);
+
+        verify(connection, after(3 * ONE_POLL_MILLIS).never()).getActivities(anyLong(), anyLong());
+    }
+}

--- a/bundles/org.openhab.binding.amazonechocontrol/src/test/java/org/openhab/binding/amazonechocontrol/internal/handler/AccountHandlerActivityDispatchTest.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/test/java/org/openhab/binding/amazonechocontrol/internal/handler/AccountHandlerActivityDispatchTest.java
@@ -43,6 +43,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InOrder;
 import org.openhab.binding.amazonechocontrol.internal.AmazonEchoControlCommandDescriptionProvider;
 import org.openhab.binding.amazonechocontrol.internal.AmazonEchoControlStateDescriptionProvider;
+import org.openhab.binding.amazonechocontrol.internal.ConnectionException;
 import org.openhab.binding.amazonechocontrol.internal.connection.Connection;
 import org.openhab.binding.amazonechocontrol.internal.connection.LoginData;
 import org.openhab.binding.amazonechocontrol.internal.dto.response.CustomerHistoryRecordTO;
@@ -85,7 +86,7 @@ public class AccountHandlerActivityDispatchTest {
     private @NonNullByDefault({}) ThingHandlerCallback echoCallback;
 
     @BeforeEach
-    public void setUp() {
+    public void setUp() throws ConnectionException {
         bridge = mock(Bridge.class);
         when(bridge.getUID()).thenReturn(ACCOUNT_UID);
         when(bridge.getConfiguration()).thenReturn(new Configuration());
@@ -168,7 +169,7 @@ public class AccountHandlerActivityDispatchTest {
     }
 
     @Test
-    public void testRefreshSwitchDeliversStoredHistoryToTheMatchingEcho() {
+    public void testRefreshSwitchDeliversStoredHistoryToTheMatchingEcho() throws ConnectionException {
         when(connection.getActivities(anyLong(), anyLong()))
                 .thenReturn(List.of(record("SERIAL_OF_NOBODY", ONE_HOUR_BEFORE_START, "for a stranger"),
                         record(ECHO_SERIAL, ONE_HOUR_BEFORE_START + 1, "for this echo")));
@@ -180,7 +181,7 @@ public class AccountHandlerActivityDispatchTest {
     }
 
     @Test
-    public void testRefreshSwitchDeliversOnlyTheNewestRecordOfADevice() {
+    public void testRefreshSwitchDeliversOnlyTheNewestRecordOfADevice() throws ConnectionException {
         when(connection.getActivities(anyLong(), anyLong()))
                 .thenReturn(List.of(record(ECHO_SERIAL, ONE_HOUR_BEFORE_START + 1_000, "the newest command"),
                         record(ECHO_SERIAL, ONE_HOUR_BEFORE_START, "the older command")));
@@ -192,7 +193,7 @@ public class AccountHandlerActivityDispatchTest {
     }
 
     @Test
-    public void testRefreshSwitchShowsOnWhileTheRequestRunsAndOffAfterwards() {
+    public void testRefreshSwitchShowsOnWhileTheRequestRunsAndOffAfterwards() throws ConnectionException {
         accountHandler.handleCommand(REFRESH_CHANNEL, OnOffType.ON);
 
         InOrder order = inOrder(accountCallback, connection);
@@ -202,7 +203,7 @@ public class AccountHandlerActivityDispatchTest {
     }
 
     @Test
-    public void testOffCommandAnswersOffWithoutARequest() {
+    public void testOffCommandAnswersOffWithoutARequest() throws ConnectionException {
         accountHandler.handleCommand(REFRESH_CHANNEL, OnOffType.OFF);
 
         verify(accountCallback).stateUpdated(REFRESH_CHANNEL, OnOffType.OFF);
@@ -210,7 +211,7 @@ public class AccountHandlerActivityDispatchTest {
     }
 
     @Test
-    public void testActivityRequestUsesTheConfiguredWindow() {
+    public void testActivityRequestUsesTheConfiguredWindow() throws ConnectionException {
         initializeWith(Map.of("activityRequestWindow", 300));
         long windowMillis = 300_000;
         long futureCushionMillis = 30_000;
@@ -229,21 +230,21 @@ public class AccountHandlerActivityDispatchTest {
     }
 
     @Test
-    public void testAConfiguredIntervalPollsTheVoiceHistory() {
+    public void testAConfiguredIntervalPollsTheVoiceHistory() throws ConnectionException {
         initializeWith(Map.of("activityPollingInterval", 1));
 
         verify(connection, timeout(5 * ONE_POLL_MILLIS).atLeastOnce()).getActivities(anyLong(), anyLong());
     }
 
     @Test
-    public void testWithoutAnIntervalNothingIsPolled() {
+    public void testWithoutAnIntervalNothingIsPolled() throws ConnectionException {
         initializeWith(Map.of());
 
         verify(connection, after(2 * ONE_POLL_MILLIS).never()).getActivities(anyLong(), anyLong());
     }
 
     @Test
-    public void testDisposeStopsThePolling() {
+    public void testDisposeStopsThePolling() throws ConnectionException {
         initializeWith(Map.of("activityPollingInterval", 1));
         verify(connection, timeout(5 * ONE_POLL_MILLIS).atLeastOnce()).getActivities(anyLong(), anyLong());
 
@@ -251,5 +252,55 @@ public class AccountHandlerActivityDispatchTest {
         clearInvocations(connection);
 
         verify(connection, after(3 * ONE_POLL_MILLIS).never()).getActivities(anyLong(), anyLong());
+    }
+
+    @Test
+    public void testRequestedActivityNeverGoesBackBehindADeliveredPushRecord() {
+        long afterStart = System.currentTimeMillis() + 5_000;
+        echoHandler.handlePushActivity(record(ECHO_SERIAL, afterStart, "the newer command"));
+        echoHandler.handleRequestedActivity(record(ECHO_SERIAL, afterStart - 1_000, "the older command"));
+
+        verify(echoCallback, never()).stateUpdated(eq(LAST_VOICE_CHANNEL), eq(new StringType("the older command")));
+    }
+
+    @Test
+    public void testActivityRecordsFetchedAcrossAReinitializationAreDiscarded() throws ConnectionException {
+        when(connection.getActivities(anyLong(), anyLong())).thenAnswer(invocation -> {
+            accountHandler.initialize();
+            return List.of(record(ECHO_SERIAL, System.currentTimeMillis() + 5_000, "from the old lifecycle"));
+        });
+
+        accountHandler.handleCommand(REFRESH_CHANNEL, OnOffType.ON);
+
+        verify(echoCallback, never()).stateUpdated(eq(LAST_VOICE_CHANNEL), any());
+    }
+
+    @Test
+    public void testAMalformedRecordDoesNotStopTheWellFormedOnes() throws ConnectionException {
+        CustomerHistoryRecordTO malformed = record(ECHO_SERIAL, ONE_HOUR_BEFORE_START + 1, "unreachable");
+        malformed.recordKey = null;
+        when(connection.getActivities(anyLong(), anyLong()))
+                .thenReturn(List.of(malformed, record(ECHO_SERIAL, ONE_HOUR_BEFORE_START + 2, "the good one")));
+
+        accountHandler.handleCommand(REFRESH_CHANNEL, OnOffType.ON);
+
+        verify(echoCallback).stateUpdated(LAST_VOICE_CHANNEL, new StringType("the good one"));
+    }
+
+    @Test
+    public void testPollingSurvivesAFailedRequest() throws ConnectionException {
+        when(connection.getActivities(anyLong(), anyLong())).thenThrow(new ConnectionException("session expired"))
+                .thenReturn(List.of());
+        initializeWith(Map.of("activityPollingInterval", 1));
+
+        verify(connection, timeout(8 * ONE_POLL_MILLIS).atLeast(2)).getActivities(anyLong(), anyLong());
+    }
+
+    @Test
+    public void testFailedPollsDoubleTheIntervalUpToTheHourlyRefresh() {
+        assertTrue(AccountHandler.failedPollTicksToSkip(1, 60) == 1, "the first failure skips one tick");
+        assertTrue(AccountHandler.failedPollTicksToSkip(2, 60) == 3, "the second failure skips three ticks");
+        assertTrue(AccountHandler.failedPollTicksToSkip(12, 60) == 59, "the skip is capped at the hourly refresh");
+        assertTrue(AccountHandler.failedPollTicksToSkip(3, 3600) == 0, "an hourly poll never skips");
     }
 }


### PR DESCRIPTION
`lastVoiceCommand` is written only from the push stream, so on an account whose push connection is dead the channel stays empty for good.

- `activityRequestWindow` (advanced, default 120 s — the value that was hardcoded) sets how far back a request reaches.
- `activityPollingInterval` (advanced, default 0 = off) requests the voice history on a timer, for accounts without push. Home Assistant's Alexa integration polls at 60 s; below that I would not go.
- `refreshActivity` answers ON while the request runs and OFF when it is done, and is no longer documented as write-only.
- A record delivered by an explicit refresh is no longer dropped by the startup guard in `EchoHandler`. Only the newest record per device is delivered, so one press updates the channel once instead of once per record in the window.
- `maxRecordSize=1` is gone: measured against the live endpoint, 1, 2, 5 and omitting it all return the same fixed page of ten records.

Tested on openHAB 5.2.1 against two Amazon accounts. One is a tester's with 16 Echo devices and no push connection; his `lastVoiceCommand` has been working again for a day and 18 polls at a 10 s interval all answered 200. On mine, one press with a ten-day window returned nine records across three devices and updated each device's channel exactly once. 179 unit tests pass, static analysis is clean.

Fixes: https://github.com/openhab/openhab-addons/issues/21513

**Transparency:** this patch and the comments on this PR were written with AI assistance (Claude); every commit carries an `AI-assisted-by` trailer. All changes were built, tested and verified on a production system by the author. Reviewed against wborn/github-review-policy at `ca8d3f4d0` (2026-08-19) before submission.
