### PR TITLE
[amazonechocontrol] Handle PUSH_DND_STATE_CHANGE push messages

### DIFF
--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/dto/push/PushDndStateChangeTO.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/dto/push/PushDndStateChangeTO.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.amazonechocontrol.internal.dto.push;
+
+import org.eclipse.jdt.annotation.NonNull;
+
+/**
+ * The {@link PushDndStateChangeTO} encapsulates PUSH_DND_STATE_CHANGE messages
+ *
+ * @author Martin Littkovsky - Initial contribution
+ */
+public class PushDndStateChangeTO extends PushDeviceTO {
+    public boolean enabled;
+
+    @Override
+    public @NonNull String toString() {
+        return "PushDndStateChangeTO{enabled=" + enabled + ", destinationUserId='" + destinationUserId + "', dopplerId="
+                + dopplerId + "}";
+    }
+}

--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/handler/AccountHandler.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/handler/AccountHandler.java
@@ -102,6 +102,7 @@ import com.google.gson.JsonSyntaxException;
  * @author Michael Geramb - Initial Contribution
  * @author Martin Littkovsky - Backoff for failed notification polls
  * @author Martin Littkovsky - Skip polls while no notification channel is linked
+ * @author Martin Littkovsky - Route the do-not-disturb push to the device handler
  */
 @NonNullByDefault
 public class AccountHandler extends BaseBridgeHandler implements PushConnection.Listener {
@@ -738,6 +739,7 @@ public class AccountHandler extends BaseBridgeHandler implements PushConnection.
             case "PUSH_VOLUME_CHANGE":
             case "PUSH_CONTENT_FOCUS_CHANGE":
             case "PUSH_EQUALIZER_STATE_CHANGE":
+            case "PUSH_DND_STATE_CHANGE":
                 if (payload.startsWith("{") && payload.endsWith("}")) {
                     PushDeviceTO devicePayload = Objects.requireNonNull(gson.fromJson(payload, PushDeviceTO.class));
                     PushDopplerIdTO dopplerId = devicePayload.dopplerId;

--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/handler/AccountHandler.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/handler/AccountHandler.java
@@ -102,7 +102,6 @@ import com.google.gson.JsonSyntaxException;
  * @author Michael Geramb - Initial Contribution
  * @author Martin Littkovsky - Backoff for failed notification polls
  * @author Martin Littkovsky - Skip polls while no notification channel is linked
- * @author Martin Littkovsky - Route the do-not-disturb push to the device handler
  */
 @NonNullByDefault
 public class AccountHandler extends BaseBridgeHandler implements PushConnection.Listener {

--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/handler/EchoHandler.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/handler/EchoHandler.java
@@ -100,7 +100,6 @@ import com.google.gson.JsonSyntaxException;
  *
  * @author Michael Geramb - Initial contribution
  * @author Martin Littkovsky - Report linked notification channels, so the account only polls for a consumer
- * @author Martin Littkovsky - Update the do-not-disturb channel from the push message
  */
 @NonNullByDefault
 public class EchoHandler extends BaseThingHandler {

--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/handler/EchoHandler.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/handler/EchoHandler.java
@@ -50,6 +50,7 @@ import org.openhab.binding.amazonechocontrol.internal.dto.PlayerStateProgressTO;
 import org.openhab.binding.amazonechocontrol.internal.dto.PlayerStateProviderTO;
 import org.openhab.binding.amazonechocontrol.internal.dto.PlayerStateVolumeTO;
 import org.openhab.binding.amazonechocontrol.internal.dto.push.PushAudioPlayerStateTO;
+import org.openhab.binding.amazonechocontrol.internal.dto.push.PushDndStateChangeTO;
 import org.openhab.binding.amazonechocontrol.internal.dto.push.PushEqualizerStateChangeTO;
 import org.openhab.binding.amazonechocontrol.internal.dto.push.PushVolumeChangeTO;
 import org.openhab.binding.amazonechocontrol.internal.dto.request.PlayerSeekMediaTO;
@@ -99,6 +100,7 @@ import com.google.gson.JsonSyntaxException;
  *
  * @author Michael Geramb - Initial contribution
  * @author Martin Littkovsky - Report linked notification channels, so the account only polls for a consumer
+ * @author Martin Littkovsky - Update the do-not-disturb channel from the push message
  */
 @NonNullByDefault
 public class EchoHandler extends BaseThingHandler {
@@ -1052,6 +1054,11 @@ public class EchoHandler extends BaseThingHandler {
                     lastKnownVolume = volumeChange.volumeSetting;
                     updateState(CHANNEL_VOLUME, new PercentType(lastKnownVolume));
                 }
+                break;
+            case "PUSH_DND_STATE_CHANGE":
+                PushDndStateChangeTO dndStateChange = Objects
+                        .requireNonNull(gson.fromJson(payload, PushDndStateChangeTO.class));
+                updateState(CHANNEL_DO_NOT_DISTURB, OnOffType.from(dndStateChange.enabled));
                 break;
             case "PUSH_EQUALIZER_STATE_CHANGE":
                 PushEqualizerStateChangeTO equalizerStateChange = Objects

--- a/bundles/org.openhab.binding.amazonechocontrol/src/test/java/org/openhab/binding/amazonechocontrol/internal/handler/EchoHandlerPushDndTest.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/test/java/org/openhab/binding/amazonechocontrol/internal/handler/EchoHandlerPushDndTest.java
@@ -17,14 +17,25 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static org.openhab.binding.amazonechocontrol.internal.AmazonEchoControlBindingConstants.CHANNEL_DO_NOT_DISTURB;
+import static org.openhab.binding.amazonechocontrol.internal.AmazonEchoControlBindingConstants.DEVICE_PROPERTY_SERIAL_NUMBER;
+import static org.openhab.binding.amazonechocontrol.internal.AmazonEchoControlBindingConstants.THING_TYPE_ACCOUNT;
 import static org.openhab.binding.amazonechocontrol.internal.AmazonEchoControlBindingConstants.THING_TYPE_ECHO;
 
+import java.util.Map;
+
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.http2.client.HTTP2Client;
 import org.junit.jupiter.api.Test;
+import org.openhab.binding.amazonechocontrol.internal.AmazonEchoControlCommandDescriptionProvider;
 import org.openhab.binding.amazonechocontrol.internal.AmazonEchoControlStateDescriptionProvider;
+import org.openhab.binding.amazonechocontrol.internal.dto.push.PushCommandTO;
 import org.openhab.binding.amazonechocontrol.internal.util.NonNullListTypeAdapterFactory;
 import org.openhab.binding.amazonechocontrol.internal.util.SerializeNullTypeAdapterFactory;
+import org.openhab.core.config.core.Configuration;
 import org.openhab.core.library.types.OnOffType;
+import org.openhab.core.storage.Storage;
+import org.openhab.core.thing.Bridge;
 import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.Thing;
 import org.openhab.core.thing.ThingUID;
@@ -41,7 +52,8 @@ import com.google.gson.GsonBuilder;
 @NonNullByDefault
 public class EchoHandlerPushDndTest {
     // reconstructed from the log in openhab/openhab-addons#21339, ids replaced
-    private static final String PAYLOAD = "{\"dopplerId\":{\"deviceSerialNumber\":\"G000AA0000000000\","
+    private static final String ECHO_SERIAL = "G000AA0000000000";
+    private static final String PAYLOAD = "{\"dopplerId\":{\"deviceSerialNumber\":\"" + ECHO_SERIAL + "\","
             + "\"deviceType\":\"A3EVMLQTU6WL1W\"},\"enabled\":%s,\"destinationUserId\":\"A1PY8QQU9P0FJP\"}";
 
     private final Gson gson = new GsonBuilder().registerTypeAdapterFactory(new NonNullListTypeAdapterFactory())
@@ -70,6 +82,34 @@ public class EchoHandlerPushDndTest {
 
         verify(callback).stateUpdated(new ChannelUID(thingUID, CHANNEL_DO_NOT_DISTURB), OnOffType.OFF);
         verifyNoMoreInteractions(callback);
+    }
+
+    @Test
+    public void aDndPushReceivedByTheAccountReachesTheDeviceChannel() {
+        EchoHandler echoHandler = createHandler();
+        AccountHandler accountHandler = createAccountHandlerKnowing(echoHandler);
+        PushCommandTO pushCommand = new PushCommandTO();
+        pushCommand.command = "PUSH_DND_STATE_CHANGE";
+        pushCommand.payload = PAYLOAD.formatted("true");
+
+        accountHandler.onPushCommandReceived(pushCommand);
+
+        verify(callback).stateUpdated(new ChannelUID(thingUID, CHANNEL_DO_NOT_DISTURB), OnOffType.ON);
+        verifyNoMoreInteractions(callback);
+    }
+
+    private AccountHandler createAccountHandlerKnowing(EchoHandler echoHandler) {
+        Bridge bridge = mock(Bridge.class);
+        when(bridge.getUID()).thenReturn(new ThingUID(THING_TYPE_ACCOUNT, "account"));
+        @SuppressWarnings("unchecked")
+        Storage<String> storage = (Storage<String>) mock(Storage.class);
+        AccountHandler accountHandler = new AccountHandler(bridge, storage, gson, mock(HttpClient.class),
+                mock(HTTP2Client.class), mock(AmazonEchoControlCommandDescriptionProvider.class));
+        accountHandler.setCallback(mock(ThingHandlerCallback.class));
+        when(thing.getConfiguration())
+                .thenReturn(new Configuration(Map.of(DEVICE_PROPERTY_SERIAL_NUMBER, ECHO_SERIAL)));
+        accountHandler.childHandlerInitialized(echoHandler, thing);
+        return accountHandler;
     }
 
     private EchoHandler createHandler() {

--- a/bundles/org.openhab.binding.amazonechocontrol/src/test/java/org/openhab/binding/amazonechocontrol/internal/handler/EchoHandlerPushDndTest.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/test/java/org/openhab/binding/amazonechocontrol/internal/handler/EchoHandlerPushDndTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.amazonechocontrol.internal.handler;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+import static org.openhab.binding.amazonechocontrol.internal.AmazonEchoControlBindingConstants.CHANNEL_DO_NOT_DISTURB;
+import static org.openhab.binding.amazonechocontrol.internal.AmazonEchoControlBindingConstants.THING_TYPE_ECHO;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.jupiter.api.Test;
+import org.openhab.binding.amazonechocontrol.internal.AmazonEchoControlStateDescriptionProvider;
+import org.openhab.binding.amazonechocontrol.internal.util.NonNullListTypeAdapterFactory;
+import org.openhab.binding.amazonechocontrol.internal.util.SerializeNullTypeAdapterFactory;
+import org.openhab.core.library.types.OnOffType;
+import org.openhab.core.thing.ChannelUID;
+import org.openhab.core.thing.Thing;
+import org.openhab.core.thing.ThingUID;
+import org.openhab.core.thing.binding.ThingHandlerCallback;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+
+/**
+ * The {@link EchoHandlerPushDndTest} contains tests for handling PUSH_DND_STATE_CHANGE messages
+ *
+ * @author Martin Littkovsky - Initial contribution
+ */
+@NonNullByDefault
+public class EchoHandlerPushDndTest {
+    // reconstructed from the log in openhab/openhab-addons#21339, ids replaced
+    private static final String PAYLOAD = "{\"dopplerId\":{\"deviceSerialNumber\":\"G000AA0000000000\","
+            + "\"deviceType\":\"A3EVMLQTU6WL1W\"},\"enabled\":%s,\"destinationUserId\":\"A1PY8QQU9P0FJP\"}";
+
+    private final Gson gson = new GsonBuilder().registerTypeAdapterFactory(new NonNullListTypeAdapterFactory())
+            .registerTypeAdapterFactory(new SerializeNullTypeAdapterFactory()).create();
+
+    private final ThingUID thingUID = new ThingUID(THING_TYPE_ECHO, "test");
+    private final Thing thing = mock(Thing.class);
+    private final ThingHandlerCallback callback = mock(ThingHandlerCallback.class);
+
+    @Test
+    public void dndEnabledUpdatesTheDoNotDisturbChannelAndNothingElse() {
+        EchoHandler handler = createHandler();
+
+        handler.handlePushCommand("PUSH_DND_STATE_CHANGE", PAYLOAD.formatted("true"));
+
+        verify(callback).stateUpdated(new ChannelUID(thingUID, CHANNEL_DO_NOT_DISTURB), OnOffType.ON);
+        // a fall-through into the equalizer case would zero three unrelated channels
+        verifyNoMoreInteractions(callback);
+    }
+
+    @Test
+    public void dndDisabledUpdatesTheDoNotDisturbChannelAndNothingElse() {
+        EchoHandler handler = createHandler();
+
+        handler.handlePushCommand("PUSH_DND_STATE_CHANGE", PAYLOAD.formatted("false"));
+
+        verify(callback).stateUpdated(new ChannelUID(thingUID, CHANNEL_DO_NOT_DISTURB), OnOffType.OFF);
+        verifyNoMoreInteractions(callback);
+    }
+
+    private EchoHandler createHandler() {
+        when(thing.getUID()).thenReturn(thingUID);
+        EchoHandler handler = new EchoHandler(thing, gson, mock(AmazonEchoControlStateDescriptionProvider.class));
+        handler.setCallback(callback);
+        return handler;
+    }
+}


### PR DESCRIPTION
Toggling do-not-disturb on a device sends `PUSH_DND_STATE_CHANGE` over the push stream. That command is not in the switch which routes the per-device pushes, so every toggle lands in the unknown-command branch and logs a WARN (#21339). The `doNotDisturb` channel only catches up on the next data refresh, up to an hour later.

The event is a well-formed per-device message, so it is now routed like the other per-device pushes and updates the channel directly.

I cannot verify this on my own installation: all my Alexa devices are Sonos-based and Amazon sends no push events for those. @clinique, who reported it, has been running a test build since 26 August. That build carries this change unchanged; it was built before three unrelated notification-poll changes landed in main. What would confirm it:

- Link a Switch item to `doNotDisturb` on one Echo, then toggle do-not-disturb on the device or in the Alexa app — not from openHAB.
- The item should follow within a second or two. That timing is the evidence: coming from the data refresh it would take up to an hour.
- `Detected unknown command from activity stream: PUSH_DND_STATE_CHANGE` should be gone from the log.
- A counter-check in the other direction: sending ON and OFF from openHAB must still work. The command path is untouched, and this patch only adds the state side.

Two unit tests cover the channel update in both directions. Full bundle suite green (170 tests), static analysis clean.

Fixes #21339

**Transparency:** this patch and the comments on this PR were written with AI assistance (Claude); every commit carries an `AI-assisted-by` trailer. All changes were built and tested by the author; the push path itself is the part that needs a second installation to confirm. Reviewed against wborn/github-review-policy at `ca8d3f4d0` (2026-08-19) before submission.
