### PR TITLE
[homeconnectdirect] Fix program progress reset

### DIFF
--- a/bundles/org.openhab.binding.homeconnectdirect/src/main/java/org/openhab/binding/homeconnectdirect/internal/handler/BaseHomeConnectDirectHandler.java
+++ b/bundles/org.openhab.binding.homeconnectdirect/src/main/java/org/openhab/binding/homeconnectdirect/internal/handler/BaseHomeConnectDirectHandler.java
@@ -591,7 +591,9 @@ public class BaseHomeConnectDirectHandler extends BaseThingHandler implements We
             } else if (PROGRAM_PROGRESS_KEY.equals(deviceDescriptionChange.key())) {
                 getLinkedChannel(CHANNEL_PROGRAM_PROGRESS).ifPresent(
                         channel -> getDeviceDescriptionServiceOptional().ifPresent(deviceDescriptionService -> {
-                            if (deviceDescriptionService.isOptionAvailableAndReadable(CHANNEL_PROGRAM_PROGRESS)) {
+                            // The option is only exposed while a program is set up or running, so it becoming
+                            // readable again marks the next run and is when the previous progress goes stale.
+                            if (deviceDescriptionService.isOptionAvailableAndReadable(deviceDescriptionChange.key())) {
                                 updateState(channel.getUID(), new QuantityType<>(0, PERCENT));
                             }
                         }));


### PR DESCRIPTION
Bugfix.

The branch that resets the `program-progress` channel to 0 % passed the channel ID (`program-progress`) to `isOptionAvailableAndReadable()`, which expects a device description key such as `BSH.Common.Option.ProgramProgress`. The lookup could therefore never match, the condition was always `false` and the branch has effectively been dead code.

The key is now taken straight from the change event, which the branch is already filtered on. The condition itself stays unnegated, because the two neighbouring branches are intentionally asymmetric:

* **Program progress** is only exposed by the appliance while a program is set up or running. When the option becomes *readable again*, the next program is being prepared, and that is the moment the progress of the previous run becomes stale and has to be reset to 0 %. At the end of a program it must not be reset, because the operation state `Finished` sets it to 100 % there.
* **Remaining program time** is the other way round: it has to be cleared when the option *disappears*, i.e. when no program is running any more.

This is an alternative to #21456, which added a negation instead; the rationale is discussed in #21341.

Note that this most likely does not change the behaviour reported in #21341: the `program-progress` channel is set to 100 % while the appliance is in the `Finished` state and back to 0 % once it leaves that state, which is handled by the operation state value handler. That part is still under investigation, so the issue should stay open.

No user-visible configuration or documentation changes.

Related to #21341

## Testing

Built with `mvn clean install -pl :org.openhab.binding.homeconnectdirect` (build success, no new static analysis findings).