### PR TITLE
[ddwrt] Enrich client names by MAC

### DIFF
--- a/bundles/org.openhab.binding.ddwrt/README.md
+++ b/bundles/org.openhab.binding.ddwrt/README.md
@@ -34,6 +34,10 @@ After adding and configuring the `network` bridge, the binding automatically dis
 - **Clients** — from radio association lists, DHCP lease tables, and ARP/neighbor caches on each device
 - **Firewall rules** — from DD-WRT nvram `filter_rule` entries (DD-WRT gateway devices only)
 
+For clients without a hostname supplied by the router, discovery reuses a friendly name published by another openHAB
+Thing or inbox result when it has the same MAC address. Router-supplied hostnames take precedence. If neither source has
+a name, discovery uses the existing OUI-based name or a stable `client-<MAC>` fallback so the client is not omitted.
+
 Discovery results appear in the openHAB inbox after each device refresh cycle.
 
 ## Quick Start

--- a/bundles/org.openhab.binding.ddwrt/src/main/java/org/openhab/binding/ddwrt/internal/ClientNameResolver.java
+++ b/bundles/org.openhab.binding.ddwrt/src/main/java/org/openhab/binding/ddwrt/internal/ClientNameResolver.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.ddwrt.internal;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.core.config.discovery.DiscoveryResult;
+import org.openhab.core.thing.Thing;
+
+/**
+ * Resolves client names by exact MAC address from metadata published by other bindings.
+ *
+ * @author Lee Ballard - Initial contribution
+ */
+@NonNullByDefault
+final class ClientNameResolver {
+
+    private static final Set<String> MAC_KEYS = Set.of("mac", "macaddress", "mac-address", "mac_address");
+    private static final Set<String> NAME_KEYS = Set.of("alias", "nickname");
+    private static final Set<String> GENERIC_NAMES = Set.of("device", "unknown", "unknown device", "wemo device");
+
+    private final Map<String, Set<String>> namesByMac = new HashMap<>();
+
+    void addThing(Thing thing) {
+        if (isDdwrt(thing.getThingTypeUID().getBindingId())) {
+            return;
+        }
+        Map<String, Object> properties = new LinkedHashMap<>(thing.getConfiguration().getProperties());
+        properties.putAll(thing.getProperties());
+        addIdentity(thing.getLabel(), properties);
+    }
+
+    void addDiscoveryResult(DiscoveryResult result) {
+        if (!isDdwrt(result.getThingTypeUID().getBindingId())) {
+            addIdentity(result.getLabel(), result.getProperties());
+        }
+    }
+
+    void addIdentity(@Nullable String label, Map<String, ?> properties) {
+        String mac = normalizeMac(findProperty(properties, MAC_KEYS));
+        if (mac.isEmpty()) {
+            return;
+        }
+
+        String name = findProperty(properties, NAME_KEYS);
+        if (name.isEmpty() && label != null) {
+            name = label.trim();
+        }
+        if (isUsefulName(name, mac)) {
+            Objects.requireNonNull(namesByMac.computeIfAbsent(mac, ignored -> new HashSet<>())).add(name);
+        }
+    }
+
+    Optional<String> resolve(String mac) {
+        Set<String> names = namesByMac.get(normalizeMac(mac));
+        if (names == null || names.isEmpty()) {
+            return Optional.empty();
+        }
+
+        Map<String, String> namesByCaseInsensitiveValue = new HashMap<>();
+        names.forEach(name -> namesByCaseInsensitiveValue.putIfAbsent(name.toLowerCase(Locale.ROOT), name));
+        return namesByCaseInsensitiveValue.size() == 1
+                ? Optional.of(namesByCaseInsensitiveValue.values().iterator().next())
+                : Optional.empty();
+    }
+
+    private static boolean isDdwrt(String bindingId) {
+        return DDWRTBindingConstants.THING_TYPE_CLIENT.getBindingId().equals(bindingId);
+    }
+
+    private static String findProperty(Map<String, ?> properties, Set<String> keys) {
+        for (Map.Entry<String, ?> entry : properties.entrySet()) {
+            if (keys.contains(entry.getKey().toLowerCase(Locale.ROOT))) {
+                Object propertyValue = entry.getValue();
+                if (propertyValue != null) {
+                    String value = propertyValue.toString().trim();
+                    if (!value.isEmpty()) {
+                        return value;
+                    }
+                }
+            }
+        }
+        return "";
+    }
+
+    private static boolean isUsefulName(String name, String mac) {
+        return !name.isEmpty() && !GENERIC_NAMES.contains(name.toLowerCase(Locale.ROOT))
+                && !normalizeMac(name).equals(mac);
+    }
+
+    static String normalizeMac(String mac) {
+        String normalized = mac.replaceAll("[^0-9A-Fa-f]", "").toLowerCase(Locale.ROOT);
+        return normalized.length() == 12 ? normalized : "";
+    }
+}

--- a/bundles/org.openhab.binding.ddwrt/src/main/java/org/openhab/binding/ddwrt/internal/DDWRTDiscoveryService.java
+++ b/bundles/org.openhab.binding.ddwrt/src/main/java/org/openhab/binding/ddwrt/internal/DDWRTDiscoveryService.java
@@ -24,6 +24,7 @@ import java.util.concurrent.TimeUnit;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.ddwrt.internal.api.DDWRTBaseDevice;
+import org.openhab.binding.ddwrt.internal.api.DDWRTClient;
 import org.openhab.binding.ddwrt.internal.api.DDWRTNetwork;
 import org.openhab.binding.ddwrt.internal.api.DDWRTNetworkCache;
 import org.openhab.binding.ddwrt.internal.api.RefreshListener;
@@ -32,6 +33,7 @@ import org.openhab.core.config.discovery.AbstractThingHandlerDiscoveryService;
 import org.openhab.core.config.discovery.DiscoveryResult;
 import org.openhab.core.config.discovery.DiscoveryResultBuilder;
 import org.openhab.core.config.discovery.inbox.Inbox;
+import org.openhab.core.thing.ThingRegistry;
 import org.openhab.core.thing.ThingUID;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -60,6 +62,9 @@ public class DDWRTDiscoveryService extends AbstractThingHandlerDiscoveryService<
 
     @Reference
     private @Nullable Inbox inbox;
+
+    @Reference
+    private @Nullable ThingRegistry thingRegistry;
 
     public DDWRTDiscoveryService() {
         super(DDWRTNetworkBridgeHandler.class, SUPPORTED_THING_TYPES_UIDS, DISCOVERY_TIMEOUT_SECONDS);
@@ -195,23 +200,24 @@ public class DDWRTDiscoveryService extends AbstractThingHandlerDiscoveryService<
     private void discoverClients(DDWRTNetwork net) {
         final ThingUID bridgeUID = thingHandler.getThing().getUID();
         final DDWRTNetworkCache cache = net.getCache();
+        final ClientNameResolver nameResolver = createClientNameResolver();
 
         cache.getWirelessClients().forEach(client -> {
-            if (client.getHostname().isEmpty()) {
-                // Skip clients without a hostname — hostname is required for client things
-                logger.debug("Skipping client without hostname: MAC={}", client.getMac());
-                return;
+            final String clientName = selectClientName(client, nameResolver);
+            String thingId = clientName.toLowerCase(Locale.ROOT).replaceAll("[^a-z0-9]", "");
+            if (thingId.isEmpty()) {
+                thingId = "client" + ClientNameResolver.normalizeMac(client.getMac());
             }
-            final String thingId = client.getHostname().toLowerCase(Locale.ROOT).replaceAll("[^a-z0-9]", "");
             final ThingUID thingUID = new ThingUID(THING_TYPE_CLIENT, bridgeUID, thingId);
 
             logger.debug("Discovered client: '{}'", thingUID);
 
             final Map<String, Object> props = new java.util.HashMap<>();
-            props.put(HOSTNAME, client.getHostname());
+            props.put(HOSTNAME, clientName);
+            props.put(MAC, client.getMac());
 
             final DiscoveryResult result = DiscoveryResultBuilder.create(thingUID).withBridge(bridgeUID)
-                    .withLabel(client.getHostname()).withProperties(props)
+                    .withLabel(clientName).withProperties(props)
                     // Keep hostname as the representation property. Some clients use
                     // MAC randomization, so the MAC is not stable enough to be the primary
                     // representation key in the inbox/UI.
@@ -219,7 +225,7 @@ public class DDWRTDiscoveryService extends AbstractThingHandlerDiscoveryService<
 
             logger.debug(
                     "Submitting discovery result for client: {} ({}) - AP: {}, SSID: {}, Channel: {}, Signal: {}dBm, SNR: {}",
-                    thingUID, client.getHostname(), client.getApMac(), client.getSsid(), client.getChannel(),
+                    thingUID, clientName, client.getApMac(), client.getSsid(), client.getChannel(),
                     client.getSignalDbm(), client.getSnr());
 
             // If this client is already sitting in the discovery inbox under an
@@ -228,9 +234,33 @@ public class DDWRTDiscoveryService extends AbstractThingHandlerDiscoveryService<
             // Matching is intentionally by hostname OR MAC. Hostname remains the preferred
             // representation property because MAC randomization can cause the MAC to change
             // for some devices.
-            replacePendingClientInboxDuplicates(thingUID, client.getHostname(), client.getMac());
+            replacePendingClientInboxDuplicates(thingUID, clientName, client.getMac());
 
             thingDiscovered(result);
+        });
+    }
+
+    private ClientNameResolver createClientNameResolver() {
+        ClientNameResolver resolver = new ClientNameResolver();
+        ThingRegistry registry = thingRegistry;
+        if (registry != null) {
+            registry.getAll().forEach(resolver::addThing);
+        }
+        Inbox inboxRef = inbox;
+        if (inboxRef != null) {
+            inboxRef.getAll().forEach(resolver::addDiscoveryResult);
+        }
+        return resolver;
+    }
+
+    static String selectClientName(DDWRTClient client, ClientNameResolver resolver) {
+        String routerHostname = client.getPrimaryHostname();
+        if (!routerHostname.isEmpty()) {
+            return routerHostname;
+        }
+        return resolver.resolve(client.getMac()).orElseGet(() -> {
+            String ouiHostname = client.getOuiHostname();
+            return !ouiHostname.isEmpty() ? ouiHostname : "client-" + ClientNameResolver.normalizeMac(client.getMac());
         });
     }
 

--- a/bundles/org.openhab.binding.ddwrt/src/test/java/org/openhab/binding/ddwrt/internal/ClientNameResolverTest.java
+++ b/bundles/org.openhab.binding.ddwrt/src/test/java/org/openhab/binding/ddwrt/internal/ClientNameResolverTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.ddwrt.internal;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import java.util.Map;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link ClientNameResolver}.
+ *
+ * @author Lee Ballard - Initial contribution
+ */
+@NonNullByDefault
+class ClientNameResolverTest {
+
+    @Test
+    void resolvesNameByNormalizedMac() {
+        ClientNameResolver resolver = new ClientNameResolver();
+        resolver.addIdentity("Kitchen Lamp", Map.of("macAddress", "AA:BB:CC:DD:EE:FF"));
+
+        assertThat(resolver.resolve("aa-bb-cc-dd-ee-ff").orElseThrow(), is("Kitchen Lamp"));
+    }
+
+    @Test
+    void prefersAliasPropertyToPresentationLabel() {
+        ClientNameResolver resolver = new ClientNameResolver();
+        resolver.addIdentity("Tapo HS200 Light-Switch", Map.of("mac", "D8-07-B6-AC-65-5A", "alias", "Jack's fan"));
+
+        assertThat(resolver.resolve("d8:07:b6:ac:65:5a").orElseThrow(), is("Jack's fan"));
+    }
+
+    @Test
+    void acceptsDuplicateCaseInsensitiveName() {
+        ClientNameResolver resolver = new ClientNameResolver();
+        resolver.addIdentity("Porch Light", Map.of("mac", "aa:bb:cc:dd:ee:ff"));
+        resolver.addIdentity("porch light", Map.of("macAddress", "aa-bb-cc-dd-ee-ff"));
+
+        assertThat(resolver.resolve("aabbccddeeff").orElseThrow().toLowerCase(), is("porch light"));
+    }
+
+    @Test
+    void rejectsAmbiguousNamesForSameMac() {
+        ClientNameResolver resolver = new ClientNameResolver();
+        resolver.addIdentity("Current Device", Map.of("mac", "aa:bb:cc:dd:ee:ff"));
+        resolver.addIdentity("Stale Device", Map.of("macAddress", "aabbccddeeff"));
+
+        assertThat(resolver.resolve("aa:bb:cc:dd:ee:ff").isEmpty(), is(true));
+    }
+
+    @Test
+    void ignoresGenericMacAndUncorrelatedLabels() {
+        ClientNameResolver resolver = new ClientNameResolver();
+        resolver.addIdentity("Unknown Device", Map.of("mac", "aa:bb:cc:dd:ee:ff"));
+        resolver.addIdentity("AA-BB-CC-DD-EE-FF", Map.of("mac", "aa:bb:cc:dd:ee:ff"));
+        resolver.addIdentity("Named but uncorrelated", Map.of("serialNumber", "1234"));
+
+        assertThat(resolver.resolve("aa:bb:cc:dd:ee:ff").isEmpty(), is(true));
+    }
+
+    @Test
+    void rejectsMalformedMac() {
+        ClientNameResolver resolver = new ClientNameResolver();
+        resolver.addIdentity("Kitchen Lamp", Map.of("mac", "not-a-mac"));
+
+        assertThat(resolver.resolve("not-a-mac").isEmpty(), is(true));
+    }
+}

--- a/bundles/org.openhab.binding.ddwrt/src/test/java/org/openhab/binding/ddwrt/internal/DDWRTDiscoveryServiceTest.java
+++ b/bundles/org.openhab.binding.ddwrt/src/test/java/org/openhab/binding/ddwrt/internal/DDWRTDiscoveryServiceTest.java
@@ -17,6 +17,7 @@ import static org.hamcrest.Matchers.is;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.junit.jupiter.api.Test;
+import org.openhab.binding.ddwrt.internal.api.DDWRTClient;
 import org.openhab.binding.ddwrt.internal.api.DDWRTRadio;
 import org.openhab.core.thing.ThingUID;
 
@@ -38,5 +39,32 @@ class DDWRTDiscoveryServiceTest {
 
         assertThat(thingUid.getId(), is("24-f5-a2-c6-16-59-wlan0-1"));
         assertThat(radio.getInterfaceId(), is("24:f5:a2:c6:16:59:wlan0.1"));
+    }
+
+    @Test
+    void routerHostnameTakesPrecedenceOverExternalName() {
+        DDWRTClient client = new DDWRTClient("aa:bb:cc:dd:ee:ff");
+        client.setHostname("router-name");
+        ClientNameResolver resolver = new ClientNameResolver();
+        resolver.addIdentity("External Name", java.util.Map.of("mac", client.getMac()));
+
+        assertThat(DDWRTDiscoveryService.selectClientName(client, resolver), is("router-name"));
+    }
+
+    @Test
+    void exactMacNameTakesPrecedenceOverOuiName() {
+        DDWRTClient client = new DDWRTClient("aa:bb:cc:dd:ee:ff");
+        client.setOuiHostname("Vendor-ddeeff");
+        ClientNameResolver resolver = new ClientNameResolver();
+        resolver.addIdentity("Kitchen Lamp", java.util.Map.of("macAddress", client.getMac()));
+
+        assertThat(DDWRTDiscoveryService.selectClientName(client, resolver), is("Kitchen Lamp"));
+    }
+
+    @Test
+    void unnamedClientGetsStableMacFallback() {
+        DDWRTClient client = new DDWRTClient("aa:bb:cc:dd:ee:ff");
+
+        assertThat(DDWRTDiscoveryService.selectClientName(client, new ClientNameResolver()), is("client-aabbccddeeff"));
     }
 }


### PR DESCRIPTION
## Description

Enriches DD-WRT client discovery with friendly names already published by other openHAB Things and pending inbox
results. Correlation is deliberately limited to an exact normalized MAC-address match; DD-WRT does not duplicate any
other binding's discovery protocol.

Router-supplied hostnames remain authoritative. For a client without one, an unambiguous exact-MAC name takes
precedence over the existing OUI fallback. If no usable name is available, discovery uses a deterministic
`client-<MAC>` fallback instead of omitting the client. This allows every observed client to become a Thing for presence
monitoring while keeping the initial change narrowly scoped.

This MVP intentionally excludes mDNS, IP-to-MAC correlation, discovery-registry listeners, automatic enrichment
rescans, static dnsmasq parsing, client-cache model changes, and OUI database updates. Those can be reviewed separately
after this foundation is merged.

Fixes #21369

## Testing

- `mvn spotless:apply`
- `mvn clean install -DwithResolver`
- 83 tests passed with no failures or skips
- Spotless, Markdown lint, Checkstyle, PMD, SpotBugs, XML validation, and Karaf feature verification passed
- Built `distro-app` with DD-WRT, Tapocontrol, TP-Link Smart Home, and WeMo included in `app.bndrun`
- Validated on the LAN-attached `openhab-dev` runtime: 95 fresh client results used the reduced MVP property shape,
  exact-MAC friendly names were reused, and 10 otherwise unnamed clients received stable MAC fallbacks
- Stopped the transient development service after validation and confirmed the production REST API remained healthy
