### PR TITLE
[bluetooth] Connectable-flag discovery + OFFLINE status detail

### DIFF
--- a/bundles/org.openhab.binding.bluetooth.generic/src/main/java/org/openhab/binding/bluetooth/generic/internal/GenericDiscoveryParticipant.java
+++ b/bundles/org.openhab.binding.bluetooth.generic/src/main/java/org/openhab/binding/bluetooth/generic/internal/GenericDiscoveryParticipant.java
@@ -55,7 +55,21 @@ public class GenericDiscoveryParticipant implements BluetoothDiscoveryParticipan
             // the thingUID will never be null in practice but this makes the null checker happy
             return null;
         }
-        String label = "Generic Connectable Bluetooth Device";
+        // If the transport reports the advertising connectability and the device is a non-connectable beacon
+        // (ADV_NONCONN_IND / ADV_SCAN_IND), do not claim it as a generic device: returning null lets discovery
+        // fall through to the default beacon result. When connectability is unknown (null) we keep the previous
+        // behavior and claim it (the process still connect-probes it via requiresConnection).
+        if (Boolean.FALSE.equals(device.getConnectable())) {
+            return null;
+        }
+        // Prefer the advertised device name (Complete/Shortened Local Name AD field, exposed as getName()) so
+        // the inbox shows something recognizable. Many devices don't advertise a name (or only expose it via
+        // GATT after connecting), and some report their address as the name; in those cases fall back to a
+        // generic label. The manufacturer (from the company id) is appended when known.
+        String name = device.getName();
+        boolean hasName = name != null && !name.isEmpty()
+                && !name.equals(device.getAddress().toString().replace(':', '-'));
+        String label = hasName ? name : "Generic Connectable Bluetooth Device";
         Map<String, Object> properties = new HashMap<>();
         properties.put(BluetoothBindingConstants.CONFIGURATION_ADDRESS, device.getAddress().toString());
         Integer txPower = device.getTxPower();
@@ -96,7 +110,11 @@ public class GenericDiscoveryParticipant implements BluetoothDiscoveryParticipan
 
     @Override
     public boolean requiresConnection(BluetoothDiscoveryDevice device) {
-        return true;
+        // When the transport reports advertising connectability we don't need a connection to decide: a
+        // connectable device is surfaced as generic directly from advertisement data (no connect probe), and a
+        // non-connectable beacon is declined in createResult(). Only when connectability is unknown (null) do we
+        // fall back to the legacy behavior of connecting to fingerprint/enrich the device.
+        return device.getConnectable() == null;
     }
 
     @Override

--- a/bundles/org.openhab.binding.bluetooth.generic/src/test/java/org/openhab/binding/bluetooth/generic/internal/GenericDiscoveryParticipantTest.java
+++ b/bundles/org.openhab.binding.bluetooth.generic/src/test/java/org/openhab/binding/bluetooth/generic/internal/GenericDiscoveryParticipantTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.bluetooth.generic.internal;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.openhab.binding.bluetooth.BluetoothAdapter;
+import org.openhab.binding.bluetooth.BluetoothAddress;
+import org.openhab.binding.bluetooth.discovery.BluetoothDiscoveryDevice;
+import org.openhab.core.config.discovery.DiscoveryResult;
+import org.openhab.core.thing.ThingUID;
+
+/**
+ * Verifies the connectability gating in {@link GenericDiscoveryParticipant}: a device that advertises as
+ * connectable is surfaced as a generic thing straight from advertisement data (no connection needed), a
+ * non-connectable beacon is declined (so discovery falls through to the beacon default), and a device whose
+ * connectability is unknown keeps the legacy connect-to-fingerprint behavior.
+ *
+ * This locks the fix for "only beacon devices appear in the inbox": previously the participant unconditionally
+ * required a connection, and on transports that refuse the discovery connect-probe every device was demoted to
+ * a beacon.
+ *
+ * @author Vlad Kolotov - Initial contribution
+ */
+@NonNullByDefault
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class GenericDiscoveryParticipantTest {
+
+    private final GenericDiscoveryParticipant participant = new GenericDiscoveryParticipant();
+
+    private BluetoothDiscoveryDevice deviceWithConnectable(@Nullable Boolean connectable) {
+        return device(connectable, null);
+    }
+
+    private BluetoothDiscoveryDevice device(@Nullable Boolean connectable, @Nullable String name) {
+        BluetoothAdapter adapter = org.mockito.Mockito.mock(BluetoothAdapter.class);
+        when(adapter.getUID()).thenReturn(new ThingUID("bluetooth:bluez:hci0"));
+        BluetoothDiscoveryDevice device = org.mockito.Mockito.mock(BluetoothDiscoveryDevice.class);
+        when(device.getAdapter()).thenReturn(adapter);
+        when(device.getAddress()).thenReturn(new BluetoothAddress("12:34:56:78:9A:BC"));
+        when(device.getConnectable()).thenReturn(connectable);
+        when(device.getName()).thenReturn(name);
+        // no manufacturer id -> no vendor suffix appended, so the label assertions test the name logic alone
+        when(device.getManufacturerId()).thenReturn(null);
+        return device;
+    }
+
+    @Test
+    void connectableDeviceIsSurfacedWithoutConnection() {
+        BluetoothDiscoveryDevice device = deviceWithConnectable(Boolean.TRUE);
+        assertFalse(participant.requiresConnection(device), "connectable device must not require a connection");
+        DiscoveryResult result = participant.createResult(device);
+        assertNotNull(result, "connectable device must produce a generic discovery result");
+    }
+
+    @Test
+    void nonConnectableBeaconIsDeclined() {
+        BluetoothDiscoveryDevice device = deviceWithConnectable(Boolean.FALSE);
+        assertFalse(participant.requiresConnection(device), "non-connectable device must not require a connection");
+        assertNull(participant.createResult(device),
+                "non-connectable beacon must be declined so discovery falls through to the beacon result");
+    }
+
+    @Test
+    void unknownConnectabilityKeepsLegacyConnectProbe() {
+        BluetoothDiscoveryDevice device = deviceWithConnectable(null);
+        assertTrue(participant.requiresConnection(device),
+                "unknown connectability must keep the legacy connect-to-fingerprint behavior");
+        assertNotNull(participant.createResult(device), "unknown connectability still claims the device (as before)");
+    }
+
+    @Test
+    void advertisedNameIsUsedAsLabel() {
+        DiscoveryResult result = participant.createResult(device(Boolean.TRUE, "Living Room Speaker"));
+        assertNotNull(result);
+        assertEquals("Living Room Speaker", result.getLabel());
+    }
+
+    @Test
+    void missingNameFallsBackToGenericLabel() {
+        DiscoveryResult result = participant.createResult(device(Boolean.TRUE, null));
+        assertNotNull(result);
+        assertEquals("Generic Connectable Bluetooth Device", result.getLabel());
+    }
+
+    @Test
+    void addressAsNameFallsBackToGenericLabel() {
+        // some devices report their own address as the "name"; that is not a useful label
+        DiscoveryResult result = participant.createResult(device(Boolean.TRUE, "12-34-56-78-9A-BC"));
+        assertNotNull(result);
+        assertEquals("Generic Connectable Bluetooth Device", result.getLabel());
+    }
+}

--- a/bundles/org.openhab.binding.bluetooth/src/main/java/org/openhab/binding/bluetooth/BaseBluetoothDevice.java
+++ b/bundles/org.openhab.binding.bluetooth/src/main/java/org/openhab/binding/bluetooth/BaseBluetoothDevice.java
@@ -77,6 +77,11 @@ public abstract class BaseBluetoothDevice extends BluetoothDevice {
      */
     protected @Nullable Boolean connectable = null;
 
+    /**
+     * Reason the last connection dropped (e.g. HCI disconnect status); null until a transport reports one.
+     */
+    protected @Nullable String disconnectReason = null;
+
     protected final transient ZonedDateTime createTime = ZonedDateTime.now();
 
     /**
@@ -203,6 +208,20 @@ public abstract class BaseBluetoothDevice extends BluetoothDevice {
     @Override
     public @Nullable Boolean getConnectable() {
         return connectable;
+    }
+
+    /**
+     * Records the reason the last connection dropped, so it can enrich the Thing status.
+     *
+     * @param disconnectReason a human-readable disconnect reason (e.g. the HCI status), or null to clear it
+     */
+    public void setDisconnectReason(@Nullable String disconnectReason) {
+        this.disconnectReason = disconnectReason;
+    }
+
+    @Override
+    public @Nullable String getDisconnectReason() {
+        return disconnectReason;
     }
 
     /**

--- a/bundles/org.openhab.binding.bluetooth/src/main/java/org/openhab/binding/bluetooth/BaseBluetoothDevice.java
+++ b/bundles/org.openhab.binding.bluetooth/src/main/java/org/openhab/binding/bluetooth/BaseBluetoothDevice.java
@@ -72,6 +72,11 @@ public abstract class BaseBluetoothDevice extends BluetoothDevice {
      */
     protected @Nullable Integer txPower = null;
 
+    /**
+     * Advertised connectability, derived from the advertising PDU type; null until a transport reports it.
+     */
+    protected @Nullable Boolean connectable = null;
+
     protected final transient ZonedDateTime createTime = ZonedDateTime.now();
 
     /**
@@ -184,6 +189,20 @@ public abstract class BaseBluetoothDevice extends BluetoothDevice {
     @Override
     public @Nullable Integer getTxPower() {
         return txPower;
+    }
+
+    /**
+     * Sets the advertised connectability of the device, as derived from the advertising PDU type.
+     *
+     * @param connectable true if the device advertises as connectable, false if it is a non-connectable beacon
+     */
+    public void setConnectable(boolean connectable) {
+        this.connectable = connectable;
+    }
+
+    @Override
+    public @Nullable Boolean getConnectable() {
+        return connectable;
     }
 
     /**

--- a/bundles/org.openhab.binding.bluetooth/src/main/java/org/openhab/binding/bluetooth/BeaconBluetoothHandler.java
+++ b/bundles/org.openhab.binding.bluetooth/src/main/java/org/openhab/binding/bluetooth/BeaconBluetoothHandler.java
@@ -210,7 +210,8 @@ public class BeaconBluetoothHandler extends BaseThingHandler implements Bluetoot
         if (receivedSignal) {
             updateStatus(ThingStatus.ONLINE);
         } else {
-            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR);
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
+                    "No signal from device (out of range or not advertising)");
         }
     }
 

--- a/bundles/org.openhab.binding.bluetooth/src/main/java/org/openhab/binding/bluetooth/BluetoothDevice.java
+++ b/bundles/org.openhab.binding.bluetooth/src/main/java/org/openhab/binding/bluetooth/BluetoothDevice.java
@@ -133,6 +133,17 @@ public abstract class BluetoothDevice {
     }
 
     /**
+     * The reason the last connection to this device was dropped, if the transport reports one (e.g. the HCI
+     * disconnect status). Used to enrich an OFFLINE/COMMUNICATION_ERROR Thing status with a human-readable
+     * cause instead of a bare error.
+     *
+     * @return the last disconnect reason, or {@code null} if none is known / the transport does not report it
+     */
+    public @Nullable String getDisconnectReason() {
+        return null;
+    }
+
+    /**
      * Returns the last Receive Signal Strength Indicator (RSSI) value or null if no RSSI has been received
      *
      * @return the last RSSI value in dBm

--- a/bundles/org.openhab.binding.bluetooth/src/main/java/org/openhab/binding/bluetooth/BluetoothDevice.java
+++ b/bundles/org.openhab.binding.bluetooth/src/main/java/org/openhab/binding/bluetooth/BluetoothDevice.java
@@ -120,6 +120,19 @@ public abstract class BluetoothDevice {
     public abstract @Nullable Integer getTxPower();
 
     /**
+     * Indicates whether this device advertises as connectable, derived from the advertising PDU type
+     * (e.g. ADV_IND is connectable; ADV_NONCONN_IND is not). Non-connectable devices are pure beacons and
+     * must never be connect-probed during discovery.
+     *
+     * @return {@link Boolean#TRUE}/{@link Boolean#FALSE} if the advertising connectability is known, or
+     *         {@code null} if the transport does not report it (in which case connectability is unknown and
+     *         callers should fall back to their previous behavior).
+     */
+    public @Nullable Boolean getConnectable() {
+        return null;
+    }
+
+    /**
      * Returns the last Receive Signal Strength Indicator (RSSI) value or null if no RSSI has been received
      *
      * @return the last RSSI value in dBm

--- a/bundles/org.openhab.binding.bluetooth/src/main/java/org/openhab/binding/bluetooth/ConnectedBluetoothHandler.java
+++ b/bundles/org.openhab.binding.bluetooth/src/main/java/org/openhab/binding/bluetooth/ConnectedBluetoothHandler.java
@@ -217,7 +217,9 @@ public abstract class ConnectedBluetoothHandler extends BeaconBluetoothHandler {
                         return;
                     }
                     if (th instanceof TimeoutException) {
-                        updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, th.getMessage());
+                        String msg = th.getMessage();
+                        updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
+                                msg != null ? msg : "Timed out reading/writing the device");
                     }
                     if (!alwaysConnected) {
                         scheduleDisconnect();
@@ -278,7 +280,8 @@ public abstract class ConnectedBluetoothHandler extends BeaconBluetoothHandler {
                 }
             }
         } else {
-            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR);
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
+                    "No signal from device (out of range or not advertising)");
         }
     }
 
@@ -310,7 +313,9 @@ public abstract class ConnectedBluetoothHandler extends BeaconBluetoothHandler {
             case DISCONNECTED:
                 cancel(pendingDisconnect, false);
                 if (alwaysConnected) {
-                    updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR);
+                    String reason = device.getDisconnectReason();
+                    updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
+                            reason != null ? "Device disconnected: " + reason : "Device disconnected");
                 }
                 break;
             default:

--- a/bundles/org.openhab.binding.bluetooth/src/main/java/org/openhab/binding/bluetooth/DelegateBluetoothDevice.java
+++ b/bundles/org.openhab.binding.bluetooth/src/main/java/org/openhab/binding/bluetooth/DelegateBluetoothDevice.java
@@ -61,6 +61,12 @@ public abstract class DelegateBluetoothDevice extends BluetoothDevice {
     }
 
     @Override
+    public @Nullable Boolean getConnectable() {
+        BluetoothDevice delegate = getDelegate();
+        return delegate != null ? delegate.getConnectable() : null;
+    }
+
+    @Override
     public @Nullable BluetoothService getServices(UUID uuid) {
         BluetoothDevice delegate = getDelegate();
         return delegate != null ? delegate.getServices(uuid) : null;

--- a/bundles/org.openhab.binding.bluetooth/src/main/java/org/openhab/binding/bluetooth/DelegateBluetoothDevice.java
+++ b/bundles/org.openhab.binding.bluetooth/src/main/java/org/openhab/binding/bluetooth/DelegateBluetoothDevice.java
@@ -67,6 +67,12 @@ public abstract class DelegateBluetoothDevice extends BluetoothDevice {
     }
 
     @Override
+    public @Nullable String getDisconnectReason() {
+        BluetoothDevice delegate = getDelegate();
+        return delegate != null ? delegate.getDisconnectReason() : null;
+    }
+
+    @Override
     public @Nullable BluetoothService getServices(UUID uuid) {
         BluetoothDevice delegate = getDelegate();
         return delegate != null ? delegate.getServices(uuid) : null;

--- a/bundles/org.openhab.binding.bluetooth/src/main/java/org/openhab/binding/bluetooth/discovery/internal/BluetoothDiscoveryProcess.java
+++ b/bundles/org.openhab.binding.bluetooth/src/main/java/org/openhab/binding/bluetooth/discovery/internal/BluetoothDiscoveryProcess.java
@@ -94,7 +94,11 @@ public class BluetoothDiscoveryProcess implements Supplier<DiscoveryResult> {
         // Since we couldn't find a result, lets try the connection based participants
         DiscoveryResult result = null;
         BluetoothAddress address = device.getAddress();
-        if (isAddressAvailable(address)) {
+        // A device that advertises as non-connectable (ADV_NONCONN_IND / ADV_SCAN_IND) can never be connected
+        // to, so skip the connection-based participants entirely and let it fall through to the beacon result.
+        // When connectability is unknown (null) we keep probing as before.
+        boolean connectable = !Boolean.FALSE.equals(device.getConnectable());
+        if (connectable && !connectionParticipants.isEmpty() && isAddressAvailable(address)) {
             result = findConnectionResult(connectionParticipants);
             // make sure to disconnect before letting go of the device
             if (device.getConnectionState() == ConnectionState.CONNECTED) {


### PR DESCRIPTION
This is a supporting PR for a larger project (new bluetooth binding for direct access).

Changes in this PR:

1. Prevent automatic connection procedure for new discovered devices. Connecting to random discovered devices works for the bluez transport because bluez caches devices and their state, so this can be quick (retrieving device name to be displayed in inbox). However it is still a questionable logic, fundamentally wrong - we can't force connection to devices just because they got discovered. The Direct-BT binding does not cache device state (name and GATT) hence it actually would establish a real connection for each rediscovered device. This change preserves the old behaviour for the bluez binding (though I would remove that logic completely and rely on the advertised name instead of attempting connection) and prevents connection for the new binding.
2. If a device advertises its name - the name is used instead of the dummy "Generic Connectable Device".
3. If a device advertises that it is not connectable - prevent creating generic connectable things. If a device does not advertise the connectable attribute, or it is connectable, then we allow creating a generic connectable thing.
4. Minor updates for observability - preserving transport errors and displaying them on the thing UI.
