### PR TITLE
[bluetooth.generic] Preserve decimals when writing integer fields with a DecimalExponent

### DIFF
--- a/bundles/org.openhab.binding.bluetooth.generic/src/main/java/org/openhab/binding/bluetooth/generic/internal/BluetoothChannelUtils.java
+++ b/bundles/org.openhab.binding.bluetooth.generic/src/main/java/org/openhab/binding/bluetooth/generic/internal/BluetoothChannelUtils.java
@@ -158,7 +158,12 @@ public class BluetoothChannelUtils {
                             request.getCharacteristicUUID(), fieldName, state);
                     return;
                 }
-                request.setField(fieldName, decimalType.longValue());
+                // Use doubleValue(), not longValue(): when the integer field carries a
+                // DecimalExponent the real-world value can be fractional (e.g. 21.5 for a
+                // sint16 in 0.01 degC units). setField(Double) divides by the field multiplier
+                // (10^exponent) before encoding, yielding the correct raw integer, whereas
+                // longValue() truncates the fraction first and corrupts the written value.
+                request.setField(fieldName, decimalType.doubleValue());
                 return;
             }
             case FLOAT_IEE754:

--- a/bundles/org.openhab.binding.bluetooth.generic/src/main/java/org/openhab/binding/bluetooth/generic/internal/BluetoothChannelUtils.java
+++ b/bundles/org.openhab.binding.bluetooth.generic/src/main/java/org/openhab/binding/bluetooth/generic/internal/BluetoothChannelUtils.java
@@ -158,11 +158,6 @@ public class BluetoothChannelUtils {
                             request.getCharacteristicUUID(), fieldName, state);
                     return;
                 }
-                // Use doubleValue(), not longValue(): when the integer field carries a
-                // DecimalExponent the real-world value can be fractional (e.g. 21.5 for a
-                // sint16 in 0.01 degC units). setField(Double) divides by the field multiplier
-                // (10^exponent) before encoding, yielding the correct raw integer, whereas
-                // longValue() truncates the fraction first and corrupts the written value.
                 request.setField(fieldName, decimalType.doubleValue());
                 return;
             }

--- a/bundles/org.openhab.binding.bluetooth.generic/src/test/java/org/openhab/binding/bluetooth/generic/internal/BluetoothChannelUtilsTest.java
+++ b/bundles/org.openhab.binding.bluetooth.generic/src/test/java/org/openhab/binding/bluetooth/generic/internal/BluetoothChannelUtilsTest.java
@@ -16,6 +16,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.junit.jupiter.api.Test;
+import org.openhab.bluetooth.gattparser.BluetoothGattParser;
+import org.openhab.bluetooth.gattparser.BluetoothGattParserFactory;
+import org.openhab.bluetooth.gattparser.GattRequest;
+import org.openhab.core.library.types.DecimalType;
 
 /**
  * @author Connor Petty - Initial contribution
@@ -24,9 +28,31 @@ import org.junit.jupiter.api.Test;
 @NonNullByDefault
 public class BluetoothChannelUtilsTest {
 
+    private static final String TEMPERATURE_UUID = "2A6E";
+    private static final String TEMPERATURE_FIELD = "Temperature";
+
     @Test
     public void encodeDecodeFieldNameTest() {
         String str = "easure";
         assertEquals(str, BluetoothChannelUtils.decodeFieldName(BluetoothChannelUtils.encodeFieldName(str)));
+    }
+
+    /**
+     * An integer field that carries a DecimalExponent represents a fractional real-world value: the
+     * Temperature characteristic (0x2A6E) is a sint16 in units of 0.01 degrees C. Writing 21.5 degrees
+     * must serialize to the raw value 2150, not 2100 (which is what truncating the state to a long
+     * before applying the field multiplier would produce).
+     */
+    @Test
+    public void updateHolderPreservesDecimalsOnIntegerFieldWithExponent() {
+        BluetoothGattParser parser = BluetoothGattParserFactory.getDefault();
+        GattRequest request = parser.prepare(TEMPERATURE_UUID);
+
+        BluetoothChannelUtils.updateHolder(parser, request, TEMPERATURE_FIELD, new DecimalType("21.5"));
+
+        byte[] serialized = parser.serialize(request);
+        // sint16, little endian: 2150 == 0x0866
+        assertEquals(2, serialized.length);
+        assertEquals(2150, (short) ((serialized[1] & 0xFF) << 8 | (serialized[0] & 0xFF)));
     }
 }


### PR DESCRIPTION
A GATT integer field can carry a DecimalExponent, which makes it represent a fractional real-world value. The Temperature characteristic (0x2A6E) is a sint16 in units of 0.01 degrees C.

When writing such a field, the state was converted with `DecimalType#longValue()`, which truncates the fraction before the field multiplier is applied. Writing 21.5 degrees serialized to a raw 2100 (21.00 degrees) instead of 2150, so everything after the decimal point was silently lost.

The fix is to use `DecimalType#doubleValue()` instead. `GattRequest#setField(String, Double)` divides by the field multiplier before encoding, so the fractional part survives into the raw integer written to the device.

Added a regression test that serializes 21.5 degrees through the Temperature characteristic.
