### PR TITLE
[bluetooth.generic] Only poll linked characteristics and recover without dropping intent

### DIFF
--- a/bundles/org.openhab.binding.bluetooth.generic/src/main/java/org/openhab/binding/bluetooth/generic/internal/GenericBluetoothHandler.java
+++ b/bundles/org.openhab.binding.bluetooth.generic/src/main/java/org/openhab/binding/bluetooth/generic/internal/GenericBluetoothHandler.java
@@ -46,6 +46,7 @@ import org.openhab.core.thing.ThingStatus;
 import org.openhab.core.thing.ThingStatusDetail;
 import org.openhab.core.thing.binding.builder.ChannelBuilder;
 import org.openhab.core.thing.binding.builder.ThingBuilder;
+import org.openhab.core.thing.link.ItemChannelLinkRegistry;
 import org.openhab.core.thing.type.ChannelTypeUID;
 import org.openhab.core.types.Command;
 import org.openhab.core.types.RefreshType;
@@ -70,13 +71,21 @@ public class GenericBluetoothHandler extends ConnectedBluetoothHandler {
     private final Map<ChannelUID, CharacteristicHandler> channelHandlers = new ConcurrentHashMap<>();
     private final BluetoothGattParser gattParser = BluetoothGattParserFactory.getDefault();
     private final CharacteristicChannelTypeProvider channelTypeProvider;
+    private final ItemChannelLinkRegistry itemChannelLinkRegistry;
+    private final boolean pollOnlyLinkedCharacteristics;
+    private final boolean reconnectOnUnresolvedServices;
     private final Map<CharacteristicHandler, List<ChannelUID>> handlerToChannels = new ConcurrentHashMap<>();
 
     private @Nullable ScheduledFuture<?> readCharacteristicJob = null;
 
-    public GenericBluetoothHandler(Thing thing, CharacteristicChannelTypeProvider channelTypeProvider) {
+    public GenericBluetoothHandler(Thing thing, CharacteristicChannelTypeProvider channelTypeProvider,
+            ItemChannelLinkRegistry itemChannelLinkRegistry, boolean pollOnlyLinkedCharacteristics,
+            boolean reconnectOnUnresolvedServices) {
         super(thing);
         this.channelTypeProvider = channelTypeProvider;
+        this.itemChannelLinkRegistry = itemChannelLinkRegistry;
+        this.pollOnlyLinkedCharacteristics = pollOnlyLinkedCharacteristics;
+        this.reconnectOnUnresolvedServices = reconnectOnUnresolvedServices;
     }
 
     @Override
@@ -84,45 +93,64 @@ public class GenericBluetoothHandler extends ConnectedBluetoothHandler {
         super.initialize();
 
         GenericBindingConfiguration config = getConfigAs(GenericBindingConfiguration.class);
-        readCharacteristicJob = scheduler.scheduleWithFixedDelay(() -> {
-            if (device.getConnectionState() == ConnectionState.CONNECTED) {
-                if (device.isServicesDiscovered()) {
-                    handlerToChannels.forEach((charHandler, channelUids) -> {
-                        // Only read the value manually if notification is not on.
-                        // Also read it the first time before we activate notifications below.
-                        if (!device.isNotifying(charHandler.characteristic) && charHandler.canRead()) {
-                            device.readCharacteristic(charHandler.characteristic);
-                            try {
-                                // TODO the ideal solution would be to use locks/conditions and timeouts
-                                // Kbetween this code and `onCharacteristicReadComplete` but
-                                // that would overcomplicate the code a bit and I plan
-                                // on implementing a better more generalized solution later
-                                Thread.sleep(50);
-                            } catch (InterruptedException e) {
-                                return;
+        readCharacteristicJob = scheduler.scheduleWithFixedDelay(this::guardedPollTick, 15, config.pollingInterval,
+                TimeUnit.SECONDS);
+    }
+
+    private void guardedPollTick() {
+        // An uncaught exception would cancel the repeating job, silently stopping all further polling.
+        try {
+            pollTick();
+        } catch (RuntimeException e) {
+            logger.warn("Characteristic poll tick failed for {}; will retry next tick", address, e);
+        }
+    }
+
+    private void pollTick() {
+        if (device.getConnectionState() == ConnectionState.CONNECTED) {
+            if (device.isServicesDiscovered()) {
+                handlerToChannels.forEach((charHandler, channelUids) -> {
+                    boolean linked = !pollOnlyLinkedCharacteristics || channelUids.stream().anyMatch(this::hasItemLink);
+                    // Only read the value manually if notification is not on.
+                    // Also read it the first time before we activate notifications below.
+                    if (linked && !device.isNotifying(charHandler.characteristic) && charHandler.canRead()) {
+                        device.readCharacteristic(charHandler.characteristic);
+                        try {
+                            // TODO the ideal solution would be to use locks/conditions and timeouts
+                            // Kbetween this code and `onCharacteristicReadComplete` but
+                            // that would overcomplicate the code a bit and I plan
+                            // on implementing a better more generalized solution later
+                            Thread.sleep(50);
+                        } catch (InterruptedException e) {
+                            return;
+                        }
+                    }
+                    if (charHandler.characteristic.canNotify()) {
+                        // Enabled/Disable notifications dependent on if the channel is linked.
+                        if (linked) {
+                            if (!device.isNotifying(charHandler.characteristic)) {
+                                device.enableNotifications(charHandler.characteristic);
+                            }
+                        } else {
+                            if (device.isNotifying(charHandler.characteristic)) {
+                                device.disableNotifications(charHandler.characteristic);
                             }
                         }
-                        if (charHandler.characteristic.canNotify()) {
-                            // Enabled/Disable notifications dependent on if the channel is linked.
-                            // TODO check why isLinked() is true for not linked channels
-                            if (channelUids.stream().anyMatch(this::isLinked)) {
-                                if (!device.isNotifying(charHandler.characteristic)) {
-                                    device.enableNotifications(charHandler.characteristic);
-                                }
-                            } else {
-                                if (device.isNotifying(charHandler.characteristic)) {
-                                    device.disableNotifications(charHandler.characteristic);
-                                }
-                            }
-                        }
-                    });
+                    }
+                });
+            } else {
+                // Connected but services never resolved: bounce the link and retry service discovery.
+                if (reconnectOnUnresolvedServices) {
+                    device.reconnect();
                 } else {
-                    // if we are connected and still haven't been able to resolve the services, try disconnecting and
-                    // then connecting again
                     device.disconnect();
                 }
             }
-        }, 15, config.pollingInterval, TimeUnit.SECONDS);
+        }
+    }
+
+    private boolean hasItemLink(ChannelUID channelUID) {
+        return !itemChannelLinkRegistry.getLinkedItemNames(channelUID).isEmpty();
     }
 
     @Override
@@ -143,6 +171,8 @@ public class GenericBluetoothHandler extends ConnectedBluetoothHandler {
         super.onServicesDiscovered();
         logger.trace("Service discovery completed for '{}'", address);
         updateThingChannels();
+        // Poll now rather than leaving the freshly resolved device idle until the next scheduled tick.
+        scheduler.execute(this::guardedPollTick);
     }
 
     @Override

--- a/bundles/org.openhab.binding.bluetooth.generic/src/main/java/org/openhab/binding/bluetooth/generic/internal/GenericBluetoothHandlerFactory.java
+++ b/bundles/org.openhab.binding.bluetooth.generic/src/main/java/org/openhab/binding/bluetooth/generic/internal/GenericBluetoothHandlerFactory.java
@@ -25,6 +25,7 @@ import org.openhab.core.thing.ThingTypeUID;
 import org.openhab.core.thing.binding.BaseThingHandlerFactory;
 import org.openhab.core.thing.binding.ThingHandler;
 import org.openhab.core.thing.binding.ThingHandlerFactory;
+import org.openhab.core.thing.link.ItemChannelLinkRegistry;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -55,18 +56,39 @@ public class GenericBluetoothHandlerFactory extends BaseThingHandlerFactory {
      */
     private static final String DEFAULT_GATT_EXTENSIONS_FOLDER = "gatt-extensions";
 
+    /** Binding config keys for the two behaviour switches (both default ON = the fixed behaviour). */
+    private static final String CONFIG_POLL_ONLY_LINKED = "pollOnlyLinkedCharacteristics";
+    private static final String CONFIG_RECONNECT_UNRESOLVED = "reconnectOnUnresolvedServices";
+
     private final Logger logger = LoggerFactory.getLogger(GenericBluetoothHandlerFactory.class);
 
     private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Set
             .of(GenericBindingConstants.THING_TYPE_GENERIC);
 
     private final CharacteristicChannelTypeProvider channelTypeProvider;
+    private final ItemChannelLinkRegistry itemChannelLinkRegistry;
+    private final boolean pollOnlyLinkedCharacteristics;
+    private final boolean reconnectOnUnresolvedServices;
 
     @Activate
     public GenericBluetoothHandlerFactory(@Reference CharacteristicChannelTypeProvider channelTypeProvider,
-            Map<String, Object> config) {
+            @Reference ItemChannelLinkRegistry itemChannelLinkRegistry, Map<String, Object> config) {
         this.channelTypeProvider = channelTypeProvider;
+        this.itemChannelLinkRegistry = itemChannelLinkRegistry;
+        this.pollOnlyLinkedCharacteristics = configBoolean(config, CONFIG_POLL_ONLY_LINKED, true);
+        this.reconnectOnUnresolvedServices = configBoolean(config, CONFIG_RECONNECT_UNRESOLVED, true);
         loadGattExtensions(config);
+    }
+
+    private static boolean configBoolean(Map<String, Object> config, String key, boolean defaultValue) {
+        Object value = config.get(key);
+        if (value instanceof Boolean b) {
+            return b;
+        }
+        if (value instanceof String s && !s.isBlank()) {
+            return Boolean.parseBoolean(s.trim());
+        }
+        return defaultValue;
     }
 
     /**
@@ -116,7 +138,8 @@ public class GenericBluetoothHandlerFactory extends BaseThingHandlerFactory {
         ThingTypeUID thingTypeUID = thing.getThingTypeUID();
 
         if (GenericBindingConstants.THING_TYPE_GENERIC.equals(thingTypeUID)) {
-            return new GenericBluetoothHandler(thing, channelTypeProvider);
+            return new GenericBluetoothHandler(thing, channelTypeProvider, itemChannelLinkRegistry,
+                    pollOnlyLinkedCharacteristics, reconnectOnUnresolvedServices);
         }
 
         return null;

--- a/bundles/org.openhab.binding.bluetooth.generic/src/main/resources/OH-INF/config/config.xml
+++ b/bundles/org.openhab.binding.bluetooth.generic/src/main/resources/OH-INF/config/config.xml
@@ -6,6 +6,19 @@
 		https://openhab.org/schemas/config-description-1.0.0.xsd">
 
 	<config-description uri="binding:bluetooth:generic">
+		<parameter name="pollOnlyLinkedCharacteristics" type="boolean">
+			<label>Poll Only Linked Characteristics</label>
+			<description>Whether to read and subscribe only to characteristics whose channel has a linked item</description>
+			<advanced>true</advanced>
+			<default>true</default>
+		</parameter>
+		<parameter name="reconnectOnUnresolvedServices" type="boolean">
+			<label>Reconnect On Unresolved Services</label>
+			<description>Whether to recover a connection with unresolved GATT services by reconnecting instead of
+				disconnecting</description>
+			<advanced>true</advanced>
+			<default>true</default>
+		</parameter>
 		<parameter name="gattExtensionsFolder" type="text">
 			<label>Custom GATT Extensions Folder</label>
 			<description>Folder containing custom GATT specification XML files for non-standard services and characteristics,

--- a/bundles/org.openhab.binding.bluetooth/src/main/java/org/openhab/binding/bluetooth/BluetoothDevice.java
+++ b/bundles/org.openhab.binding.bluetooth/src/main/java/org/openhab/binding/bluetooth/BluetoothDevice.java
@@ -195,6 +195,23 @@ public abstract class BluetoothDevice {
     public abstract boolean disconnect();
 
     /**
+     * Re-establishes the link to a device <em>without</em> changing the caller's intent to stay connected. This
+     * is the recovery path for a connection that is up at the link level but has not produced usable GATT
+     * services (the handler wants to bounce the link and try service discovery again, not give the device up).
+     * <p>
+     * It is distinct from {@link #disconnect()}, which signals "no longer want this device connected". A
+     * transport that tracks connection intent (e.g. to keep an {@code alwaysConnected} device connected) must
+     * NOT treat a {@code reconnect()} as a request to stop connecting. The default implementation falls back to
+     * {@link #disconnect()} so transports that do not track intent keep their existing disconnect-then-reconnect
+     * recovery behaviour unchanged.
+     *
+     * @return true if the reconnect (or fallback disconnect) process is started successfully
+     */
+    public boolean reconnect() {
+        return disconnect();
+    }
+
+    /**
      * Starts a discovery on a device. This will iterate through all services and characteristics to build up a view of
      * the device.
      * <p>


### PR DESCRIPTION
This is a supporting PR for a larger project (new bluetooth binding for direct access).


Four fixes to the generic binding's characteristic polling job, plus the core API change one of them needs. Each behaviour change sits behind a binding config switch that defaults to the new behaviour, so it can be turned off if it misbehaves on some device or transport.

1. Poll only linked characteristics. 

2. Recover unresolved services without dropping connection intent. When a device is connected but its GATT services never resolve, the job bounced the link with `disconnect()`, which is also how a handler says it no longer wants the device connected. A transport that tracks intent cannot tell the two apart and reads the recovery as a request to stop connecting, so it flaps.

3. Guard the tick body. An uncaught RuntimeException from a transport call cancells the repeating job, and polling then stopped and nothing in the logs.

4. Also polls once as soon as service discovery completes, rather than leaving a freshly resolved device idle until the next scheduled tick.

