### PR TITLE
[hue] Improve support for increase/decrease commands

### DIFF
--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/api/dto/clip2/helper/Setters.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/api/dto/clip2/helper/Setters.java
@@ -36,10 +36,8 @@ import org.openhab.binding.hue.internal.api.dto.clip2.Resource;
 import org.openhab.binding.hue.internal.api.dto.clip2.TimedEffects;
 import org.openhab.binding.hue.internal.api.dto.clip2.enums.ActionType;
 import org.openhab.binding.hue.internal.api.dto.clip2.enums.EffectType;
-import org.openhab.binding.hue.internal.exceptions.CriticalFieldMissingException;
 import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.library.types.HSBType;
-import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.library.types.PercentType;
 import org.openhab.core.library.types.QuantityType;
 import org.openhab.core.library.types.StringType;
@@ -353,31 +351,6 @@ public class Setters {
         }
 
         return resources;
-    }
-
-    /**
-     * Create an OnOffType command based on the given brightness (absolute) or brightness delta (relative to cached
-     * value). The purpose is to send a "hard" ON if the lamp is definitely ON and a hard "OFF" if it is definitely OFF,
-     * and thus avoiding sending "soft off" commands to the light.
-     *
-     * 
-     * @param brightnessValue the target brightness or the delta to be added to the prior cached value.
-     * @param valueIsAbsolute true if the brightnessValue is an absolute value, false if it is a delta.
-     * @param source the cached resource to get the prior brightness from when valueIsAbsolute is false (may be null).
-     * @return the OnOffType command to be sent.
-     * @throws CriticalFieldMissingException if there is not enough data to create the command.
-     */
-    public static OnOffType getHardOnOff(Resource target, Double brightnessValue, boolean valueIsAbsolute,
-            @Nullable Resource source) throws CriticalFieldMissingException {
-        Double bri;
-        if (valueIsAbsolute) {
-            bri = brightnessValue;
-        } else if (source != null && source.getDimmingValue() instanceof Double dim) {
-            bri = dim + brightnessValue;
-        } else {
-            throw new CriticalFieldMissingException("Not enough data to create hard on/off command");
-        }
-        return OnOffType.from(bri > 0.0);
     }
 
     /**

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/Clip2ThingHandler.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/Clip2ThingHandler.java
@@ -1894,9 +1894,9 @@ public class Clip2ThingHandler extends BaseThingHandler {
 
     /**
      * Helper for {@link IncreaseDecreaseType} command processing.
-     * Handles the logic for adjusting the brightness based on the given Increase/Decrease command, and returns
-     * an adjunct {@link OnOffType.ON} to be appended to the pay-load. It translates the +/- relative command
-     * to absolute brightness commands (since these are more reliable).
+     * Adjusts brightness based on the given Increase/Decrease command and returns an adjunct {@link OnOffType}
+     * (ON or OFF) to be appended to the payload. It converts the relative command into an absolute brightness value
+     * when possible (using the bridge’s current state) to avoid relying on potentially stale cached values.
      *
      * @param command the {@link IncreaseDecreaseType} command.
      * @param putResource the resource to be sent to the bridge.

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/Clip2ThingHandler.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/Clip2ThingHandler.java
@@ -46,6 +46,7 @@ import org.openhab.binding.hue.internal.api.dto.clip2.Effects;
 import org.openhab.binding.hue.internal.api.dto.clip2.Gamut2;
 import org.openhab.binding.hue.internal.api.dto.clip2.MetaData;
 import org.openhab.binding.hue.internal.api.dto.clip2.MirekSchema;
+import org.openhab.binding.hue.internal.api.dto.clip2.OnState;
 import org.openhab.binding.hue.internal.api.dto.clip2.PairXy;
 import org.openhab.binding.hue.internal.api.dto.clip2.ProductData;
 import org.openhab.binding.hue.internal.api.dto.clip2.Resource;
@@ -1908,14 +1909,16 @@ public class Clip2ThingHandler extends BaseThingHandler {
         if (cache != null) {
             Resource actual = getResource(cache.getType(), cache.getId());
             if (actual != null) {
-                double brightnessActual = actual.getDimming() instanceof Dimming dim
-                        && dim.getBrightness() instanceof Double bri ? bri : -1;
-                if (brightnessActual >= 0) {
-                    double brightnessTarget = inc //
-                            ? Math.min(100.0, brightnessActual + INCREASE_DECREASE_PERCENT)
-                            : Math.max(0.0, brightnessActual - INCREASE_DECREASE_PERCENT);
-                    putResource.setBrightness(new PercentType(BigDecimal.valueOf(brightnessTarget)));
-                    return OnOffType.from(brightnessTarget > 0.0);
+                double brightnessActual = (actual.getDimming() instanceof Dimming dim
+                        && dim.getBrightness() instanceof Double bri) ? bri : -1;
+                if (brightnessActual >= 0.0) {
+                    if (inc || (actual.getOnState() instanceof OnState on && Boolean.TRUE.equals(on.getOn()))) {
+                        double brightnessTarget = inc //
+                                ? Math.min(100.0, brightnessActual + INCREASE_DECREASE_PERCENT)
+                                : Math.max(0.0, brightnessActual - INCREASE_DECREASE_PERCENT);
+                        putResource.setBrightness(new PercentType(BigDecimal.valueOf(brightnessTarget)));
+                        return OnOffType.from(brightnessTarget > 0.0);
+                    }
                 }
             }
         }

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/Clip2ThingHandler.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/Clip2ThingHandler.java
@@ -167,7 +167,7 @@ public class Clip2ThingHandler extends BaseThingHandler {
     private static final QuantityType<?> DEFAULT_ALARM_DURATION = QuantityType.valueOf(3, Units.SECOND);
 
     // step size for IncreaseDecreaseType commands on brightness and color temperature channels
-    private static final int INC_DEC_STEP = 10;
+    private static final int INC_DEC_PERCENT = 10;
 
     /**
      * A map of service Resources whose state contributes to the overall state of this thing. It is a map between the
@@ -449,8 +449,12 @@ public class Clip2ThingHandler extends BaseThingHandler {
                 break;
 
             case CHANNEL_2_COLOR_TEMP_PERCENT:
-                if (command instanceof IncreaseDecreaseType increaseDecreaseCommand) {
-                    putResource = new Resource(lightResourceType).setMirekDelta(increaseDecreaseCommand, INC_DEC_STEP);
+                if (command instanceof IncreaseDecreaseType incDecCommand) {
+                    MirekSchema schema = cache != null ? cache.getMirekSchema() : null;
+                    schema = schema != null ? schema : MirekSchema.DEFAULT_SCHEMA;
+                    double mirekRange = schema.getMirekMaximum() - schema.getMirekMinimum();
+                    int mirekDelta = (int) Math.max(mirekRange * INC_DEC_PERCENT / 100.0, INC_DEC_PERCENT);
+                    putResource = new Resource(lightResourceType).setMirekDelta(incDecCommand, mirekDelta);
                     break;
                 }
                 if (command instanceof OnOffType) {
@@ -473,12 +477,12 @@ public class Clip2ThingHandler extends BaseThingHandler {
 
             case CHANNEL_2_BRIGHTNESS:
                 putResource = Objects.nonNull(putResource) ? putResource : new Resource(lightResourceType);
-                if (command instanceof IncreaseDecreaseType increaseDecreaseCommand) {
-                    putResource.setDimmingDelta(increaseDecreaseCommand, INC_DEC_STEP);
-                    if (IncreaseDecreaseType.INCREASE == increaseDecreaseCommand) {
+                if (command instanceof IncreaseDecreaseType incDecCommand) {
+                    putResource.setDimmingDelta(incDecCommand, INC_DEC_PERCENT);
+                    if (IncreaseDecreaseType.INCREASE == incDecCommand) {
                         command = OnOffType.ON;
                     } else if (Objects.nonNull(cache) && cache.getDimming() instanceof Dimming dimming
-                            && dimming.getBrightness() <= INC_DEC_STEP) {
+                            && dimming.getBrightness() <= INC_DEC_PERCENT) {
                         command = OnOffType.OFF;
                     } else {
                         break; // i.e. don't append an on-off command
@@ -502,9 +506,8 @@ public class Clip2ThingHandler extends BaseThingHandler {
                 break;
 
             case CHANNEL_2_DIMMING_ONLY:
-                if (command instanceof IncreaseDecreaseType increaseDecreaseCommand) {
-                    putResource = new Resource(lightResourceType).setDimmingDelta(increaseDecreaseCommand,
-                            INC_DEC_STEP);
+                if (command instanceof IncreaseDecreaseType incDecCommand) {
+                    putResource = new Resource(lightResourceType).setDimmingDelta(incDecCommand, INC_DEC_PERCENT);
                 } else {
                     putResource = new Resource(lightResourceType).setBrightness(command);
                 }

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/Clip2ThingHandler.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/Clip2ThingHandler.java
@@ -1940,7 +1940,7 @@ public class Clip2ThingHandler extends BaseThingHandler {
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
         } catch (Exception e) {
-            logger.debug("Failed to fetch light resource type:{}, id:{}", type, id, e);
+            logger.debug("Failed to fetch resource type:{}, id:{}", type, id, e);
         }
         return null;
     }

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/Clip2ThingHandler.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/Clip2ThingHandler.java
@@ -509,8 +509,9 @@ public class Clip2ThingHandler extends BaseThingHandler {
                     // fall through to append the on-off command
                 } else if (command instanceof PercentType brightnessCommand) {
                     putResource = putResource.setBrightness(brightnessCommand);
-                    predictedBrightness = Math.max(0.0, Math.min(100.0, brightnessCommand.doubleValue()));
-                    command = OnOffType.from(predictedBrightness > 0.0); // avoid "soft off"
+                    double predicted = Math.max(0.0, Math.min(100.0, brightnessCommand.doubleValue()));
+                    predictedBrightness = predicted;
+                    command = OnOffType.from(predicted > 0.0); // avoid "soft off"
                 }
                 // NB fall through for handling of switch related commands !!
 
@@ -720,11 +721,11 @@ public class Clip2ThingHandler extends BaseThingHandler {
             logger.debug("{} -> loopBackNotify() with resource {}", resourceId, resource);
 
             // align dimming with the locally predicted brightness for synthetic updates
-            if (LIGHT_TYPES.contains(resource.getType()) && predictedBrightness != null) {
+            if (LIGHT_TYPES.contains(resource.getType()) && predictedBrightness instanceof Double predicted) {
                 if (resource.getDimming() instanceof Dimming dimming) {
-                    dimming.setBrightness(predictedBrightness);
+                    dimming.setBrightness(predicted);
                 } else {
-                    resource.setDimming(new Dimming().setBrightness(predictedBrightness));
+                    resource.setDimming(new Dimming().setBrightness(predicted));
                 }
             }
 
@@ -948,15 +949,15 @@ public class Clip2ThingHandler extends BaseThingHandler {
             Resource cachedResource = getResourceFromCache(resource);
             if (cachedResource != null) {
                 Setters.setResource(resource, cachedResource);
-                if (LIGHT_TYPES.contains(resource.getType()) && predictedBrightness != null) {
+                if (LIGHT_TYPES.contains(resource.getType()) && predictedBrightness instanceof Double predicted) {
                     if (resource.getOnState() instanceof OnState onState && Boolean.FALSE.equals(onState.getOn())) {
                         if (resource.getDimming() instanceof Dimming dimming) {
-                            dimming.setBrightness(predictedBrightness);
+                            dimming.setBrightness(predicted);
                         } else {
-                            resource.setDimming(new Dimming().setBrightness(predictedBrightness));
+                            resource.setDimming(new Dimming().setBrightness(predicted));
                         }
-                    } else if (resource.getDimming() instanceof Dimming dimming
-                            && Math.abs(dimming.getBrightness() - predictedBrightness) < 0.01) {
+                    } else if (resource.getDimming() instanceof Dimming dim && dim.getBrightness() instanceof Double bri
+                            && Math.abs(bri - predicted) < 0.01) {
                         predictedBrightness = null;
                     }
                 }
@@ -1946,8 +1947,9 @@ public class Clip2ThingHandler extends BaseThingHandler {
      * Private helper for increase/decrease commands.
      */
     private double getPredictedBrightness(@Nullable Resource cache) {
-        if (predictedBrightness != null) {
-            return predictedBrightness;
+        Double predicted = predictedBrightness;
+        if (predicted != null) {
+            return predicted;
         }
         if (cache != null && cache.getDimming() instanceof Dimming dim && dim.getBrightness() instanceof Double bri) {
             return bri.doubleValue();

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/Clip2ThingHandler.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/Clip2ThingHandler.java
@@ -14,7 +14,6 @@ package org.openhab.binding.hue.internal.handler;
 
 import static org.openhab.binding.hue.internal.HueBindingConstants.*;
 
-import java.math.BigDecimal;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -166,6 +165,9 @@ public class Clip2ThingHandler extends BaseThingHandler {
     // smart chime devices use write-only volume and duration channels, so these are their default values
     private static final PercentType DEFAULT_SOUND_VOLUME = new PercentType(50);
     private static final QuantityType<?> DEFAULT_ALARM_DURATION = QuantityType.valueOf(3, Units.SECOND);
+
+    // step size for IncreaseDecreaseType commands on brightness and color temperature channels
+    private static final int INC_DEC_STEP = 10;
 
     /**
      * A map of service Resources whose state contributes to the overall state of this thing. It is a map between the
@@ -447,10 +449,11 @@ public class Clip2ThingHandler extends BaseThingHandler {
                 break;
 
             case CHANNEL_2_COLOR_TEMP_PERCENT:
-                if (command instanceof IncreaseDecreaseType increaseDecreaseCommand && Objects.nonNull(cache)) {
-                    command = translateIncreaseDecreaseCommand(increaseDecreaseCommand,
-                            cache.getColorTemperaturePercentState());
-                } else if (command instanceof OnOffType) {
+                if (command instanceof IncreaseDecreaseType increaseDecreaseCommand) {
+                    putResource = new Resource(lightResourceType).setMirekDelta(increaseDecreaseCommand, INC_DEC_STEP);
+                    break;
+                }
+                if (command instanceof OnOffType) {
                     command = OnOffType.OFF == command ? PercentType.ZERO : PercentType.HUNDRED;
                 }
                 putResource = Setters.setColorTemperaturePercent(new Resource(lightResourceType), command, cache);
@@ -470,13 +473,20 @@ public class Clip2ThingHandler extends BaseThingHandler {
 
             case CHANNEL_2_BRIGHTNESS:
                 putResource = Objects.nonNull(putResource) ? putResource : new Resource(lightResourceType);
-                if (command instanceof IncreaseDecreaseType increaseDecreaseCommand && Objects.nonNull(cache)) {
-                    command = translateIncreaseDecreaseCommand(increaseDecreaseCommand, cache.getBrightnessState());
-                }
-                if (command instanceof PercentType brightnessCommand) {
+                if (command instanceof IncreaseDecreaseType increaseDecreaseCommand) {
+                    putResource.setDimmingDelta(increaseDecreaseCommand, INC_DEC_STEP);
+                    if (IncreaseDecreaseType.INCREASE == increaseDecreaseCommand) {
+                        command = OnOffType.ON;
+                    } else if (Objects.nonNull(cache) && cache.getDimming() instanceof Dimming dimming
+                            && dimming.getBrightness() <= INC_DEC_STEP) {
+                        command = OnOffType.OFF;
+                    } else {
+                        break; // i.e. don't append an on-off command
+                    }
+                    // fall through to append the on-off command
+                } else if (command instanceof PercentType brightnessCommand) {
                     putResource = putResource.setBrightness(brightnessCommand);
-                    double brightnessAbsolute = brightnessCommand.doubleValue();
-                    command = Setters.getHardOnOff(putResource, brightnessAbsolute, true, cache); // avoid "soft off"
+                    command = OnOffType.from(brightnessCommand.doubleValue() > 0.0); // avoid "soft off"
                 }
                 // NB fall through for handling of switch related commands !!
 
@@ -492,7 +502,12 @@ public class Clip2ThingHandler extends BaseThingHandler {
                 break;
 
             case CHANNEL_2_DIMMING_ONLY:
-                putResource = new Resource(lightResourceType).setBrightness(command);
+                if (command instanceof IncreaseDecreaseType increaseDecreaseCommand) {
+                    putResource = new Resource(lightResourceType).setDimmingDelta(increaseDecreaseCommand,
+                            INC_DEC_STEP);
+                } else {
+                    putResource = new Resource(lightResourceType).setBrightness(command);
+                }
                 break;
 
             case CHANNEL_2_ON_OFF_ONLY:
@@ -719,16 +734,6 @@ public class Clip2ThingHandler extends BaseThingHandler {
      */
     private ResourceType getExtendedResourceType(ResourceType baseType) {
         return extendedResourceTypes.get(baseType) instanceof ResourceType extendedType ? extendedType : baseType;
-    }
-
-    private Command translateIncreaseDecreaseCommand(IncreaseDecreaseType command, State currentValue) {
-        if (currentValue instanceof PercentType currentPercent) {
-            int delta = command == IncreaseDecreaseType.INCREASE ? 10 : -10;
-            double newPercent = Math.min(100.0, Math.max(0.0, currentPercent.doubleValue() + delta));
-            return new PercentType(new BigDecimal(newPercent, Resource.PERCENT_MATH_CONTEXT));
-        }
-
-        return command;
     }
 
     private void refreshAllChannels() {

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/Clip2ThingHandler.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/Clip2ThingHandler.java
@@ -1895,7 +1895,7 @@ public class Clip2ThingHandler extends BaseThingHandler {
      * Helper for {@link IncreaseDecreaseType} command processing.
      * Adjusts brightness based on the given Increase/Decrease command and returns an adjunct {@link OnOffType}
      * to be appended to the payload. It converts the relative command into an absolute brightness value since
-     * live testing has shown that it leads to a more predictable / reliable outcomes.
+     * live testing has shown that it leads to more predictable / reliable outcomes.
      *
      * @param command the {@link IncreaseDecreaseType} command.
      * @param putResource the resource to be sent to the bridge.
@@ -1940,7 +1940,7 @@ public class Clip2ThingHandler extends BaseThingHandler {
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
         } catch (Exception e) {
-            logger.debug("Failed to fetch light resource type:{}, id:{} {}", type, id, e.getMessage(), e);
+            logger.debug("Failed to fetch light resource type:{}, id:{}", type, id, e);
         }
         return null;
     }

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/Clip2ThingHandler.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/Clip2ThingHandler.java
@@ -482,27 +482,38 @@ public class Clip2ThingHandler extends BaseThingHandler {
             case CHANNEL_2_BRIGHTNESS:
                 putResource = Objects.nonNull(putResource) ? putResource : new Resource(lightResourceType);
                 if (command instanceof IncreaseDecreaseType incDecCommand) {
-                    double brightnessBefore = getPredictedBrightness(cache);
-                    double brightnessAfter = switch (incDecCommand) {
-                        case INCREASE -> Math.min(100.0, brightnessBefore + INC_DEC_PERCENT);
-                        case DECREASE -> Math.max(0.0, brightnessBefore - INC_DEC_PERCENT);
-                    };
-                    predictedBrightness = brightnessAfter;
-                    command = switch (incDecCommand) {
-                        case INCREASE -> {
-                            putResource.setDimmingDelta(incDecCommand, INC_DEC_PERCENT);
-                            yield brightnessBefore <= 0.0 ? OnOffType.ON : null;
+                    Double brightnessBeforeObj = predictedBrightness;
+                    if (brightnessBeforeObj == null && cache != null && cache.getDimming() instanceof Dimming dimming
+                            && dimming.getBrightness() instanceof Double cachedBrightness) {
+                        brightnessBeforeObj = cachedBrightness;
+                    }
+                    if (brightnessBeforeObj == null) {
+                        putResource.setDimmingDelta(incDecCommand, INC_DEC_PERCENT);
+                        if (incDecCommand == IncreaseDecreaseType.INCREASE) {
+                            command = OnOffType.ON;
+                        } else {
+                            break;
                         }
-                        case DECREASE -> {
-                            if (brightnessAfter <= 0.0) {
-                                putResource = new Resource(lightResourceType);
-                                yield OnOffType.OFF;
-                            } else {
-                                putResource.setDimmingDelta(incDecCommand, INC_DEC_PERCENT);
-                                yield null;
+                    } else {
+                        double brightnessBefore = brightnessBeforeObj.doubleValue();
+                        double brightnessAfter = switch (incDecCommand) {
+                            case INCREASE -> Math.min(100.0, brightnessBefore + INC_DEC_PERCENT);
+                            case DECREASE -> Math.max(0.0, brightnessBefore - INC_DEC_PERCENT);
+                        };
+                        predictedBrightness = brightnessAfter;
+                        command = switch (incDecCommand) {
+                            case INCREASE -> brightnessBefore <= 0.0 ? OnOffType.ON : null;
+                            case DECREASE -> {
+                                if (brightnessAfter <= 0.0) {
+                                    putResource = new Resource(lightResourceType);
+                                    yield OnOffType.OFF;
+                                } else {
+                                    putResource.setDimmingDelta(incDecCommand, INC_DEC_PERCENT);
+                                    yield null;
+                                }
                             }
-                        }
-                    };
+                        };
+                    }
                     if (command == null) {
                         break; // i.e. don't append an on-off command
                     }
@@ -647,7 +658,9 @@ public class Clip2ThingHandler extends BaseThingHandler {
                 return;
         }
 
-        if (putResource == null) {
+        if (putResource == null)
+
+        {
             if (logger.isDebugEnabled()) {
                 logger.debug("{} -> handleCommand() command:{} not supported on channelUID:{}", resourceId, command,
                         channelUID);
@@ -1941,19 +1954,5 @@ public class Clip2ThingHandler extends BaseThingHandler {
             }
             updateLightCacheRequiredFieldsDone = true;
         }
-    }
-
-    /**
-     * Private helper for increase/decrease commands.
-     */
-    private double getPredictedBrightness(@Nullable Resource cache) {
-        Double predicted = predictedBrightness;
-        if (predicted != null) {
-            return predicted;
-        }
-        if (cache != null && cache.getDimming() instanceof Dimming dim && dim.getBrightness() instanceof Double bri) {
-            return bri.doubleValue();
-        }
-        return 0.0;
     }
 }

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/Clip2ThingHandler.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/Clip2ThingHandler.java
@@ -45,6 +45,7 @@ import org.openhab.binding.hue.internal.api.dto.clip2.Effects;
 import org.openhab.binding.hue.internal.api.dto.clip2.Gamut2;
 import org.openhab.binding.hue.internal.api.dto.clip2.MetaData;
 import org.openhab.binding.hue.internal.api.dto.clip2.MirekSchema;
+import org.openhab.binding.hue.internal.api.dto.clip2.OnState;
 import org.openhab.binding.hue.internal.api.dto.clip2.PairXy;
 import org.openhab.binding.hue.internal.api.dto.clip2.ProductData;
 import org.openhab.binding.hue.internal.api.dto.clip2.Resource;
@@ -253,6 +254,8 @@ public class Clip2ThingHandler extends BaseThingHandler {
     private @Nullable Future<?> updateDependenciesTask;
     private @Nullable Future<?> updateServiceContributorsTask;
 
+    private @Nullable Double predictedBrightness; // support for increase/decrease commands
+
     public Clip2ThingHandler(Thing thing, Clip2StateDescriptionProvider stateDescriptionProvider,
             ThingRegistry thingRegistry, ItemChannelLinkRegistry itemChannelLinkRegistry) {
         super(thing);
@@ -347,6 +350,7 @@ public class Clip2ThingHandler extends BaseThingHandler {
         serviceContributorsCache.clear();
         controlIds.clear();
         extendedResourceTypes.clear();
+        predictedBrightness = null;
     }
 
     /**
@@ -478,19 +482,35 @@ public class Clip2ThingHandler extends BaseThingHandler {
             case CHANNEL_2_BRIGHTNESS:
                 putResource = Objects.nonNull(putResource) ? putResource : new Resource(lightResourceType);
                 if (command instanceof IncreaseDecreaseType incDecCommand) {
-                    putResource.setDimmingDelta(incDecCommand, INC_DEC_PERCENT);
-                    if (IncreaseDecreaseType.INCREASE == incDecCommand) {
-                        command = OnOffType.ON;
-                    } else if (Objects.nonNull(cache) && cache.getDimming() instanceof Dimming dimming
-                            && dimming.getBrightness() <= INC_DEC_PERCENT) {
-                        command = OnOffType.OFF;
-                    } else {
+                    double brightnessBefore = getPredictedBrightness(cache);
+                    double brightnessAfter = switch (incDecCommand) {
+                        case INCREASE -> Math.min(100.0, brightnessBefore + INC_DEC_PERCENT);
+                        case DECREASE -> Math.max(0.0, brightnessBefore - INC_DEC_PERCENT);
+                    };
+                    predictedBrightness = brightnessAfter;
+                    command = switch (incDecCommand) {
+                        case INCREASE -> {
+                            putResource.setDimmingDelta(incDecCommand, INC_DEC_PERCENT);
+                            yield brightnessBefore <= 0.0 ? OnOffType.ON : null;
+                        }
+                        case DECREASE -> {
+                            if (brightnessAfter <= 0.0) {
+                                putResource = new Resource(lightResourceType);
+                                yield OnOffType.OFF;
+                            } else {
+                                putResource.setDimmingDelta(incDecCommand, INC_DEC_PERCENT);
+                                yield null;
+                            }
+                        }
+                    };
+                    if (command == null) {
                         break; // i.e. don't append an on-off command
                     }
                     // fall through to append the on-off command
                 } else if (command instanceof PercentType brightnessCommand) {
                     putResource = putResource.setBrightness(brightnessCommand);
-                    command = OnOffType.from(brightnessCommand.doubleValue() > 0.0); // avoid "soft off"
+                    predictedBrightness = Math.max(0.0, Math.min(100.0, brightnessCommand.doubleValue()));
+                    command = OnOffType.from(predictedBrightness > 0.0); // avoid "soft off"
                 }
                 // NB fall through for handling of switch related commands !!
 
@@ -699,6 +719,15 @@ public class Clip2ThingHandler extends BaseThingHandler {
         scheduler.submit(() -> {
             logger.debug("{} -> loopBackNotify() with resource {}", resourceId, resource);
 
+            // align dimming with the locally predicted brightness for synthetic updates
+            if (LIGHT_TYPES.contains(resource.getType()) && predictedBrightness != null) {
+                if (resource.getDimming() instanceof Dimming dimming) {
+                    dimming.setBrightness(predictedBrightness);
+                } else {
+                    resource.setDimming(new Dimming().setBrightness(predictedBrightness));
+                }
+            }
+
             // add DTO fields to synch ColorXy and ColorTemperature for commands to the counterpart channel
             if (ResourceType.LIGHT == resource.getType()) {
                 ColorXy colorXy = resource.getColorXy();
@@ -846,6 +875,7 @@ public class Clip2ThingHandler extends BaseThingHandler {
         updateLightCacheRequiredFieldsDone = false;
         updateSceneContributorsDone = false;
         legacyLightState = null;
+        predictedBrightness = null;
 
         Bridge bridge = getBridge();
         if (Objects.nonNull(bridge)) {
@@ -918,6 +948,18 @@ public class Clip2ThingHandler extends BaseThingHandler {
             Resource cachedResource = getResourceFromCache(resource);
             if (cachedResource != null) {
                 Setters.setResource(resource, cachedResource);
+                if (LIGHT_TYPES.contains(resource.getType()) && predictedBrightness != null) {
+                    if (resource.getOnState() instanceof OnState onState && Boolean.FALSE.equals(onState.getOn())) {
+                        if (resource.getDimming() instanceof Dimming dimming) {
+                            dimming.setBrightness(predictedBrightness);
+                        } else {
+                            resource.setDimming(new Dimming().setBrightness(predictedBrightness));
+                        }
+                    } else if (resource.getDimming() instanceof Dimming dimming
+                            && Math.abs(dimming.getBrightness() - predictedBrightness) < 0.01) {
+                        predictedBrightness = null;
+                    }
+                }
                 resourceConsumedFlags |= FLAG_CACHE_UPDATE;
                 resourceConsumedFlags |= updateChannels && updateChannels(resource) ? FLAG_CHANNELS_UPDATE : 0;
                 putResourceToCache(resource);
@@ -1898,5 +1940,18 @@ public class Clip2ThingHandler extends BaseThingHandler {
             }
             updateLightCacheRequiredFieldsDone = true;
         }
+    }
+
+    /**
+     * Private helper for increase/decrease commands.
+     */
+    private double getPredictedBrightness(@Nullable Resource cache) {
+        if (predictedBrightness != null) {
+            return predictedBrightness;
+        }
+        if (cache != null && cache.getDimming() instanceof Dimming dim && dim.getBrightness() instanceof Double bri) {
+            return bri.doubleValue();
+        }
+        return 0.0;
     }
 }

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/Clip2ThingHandler.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/Clip2ThingHandler.java
@@ -1894,8 +1894,8 @@ public class Clip2ThingHandler extends BaseThingHandler {
     /**
      * Helper for {@link IncreaseDecreaseType} command processing.
      * Adjusts brightness based on the given Increase/Decrease command and returns an adjunct {@link OnOffType}
-     * (ON or OFF) to be appended to the payload. It converts the relative command into an absolute brightness value
-     * when possible (using the bridge’s current state) to avoid relying on potentially stale cached values.
+     * to be appended to the payload. It converts the relative command into an absolute brightness value since
+     * live testing has shown that it leads to a more predictable / reliable outcomes.
      *
      * @param command the {@link IncreaseDecreaseType} command.
      * @param putResource the resource to be sent to the bridge.
@@ -1931,7 +1931,7 @@ public class Clip2ThingHandler extends BaseThingHandler {
      *
      * @param type the resource type.
      * @param id the resource id.
-     * @return the current resource, or null if it cannot be fetched.
+     * @return the respective resource or null if it cannot be fetched.
      */
     private @Nullable Resource getResource(ResourceType type, String id) {
         try {
@@ -1940,7 +1940,7 @@ public class Clip2ThingHandler extends BaseThingHandler {
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
         } catch (Exception e) {
-            logger.debug("Failed to fetch current light resource: {}", e.getMessage());
+            logger.debug("Failed to fetch light resource type:{}, id:{} {}", type, id, e.getMessage(), e);
         }
         return null;
     }

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/Clip2ThingHandler.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/Clip2ThingHandler.java
@@ -501,7 +501,7 @@ public class Clip2ThingHandler extends BaseThingHandler {
                 break;
 
             case CHANNEL_2_DIMMING_ONLY:
-                putResource = new Resource(lightResourceType).setBrightness(brightnessCommand);
+                putResource = new Resource(lightResourceType).setBrightness(command);
                 break;
 
             case CHANNEL_2_ON_OFF_ONLY:

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/Clip2ThingHandler.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/Clip2ThingHandler.java
@@ -254,7 +254,7 @@ public class Clip2ThingHandler extends BaseThingHandler {
     private @Nullable Future<?> updateDependenciesTask;
     private @Nullable Future<?> updateServiceContributorsTask;
 
-    private @Nullable Double predictedBrightness; // support for increase/decrease commands
+    private volatile @Nullable Double predictedBrightness; // support for increase/decrease commands
 
     public Clip2ThingHandler(Thing thing, Clip2StateDescriptionProvider stateDescriptionProvider,
             ThingRegistry thingRegistry, ItemChannelLinkRegistry itemChannelLinkRegistry) {

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/Clip2ThingHandler.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/Clip2ThingHandler.java
@@ -130,6 +130,7 @@ public class Clip2ThingHandler extends BaseThingHandler {
             Archetype.HUE_LIGHTSTRIP_TV, Archetype.HUE_TUBE, Archetype.STRING_LIGHT, Archetype.CHRISTMAS_TREE);
 
     private static final Duration DYNAMICS_ACTIVE_WINDOW = Duration.ofSeconds(10);
+    private static final Duration PREDICTED_BRIGHTNESS_RESET_DELAY = Duration.ofSeconds(2);
 
     /*
      * Pre-compiled pattern matcher based on the following set of Model Id regular expressions for devices having
@@ -253,8 +254,10 @@ public class Clip2ThingHandler extends BaseThingHandler {
     private @Nullable Future<?> dynamicsResetTask;
     private @Nullable Future<?> updateDependenciesTask;
     private @Nullable Future<?> updateServiceContributorsTask;
+    private @Nullable Future<?> predictedBrightnessResetTask;
 
-    private volatile @Nullable Double predictedBrightness; // support for increase/decrease commands
+    // support for IncreaseDecreaseType commands on brightness channels where bridge feedback may lag
+    private volatile @Nullable Double predictedBrightness;
 
     public Clip2ThingHandler(Thing thing, Clip2StateDescriptionProvider stateDescriptionProvider,
             ThingRegistry thingRegistry, ItemChannelLinkRegistry itemChannelLinkRegistry) {
@@ -338,10 +341,12 @@ public class Clip2ThingHandler extends BaseThingHandler {
         cancelTask(dynamicsResetTask, true);
         cancelTask(updateDependenciesTask, true);
         cancelTask(updateServiceContributorsTask, true);
+        cancelTask(predictedBrightnessResetTask, true);
         alertResetTask = null;
         dynamicsResetTask = null;
         updateDependenciesTask = null;
         updateServiceContributorsTask = null;
+        predictedBrightnessResetTask = null;
         legacyLinkedChannelUIDs.clear();
         sceneContributorsCache.clear();
         sceneResourceEntries.clear();
@@ -350,7 +355,7 @@ public class Clip2ThingHandler extends BaseThingHandler {
         serviceContributorsCache.clear();
         controlIds.clear();
         extendedResourceTypes.clear();
-        predictedBrightness = null;
+        clearPredictedBrightness();
     }
 
     /**
@@ -482,56 +487,25 @@ public class Clip2ThingHandler extends BaseThingHandler {
             case CHANNEL_2_BRIGHTNESS:
                 putResource = Objects.nonNull(putResource) ? putResource : new Resource(lightResourceType);
                 if (command instanceof IncreaseDecreaseType incDecCommand) {
-                    Double brightnessBeforeObj = predictedBrightness;
-                    if (brightnessBeforeObj == null && cache != null && cache.getDimming() instanceof Dimming dimming
-                            && dimming.getBrightness() instanceof Double cachedBrightness) {
-                        brightnessBeforeObj = cachedBrightness;
-                    }
-                    if (brightnessBeforeObj == null) {
-                        putResource.setDimmingDelta(incDecCommand, INC_DEC_PERCENT);
-                        if (incDecCommand == IncreaseDecreaseType.INCREASE) {
-                            command = OnOffType.ON;
-                        } else {
-                            break;
-                        }
-                    } else {
-                        double brightnessBefore = brightnessBeforeObj.doubleValue();
-                        double brightnessAfter = switch (incDecCommand) {
-                            case INCREASE -> Math.min(100.0, brightnessBefore + INC_DEC_PERCENT);
-                            case DECREASE -> Math.max(0.0, brightnessBefore - INC_DEC_PERCENT);
-                        };
-                        predictedBrightness = brightnessAfter;
-                        command = switch (incDecCommand) {
-                            case INCREASE -> {
-                                putResource.setDimmingDelta(incDecCommand, INC_DEC_PERCENT);
-                                yield brightnessBefore <= 0.0 ? OnOffType.ON : null;
-                            }
-                            case DECREASE -> {
-                                if (brightnessAfter <= 0.0) {
-                                    putResource = new Resource(lightResourceType);
-                                    yield OnOffType.OFF;
-                                } else {
-                                    putResource.setDimmingDelta(incDecCommand, INC_DEC_PERCENT);
-                                    yield null;
-                                }
-                            }
-                        };
-                    }
+                    command = handleIncreaseDecreaseBrightnessCommand(incDecCommand, putResource, cache);
                     if (command == null) {
-                        break; // i.e. don't append an on-off command
+                        break; // i.e. no on-off command to append
                     }
-                    // fall through to append the on-off command
+                    // fall through to append any on-off command
                 } else if (command instanceof PercentType brightnessCommand) {
                     putResource = putResource.setBrightness(brightnessCommand);
-                    double predicted = Math.max(0.0, Math.min(100.0, brightnessCommand.doubleValue()));
-                    predictedBrightness = predicted;
-                    command = OnOffType.from(predicted > 0.0); // avoid "soft off"
+                    double brightness = Math.max(0.0, Math.min(100.0, brightnessCommand.doubleValue()));
+                    clearPredictedBrightness();
+                    command = OnOffType.from(brightness > 0.0); // avoid "soft off"
                 }
                 // NB fall through for handling of switch related commands !!
 
             case CHANNEL_2_SWITCH:
                 putResource = Objects.nonNull(putResource) ? putResource : new Resource(lightResourceType);
                 putResource.setOnOff(command);
+                if (OnOffType.OFF == command) {
+                    clearPredictedBrightness();
+                }
                 applyOffTransitionWorkAround(command, putResource);
                 applyColorTemperatureWorkAround(command, putResource);
                 break;
@@ -541,15 +515,17 @@ public class Clip2ThingHandler extends BaseThingHandler {
                 break;
 
             case CHANNEL_2_DIMMING_ONLY:
-                if (command instanceof IncreaseDecreaseType incDecCommand) {
-                    putResource = new Resource(lightResourceType).setDimmingDelta(incDecCommand, INC_DEC_PERCENT);
-                } else {
-                    putResource = new Resource(lightResourceType).setBrightness(command);
+                if (command instanceof PercentType brightnessCommand) {
+                    putResource = new Resource(lightResourceType).setBrightness(brightnessCommand);
+                    clearPredictedBrightness();
                 }
                 break;
 
             case CHANNEL_2_ON_OFF_ONLY:
                 putResource = new Resource(lightResourceType).setOnOff(command);
+                if (OnOffType.OFF == command) {
+                    clearPredictedBrightness();
+                }
                 applyOffTransitionWorkAround(command, putResource);
                 break;
 
@@ -661,9 +637,7 @@ public class Clip2ThingHandler extends BaseThingHandler {
                 return;
         }
 
-        if (putResource == null)
-
-        {
+        if (putResource == null) {
             if (logger.isDebugEnabled()) {
                 logger.debug("{} -> handleCommand() command:{} not supported on channelUID:{}", resourceId, command,
                         channelUID);
@@ -737,12 +711,8 @@ public class Clip2ThingHandler extends BaseThingHandler {
             logger.debug("{} -> loopBackNotify() with resource {}", resourceId, resource);
 
             // align dimming with the locally predicted brightness for synthetic updates
-            if (LIGHT_TYPES.contains(resource.getType()) && predictedBrightness instanceof Double predicted) {
-                if (resource.getDimming() instanceof Dimming dimming) {
-                    dimming.setBrightness(predicted);
-                } else {
-                    resource.setDimming(new Dimming().setBrightness(predicted));
-                }
+            if (LIGHT_TYPES.contains(resource.getType())) {
+                updateDimmingFromPredictedBrightness(resource);
             }
 
             // add DTO fields to synch ColorXy and ColorTemperature for commands to the counterpart channel
@@ -892,7 +862,8 @@ public class Clip2ThingHandler extends BaseThingHandler {
         updateLightCacheRequiredFieldsDone = false;
         updateSceneContributorsDone = false;
         legacyLightState = null;
-        predictedBrightness = null;
+
+        clearPredictedBrightness();
 
         Bridge bridge = getBridge();
         if (Objects.nonNull(bridge)) {
@@ -965,17 +936,8 @@ public class Clip2ThingHandler extends BaseThingHandler {
             Resource cachedResource = getResourceFromCache(resource);
             if (cachedResource != null) {
                 Setters.setResource(resource, cachedResource);
-                if (LIGHT_TYPES.contains(resource.getType()) && predictedBrightness instanceof Double predicted) {
-                    if (resource.getOnState() instanceof OnState onState && Boolean.FALSE.equals(onState.getOn())) {
-                        if (resource.getDimming() instanceof Dimming dimming) {
-                            dimming.setBrightness(predicted);
-                        } else {
-                            resource.setDimming(new Dimming().setBrightness(predicted));
-                        }
-                    } else if (resource.getDimming() instanceof Dimming dim && dim.getBrightness() instanceof Double bri
-                            && Math.abs(bri - predicted) < 0.01) {
-                        predictedBrightness = null;
-                    }
+                if (LIGHT_TYPES.contains(resource.getType())) {
+                    updatePredictedBrightness(resource);
                 }
                 resourceConsumedFlags |= FLAG_CACHE_UPDATE;
                 resourceConsumedFlags |= updateChannels && updateChannels(resource) ? FLAG_CHANNELS_UPDATE : 0;
@@ -1957,5 +1919,146 @@ public class Clip2ThingHandler extends BaseThingHandler {
             }
             updateLightCacheRequiredFieldsDone = true;
         }
+    }
+
+    /**
+     * Helper for increase/decrease command processing. Get the predicted brightness value, if it is set,
+     * otherwise get the cached brightness value from the given resource.
+     *
+     * @param cachedResource the cached resource with the current state, may be null.
+     * @return the predicted brightness value, or null if not set and not available in the cache.
+     */
+    private @Nullable Double getPredictedBrightness(@Nullable Resource cachedResource) {
+        Double predicted = predictedBrightness;
+        if (predicted != null) {
+            return predicted;
+        }
+        if (cachedResource != null && cachedResource.getDimming() instanceof Dimming dimming
+                && dimming.getBrightness() instanceof Double brightness) {
+            return brightness;
+        }
+        return null;
+    }
+
+    /**
+     * Helper for increase/decrease command processing. Set the predicted brightness value, ensuring it is
+     * clamped between 0.0 and 100.0.
+     *
+     * @param brightness the predicted brightness value to set.
+     */
+    private void setPredictedBrightness(double brightness) {
+        predictedBrightness = Math.max(0.0, Math.min(100.0, brightness));
+        restartPredictedBrightnessResetTask();
+    }
+
+    /**
+     * Helper for {@link IncreaseDecreaseType} command processing. Handles the logic for adjusting the brightness of
+     * a light resource based on the given INCREASE or DECREASE command. It compares the intent of the command against
+     * the current predicted brightness, and handles the following edge cases:
+     * <ul>
+     * <li>If increasing and old brightness is null, sets putResource to an ABSOLUTE amount and returns adjunct ON
+     * command.</li>
+     * <li>If increasing and old brightness is zero, sets putResource to an ABSOLUTE amount and returns adjunct ON
+     * command.</li>
+     * <li>If increasing and old brightness is above zero, sets putResource to increase by a RELATIVE amount.</li>
+     * <li>If decreasing and old brightness is null, sets putResource to decrease by a RELATIVE amount.</li>
+     * <li>If decreasing and new brightness is above zero, sets putResource to decrease by a RELATIVE amount.</li>
+     * <li>If decreasing and new brightness is zero or below, returns adjunct OFF command.</li>
+     * </ul>
+     *
+     * @param command the INCREASE or DECREASE command.
+     * @param putResource the resource to be sent to the bridge.
+     * @param cacheResource the cached resource with the current state, may be null.
+     * @return an adjunct ON or OFF command, or null.
+     */
+    private @Nullable OnOffType handleIncreaseDecreaseBrightnessCommand(IncreaseDecreaseType command,
+            Resource putResource, @Nullable Resource cacheResource) {
+        Double brightnessBeforeObj = getPredictedBrightness(cacheResource);
+
+        if (brightnessBeforeObj == null) {
+            if (IncreaseDecreaseType.INCREASE == command) {
+                putResource.setBrightness(new PercentType(INC_DEC_PERCENT));
+                setPredictedBrightness(INC_DEC_PERCENT);
+                return OnOffType.ON;
+            } else {
+                putResource.setDimmingDelta(command, INC_DEC_PERCENT);
+                return null;
+            }
+        } else {
+            double brightnessBefore = brightnessBeforeObj.doubleValue();
+            double brightnessAfter = switch (command) {
+                case INCREASE -> Math.min(100.0, brightnessBefore + INC_DEC_PERCENT);
+                case DECREASE -> Math.max(0.0, brightnessBefore - INC_DEC_PERCENT);
+            };
+            boolean lightIsOff = cacheResource != null && cacheResource.getOnState() instanceof OnState onState
+                    && Boolean.FALSE.equals(onState.getOn());
+
+            if (IncreaseDecreaseType.INCREASE == command && (lightIsOff || brightnessBefore <= 0.0)) {
+                putResource.setBrightness(new PercentType(INC_DEC_PERCENT));
+                setPredictedBrightness(INC_DEC_PERCENT);
+                return OnOffType.ON;
+            } else if (IncreaseDecreaseType.DECREASE == command && brightnessAfter <= 0.0) {
+                return OnOffType.OFF;
+            } else {
+                putResource.setDimmingDelta(command, INC_DEC_PERCENT);
+                setPredictedBrightness(brightnessAfter);
+                return null;
+            }
+        }
+    }
+
+    /**
+     * Helper for Increase/Decrease command processing. Update the predicted brightness value based on the
+     * given resource.
+     *
+     * @param resource the resource to check for brightness updates.
+     */
+    private void updatePredictedBrightness(Resource resource) {
+        if (resource.getOnState() instanceof OnState onState && Boolean.FALSE.equals(onState.getOn())) {
+            clearPredictedBrightness();
+        } else if (resource.getDimming() instanceof Dimming dimming
+                && dimming.getBrightness() instanceof Double brightness) {
+            Double predicted = predictedBrightness;
+            if (predicted != null && Math.abs(brightness - predicted) < 0.01) {
+                clearPredictedBrightness();
+            }
+        }
+    }
+
+    /**
+     * Helper for Increase/Decrease command processing. Update the dimming brightness value of the given
+     * resource to the predicted brightness.
+     *
+     * @param resource the resource to update.
+     */
+    private void updateDimmingFromPredictedBrightness(Resource resource) {
+        Double predicted = predictedBrightness;
+        if (predicted != null) {
+            if (resource.getOnState() instanceof OnState onState && Boolean.FALSE.equals(onState.getOn())) {
+                if (resource.getDimming() instanceof Dimming dimming) {
+                    dimming.setBrightness(predicted);
+                } else {
+                    resource.setDimming(new Dimming().setBrightness(predicted));
+                }
+            } else if (resource.getDimming() instanceof Dimming dimming) {
+                dimming.setBrightness(predicted);
+            } else {
+                resource.setDimming(new Dimming().setBrightness(predicted));
+            }
+        }
+    }
+
+    private void clearPredictedBrightness() {
+        predictedBrightness = null;
+        cancelTask(predictedBrightnessResetTask, false);
+        predictedBrightnessResetTask = null;
+    }
+
+    private void restartPredictedBrightnessResetTask() {
+        cancelTask(predictedBrightnessResetTask, false);
+        predictedBrightnessResetTask = scheduler.schedule(() -> {
+            predictedBrightness = null;
+            predictedBrightnessResetTask = null;
+        }, PREDICTED_BRIGHTNESS_RESET_DELAY.toMillis(), TimeUnit.MILLISECONDS);
     }
 }

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/Clip2ThingHandler.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/Clip2ThingHandler.java
@@ -14,6 +14,7 @@ package org.openhab.binding.hue.internal.handler;
 
 import static org.openhab.binding.hue.internal.HueBindingConstants.*;
 
+import java.math.BigDecimal;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -45,7 +46,6 @@ import org.openhab.binding.hue.internal.api.dto.clip2.Effects;
 import org.openhab.binding.hue.internal.api.dto.clip2.Gamut2;
 import org.openhab.binding.hue.internal.api.dto.clip2.MetaData;
 import org.openhab.binding.hue.internal.api.dto.clip2.MirekSchema;
-import org.openhab.binding.hue.internal.api.dto.clip2.OnState;
 import org.openhab.binding.hue.internal.api.dto.clip2.PairXy;
 import org.openhab.binding.hue.internal.api.dto.clip2.ProductData;
 import org.openhab.binding.hue.internal.api.dto.clip2.Resource;
@@ -130,7 +130,6 @@ public class Clip2ThingHandler extends BaseThingHandler {
             Archetype.HUE_LIGHTSTRIP_TV, Archetype.HUE_TUBE, Archetype.STRING_LIGHT, Archetype.CHRISTMAS_TREE);
 
     private static final Duration DYNAMICS_ACTIVE_WINDOW = Duration.ofSeconds(10);
-    private static final Duration PREDICTED_BRIGHTNESS_RESET_DELAY = Duration.ofSeconds(2);
 
     /*
      * Pre-compiled pattern matcher based on the following set of Model Id regular expressions for devices having
@@ -168,8 +167,8 @@ public class Clip2ThingHandler extends BaseThingHandler {
     private static final PercentType DEFAULT_SOUND_VOLUME = new PercentType(50);
     private static final QuantityType<?> DEFAULT_ALARM_DURATION = QuantityType.valueOf(3, Units.SECOND);
 
-    // step size for IncreaseDecreaseType commands on brightness and color temperature channels
-    private static final int INC_DEC_PERCENT = 10;
+    // step size for IncreaseDecreaseType commands
+    private static final int INCREASE_DECREASE_PERCENT = 10;
 
     /**
      * A map of service Resources whose state contributes to the overall state of this thing. It is a map between the
@@ -254,10 +253,6 @@ public class Clip2ThingHandler extends BaseThingHandler {
     private @Nullable Future<?> dynamicsResetTask;
     private @Nullable Future<?> updateDependenciesTask;
     private @Nullable Future<?> updateServiceContributorsTask;
-    private @Nullable Future<?> predictedBrightnessResetTask;
-
-    // support for IncreaseDecreaseType commands on brightness channels where bridge feedback may lag
-    private volatile @Nullable Double predictedBrightness;
 
     public Clip2ThingHandler(Thing thing, Clip2StateDescriptionProvider stateDescriptionProvider,
             ThingRegistry thingRegistry, ItemChannelLinkRegistry itemChannelLinkRegistry) {
@@ -341,12 +336,10 @@ public class Clip2ThingHandler extends BaseThingHandler {
         cancelTask(dynamicsResetTask, true);
         cancelTask(updateDependenciesTask, true);
         cancelTask(updateServiceContributorsTask, true);
-        cancelTask(predictedBrightnessResetTask, true);
         alertResetTask = null;
         dynamicsResetTask = null;
         updateDependenciesTask = null;
         updateServiceContributorsTask = null;
-        predictedBrightnessResetTask = null;
         legacyLinkedChannelUIDs.clear();
         sceneContributorsCache.clear();
         sceneResourceEntries.clear();
@@ -355,7 +348,6 @@ public class Clip2ThingHandler extends BaseThingHandler {
         serviceContributorsCache.clear();
         controlIds.clear();
         extendedResourceTypes.clear();
-        clearPredictedBrightness();
     }
 
     /**
@@ -462,7 +454,8 @@ public class Clip2ThingHandler extends BaseThingHandler {
                     MirekSchema schema = cache != null ? cache.getMirekSchema() : null;
                     schema = schema != null ? schema : MirekSchema.DEFAULT_SCHEMA;
                     double mirekRange = schema.getMirekMaximum() - schema.getMirekMinimum();
-                    int mirekDelta = (int) Math.max(mirekRange * INC_DEC_PERCENT / 100.0, INC_DEC_PERCENT);
+                    int mirekDelta = (int) Math.max(mirekRange * INCREASE_DECREASE_PERCENT / 100.0,
+                            INCREASE_DECREASE_PERCENT);
                     putResource = new Resource(lightResourceType).setMirekDelta(incDecCommand, mirekDelta);
                     break;
                 }
@@ -488,14 +481,10 @@ public class Clip2ThingHandler extends BaseThingHandler {
                 putResource = Objects.nonNull(putResource) ? putResource : new Resource(lightResourceType);
                 if (command instanceof IncreaseDecreaseType incDecCommand) {
                     command = handleIncreaseDecreaseBrightnessCommand(incDecCommand, putResource, cache);
-                    if (command == null) {
-                        break; // i.e. no on-off command to append
-                    }
-                    // fall through to append any on-off command
+                    // fall through
                 } else if (command instanceof PercentType brightnessCommand) {
                     putResource = putResource.setBrightness(brightnessCommand);
                     double brightness = Math.max(0.0, Math.min(100.0, brightnessCommand.doubleValue()));
-                    clearPredictedBrightness();
                     command = OnOffType.from(brightness > 0.0); // avoid "soft off"
                 }
                 // NB fall through for handling of switch related commands !!
@@ -503,9 +492,6 @@ public class Clip2ThingHandler extends BaseThingHandler {
             case CHANNEL_2_SWITCH:
                 putResource = Objects.nonNull(putResource) ? putResource : new Resource(lightResourceType);
                 putResource.setOnOff(command);
-                if (OnOffType.OFF == command) {
-                    clearPredictedBrightness();
-                }
                 applyOffTransitionWorkAround(command, putResource);
                 applyColorTemperatureWorkAround(command, putResource);
                 break;
@@ -517,15 +503,11 @@ public class Clip2ThingHandler extends BaseThingHandler {
             case CHANNEL_2_DIMMING_ONLY:
                 if (command instanceof PercentType brightnessCommand) {
                     putResource = new Resource(lightResourceType).setBrightness(brightnessCommand);
-                    clearPredictedBrightness();
                 }
                 break;
 
             case CHANNEL_2_ON_OFF_ONLY:
                 putResource = new Resource(lightResourceType).setOnOff(command);
-                if (OnOffType.OFF == command) {
-                    clearPredictedBrightness();
-                }
                 applyOffTransitionWorkAround(command, putResource);
                 break;
 
@@ -710,11 +692,6 @@ public class Clip2ThingHandler extends BaseThingHandler {
         scheduler.submit(() -> {
             logger.debug("{} -> loopBackNotify() with resource {}", resourceId, resource);
 
-            // align dimming with the locally predicted brightness for synthetic updates
-            if (LIGHT_TYPES.contains(resource.getType())) {
-                updateDimmingFromPredictedBrightness(resource);
-            }
-
             // add DTO fields to synch ColorXy and ColorTemperature for commands to the counterpart channel
             if (ResourceType.LIGHT == resource.getType()) {
                 ColorXy colorXy = resource.getColorXy();
@@ -863,8 +840,6 @@ public class Clip2ThingHandler extends BaseThingHandler {
         updateSceneContributorsDone = false;
         legacyLightState = null;
 
-        clearPredictedBrightness();
-
         Bridge bridge = getBridge();
         if (Objects.nonNull(bridge)) {
             BridgeHandler bridgeHandler = bridge.getHandler();
@@ -936,9 +911,6 @@ public class Clip2ThingHandler extends BaseThingHandler {
             Resource cachedResource = getResourceFromCache(resource);
             if (cachedResource != null) {
                 Setters.setResource(resource, cachedResource);
-                if (LIGHT_TYPES.contains(resource.getType())) {
-                    updatePredictedBrightness(resource);
-                }
                 resourceConsumedFlags |= FLAG_CACHE_UPDATE;
                 resourceConsumedFlags |= updateChannels && updateChannels(resource) ? FLAG_CHANNELS_UPDATE : 0;
                 putResourceToCache(resource);
@@ -1922,143 +1894,54 @@ public class Clip2ThingHandler extends BaseThingHandler {
     }
 
     /**
-     * Helper for increase/decrease command processing. Get the predicted brightness value, if it is set,
-     * otherwise get the cached brightness value from the given resource.
+     * Helper for {@link IncreaseDecreaseType} command processing.
+     * Handles the logic for adjusting the brightness based on the given Increase/Decrease command, and returns
+     * an adjunct {@link OnOffType.ON} to be appended to the pay-load. It translates the +/- relative command
+     * to absolute brightness commands (since these are more reliable).
      *
-     * @param cachedResource the cached resource with the current state, may be null.
-     * @return the predicted brightness value, or null if not set and not available in the cache.
+     * @param command the {@link IncreaseDecreaseType} command.
+     * @param putResource the resource to be sent to the bridge.
+     * @param cache the cached resource with the current state, may be null.
+     * @return an adjunct {@link OnOffType.ON} .
      */
-    private @Nullable Double getPredictedBrightness(@Nullable Resource cachedResource) {
-        Double predicted = predictedBrightness;
-        if (predicted != null) {
-            return predicted;
+    private OnOffType handleIncreaseDecreaseBrightnessCommand(IncreaseDecreaseType command, Resource putResource,
+            @Nullable Resource cache) {
+        boolean inc = IncreaseDecreaseType.INCREASE == command;
+        if (cache != null) {
+            Resource actual = getResource(cache.getType(), cache.getId());
+            if (actual != null) {
+                double brightnessActual = actual.getDimming() instanceof Dimming dim
+                        && dim.getBrightness() instanceof Double bri ? bri : -1;
+                if (brightnessActual >= 0) {
+                    double brightnessTarget = inc //
+                            ? Math.min(100.0, brightnessActual + INCREASE_DECREASE_PERCENT)
+                            : Math.max(0.0, brightnessActual - INCREASE_DECREASE_PERCENT);
+                    putResource.setBrightness(new PercentType(BigDecimal.valueOf(brightnessTarget)));
+                    return OnOffType.from(brightnessTarget > 0.0);
+                }
+            }
         }
-        if (cachedResource != null && cachedResource.getDimming() instanceof Dimming dimming
-                && dimming.getBrightness() instanceof Double brightness) {
-            return brightness;
+        putResource.setBrightness(inc ? PercentType.HUNDRED : PercentType.ZERO);
+        return OnOffType.from(inc);
+    }
+
+    /**
+     * Fetch the current resource from the bridge for the given type and id. Returns null if the resource
+     * cannot be fetched.
+     *
+     * @param type the resource type.
+     * @param id the resource id.
+     * @return the current resource, or null if it cannot be fetched.
+     */
+    private @Nullable Resource getResource(ResourceType type, String id) {
+        try {
+            Resources resources = getBridgeHandler().getResources(new ResourceReference().setType(type).setId(id));
+            return resources.getResources().get(0);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        } catch (Exception e) {
+            logger.debug("Failed to fetch current light resource: {}", e.getMessage());
         }
         return null;
-    }
-
-    /**
-     * Helper for increase/decrease command processing. Set the predicted brightness value, ensuring it is
-     * clamped between 0.0 and 100.0.
-     *
-     * @param brightness the predicted brightness value to set.
-     */
-    private void setPredictedBrightness(double brightness) {
-        predictedBrightness = Math.max(0.0, Math.min(100.0, brightness));
-        restartPredictedBrightnessResetTask();
-    }
-
-    /**
-     * Helper for {@link IncreaseDecreaseType} command processing. Handles the logic for adjusting the brightness of
-     * a light resource based on the given INCREASE or DECREASE command. It compares the intent of the command against
-     * the current predicted brightness, and handles the following edge cases:
-     * <ul>
-     * <li>If increasing and old brightness is null, sets putResource to an ABSOLUTE amount and returns adjunct ON
-     * command.</li>
-     * <li>If increasing and old brightness is zero, sets putResource to an ABSOLUTE amount and returns adjunct ON
-     * command.</li>
-     * <li>If increasing and old brightness is above zero, sets putResource to increase by a RELATIVE amount.</li>
-     * <li>If decreasing and old brightness is null, sets putResource to decrease by a RELATIVE amount.</li>
-     * <li>If decreasing and new brightness is above zero, sets putResource to decrease by a RELATIVE amount.</li>
-     * <li>If decreasing and new brightness is zero or below, returns adjunct OFF command.</li>
-     * </ul>
-     *
-     * @param command the INCREASE or DECREASE command.
-     * @param putResource the resource to be sent to the bridge.
-     * @param cacheResource the cached resource with the current state, may be null.
-     * @return an adjunct ON or OFF command, or null.
-     */
-    private @Nullable OnOffType handleIncreaseDecreaseBrightnessCommand(IncreaseDecreaseType command,
-            Resource putResource, @Nullable Resource cacheResource) {
-        Double brightnessBeforeObj = getPredictedBrightness(cacheResource);
-
-        if (brightnessBeforeObj == null) {
-            if (IncreaseDecreaseType.INCREASE == command) {
-                putResource.setBrightness(new PercentType(INC_DEC_PERCENT));
-                setPredictedBrightness(INC_DEC_PERCENT);
-                return OnOffType.ON;
-            } else {
-                putResource.setDimmingDelta(command, INC_DEC_PERCENT);
-                return null;
-            }
-        } else {
-            double brightnessBefore = brightnessBeforeObj.doubleValue();
-            double brightnessAfter = switch (command) {
-                case INCREASE -> Math.min(100.0, brightnessBefore + INC_DEC_PERCENT);
-                case DECREASE -> Math.max(0.0, brightnessBefore - INC_DEC_PERCENT);
-            };
-            boolean lightIsOff = cacheResource != null && cacheResource.getOnState() instanceof OnState onState
-                    && Boolean.FALSE.equals(onState.getOn());
-
-            if (IncreaseDecreaseType.INCREASE == command && (lightIsOff || brightnessBefore <= 0.0)) {
-                putResource.setBrightness(new PercentType(INC_DEC_PERCENT));
-                setPredictedBrightness(INC_DEC_PERCENT);
-                return OnOffType.ON;
-            } else if (IncreaseDecreaseType.DECREASE == command && brightnessAfter <= 0.0) {
-                return OnOffType.OFF;
-            } else {
-                putResource.setDimmingDelta(command, INC_DEC_PERCENT);
-                setPredictedBrightness(brightnessAfter);
-                return null;
-            }
-        }
-    }
-
-    /**
-     * Helper for Increase/Decrease command processing. Update the predicted brightness value based on the
-     * given resource.
-     *
-     * @param resource the resource to check for brightness updates.
-     */
-    private void updatePredictedBrightness(Resource resource) {
-        if (resource.getOnState() instanceof OnState onState && Boolean.FALSE.equals(onState.getOn())) {
-            clearPredictedBrightness();
-        } else if (resource.getDimming() instanceof Dimming dimming
-                && dimming.getBrightness() instanceof Double brightness) {
-            Double predicted = predictedBrightness;
-            if (predicted != null && Math.abs(brightness - predicted) < 0.01) {
-                clearPredictedBrightness();
-            }
-        }
-    }
-
-    /**
-     * Helper for Increase/Decrease command processing. Update the dimming brightness value of the given
-     * resource to the predicted brightness.
-     *
-     * @param resource the resource to update.
-     */
-    private void updateDimmingFromPredictedBrightness(Resource resource) {
-        Double predicted = predictedBrightness;
-        if (predicted != null) {
-            if (resource.getOnState() instanceof OnState onState && Boolean.FALSE.equals(onState.getOn())) {
-                if (resource.getDimming() instanceof Dimming dimming) {
-                    dimming.setBrightness(predicted);
-                } else {
-                    resource.setDimming(new Dimming().setBrightness(predicted));
-                }
-            } else if (resource.getDimming() instanceof Dimming dimming) {
-                dimming.setBrightness(predicted);
-            } else {
-                resource.setDimming(new Dimming().setBrightness(predicted));
-            }
-        }
-    }
-
-    private void clearPredictedBrightness() {
-        predictedBrightness = null;
-        cancelTask(predictedBrightnessResetTask, false);
-        predictedBrightnessResetTask = null;
-    }
-
-    private void restartPredictedBrightnessResetTask() {
-        cancelTask(predictedBrightnessResetTask, false);
-        predictedBrightnessResetTask = scheduler.schedule(() -> {
-            predictedBrightness = null;
-            predictedBrightnessResetTask = null;
-        }, PREDICTED_BRIGHTNESS_RESET_DELAY.toMillis(), TimeUnit.MILLISECONDS);
     }
 }

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/Clip2ThingHandler.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/Clip2ThingHandler.java
@@ -502,7 +502,10 @@ public class Clip2ThingHandler extends BaseThingHandler {
                         };
                         predictedBrightness = brightnessAfter;
                         command = switch (incDecCommand) {
-                            case INCREASE -> brightnessBefore <= 0.0 ? OnOffType.ON : null;
+                            case INCREASE -> {
+                                putResource.setDimmingDelta(incDecCommand, INC_DEC_PERCENT);
+                                yield brightnessBefore <= 0.0 ? OnOffType.ON : null;
+                            }
                             case DECREASE -> {
                                 if (brightnessAfter <= 0.0) {
                                     putResource = new Resource(lightResourceType);

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/Clip2ThingHandler.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/Clip2ThingHandler.java
@@ -501,9 +501,7 @@ public class Clip2ThingHandler extends BaseThingHandler {
                 break;
 
             case CHANNEL_2_DIMMING_ONLY:
-                if (command instanceof PercentType brightnessCommand) {
-                    putResource = new Resource(lightResourceType).setBrightness(brightnessCommand);
-                }
+                putResource = new Resource(lightResourceType).setBrightness(brightnessCommand);
                 break;
 
             case CHANNEL_2_ON_OFF_ONLY:

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/Clip2ThingHandler.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/Clip2ThingHandler.java
@@ -168,8 +168,8 @@ public class Clip2ThingHandler extends BaseThingHandler {
     private static final PercentType DEFAULT_SOUND_VOLUME = new PercentType(50);
     private static final QuantityType<?> DEFAULT_ALARM_DURATION = QuantityType.valueOf(3, Units.SECOND);
 
-    // step size for IncreaseDecreaseType commands
     private static final int INCREASE_DECREASE_PERCENT = 10;
+    private static final int MIN_MIREK_DELTA = 10;
 
     /**
      * A map of service Resources whose state contributes to the overall state of this thing. It is a map between the
@@ -455,8 +455,7 @@ public class Clip2ThingHandler extends BaseThingHandler {
                     MirekSchema schema = cache != null ? cache.getMirekSchema() : null;
                     schema = schema != null ? schema : MirekSchema.DEFAULT_SCHEMA;
                     double mirekRange = schema.getMirekMaximum() - schema.getMirekMinimum();
-                    int mirekDelta = (int) Math.max(mirekRange * INCREASE_DECREASE_PERCENT / 100.0,
-                            INCREASE_DECREASE_PERCENT);
+                    int mirekDelta = (int) Math.max(mirekRange * INCREASE_DECREASE_PERCENT / 100.0, MIN_MIREK_DELTA);
                     putResource = new Resource(lightResourceType).setMirekDelta(incDecCommand, mirekDelta);
                     break;
                 }


### PR DESCRIPTION
Until now, the API v2 binding would convert relative `IncreaseDecrease` commands to an absolute value based on the prior value plus/minus the delta. And if commands are sent too rapidly the "prior" value would not yet have been updated, so repeated `IncreaseDecrease` commands would have no impact. This PR now does a GET for the "prior" value immediately before processing `IncreaseDecrease` commands, which means that it can always be used as a solid live basis for building the next new value. The PR also sends ON and OFF commands (in the case of increase/decrease brightness) to turn on the light when increase is commanded, and to turn it off if a decrease command results in the brightness going to zero.

Signed-off-by: Andrew Fiddian-Green <software@whitebear.ch>
