### PR TITLE
[tuya] Add gateway support

### DIFF
--- a/bundles/org.openhab.binding.tuya/README.md
+++ b/bundles/org.openhab.binding.tuya/README.md
@@ -14,7 +14,7 @@ The other app (and/or tuya-mqtt) must be closed in order for this binding to ope
 
 ## Supported Things
 
-There are two things: `project` and `tuyaDevice`.
+There are four things: `project`, `tuyaDevice`, `tuyaGateway` and `tuyaSubDevice`.
 
 The `project` Thing represents a Tuya developer portal cloud project (see below).
 `project` things must be configured manually and are needed for discovery only.
@@ -22,13 +22,26 @@ The `project` Thing represents a Tuya developer portal cloud project (see below)
 `tuyaDevice` things represent a single device.
 They can be configured manually or by discovery.
 
+`tuyaGateway` things represent a device that relays for other devices, e.g. a Bluetooth or ZigBee gateway.
+Apart from being a bridge for its sub-devices, a `tuyaGateway` behaves exactly like a `tuyaDevice` and has its own channels.
+
+`tuyaSubDevice` things represent a device that is reached through a gateway.
+A `tuyaSubDevice` has no connection of its own: all its traffic is relayed by the `tuyaGateway` it is a child of.
+
 Note that `project` is a regular Thing and not a bridge.
 `tuyaDevice` things communicate with the device directly over the local network and do not need a bridge at runtime.
+Only `tuyaSubDevice` things need a bridge, namely the `tuyaGateway` they are connected to.
 
 ## Discovery
 
-Discovery is supported for `tuyaDevice` things.
+Discovery is supported for `tuyaDevice`, `tuyaGateway` and `tuyaSubDevice` things.
 By using discovery all necessary settings of the device are retrieved from your cloud account.
+Devices that turn out to have sub-devices in the cloud account are discovered as `tuyaGateway` instead of `tuyaDevice`, and their sub-devices are discovered underneath them.
+
+A `tuyaSubDevice` cannot exist without its bridge, so sub-devices are only reported once their gateway has been added as a Thing.
+Add the gateway first, then run discovery again to get its sub-devices (background discovery picks them up within a few minutes).
+
+If you already added a gateway as a `tuyaDevice`, you have to delete it and add it again as `tuyaGateway` before its sub-devices can be used.
 
 ## Thing Configuration
 
@@ -85,6 +98,23 @@ The `pollingInterval` can be used to adjust how often channels are updated and c
 Note that this has no practical effect on battery powered devices. These only wake up when they have something to say and then go straight back to sleep.
 
 In case something is not working, please open an issue on [GitHub](https://github.com/openhab/openhab-addons/issues/new?title=[tuya]) and add TRACE level logs.
+
+### `tuyaGateway`
+
+A `tuyaGateway` takes exactly the same parameters as a `tuyaDevice`, and they have the same meaning.
+Use this Thing type instead of `tuyaDevice` for devices that other devices are paired to, such as Bluetooth or ZigBee gateways.
+
+### `tuyaSubDevice`
+
+The mandatory parameters are `deviceId`, `productId` and `subDeviceId`, and the Thing must be a child of the `tuyaGateway` the device is paired to.
+All of these are set during discovery.
+
+The `deviceId` and `productId` have the same meaning as for a `tuyaDevice`.
+The `subDeviceId` is the node ID that identifies the device towards its gateway (`node_id` in the cloud account).
+
+A sub-device has no `ip`, `port`, `protocol` or `localKey`: it is reached through the gateway, which supplies all of these.
+
+The `pollingInterval` works as for a `tuyaDevice`, except that the gateway is asked for the full state of the sub-device on every poll, as sub-devices do not support partial refreshes.
 
 ## Channels
 
@@ -220,12 +250,34 @@ Thing tuya:tuyaDevice:plug "Smart Plug" [
 }
 ```
 
+A gateway and its sub-devices:
+
+```java
+Bridge tuya:tuyaGateway:gateway "ZigBee Gateway" [
+    deviceId="GATEWAY_DEVICE_ID",
+    productId="GATEWAY_PRODUCT_ID",
+    localKey="GATEWAY_LOCAL_KEY",
+    ip="192.168.1.101",
+    protocol="3.3"
+] {
+    Thing tuyaSubDevice sensor "Door Sensor" [
+        deviceId="SUB_DEVICE_ID",
+        productId="SUB_DEVICE_PRODUCT_ID",
+        subDeviceId="NODE_ID"
+    ] {
+        Channels:
+            Type switch : doorcontact_state        [ dp=1 ]
+    }
+}
+```
+
 tuya.items:
 
 ```java
 Switch Plug_Power       "Power"              { channel="tuya:tuyaDevice:plug:power" }
 String Plug_WorkMode    "Work mode"          { channel="tuya:tuyaDevice:plug:work_mode" }
 Number Plug_Countdown   "Countdown [%d s]"   { channel="tuya:tuyaDevice:plug:countdown" }
+Switch Door_Contact     "Door"               { channel="tuya:tuyaSubDevice:gateway:sensor:doorcontact_state" }
 ```
 
 ## Troubleshooting

--- a/bundles/org.openhab.binding.tuya/src/main/java/org/openhab/binding/tuya/internal/TuyaBindingConstants.java
+++ b/bundles/org.openhab.binding.tuya/src/main/java/org/openhab/binding/tuya/internal/TuyaBindingConstants.java
@@ -23,6 +23,7 @@ import org.openhab.core.thing.type.ChannelTypeUID;
  * used across the whole binding.
  *
  * @author Jan N. Klug - Initial contribution
+ * @author Maciej Jarzebowski - Add gateway and sub-device thing types
  */
 @NonNullByDefault
 public class TuyaBindingConstants {
@@ -31,6 +32,8 @@ public class TuyaBindingConstants {
     // List of all Thing Type UIDs
     public static final ThingTypeUID THING_TYPE_PROJECT = new ThingTypeUID(BINDING_ID, "project");
     public static final ThingTypeUID THING_TYPE_TUYA_DEVICE = new ThingTypeUID(BINDING_ID, "tuyaDevice");
+    public static final ThingTypeUID THING_TYPE_TUYA_GATEWAY = new ThingTypeUID(BINDING_ID, "tuyaGateway");
+    public static final ThingTypeUID THING_TYPE_TUYA_SUB_DEVICE = new ThingTypeUID(BINDING_ID, "tuyaSubDevice");
 
     public static final String PROPERTY_CATEGORY = "category";
 
@@ -44,6 +47,7 @@ public class TuyaBindingConstants {
     public static final String CONFIG_MAX = "max";
     public static final String CONFIG_PROTOCOL = "protocol";
     public static final String CONFIG_RANGE = "range";
+    public static final String CONFIG_SUB_DEVICE_ID = "subDeviceId";
 
     public static final ChannelTypeUID CHANNEL_TYPE_UID_NUMBER = new ChannelTypeUID(BINDING_ID, "number");
     public static final ChannelTypeUID CHANNEL_TYPE_UID_IR_CODE = new ChannelTypeUID(BINDING_ID, "ir-code");

--- a/bundles/org.openhab.binding.tuya/src/main/java/org/openhab/binding/tuya/internal/TuyaDiscoveryService.java
+++ b/bundles/org.openhab.binding.tuya/src/main/java/org/openhab/binding/tuya/internal/TuyaDiscoveryService.java
@@ -15,24 +15,30 @@ package org.openhab.binding.tuya.internal;
 import static org.openhab.binding.tuya.internal.TuyaBindingConstants.CONFIG_DEVICE_ID;
 import static org.openhab.binding.tuya.internal.TuyaBindingConstants.CONFIG_LOCAL_KEY;
 import static org.openhab.binding.tuya.internal.TuyaBindingConstants.CONFIG_PRODUCT_ID;
+import static org.openhab.binding.tuya.internal.TuyaBindingConstants.CONFIG_SUB_DEVICE_ID;
 import static org.openhab.binding.tuya.internal.TuyaBindingConstants.PROPERTY_CATEGORY;
 import static org.openhab.binding.tuya.internal.TuyaBindingConstants.THING_TYPE_TUYA_DEVICE;
+import static org.openhab.binding.tuya.internal.TuyaBindingConstants.THING_TYPE_TUYA_GATEWAY;
+import static org.openhab.binding.tuya.internal.TuyaBindingConstants.THING_TYPE_TUYA_SUB_DEVICE;
 
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.tuya.internal.cloud.TuyaOpenAPI;
 import org.openhab.binding.tuya.internal.cloud.dto.DeviceListInfo;
 import org.openhab.binding.tuya.internal.cloud.dto.DeviceSchema;
+import org.openhab.binding.tuya.internal.cloud.dto.SubDeviceInfo;
 import org.openhab.binding.tuya.internal.handler.ProjectHandler;
 import org.openhab.binding.tuya.internal.local.UdpDiscoverySender;
 import org.openhab.binding.tuya.internal.util.SchemaDp;
@@ -40,9 +46,12 @@ import org.openhab.core.config.discovery.AbstractThingHandlerDiscoveryService;
 import org.openhab.core.config.discovery.DiscoveryResult;
 import org.openhab.core.config.discovery.DiscoveryResultBuilder;
 import org.openhab.core.thing.Thing;
+import org.openhab.core.thing.ThingRegistry;
 import org.openhab.core.thing.ThingTypeUID;
 import org.openhab.core.thing.ThingUID;
+import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ServiceScope;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -53,22 +62,34 @@ import com.google.gson.Gson;
  * The {@link TuyaDiscoveryService} implements the discovery service for Tuya devices from the cloud
  *
  * @author Jan N. Klug - Initial contribution
+ * @author Maciej Jarzebowski - Add gateway and sub-device discovery
  */
 @Component(scope = ServiceScope.PROTOTYPE, service = TuyaDiscoveryService.class)
 @NonNullByDefault
 public class TuyaDiscoveryService extends AbstractThingHandlerDiscoveryService<ProjectHandler> {
-    public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES = Set.of(THING_TYPE_TUYA_DEVICE);
+    public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES = Set.of(THING_TYPE_TUYA_DEVICE,
+            THING_TYPE_TUYA_GATEWAY, THING_TYPE_TUYA_SUB_DEVICE);
     private static final int SEARCH_TIME = 5;
+    private static final int GATEWAY_PROBE_ATTEMPTS = 2;
+    private static final int GATEWAY_PROBE_RETRY_DELAY = 10; // Seconds
+    // The factory information endpoint accepts at most 20 device ids per request
+    private static final int FACTORY_INFORMATION_BATCH_SIZE = 20;
 
     private final Logger logger = LoggerFactory.getLogger(TuyaDiscoveryService.class);
     private final Gson gson = new Gson();
     private @Nullable ScheduledFuture<?> discoveryJob;
+    private @Nullable ScheduledFuture<?> gatewayProbeRetry;
+    private volatile boolean disposed = false;
     private @Nullable ScheduledFuture<?> broadcastJob;
 
     private final UdpDiscoverySender udpDiscoverySender = new UdpDiscoverySender();
 
-    public TuyaDiscoveryService() {
+    private final ThingRegistry thingRegistry;
+
+    @Activate
+    public TuyaDiscoveryService(@Reference ThingRegistry thingRegistry) {
         super(ProjectHandler.class, SUPPORTED_THING_TYPES, SEARCH_TIME);
+        this.thingRegistry = thingRegistry;
     }
 
     @Override
@@ -80,6 +101,11 @@ public class TuyaDiscoveryService extends AbstractThingHandlerDiscoveryService<P
 
     @Override
     public void dispose() {
+        // Stops the asynchronous scan from issuing further cloud requests or publishing results for a project that
+        // is being removed or reinitialized
+        disposed = true;
+        cancelGatewayProbeRetry();
+
         super.dispose();
 
         removeOlderResults(Instant.now());
@@ -96,45 +122,252 @@ public class TuyaDiscoveryService extends AbstractThingHandlerDiscoveryService<P
             return;
         }
 
-        processDeviceResponse(List.of(), api, 0);
+        // A previous scan may still have a probe pending; it must not report into this one
+        cancelGatewayProbeRetry();
+
+        collectDevices(new ArrayList<>(), List.of(), api, 0);
     }
 
-    private void processDeviceResponse(List<DeviceListInfo> deviceList, TuyaOpenAPI api, int page) {
-        deviceList.forEach(device -> processDevice(device, api));
-        if (page == 0 || deviceList.size() == 100) {
-            int nextPage = page + 1;
-            thingHandler.getAllDevices(nextPage)
-                    .thenAccept(nextDeviceList -> processDeviceResponse(nextDeviceList, api, nextPage));
+    private synchronized void cancelGatewayProbeRetry() {
+        ScheduledFuture<?> gatewayProbeRetry = this.gatewayProbeRetry;
+        if (gatewayProbeRetry != null) {
+            this.gatewayProbeRetry = null;
+            gatewayProbeRetry.cancel(true);
         }
     }
 
-    private void processDevice(DeviceListInfo device, TuyaOpenAPI api) {
-        api.getFactoryInformation(List.of(device.id)).thenAccept(fiList -> {
-            ThingUID thingUid = new ThingUID(THING_TYPE_TUYA_DEVICE, device.id);
-            String deviceMac = fiList.stream().filter(fi -> fi.id.equals(device.id)).findAny().map(fi -> fi.mac)
-                    .orElse("");
-
-            Map<String, Object> properties = new HashMap<>();
-            properties.put(PROPERTY_CATEGORY, device.category);
-            properties.put(Thing.PROPERTY_MAC_ADDRESS,
-                    Objects.requireNonNull(deviceMac).replaceAll("(..)(?!$)", "$1:"));
-            properties.put(CONFIG_LOCAL_KEY, device.localKey);
-            properties.put(CONFIG_DEVICE_ID, device.id);
-            properties.put(CONFIG_PRODUCT_ID, device.productId);
-
-            DiscoveryResult discoveryResult = DiscoveryResultBuilder.create(thingUid).withLabel(device.name)
-                    .withRepresentationProperty(CONFIG_DEVICE_ID).withProperties(properties).build();
-
-            api.getDeviceSchema(device.id).thenAccept(schema -> {
-                if (!TuyaSchemaDB.contains(device.productId)) {
-                    List<SchemaDp> schemaDps = new ArrayList<>();
-                    schema.functions.forEach(description -> addUniqueSchemaDp(description, schemaDps, Boolean.FALSE));
-                    schema.status.forEach(description -> addUniqueSchemaDp(description, schemaDps, Boolean.TRUE));
-                    TuyaSchemaDB.put(device.productId, schemaDps);
+    private void collectDevices(List<DeviceListInfo> allDevices, List<DeviceListInfo> page, TuyaOpenAPI api,
+            int pageNo) {
+        allDevices.addAll(page);
+        if (pageNo == 0 || page.size() == 100) {
+            int nextPageNo = pageNo + 1;
+            thingHandler.getAllDevices(nextPageNo).whenComplete((nextPage, throwable) -> {
+                if (throwable != null || nextPage == null) {
+                    // Report what we have rather than nothing at all
+                    logger.debug("Could not retrieve device list page {}", nextPageNo);
+                    processDevices(allDevices, api);
+                } else {
+                    collectDevices(allDevices, nextPage, api, nextPageNo);
                 }
             });
+        } else {
+            processDevices(allDevices, api);
+        }
+    }
 
-            thingDiscovered(discoveryResult);
+    /**
+     * Classifies the devices of the account and creates the discovery results.
+     *
+     * The device list does not tell which gateway a sub-device belongs to, so the gateways have to be identified by
+     * asking every device for its sub-devices. The extra request is only made if the account contains sub-devices at
+     * all. Note that a gateway can itself be flagged as a sub-device, so no device can be excluded up front.
+     */
+    private void processDevices(List<DeviceListInfo> allDevices, TuyaOpenAPI api) {
+        if (allDevices.stream().noneMatch(device -> device.subDevice)) {
+            collectMacAddresses(allDevices, api).thenAccept(macAddresses -> allDevices
+                    .forEach(device -> processDevice(device, api, THING_TYPE_TUYA_DEVICE, macAddresses)));
+            return;
+        }
+
+        probeGateway(new GatewayScan(allDevices, new HashMap<>(), new HashSet<>()), allDevices, 0, 1, api);
+    }
+
+    /**
+     * Asks each device in turn for its sub-devices.
+     *
+     * The requests are chained rather than issued at once because a scan already makes several cloud calls per device
+     * and the API rejects large bursts.
+     */
+    private void probeGateway(GatewayScan scan, List<DeviceListInfo> queue, int index, int attempt, TuyaOpenAPI api) {
+        if (disposed) {
+            return;
+        }
+
+        if (index < queue.size()) {
+            DeviceListInfo device = queue.get(index);
+            api.getSubDevices(device.id).handle((subDevices, throwable) -> {
+                if (throwable != null) {
+                    logger.debug("Could not determine whether device '{}' is a gateway: {}", device.id,
+                            throwable.getMessage());
+                    scan.unclassifiedDeviceIds().add(device.id);
+                } else {
+                    scan.unclassifiedDeviceIds().remove(device.id);
+                    if (!subDevices.isEmpty()) {
+                        scan.subDevicesByGateway().put(device.id, subDevices);
+                    }
+                }
+
+                probeGateway(scan, queue, index + 1, attempt, api);
+                return null;
+            });
+            return;
+        }
+
+        List<DeviceListInfo> failed = queue.stream().filter(device -> scan.unclassifiedDeviceIds().contains(device.id))
+                .toList();
+        if (!failed.isEmpty() && attempt < GATEWAY_PROBE_ATTEMPTS) {
+            // The cloud rejects request bursts and a scan asks for a lot at once. Giving it a moment usually clears
+            // a failed probe, and an unresolved device holds back the classification of the whole account.
+            logger.debug("Retrying the gateway probe for {} device(s)", failed.size());
+            synchronized (this) {
+                gatewayProbeRetry = scheduler.schedule(() -> probeGateway(scan, failed, 0, attempt + 1, api),
+                        GATEWAY_PROBE_RETRY_DELAY, TimeUnit.SECONDS);
+            }
+            return;
+        }
+
+        if (!failed.isEmpty()) {
+            logger.warn("Could not determine whether {} device(s) are gateways, leaving them for the next scan",
+                    failed.size());
+        }
+
+        reportDevices(scan, api);
+    }
+
+    /**
+     * Creates the discovery results once every device has been classified. A device that reported sub-devices becomes
+     * a gateway together with its children, a device claimed by a gateway is left to that gateway, and everything else
+     * is a regular device.
+     */
+    private void reportDevices(GatewayScan scan, TuyaOpenAPI api) {
+        if (disposed) {
+            return;
+        }
+
+        collectMacAddresses(scan.allDevices(), api).thenAccept(macAddresses -> reportDevices(scan, api, macAddresses));
+    }
+
+    /**
+     * Retrieves the MAC address of every device. The factory information endpoint takes a list of device ids, so the
+     * whole account is covered by a handful of requests instead of one per device.
+     *
+     * The batches are chained rather than issued at once because the cloud rejects request bursts. A MAC address is
+     * optional enrichment, so a failed batch only means those devices are reported without one.
+     */
+    private CompletableFuture<Map<String, String>> collectMacAddresses(List<DeviceListInfo> devices, TuyaOpenAPI api) {
+        List<String> deviceIds = devices.stream().map(device -> device.id).toList();
+        CompletableFuture<Map<String, String>> macAddresses = CompletableFuture.completedFuture(new HashMap<>());
+
+        for (int from = 0; from < deviceIds.size(); from += FACTORY_INFORMATION_BATCH_SIZE) {
+            List<String> batch = deviceIds.subList(from,
+                    Math.min(from + FACTORY_INFORMATION_BATCH_SIZE, deviceIds.size()));
+            macAddresses = macAddresses
+                    .thenCompose(collected -> api.getFactoryInformation(batch).exceptionally(throwable -> {
+                        logger.debug("Could not retrieve factory information for {} device(s): {}", batch.size(),
+                                throwable.getMessage());
+                        return List.of();
+                    }).thenApply(factoryInformation -> {
+                        factoryInformation.forEach(information -> collected.put(information.id, information.mac));
+                        return collected;
+                    }));
+        }
+
+        return macAddresses;
+    }
+
+    private void reportDevices(GatewayScan scan, TuyaOpenAPI api, Map<String, String> macAddresses) {
+        if (disposed) {
+            return;
+        }
+
+        Map<String, List<SubDeviceInfo>> subDevicesByGateway = scan.subDevicesByGateway();
+        Set<String> claimed = subDevicesByGateway.values().stream().flatMap(List::stream).map(subDevice -> subDevice.id)
+                .collect(Collectors.toSet());
+        // Only a scan that classified every device knows for certain that no gateway claims a given device
+        boolean complete = scan.unclassifiedDeviceIds().isEmpty();
+        // If not a single device could be classified, the account cannot use the sub-device API at all. Report the
+        // devices as plain ones rather than discovering nothing.
+        boolean classified = scan.unclassifiedDeviceIds().size() < scan.allDevices().size();
+
+        for (DeviceListInfo device : scan.allDevices()) {
+            List<SubDeviceInfo> subDevices = subDevicesByGateway.get(device.id);
+            if (subDevices != null) {
+                ThingUID gatewayUid = processDevice(device, api, THING_TYPE_TUYA_GATEWAY, macAddresses);
+                if (thingRegistry.get(gatewayUid) != null) {
+                    subDevices.forEach(subDevice -> processSubDevice(subDevice, api, gatewayUid));
+                } else {
+                    // A sub-device cannot be created before its bridge exists, so it is only offered once the gateway
+                    // has been added. The next scan reports them.
+                    logger.debug("Not reporting the {} sub-devices of '{}' because its gateway thing does not exist",
+                            subDevices.size(), device.id);
+                }
+                continue;
+            }
+
+            if (claimed.contains(device.id) || scan.unclassifiedDeviceIds().contains(device.id)) {
+                // Reported by its gateway, or this scan could not tell what the device is
+                continue;
+            }
+
+            if (!complete && classified) {
+                // A gateway this scan could not ask may claim this device as its child. The cloud marks sub-devices
+                // unreliably, so nothing rules that out here, and reporting the device as a regular one would
+                // duplicate the entry its gateway creates once it can be reached again.
+                logger.debug("Not reporting device '{}' because the scan could not classify every device", device.id);
+                continue;
+            }
+
+            processDevice(device, api, THING_TYPE_TUYA_DEVICE, macAddresses);
+        }
+    }
+
+    /**
+     * The state of a single scan while the devices of the account are being classified.
+     */
+    private record GatewayScan(List<DeviceListInfo> allDevices, Map<String, List<SubDeviceInfo>> subDevicesByGateway,
+            Set<String> unclassifiedDeviceIds) {
+    }
+
+    private ThingUID processDevice(DeviceListInfo device, TuyaOpenAPI api, ThingTypeUID thingTypeUID,
+            Map<String, String> macAddresses) {
+        ThingUID thingUid = new ThingUID(thingTypeUID, device.id);
+
+        Map<String, Object> properties = new HashMap<>();
+        properties.put(PROPERTY_CATEGORY, device.category);
+        properties.put(Thing.PROPERTY_MAC_ADDRESS,
+                macAddresses.getOrDefault(device.id, "").replaceAll("(..)(?!$)", "$1:"));
+        properties.put(CONFIG_LOCAL_KEY, device.localKey);
+        properties.put(CONFIG_DEVICE_ID, device.id);
+        properties.put(CONFIG_PRODUCT_ID, device.productId);
+
+        DiscoveryResult discoveryResult = DiscoveryResultBuilder.create(thingUid).withLabel(device.name)
+                .withRepresentationProperty(CONFIG_DEVICE_ID).withProperties(properties).build();
+
+        refreshSchema(device.id, device.productId, api);
+
+        thingDiscovered(discoveryResult);
+
+        return thingUid;
+    }
+
+    private void processSubDevice(SubDeviceInfo subDevice, TuyaOpenAPI api, ThingUID gatewayUid) {
+        ThingUID thingUid = new ThingUID(THING_TYPE_TUYA_SUB_DEVICE, gatewayUid, subDevice.id);
+
+        Map<String, Object> properties = new HashMap<>();
+        properties.put(PROPERTY_CATEGORY, subDevice.category);
+        properties.put(CONFIG_DEVICE_ID, subDevice.id);
+        properties.put(CONFIG_PRODUCT_ID, subDevice.productId);
+        properties.put(CONFIG_SUB_DEVICE_ID, subDevice.nodeId);
+
+        DiscoveryResult discoveryResult = DiscoveryResultBuilder.create(thingUid).withLabel(subDevice.name)
+                .withBridge(gatewayUid).withRepresentationProperty(CONFIG_DEVICE_ID).withProperties(properties).build();
+
+        refreshSchema(subDevice.id, subDevice.productId, api);
+
+        thingDiscovered(discoveryResult);
+    }
+
+    private void refreshSchema(String deviceId, String productId, TuyaOpenAPI api) {
+        if (TuyaSchemaDB.contains(productId)) {
+            // The schema of a product does not change, and a scan is already close to the request limits of the cloud
+            return;
+        }
+
+        api.getDeviceSchema(deviceId).thenAccept(schema -> {
+            List<SchemaDp> schemaDps = new ArrayList<>();
+            schema.functions.forEach(description -> addUniqueSchemaDp(description, schemaDps, Boolean.FALSE));
+            schema.status.forEach(description -> addUniqueSchemaDp(description, schemaDps, Boolean.TRUE));
+            TuyaSchemaDB.put(productId, schemaDps);
         });
     }
 

--- a/bundles/org.openhab.binding.tuya/src/main/java/org/openhab/binding/tuya/internal/TuyaHandlerFactory.java
+++ b/bundles/org.openhab.binding.tuya/src/main/java/org/openhab/binding/tuya/internal/TuyaHandlerFactory.java
@@ -14,6 +14,8 @@ package org.openhab.binding.tuya.internal;
 
 import static org.openhab.binding.tuya.internal.TuyaBindingConstants.THING_TYPE_PROJECT;
 import static org.openhab.binding.tuya.internal.TuyaBindingConstants.THING_TYPE_TUYA_DEVICE;
+import static org.openhab.binding.tuya.internal.TuyaBindingConstants.THING_TYPE_TUYA_GATEWAY;
+import static org.openhab.binding.tuya.internal.TuyaBindingConstants.THING_TYPE_TUYA_SUB_DEVICE;
 
 import java.lang.reflect.Type;
 import java.util.List;
@@ -24,10 +26,13 @@ import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.jetty.client.HttpClient;
 import org.openhab.binding.tuya.internal.handler.ProjectHandler;
 import org.openhab.binding.tuya.internal.handler.TuyaDeviceHandler;
+import org.openhab.binding.tuya.internal.handler.TuyaGatewayHandler;
+import org.openhab.binding.tuya.internal.handler.TuyaSubDeviceHandler;
 import org.openhab.binding.tuya.internal.local.UdpDiscoveryListener;
 import org.openhab.binding.tuya.internal.util.SchemaDp;
 import org.openhab.core.io.net.http.HttpClientFactory;
 import org.openhab.core.storage.StorageService;
+import org.openhab.core.thing.Bridge;
 import org.openhab.core.thing.Thing;
 import org.openhab.core.thing.ThingTypeUID;
 import org.openhab.core.thing.binding.BaseThingHandlerFactory;
@@ -37,6 +42,8 @@ import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
@@ -49,16 +56,19 @@ import io.netty.channel.nio.NioEventLoopGroup;
  * handlers.
  *
  * @author Jan N. Klug - Initial contribution
+ * @author Maciej Jarzebowski - Add gateway and sub-device handlers
  */
 @NonNullByDefault
 @Component(configurationPid = "binding.tuya", service = ThingHandlerFactory.class)
 @SuppressWarnings("unused")
 public class TuyaHandlerFactory extends BaseThingHandlerFactory {
     private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Set.of(THING_TYPE_PROJECT,
-            THING_TYPE_TUYA_DEVICE);
+            THING_TYPE_TUYA_DEVICE, THING_TYPE_TUYA_GATEWAY, THING_TYPE_TUYA_SUB_DEVICE);
     private static final Type STORAGE_TYPE = TypeToken.getParameterized(List.class, SchemaDp.class).getType();
 
     public static final TuyaSchemaDB SCHEMAS = new TuyaSchemaDB();
+
+    private final Logger logger = LoggerFactory.getLogger(TuyaHandlerFactory.class);
 
     private final TuyaDynamicCommandDescriptionProvider dynamicCommandDescriptionProvider;
     private final TuyaDynamicStateDescriptionProvider dynamicStateDescriptionProvider;
@@ -101,6 +111,18 @@ public class TuyaHandlerFactory extends BaseThingHandlerFactory {
         } else if (THING_TYPE_TUYA_DEVICE.equals(thingTypeUID)) {
             return new TuyaDeviceHandler(thing, gson, dynamicCommandDescriptionProvider,
                     dynamicStateDescriptionProvider, eventLoopGroup, udpDiscoveryListener);
+        } else if (THING_TYPE_TUYA_GATEWAY.equals(thingTypeUID)) {
+            if (thing instanceof Bridge bridge) {
+                return new TuyaGatewayHandler(bridge, gson, dynamicCommandDescriptionProvider,
+                        dynamicStateDescriptionProvider, eventLoopGroup, udpDiscoveryListener);
+            }
+            // A thing is created as a bridge only if the bridge type was known at the time, and whether it is one is
+            // persisted with the thing. A gateway created before this binding was fully started stays a plain thing.
+            logger.warn("Thing '{}' was not created as a bridge and cannot serve sub-devices. Remove and re-add it.",
+                    thing.getUID());
+        } else if (THING_TYPE_TUYA_SUB_DEVICE.equals(thingTypeUID)) {
+            return new TuyaSubDeviceHandler(thing, gson, dynamicCommandDescriptionProvider,
+                    dynamicStateDescriptionProvider);
         }
 
         return null;

--- a/bundles/org.openhab.binding.tuya/src/main/java/org/openhab/binding/tuya/internal/cloud/TuyaOpenAPI.java
+++ b/bundles/org.openhab.binding.tuya/src/main/java/org/openhab/binding/tuya/internal/cloud/TuyaOpenAPI.java
@@ -39,6 +39,7 @@ import org.openhab.binding.tuya.internal.cloud.dto.DeviceSchema;
 import org.openhab.binding.tuya.internal.cloud.dto.FactoryInformation;
 import org.openhab.binding.tuya.internal.cloud.dto.Login;
 import org.openhab.binding.tuya.internal.cloud.dto.ResultResponse;
+import org.openhab.binding.tuya.internal.cloud.dto.SubDeviceInfo;
 import org.openhab.binding.tuya.internal.cloud.dto.Token;
 import org.openhab.binding.tuya.internal.config.ProjectConfiguration;
 import org.openhab.binding.tuya.internal.util.CryptoUtil;
@@ -53,6 +54,7 @@ import com.google.gson.reflect.TypeToken;
  * The {@link TuyaOpenAPI} is an implementation of the Tuya OpenApi specification
  *
  * @author Jan N. Klug - Initial contribution
+ * @author Maciej Jarzebowski - Add sub-device retrieval
  */
 @NonNullByDefault
 public class TuyaOpenAPI {
@@ -161,6 +163,17 @@ public class TuyaOpenAPI {
     public CompletableFuture<DeviceSchema> getDeviceSchema(String deviceId) {
         return request(HttpMethod.GET, "/v1.1/devices/" + deviceId + "/specifications", Map.of(), null)
                 .thenCompose(s -> processResponse(s, DeviceSchema.class));
+    }
+
+    /**
+     * Retrieves the devices connected through the given gateway.
+     *
+     * @param deviceId the device id of the gateway
+     * @return the sub-devices, an empty list if the device is not a gateway
+     */
+    public CompletableFuture<List<SubDeviceInfo>> getSubDevices(String deviceId) {
+        return request(HttpMethod.GET, "/v1.0/devices/" + deviceId + "/sub-devices", Map.of(), null).thenCompose(
+                s -> processResponse(s, TypeToken.getParameterized(List.class, SubDeviceInfo.class).getType()));
     }
 
     public CompletableFuture<Boolean> sendCommand(String deviceId, CommandRequest command) {

--- a/bundles/org.openhab.binding.tuya/src/main/java/org/openhab/binding/tuya/internal/cloud/dto/SubDeviceInfo.java
+++ b/bundles/org.openhab.binding.tuya/src/main/java/org/openhab/binding/tuya/internal/cloud/dto/SubDeviceInfo.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.tuya.internal.cloud.dto;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * The {@link SubDeviceInfo} encapsulates the information about a device connected through a gateway
+ *
+ * @author Maciej Jarzebowski - Initial contribution
+ */
+@NonNullByDefault
+@SuppressWarnings("unused")
+public class SubDeviceInfo {
+    public String id = "";
+    public String name = "";
+    public String category = "";
+    public String icon = "";
+    public boolean online = false;
+
+    @SerializedName("node_id")
+    public String nodeId = "";
+    @SerializedName("product_id")
+    public String productId = "";
+    @SerializedName("owner_id")
+    public String ownerId = "";
+
+    @SerializedName("active_time")
+    public long activeTime = 0;
+    @SerializedName("update_time")
+    public long updateTime = 0;
+
+    @Override
+    public String toString() {
+        return "SubDeviceInfo{" + "id='" + id + "', name='" + name + "', category='" + category + "', icon='" + icon
+                + "', online=" + online + ", nodeId='" + nodeId + "', productId='" + productId + "', ownerId='"
+                + ownerId + "', activeTime=" + activeTime + ", updateTime=" + updateTime + "}";
+    }
+}

--- a/bundles/org.openhab.binding.tuya/src/main/java/org/openhab/binding/tuya/internal/config/DeviceConfiguration.java
+++ b/bundles/org.openhab.binding.tuya/src/main/java/org/openhab/binding/tuya/internal/config/DeviceConfiguration.java
@@ -18,12 +18,18 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
  * The {@link DeviceConfiguration} holds the configuration of a single device
  *
  * @author Jan N. Klug - Initial contribution
+ * @author Maciej Jarzebowski - Add sub-device node id
  */
 @NonNullByDefault
 public class DeviceConfiguration {
     public String productId = "";
     public String deviceId = "";
     public String localKey = "";
+
+    /**
+     * The node id of a sub-device connected through a gateway. Empty for devices that are reached directly.
+     */
+    public String subDeviceId = "";
 
     public String ip = "";
     public int port = 6668;

--- a/bundles/org.openhab.binding.tuya/src/main/java/org/openhab/binding/tuya/internal/handler/BaseTuyaDeviceHandler.java
+++ b/bundles/org.openhab.binding.tuya/src/main/java/org/openhab/binding/tuya/internal/handler/BaseTuyaDeviceHandler.java
@@ -1,0 +1,803 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.tuya.internal.handler;
+
+import static org.openhab.binding.tuya.internal.TuyaBindingConstants.BINDING_ID;
+import static org.openhab.binding.tuya.internal.TuyaBindingConstants.CHANNEL_TYPE_UID_IR_CODE;
+import static org.openhab.binding.tuya.internal.TuyaBindingConstants.CHANNEL_TYPE_UID_NUMBER;
+import static org.openhab.binding.tuya.internal.TuyaBindingConstants.CONFIG_DP;
+import static org.openhab.binding.tuya.internal.TuyaBindingConstants.CONFIG_DP2;
+import static org.openhab.binding.tuya.internal.TuyaBindingConstants.CONFIG_MAX;
+import static org.openhab.binding.tuya.internal.TuyaBindingConstants.CONFIG_MIN;
+import static org.openhab.binding.tuya.internal.TuyaBindingConstants.CONFIG_PRODUCT_ID;
+import static org.openhab.binding.tuya.internal.TuyaBindingConstants.CONFIG_RANGE;
+import static org.openhab.core.library.CoreItemFactory.COLOR;
+import static org.openhab.core.library.CoreItemFactory.DIMMER;
+import static org.openhab.core.library.CoreItemFactory.NUMBER;
+import static org.openhab.core.library.CoreItemFactory.STRING;
+import static org.openhab.core.library.CoreItemFactory.SWITCH;
+
+import java.math.BigDecimal;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import javax.measure.Unit;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.tuya.internal.TuyaDynamicCommandDescriptionProvider;
+import org.openhab.binding.tuya.internal.TuyaDynamicStateDescriptionProvider;
+import org.openhab.binding.tuya.internal.TuyaSchemaDB;
+import org.openhab.binding.tuya.internal.config.ChannelConfiguration;
+import org.openhab.binding.tuya.internal.config.DeviceConfiguration;
+import org.openhab.binding.tuya.internal.local.dto.IrCode;
+import org.openhab.binding.tuya.internal.util.ConversionUtil;
+import org.openhab.binding.tuya.internal.util.IrUtils;
+import org.openhab.binding.tuya.internal.util.SchemaDp;
+import org.openhab.core.cache.ExpiringCache;
+import org.openhab.core.cache.ExpiringCacheMap;
+import org.openhab.core.config.core.Configuration;
+import org.openhab.core.library.types.DecimalType;
+import org.openhab.core.library.types.HSBType;
+import org.openhab.core.library.types.OnOffType;
+import org.openhab.core.library.types.PercentType;
+import org.openhab.core.library.types.QuantityType;
+import org.openhab.core.library.types.StringType;
+import org.openhab.core.thing.Channel;
+import org.openhab.core.thing.ChannelUID;
+import org.openhab.core.thing.Thing;
+import org.openhab.core.thing.ThingStatus;
+import org.openhab.core.thing.ThingUID;
+import org.openhab.core.thing.binding.BaseThingHandler;
+import org.openhab.core.thing.binding.ThingHandlerCallback;
+import org.openhab.core.thing.binding.builder.ThingBuilder;
+import org.openhab.core.thing.type.ChannelTypeUID;
+import org.openhab.core.types.Command;
+import org.openhab.core.types.CommandOption;
+import org.openhab.core.types.RefreshType;
+import org.openhab.core.types.State;
+import org.openhab.core.types.UnDefType;
+import org.openhab.core.util.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonSyntaxException;
+
+/**
+ * The {@link BaseTuyaDeviceHandler} implements the schema, channel and data point handling that is common to all Tuya
+ * devices, independent of how the device is reached. Subclasses provide the transport, either an own connection (see
+ * {@link TuyaDeviceHandler}) or a gateway relaying for a sub-device (see {@link TuyaSubDeviceHandler}).
+ *
+ * @author Jan N. Klug - Initial contribution
+ * @author Maciej Jarzebowski - Extracted from TuyaDeviceHandler for gateway support
+ */
+@NonNullByDefault
+public abstract class BaseTuyaDeviceHandler extends BaseThingHandler {
+    protected final Logger logger = LoggerFactory.getLogger(getClass());
+
+    private final Gson gson;
+    private final TuyaDynamicCommandDescriptionProvider dynamicCommandDescriptionProvider;
+    private final TuyaDynamicStateDescriptionProvider dynamicStateDescriptionProvider;
+    private final Map<String, SchemaDp> schemaDps;
+
+    protected DeviceConfiguration configuration = new DeviceConfiguration();
+
+    private int pollBurst = 0;
+    private boolean oldColorMode = false;
+
+    private @Nullable ScheduledFuture<?> pollingJob;
+    private @Nullable ScheduledFuture<?> irLearnJob;
+
+    private final Map<Integer, String> dpToChannelId = new HashMap<>();
+    private final Map<Integer, List<String>> dp2ToChannelId = new HashMap<>();
+    private final Map<String, ChannelTypeUID> channelIdToChannelTypeUID = new HashMap<>();
+    private final Map<String, ChannelConfiguration> channelIdToConfiguration = new HashMap<>();
+
+    private final ExpiringCacheMap<Integer, @Nullable Object> deviceStatusCache = new ExpiringCacheMap<>(
+            Duration.ofSeconds(10));
+    private final Map<String, State> channelStateCache = new HashMap<>();
+
+    protected BaseTuyaDeviceHandler(Thing thing, Gson gson,
+            TuyaDynamicCommandDescriptionProvider dynamicCommandDescriptionProvider,
+            TuyaDynamicStateDescriptionProvider dynamicStateDescriptionProvider) {
+        super(thing);
+        this.schemaDps = Objects.requireNonNullElse(TuyaSchemaDB.getOrConvert(
+                (String) thing.getConfiguration().get(CONFIG_PRODUCT_ID), thing.getUID().getId()), Map.of());
+        this.gson = gson;
+        this.dynamicCommandDescriptionProvider = dynamicCommandDescriptionProvider;
+        this.dynamicStateDescriptionProvider = dynamicStateDescriptionProvider;
+    }
+
+    /**
+     * Sends data points to the device.
+     */
+    protected abstract void sendCommand(Map<Integer, @Nullable Object> command);
+
+    /**
+     * Queries the full status of the device. Used when communication has just been established and the device state is
+     * unknown.
+     */
+    protected abstract void requestStatus();
+
+    /**
+     * Requests an update of the measurable data points of the device.
+     */
+    protected abstract void refreshStatus();
+
+    /**
+     * @return whether the device can currently be reached
+     */
+    protected abstract boolean canCommunicate();
+
+    /**
+     * Whether {@link #refreshStatus()} repeats the full query that {@link #requestStatus()} performs.
+     *
+     * A device reached through a gateway has no partial refresh, so both are the same request, and its reply is
+     * itself a status report. Refreshing in reaction to a status would therefore trigger another status, and the two
+     * would keep triggering each other.
+     */
+    protected boolean refreshRepeatsFullQuery() {
+        return false;
+    }
+
+    public @Nullable SchemaDp getSchemaForChannelId(String channelId) {
+        return schemaDps.get(channelId);
+    }
+
+    protected List<Integer> getAllDpIds() {
+        return schemaDps.values().stream().map(e -> e.id).toList();
+    }
+
+    protected void processDeviceStatus(Map<Integer, Object> deviceStatus) {
+        // Changes to function DPs might lead to changes in status DPs. For instance, if a
+        // power switch is turned on the measured current and power can be expected to change
+        // within a few seconds.
+        boolean needRefresh = false;
+        boolean missingStatus = false;
+        for (var e : schemaDps.values()) {
+            Object value = deviceStatus.get(e.id);
+
+            if (value != null) {
+                addSingleExpiringCache(e.id, value);
+
+                if (!e.readOnly) {
+                    needRefresh = true;
+                }
+            } else if (e.readOnly) {
+                missingStatus = true;
+            }
+        }
+
+        if (needRefresh && configuration.pollingInterval > 0 && !refreshRepeatsFullQuery()) {
+            // We cannot assume that DPs are current or that the device will automatically
+            // re-measure on a function change.
+            if (canCommunicate()) {
+                synchronized (this) {
+                    ScheduledFuture<?> pollingJob = this.pollingJob;
+                    if (pollingJob != null) {
+                        pollingJob.cancel(true);
+                    }
+
+                    pollBurst = 3;
+                    this.pollingJob = scheduler.scheduleWithFixedDelay(this::burstPoller, 0, 1, TimeUnit.SECONDS);
+                }
+            }
+        } else if (!missingStatus) {
+            // If we have updates for everything we can stand down the burst polling.
+            pollBurst = 0;
+        }
+
+        deviceStatus.forEach(this::processChannelStatus);
+    }
+
+    private void burstPoller() {
+        if (!canCommunicate()) {
+            return;
+        }
+
+        if (pollBurst > 0) {
+            refreshStatus();
+            pollBurst = pollBurst - 1;
+        } else {
+            synchronized (this) {
+                if (!Thread.interrupted()) {
+                    ScheduledFuture<?> pollingJob = this.pollingJob;
+                    if (pollingJob != null) {
+                        this.pollingJob = null;
+                        pollingJob.cancel(false);
+                    }
+
+                    int pollingInterval = configuration.pollingInterval;
+                    if (pollingInterval > 0) {
+                        this.pollingJob = scheduler.scheduleWithFixedDelay(this::refreshStatus, pollingInterval,
+                                pollingInterval, TimeUnit.SECONDS);
+                    }
+                }
+            }
+        }
+    }
+
+    private void processChannelStatus(Integer dp, Object value) {
+        String channelId = dpToChannelId.get(dp);
+        if (channelId != null) {
+            ChannelConfiguration channelConfiguration = channelIdToConfiguration.get(channelId);
+            ChannelTypeUID channelTypeUID = channelIdToChannelTypeUID.get(channelId);
+
+            if (channelConfiguration == null || channelTypeUID == null) {
+                logger.warn("Could not find configuration or type for channel '{}' in thing '{}'", channelId,
+                        thing.getUID());
+                return;
+            }
+
+            if (Boolean.FALSE.equals(deviceStatusCache.get(channelConfiguration.dp2))) {
+                // skip update if the channel is off!
+                return;
+            }
+
+            Channel channel = thing.getChannel(channelId);
+            String acceptedItemType = (channel != null ? channel.getAcceptedItemType() : "");
+
+            try {
+                if (value instanceof String stringValue && COLOR.equals(acceptedItemType)) {
+                    oldColorMode = stringValue.length() == 14;
+                    updateState(channelId, ConversionUtil.hexColorDecode(stringValue));
+                    return;
+                } else if (value instanceof String stringValue && STRING.equals(acceptedItemType)) {
+                    if (!channelConfiguration.range.isEmpty() && channel != null) {
+                        // The device schemas only seem to specify the commands that can be sent to
+                        // a device. We have to learn the states sent by a device as they are seen.
+                        dynamicStateDescriptionProvider.addStateOption(channel.getUID(), stringValue);
+                    }
+                    updateState(channelId, new StringType(stringValue));
+                    return;
+                } else if (Double.class.isAssignableFrom(value.getClass()) && DIMMER.equals(acceptedItemType)) {
+                    updateState(channelId,
+                            ConversionUtil.brightnessDecode((double) value, 0, channelConfiguration.max));
+                    return;
+                } else if (CHANNEL_TYPE_UID_NUMBER.equals(channelTypeUID)) {
+                    // Deprecated: retained for compatibility with old Things that have not been re-added.
+                    // This MUST come before the startsWith("Number") case that follows!
+                    if (Double.class.isAssignableFrom(value.getClass())) {
+                        updateState(channelId, new DecimalType((double) value));
+                        return;
+                    } else if (value instanceof String string) {
+                        updateState(channelId, new DecimalType(string));
+                        return;
+                    }
+                } else if ((Double.class.isAssignableFrom(value.getClass()) || value instanceof String)
+                        && acceptedItemType != null && acceptedItemType.startsWith(NUMBER)) {
+                    BigDecimal d;
+                    if (value instanceof String stringValue) {
+                        d = new BigDecimal(stringValue);
+                    } else {
+                        d = new BigDecimal((double) value);
+                    }
+
+                    SchemaDp schemaDp = schemaDps.get(channelId);
+
+                    if (schemaDp != null) {
+                        d = d.movePointLeft(schemaDp.scale);
+
+                        Unit<?> unit = schemaDp.parsedUnit;
+                        if (unit != null) {
+                            updateState(channelId, new QuantityType<>(d, unit));
+                            return;
+                        }
+                    }
+
+                    updateState(channelId, new DecimalType(d));
+                    return;
+                } else if (Boolean.class.isAssignableFrom(value.getClass()) && SWITCH.equals(acceptedItemType)) {
+                    updateState(channelId, OnOffType.from((boolean) value));
+                    return;
+                } else if (value instanceof String && CHANNEL_TYPE_UID_IR_CODE.equals(channelTypeUID)) {
+                    if (channelConfiguration.dp == 2) {
+                        String decoded = convertBase64Code(channelConfiguration, (String) value);
+                        logger.info("thing {} received ir code: {}", thing.getUID(), decoded);
+                        updateState(channelId, new StringType(decoded));
+                        irStartLearning(channelConfiguration.activeListen);
+                    }
+                    return;
+                }
+            } catch (IllegalArgumentException ignored) {
+            }
+            logger.warn("Could not update channel '{}' of thing '{}' with value '{}'. Datatype incompatible.",
+                    channelId, getThing().getUID(), value);
+            updateState(channelId, UnDefType.UNDEF);
+        } else {
+            // try additional channelDps, only OnOffType
+            List<String> channelIds = dp2ToChannelId.get(dp);
+            if (channelIds == null) {
+                logger.debug("Could not find channel for dp '{}' in thing '{}'", dp, thing.getUID());
+            } else {
+                if (Boolean.class.isAssignableFrom(value.getClass())) {
+                    OnOffType state = OnOffType.from((boolean) value);
+                    channelIds.forEach(ch -> updateState(ch, state));
+                    return;
+                }
+                logger.warn("Could not update channel '{}' of thing '{}' with value {}. Datatype incompatible.",
+                        channelIds, getThing().getUID(), value);
+            }
+        }
+    }
+
+    /**
+     * Called when the device became reachable. Queries the device state and starts polling and, if applicable, IR
+     * learning.
+     *
+     * @param initialDelay how long to wait before sending the first query, in milliseconds
+     */
+    protected void onCommunicationEstablished(int initialDelay) {
+        synchronized (this) {
+            if (pollingJob == null) {
+                // When we first connect the device state is unknown so we want to query for everything.
+                // Some devices seem to initialize their stacks in the wrong order and
+                // requests that come too soon can be either ignored completely or responded
+                // to with a, "not supported". The lower level protocol handler suggests an
+                // initial delay where it might be advisable.
+                pollingJob = scheduler.schedule(() -> {
+                    requestStatus();
+
+                    // After that we poll for the measurable DPs.
+                    int pollingInterval = configuration.pollingInterval;
+                    if (pollingInterval > 0) {
+                        synchronized (this) {
+                            // The first refresh request is immediate because we do not know how old the current
+                            // status might be, unless the query above already answered that.
+                            long initialRefreshDelay = refreshRepeatsFullQuery() ? pollingInterval : 0;
+                            pollingJob = scheduler.scheduleWithFixedDelay(this::refreshStatus, initialRefreshDelay,
+                                    pollingInterval, TimeUnit.SECONDS);
+                        }
+                    }
+                }, initialDelay, TimeUnit.MILLISECONDS);
+            } else {
+                logger.debug("{}: polling job already exists?!?", thing.getUID().getId());
+            }
+        }
+
+        // start learning code if thing is online and presents 'ir-code' channel
+        channelIdToChannelTypeUID.entrySet().stream().filter(e -> CHANNEL_TYPE_UID_IR_CODE.equals(e.getValue()))
+                .map(Map.Entry::getKey).findAny().map(channelIdToConfiguration::get)
+                .ifPresent(irCodeChannelConfig -> irStartLearning(irCodeChannelConfig.activeListen));
+    }
+
+    /**
+     * Called when the device is no longer reachable.
+     */
+    protected void onCommunicationLost() {
+        stopPolling();
+
+        if (channelIdToChannelTypeUID.containsValue(CHANNEL_TYPE_UID_IR_CODE)) {
+            irStopLearning();
+        }
+    }
+
+    private void stopPolling() {
+        synchronized (this) {
+            ScheduledFuture<?> pollingJob = this.pollingJob;
+            if (pollingJob != null) {
+                this.pollingJob = null;
+                pollingJob.cancel(true);
+            }
+        }
+    }
+
+    @Override
+    public void handleCommand(ChannelUID channelUID, Command command) {
+        if (command instanceof RefreshType) {
+            State state = channelStateCache.get(channelUID.getId());
+            if (state != null) {
+                updateState(channelUID, state);
+            }
+            return;
+        }
+
+        if (getThing().getStatus() != ThingStatus.ONLINE) {
+            logger.warn("Channel '{}' received a command but device is not ONLINE. Discarding command.", channelUID);
+            return;
+        }
+
+        Map<Integer, @Nullable Object> commandRequest = new HashMap<>();
+
+        ChannelTypeUID channelTypeUID = channelIdToChannelTypeUID.get(channelUID.getId());
+        ChannelConfiguration configuration = channelIdToConfiguration.get(channelUID.getId());
+        if (channelTypeUID == null || configuration == null) {
+            logger.warn("Could not determine channel type or configuration for channel '{}'. Discarding command.",
+                    channelUID);
+            return;
+        }
+
+        Channel channel = thing.getChannel(channelUID.getId());
+        String acceptedItemType = (channel != null ? channel.getAcceptedItemType() : "");
+
+        if (COLOR.equals(acceptedItemType)) {
+            if (command instanceof HSBType) {
+                commandRequest.put(configuration.dp, ConversionUtil.hexColorEncode((HSBType) command, oldColorMode));
+                ChannelConfiguration workModeConfig = channelIdToConfiguration.get("work_mode");
+                if (workModeConfig != null) {
+                    commandRequest.put(workModeConfig.dp, "colour");
+                }
+                if (configuration.dp2 != 0) {
+                    commandRequest.put(configuration.dp2, ((HSBType) command).getBrightness().doubleValue() > 0.0);
+                }
+            } else if (command instanceof PercentType percentCommand) {
+                State oldState = channelStateCache.get(channelUID.getId());
+                if (!(oldState instanceof HSBType)) {
+                    logger.debug("Discarding command '{}' to channel '{}', cannot determine old state", command,
+                            channelUID);
+                    return;
+                }
+                HSBType newState = new HSBType(((HSBType) oldState).getHue(), ((HSBType) oldState).getSaturation(),
+                        percentCommand);
+                commandRequest.put(configuration.dp, ConversionUtil.hexColorEncode(newState, oldColorMode));
+                ChannelConfiguration workModeConfig = channelIdToConfiguration.get("work_mode");
+                if (workModeConfig != null) {
+                    commandRequest.put(workModeConfig.dp, "colour");
+                }
+                if (configuration.dp2 != 0) {
+                    commandRequest.put(configuration.dp2, (percentCommand).doubleValue() > 0.0);
+                }
+            } else if (command instanceof OnOffType) {
+                if (configuration.dp2 != 0) {
+                    commandRequest.put(configuration.dp2, OnOffType.ON.equals(command));
+                }
+            }
+        } else if (DIMMER.equals(acceptedItemType)) {
+            if (command instanceof PercentType percentCommand) {
+                int value = ConversionUtil.brightnessEncode(percentCommand, 0, configuration.max);
+                if (configuration.reversed) {
+                    value = configuration.max - value;
+                }
+                if (value >= configuration.min) {
+                    commandRequest.put(configuration.dp, value);
+                }
+                if (configuration.dp2 != 0) {
+                    commandRequest.put(configuration.dp2, value >= configuration.min);
+                }
+                ChannelConfiguration workModeConfig = channelIdToConfiguration.get("work_mode");
+                if (workModeConfig != null) {
+                    commandRequest.put(workModeConfig.dp, "white");
+                }
+            } else if (command instanceof OnOffType) {
+                if (configuration.dp2 != 0) {
+                    commandRequest.put(configuration.dp2, OnOffType.ON.equals(command));
+                }
+            }
+        } else if (STRING.equals(acceptedItemType)) {
+            commandRequest.put(configuration.dp, command.toString());
+        } else if (acceptedItemType != null && acceptedItemType.startsWith(NUMBER)) {
+            if (command instanceof QuantityType quantityType) {
+                SchemaDp schemaDp = schemaDps.get(channelUID.getId());
+
+                if (schemaDp != null && !schemaDp.unit.isEmpty()) {
+                    // If the item type for the channel is not dimensioned the unit is not usable and we
+                    // assume whoever sent a quantity instead of a bare number knows what they are doing.
+                    if (!NUMBER.equals(acceptedItemType)) {
+                        quantityType = quantityType.toUnit(schemaDp.unit);
+                    }
+                }
+
+                if (quantityType != null) {
+                    BigDecimal d = quantityType.toBigDecimal();
+                    if (schemaDp != null) {
+                        d = d.movePointRight(schemaDp.scale);
+                    }
+                    command = new DecimalType(d);
+                }
+            }
+
+            if (command instanceof DecimalType decimalType) {
+                commandRequest.put(configuration.dp,
+                        configuration.sendAsString ? String.format("%d", decimalType.intValue())
+                                : decimalType.intValue());
+            }
+        } else if (SWITCH.equals(acceptedItemType)) {
+            if (command instanceof OnOffType) {
+                commandRequest.put(configuration.dp, OnOffType.ON.equals(command));
+            }
+        } else if (CHANNEL_TYPE_UID_IR_CODE.equals(channelTypeUID)) {
+            if (command instanceof StringType) {
+                switch (configuration.irType) {
+                    case "base64" -> {
+                        commandRequest.put(1, "study_key");
+                        commandRequest.put(7, command.toString());
+                    }
+                    case "tuya-head" -> {
+                        if (!configuration.irCode.isBlank()) {
+                            commandRequest.put(1, "send_ir");
+                            commandRequest.put(3, configuration.irCode);
+                            commandRequest.put(4, command.toString());
+                            commandRequest.put(10, configuration.irSendDelay);
+                            commandRequest.put(13, configuration.irCodeType);
+                        } else {
+                            logger.warn("irCode is not set for channel {}", channelUID);
+                        }
+                    }
+                    case "nec" -> {
+                        long code = convertHexCode(command.toString());
+                        String base64Code = IrUtils.necToBase64(code);
+                        commandRequest.put(1, "study_key");
+                        commandRequest.put(7, base64Code);
+                    }
+                    case "samsung" -> {
+                        long code = convertHexCode(command.toString());
+                        String base64Code = IrUtils.samsungToBase64(code);
+                        commandRequest.put(1, "study_key");
+                        commandRequest.put(7, base64Code);
+                    }
+                }
+                irStopLearning();
+            }
+        }
+
+        if (!commandRequest.isEmpty()) {
+            sendCommand(commandRequest);
+        }
+
+        if (CHANNEL_TYPE_UID_IR_CODE.equals(channelTypeUID)) {
+            if (command instanceof StringType) {
+                irStartLearning(configuration.activeListen);
+            }
+        }
+    }
+
+    @Override
+    public void dispose() {
+        logger.debug("{}: dispose", thing.getUID().getId());
+
+        stopPolling();
+        irStopLearning();
+
+        dpToChannelId.clear();
+        dp2ToChannelId.clear();
+        channelIdToChannelTypeUID.clear();
+        channelIdToConfiguration.clear();
+    }
+
+    @Override
+    public void initialize() {
+        configuration = getConfigAs(DeviceConfiguration.class);
+
+        boolean hasStatusDps = false;
+        for (var e : schemaDps.values()) {
+            if (e.readOnly) {
+                hasStatusDps = true;
+                break;
+            }
+        }
+        if (!hasStatusDps) {
+            logger.debug("{}: no status DPs - polling disabled", thing.getUID().getId());
+            configuration.pollingInterval = 0;
+        }
+
+        // Update the channel list.
+        addChannels();
+
+        thing.getChannels().forEach(this::configureChannel);
+
+        initializeTransport();
+    }
+
+    /**
+     * Establishes whatever is needed to reach the device and sets the initial thing status. Called at the end of
+     * {@link #initialize()}, after the channels have been set up.
+     */
+    protected abstract void initializeTransport();
+
+    private void addChannels() {
+        ThingBuilder thingBuilder = editThing();
+        ThingUID thingUID = thing.getUID();
+        ThingHandlerCallback callback = getCallback();
+
+        if (callback == null) {
+            logger.warn("Thing callback not found. Cannot auto-detect thing '{}' channels.", thingUID);
+            return;
+        }
+
+        Map<String, Channel> channels = new LinkedHashMap<>(schemaDps.entrySet().stream().map(e -> {
+            String channelId = e.getKey();
+            SchemaDp schemaDp = e.getValue();
+
+            ChannelTypeUID channeltypeUID = new ChannelTypeUID(BINDING_ID, configuration.productId + "_" + channelId);
+            ChannelUID channelUID = new ChannelUID(thingUID, channelId);
+
+            Map<@Nullable String, @Nullable Object> configuration = new HashMap<>();
+            configuration.put(CONFIG_DP, schemaDp.id);
+
+            if ("enum".equals(schemaDp.type)) {
+                List<String> range = Objects.requireNonNullElse(schemaDp.range, List.of());
+                configuration.put(CONFIG_RANGE, String.join(",", range));
+            } else if ("value".equals(schemaDp.type)) {
+                if (schemaDp.scale > 0) {
+                    Double d = schemaDp.min;
+                    if (d != null) {
+                        configuration.put(CONFIG_MIN, new BigDecimal(d).movePointLeft(schemaDp.scale));
+                    }
+
+                    d = schemaDp.max;
+                    if (d != null) {
+                        configuration.put(CONFIG_MAX, new BigDecimal(d).movePointLeft(schemaDp.scale));
+                    }
+                } else {
+                    configuration.put(CONFIG_MIN, schemaDp.min);
+                    configuration.put(CONFIG_MAX, schemaDp.max);
+                }
+            }
+
+            return Map.entry(channelId, callback.createChannelBuilder(channelUID, channeltypeUID) //
+                    .withConfiguration(new Configuration(configuration)) //
+                    .build());
+        }).filter(c -> !c.getKey().isEmpty())
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (e1, e2) -> e1, LinkedHashMap::new)));
+
+        List<String> channelSuffixes = List.of("", "_1", "_2");
+        List<String> switchChannels = List.of("switch_led", "led_switch");
+        channelSuffixes.forEach(suffix -> switchChannels.forEach(channel -> {
+            Channel switchChannel = channels.get(channel + suffix);
+            if (switchChannel != null) {
+                // remove switch channel if brightness or color is present and add to dp2 instead
+                ChannelConfiguration config = switchChannel.getConfiguration().as(ChannelConfiguration.class);
+                Channel colourChannel = channels.get("colour_data" + suffix);
+                Channel brightChannel = channels.get("bright_value" + suffix);
+                boolean remove = false;
+
+                if (colourChannel != null) {
+                    colourChannel.getConfiguration().put(CONFIG_DP2, config.dp);
+                    remove = true;
+                }
+                if (brightChannel != null) {
+                    brightChannel.getConfiguration().put(CONFIG_DP2, config.dp);
+                    remove = true;
+                }
+
+                if (remove) {
+                    channels.remove(channel + suffix);
+                }
+            }
+        }));
+
+        var existingChannels = thing.getChannels();
+
+        // Starting from scratch...
+        thingBuilder.withChannels(List.of());
+
+        // Add the channels from the schema.
+        channels.values().forEach(thingBuilder::withChannel);
+
+        // Add pre-existing channels that weren't in the schema (user-added channels).
+        existingChannels.stream() //
+                .filter(channel -> !channels.containsKey(channel.getUID().getId())) //
+                .forEach(thingBuilder::withChannel);
+
+        updateThing(thingBuilder.build());
+    }
+
+    private void configureChannel(Channel channel) {
+        ChannelConfiguration configuration = channel.getConfiguration().as(ChannelConfiguration.class);
+        ChannelTypeUID channelTypeUID = channel.getChannelTypeUID();
+
+        if (channelTypeUID == null) {
+            logger.warn("Could not determine ChannelTypeUID for '{}'", channel.getUID());
+            return;
+        }
+
+        String channelId = channel.getUID().getId();
+
+        if (!configuration.range.isEmpty()) {
+            List<CommandOption> commandOptions = toCommandOptionList(
+                    Arrays.stream(configuration.range.split(",")).collect(Collectors.toList()));
+            dynamicCommandDescriptionProvider.setCommandOptions(channel.getUID(), commandOptions);
+        }
+
+        dpToChannelId.put(configuration.dp, channelId);
+        channelIdToConfiguration.put(channelId, configuration);
+        channelIdToChannelTypeUID.put(channelId, channelTypeUID);
+
+        // check if we have additional DPs (these are switch DP for color or brightness only)
+        if (configuration.dp2 != 0) {
+            List<String> list = Objects
+                    .requireNonNull(dp2ToChannelId.computeIfAbsent(configuration.dp2, ArrayList::new));
+            list.add(channelId);
+        }
+        if (CHANNEL_TYPE_UID_IR_CODE.equals(channelTypeUID)) {
+            irStartLearning(configuration.activeListen);
+        }
+    }
+
+    private List<CommandOption> toCommandOptionList(List<String> options) {
+        return options.stream()
+                .map(c -> new CommandOption(c, StringUtils.capitalizeByWhitespace(c.replaceAll("_", " ")))).toList();
+    }
+
+    private void addSingleExpiringCache(Integer key, Object value) {
+        ExpiringCache<@Nullable Object> expiringCache = new ExpiringCache<>(Duration.ofSeconds(10), () -> null);
+        expiringCache.putValue(value);
+        deviceStatusCache.put(key, expiringCache);
+    }
+
+    @Override
+    protected void updateState(String channelId, State state) {
+        channelStateCache.put(channelId, state);
+        super.updateState(channelId, state);
+    }
+
+    private long convertHexCode(String code) {
+        String sCode = code.startsWith("0x") ? code.substring(2) : code;
+        return Long.parseLong(sCode, 16);
+    }
+
+    private String convertBase64Code(ChannelConfiguration channelConfig, String encoded) {
+        String decoded = "";
+        try {
+            if (channelConfig.irType.equals("nec")) {
+                decoded = IrUtils.base64ToNec(encoded);
+                IrCode code = Objects.requireNonNull(gson.fromJson(decoded, IrCode.class));
+                decoded = "0x" + code.hex;
+            } else if (channelConfig.irType.equals("samsung")) {
+                decoded = IrUtils.base64ToSamsung(encoded);
+                IrCode code = Objects.requireNonNull(gson.fromJson(decoded, IrCode.class));
+                decoded = "0x" + code.hex;
+            } else {
+                if (encoded.length() > 68) {
+                    decoded = IrUtils.base64ToNec(encoded);
+                    if (decoded.isEmpty()) {
+                        decoded = IrUtils.base64ToSamsung(encoded);
+                    }
+                    IrCode code = Objects.requireNonNull(gson.fromJson(decoded, IrCode.class));
+                    decoded = code.type + ": 0x" + code.hex;
+                } else {
+                    decoded = encoded;
+                }
+            }
+        } catch (JsonSyntaxException e) {
+            logger.warn("Incorrect json response: {}", e.getMessage());
+            decoded = encoded;
+        } catch (RuntimeException e) {
+            logger.warn("Unable decode key code'{}', reason: {}", decoded, e.getMessage());
+        }
+        return decoded;
+    }
+
+    private void repeatStudyCode() {
+        Map<Integer, @Nullable Object> commandRequest = new HashMap<>();
+        commandRequest.put(1, "study");
+        sendCommand(commandRequest);
+    }
+
+    private void irStopLearning() {
+        logger.debug("[tuya:ir-controller] stop ir learning");
+        ScheduledFuture<?> feature = irLearnJob;
+        if (feature != null) {
+            feature.cancel(true);
+            this.irLearnJob = null;
+        }
+    }
+
+    private void irStartLearning(boolean available) {
+        irStopLearning();
+        if (available) {
+            logger.debug("[tuya:ir-controller] start ir learning");
+            irLearnJob = scheduler.scheduleWithFixedDelay(this::repeatStudyCode, 200, 29000, TimeUnit.MILLISECONDS);
+        }
+    }
+}

--- a/bundles/org.openhab.binding.tuya/src/main/java/org/openhab/binding/tuya/internal/handler/TuyaDeviceHandler.java
+++ b/bundles/org.openhab.binding.tuya/src/main/java/org/openhab/binding/tuya/internal/handler/TuyaDeviceHandler.java
@@ -12,315 +12,111 @@
  */
 package org.openhab.binding.tuya.internal.handler;
 
-import static org.openhab.binding.tuya.internal.TuyaBindingConstants.BINDING_ID;
-import static org.openhab.binding.tuya.internal.TuyaBindingConstants.CHANNEL_TYPE_UID_IR_CODE;
-import static org.openhab.binding.tuya.internal.TuyaBindingConstants.CHANNEL_TYPE_UID_NUMBER;
-import static org.openhab.binding.tuya.internal.TuyaBindingConstants.CONFIG_DP;
-import static org.openhab.binding.tuya.internal.TuyaBindingConstants.CONFIG_DP2;
 import static org.openhab.binding.tuya.internal.TuyaBindingConstants.CONFIG_IP;
-import static org.openhab.binding.tuya.internal.TuyaBindingConstants.CONFIG_MAX;
-import static org.openhab.binding.tuya.internal.TuyaBindingConstants.CONFIG_MIN;
-import static org.openhab.binding.tuya.internal.TuyaBindingConstants.CONFIG_PRODUCT_ID;
 import static org.openhab.binding.tuya.internal.TuyaBindingConstants.CONFIG_PROTOCOL;
-import static org.openhab.binding.tuya.internal.TuyaBindingConstants.CONFIG_RANGE;
-import static org.openhab.core.library.CoreItemFactory.COLOR;
-import static org.openhab.core.library.CoreItemFactory.DIMMER;
-import static org.openhab.core.library.CoreItemFactory.NUMBER;
-import static org.openhab.core.library.CoreItemFactory.STRING;
-import static org.openhab.core.library.CoreItemFactory.SWITCH;
 
-import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
-import java.time.Duration;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
-import java.util.Objects;
-import java.util.concurrent.ScheduledFuture;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
-
-import javax.measure.Unit;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.tuya.internal.TuyaDynamicCommandDescriptionProvider;
 import org.openhab.binding.tuya.internal.TuyaDynamicStateDescriptionProvider;
-import org.openhab.binding.tuya.internal.TuyaSchemaDB;
-import org.openhab.binding.tuya.internal.config.ChannelConfiguration;
-import org.openhab.binding.tuya.internal.config.DeviceConfiguration;
 import org.openhab.binding.tuya.internal.local.DeviceInfoSubscriber;
 import org.openhab.binding.tuya.internal.local.DeviceStatusListener;
 import org.openhab.binding.tuya.internal.local.TuyaDevice;
 import org.openhab.binding.tuya.internal.local.UdpDiscoveryListener;
 import org.openhab.binding.tuya.internal.local.dto.DeviceInfo;
-import org.openhab.binding.tuya.internal.local.dto.IrCode;
-import org.openhab.binding.tuya.internal.util.ConversionUtil;
-import org.openhab.binding.tuya.internal.util.IrUtils;
-import org.openhab.binding.tuya.internal.util.SchemaDp;
-import org.openhab.core.cache.ExpiringCache;
-import org.openhab.core.cache.ExpiringCacheMap;
 import org.openhab.core.config.core.Configuration;
-import org.openhab.core.library.types.DecimalType;
-import org.openhab.core.library.types.HSBType;
-import org.openhab.core.library.types.OnOffType;
-import org.openhab.core.library.types.PercentType;
-import org.openhab.core.library.types.QuantityType;
-import org.openhab.core.library.types.StringType;
-import org.openhab.core.thing.Channel;
-import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.Thing;
 import org.openhab.core.thing.ThingStatus;
 import org.openhab.core.thing.ThingStatusDetail;
-import org.openhab.core.thing.ThingUID;
-import org.openhab.core.thing.binding.BaseThingHandler;
-import org.openhab.core.thing.binding.ThingHandlerCallback;
-import org.openhab.core.thing.binding.builder.ThingBuilder;
-import org.openhab.core.thing.type.ChannelTypeUID;
-import org.openhab.core.types.Command;
-import org.openhab.core.types.CommandOption;
-import org.openhab.core.types.RefreshType;
-import org.openhab.core.types.State;
-import org.openhab.core.types.UnDefType;
-import org.openhab.core.util.StringUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.google.gson.Gson;
-import com.google.gson.JsonSyntaxException;
 
 import io.netty.channel.EventLoopGroup;
 
 /**
- * The {@link TuyaDeviceHandler} handles commands and state updates
+ * The {@link TuyaDeviceHandler} handles commands and state updates for a device that is reached directly over the
+ * local network
  *
  * @author Jan N. Klug - Initial contribution
+ * @author Maciej Jarzebowski - Extract common handling into BaseTuyaDeviceHandler
  */
 @NonNullByDefault
-public class TuyaDeviceHandler extends BaseThingHandler implements DeviceInfoSubscriber, DeviceStatusListener {
-    private final Logger logger = LoggerFactory.getLogger(TuyaDeviceHandler.class);
-
+public class TuyaDeviceHandler extends BaseTuyaDeviceHandler implements DeviceInfoSubscriber, DeviceStatusListener {
     private final Gson gson;
     private final UdpDiscoveryListener udpDiscoveryListener;
-    private final TuyaDynamicCommandDescriptionProvider dynamicCommandDescriptionProvider;
-    private final TuyaDynamicStateDescriptionProvider dynamicStateDescriptionProvider;
     private final EventLoopGroup eventLoopGroup;
-    private DeviceConfiguration configuration = new DeviceConfiguration();
+
     private @Nullable TuyaDevice tuyaDevice;
-    private final Map<String, SchemaDp> schemaDps;
-    private int pollBurst = 0;
-    private boolean oldColorMode = false;
-
-    private @Nullable ScheduledFuture<?> pollingJob;
-    private @Nullable ScheduledFuture<?> irLearnJob;
-
-    private final Map<Integer, String> dpToChannelId = new HashMap<>();
-    private final Map<Integer, List<String>> dp2ToChannelId = new HashMap<>();
-    private final Map<String, ChannelTypeUID> channelIdToChannelTypeUID = new HashMap<>();
-    private final Map<String, ChannelConfiguration> channelIdToConfiguration = new HashMap<>();
-
-    private final ExpiringCacheMap<Integer, @Nullable Object> deviceStatusCache = new ExpiringCacheMap<>(
-            Duration.ofSeconds(10));
-    private final Map<String, State> channelStateCache = new HashMap<>();
+    private volatile boolean connected = false;
 
     public TuyaDeviceHandler(Thing thing, Gson gson,
             TuyaDynamicCommandDescriptionProvider dynamicCommandDescriptionProvider,
             TuyaDynamicStateDescriptionProvider dynamicStateDescriptionProvider, EventLoopGroup eventLoopGroup,
             UdpDiscoveryListener udpDiscoveryListener) {
-        super(thing);
-        this.schemaDps = Objects.requireNonNullElse(TuyaSchemaDB.getOrConvert(
-                (String) thing.getConfiguration().get(CONFIG_PRODUCT_ID), thing.getUID().getId()), Map.of());
+        super(thing, gson, dynamicCommandDescriptionProvider, dynamicStateDescriptionProvider);
         this.gson = gson;
         this.udpDiscoveryListener = udpDiscoveryListener;
         this.eventLoopGroup = eventLoopGroup;
-        this.dynamicCommandDescriptionProvider = dynamicCommandDescriptionProvider;
-        this.dynamicStateDescriptionProvider = dynamicStateDescriptionProvider;
     }
 
-    public @Nullable SchemaDp getSchemaForChannelId(String channelId) {
-        return schemaDps.get(channelId);
+    /**
+     * @return whether the connection to the device is currently established
+     */
+    protected boolean isConnected() {
+        return connected;
+    }
+
+    protected @Nullable TuyaDevice getTuyaDevice() {
+        return tuyaDevice;
     }
 
     @Override
-    public void processDeviceStatus(Map<Integer, Object> deviceStatus) {
-        // Changes to function DPs might lead to changes in status DPs. For instance, if a
-        // power switch is turned on the measured current and power can be expected to change
-        // within a few seconds.
-        boolean needRefresh = false;
-        boolean missingStatus = false;
-        for (var e : schemaDps.values()) {
-            Object value = deviceStatus.get(e.id);
-
-            if (value != null) {
-                addSingleExpiringCache(e.id, value);
-
-                if (!e.readOnly) {
-                    needRefresh = true;
-                }
-            } else if (e.readOnly) {
-                missingStatus = true;
-            }
-        }
-
-        if (needRefresh && configuration.pollingInterval > 0) {
-            // We cannot assume that DPs are current or that the device will automatically
-            // re-measure on a function change.
-            TuyaDevice tuyaDevice = this.tuyaDevice;
-            if (tuyaDevice != null) {
-                synchronized (this) {
-                    ScheduledFuture<?> pollingJob = this.pollingJob;
-                    if (pollingJob != null) {
-                        pollingJob.cancel(true);
-                    }
-
-                    pollBurst = 3;
-                    this.pollingJob = scheduler.scheduleWithFixedDelay(this::burstPoller, 0, 1, TimeUnit.SECONDS);
-                }
-            }
-        } else if (!missingStatus) {
-            // If we have updates for everything we can stand down the burst polling.
-            pollBurst = 0;
-        }
-
-        deviceStatus.forEach(this::processChannelStatus);
+    protected boolean canCommunicate() {
+        return tuyaDevice != null;
     }
 
-    private void burstPoller() {
+    @Override
+    protected void sendCommand(Map<Integer, @Nullable Object> command) {
         TuyaDevice tuyaDevice = this.tuyaDevice;
         if (tuyaDevice != null) {
-            if (pollBurst > 0) {
-                tuyaDevice.refreshStatus();
-                pollBurst = pollBurst - 1;
-            } else {
-                synchronized (this) {
-                    if (!Thread.interrupted()) {
-                        ScheduledFuture<?> pollingJob = this.pollingJob;
-                        if (pollingJob != null) {
-                            this.pollingJob = null;
-                            pollingJob.cancel(false);
-                        }
-
-                        int pollingInterval = configuration.pollingInterval;
-                        if (pollingInterval > 0) {
-                            this.pollingJob = scheduler.scheduleWithFixedDelay(() -> {
-                                tuyaDevice.refreshStatus();
-                            }, pollingInterval, pollingInterval, TimeUnit.SECONDS);
-                        }
-                    }
-                }
-            }
+            tuyaDevice.set(command);
         }
     }
 
-    private void processChannelStatus(Integer dp, Object value) {
-        String channelId = dpToChannelId.get(dp);
-        if (channelId != null) {
-            ChannelConfiguration channelConfiguration = channelIdToConfiguration.get(channelId);
-            ChannelTypeUID channelTypeUID = channelIdToChannelTypeUID.get(channelId);
-
-            if (channelConfiguration == null || channelTypeUID == null) {
-                logger.warn("Could not find configuration or type for channel '{}' in thing '{}'", channelId,
-                        thing.getUID());
-                return;
-            }
-
-            if (Boolean.FALSE.equals(deviceStatusCache.get(channelConfiguration.dp2))) {
-                // skip update if the channel is off!
-                return;
-            }
-
-            Channel channel = thing.getChannel(channelId);
-            String acceptedItemType = (channel != null ? channel.getAcceptedItemType() : "");
-
-            try {
-                if (value instanceof String stringValue && COLOR.equals(acceptedItemType)) {
-                    oldColorMode = stringValue.length() == 14;
-                    updateState(channelId, ConversionUtil.hexColorDecode(stringValue));
-                    return;
-                } else if (value instanceof String stringValue && STRING.equals(acceptedItemType)) {
-                    if (!channelConfiguration.range.isEmpty() && channel != null) {
-                        // The device schemas only seem to specify the commands that can be sent to
-                        // a device. We have to learn the states sent by a device as they are seen.
-                        dynamicStateDescriptionProvider.addStateOption(channel.getUID(), stringValue);
-                    }
-                    updateState(channelId, new StringType(stringValue));
-                    return;
-                } else if (Double.class.isAssignableFrom(value.getClass()) && DIMMER.equals(acceptedItemType)) {
-                    updateState(channelId,
-                            ConversionUtil.brightnessDecode((double) value, 0, channelConfiguration.max));
-                    return;
-                } else if (CHANNEL_TYPE_UID_NUMBER.equals(channelTypeUID)) {
-                    // Deprecated: retained for compatibility with old Things that have not been re-added.
-                    // This MUST come before the startsWith("Number") case that follows!
-                    if (Double.class.isAssignableFrom(value.getClass())) {
-                        updateState(channelId, new DecimalType((double) value));
-                        return;
-                    } else if (value instanceof String string) {
-                        updateState(channelId, new DecimalType(string));
-                        return;
-                    }
-                } else if ((Double.class.isAssignableFrom(value.getClass()) || value instanceof String)
-                        && acceptedItemType != null && acceptedItemType.startsWith(NUMBER)) {
-                    BigDecimal d;
-                    if (value instanceof String stringValue) {
-                        d = new BigDecimal(stringValue);
-                    } else {
-                        d = new BigDecimal((double) value);
-                    }
-
-                    SchemaDp schemaDp = schemaDps.get(channelId);
-
-                    if (schemaDp != null) {
-                        d = d.movePointLeft(schemaDp.scale);
-
-                        Unit<?> unit = schemaDp.parsedUnit;
-                        if (unit != null) {
-                            updateState(channelId, new QuantityType<>(d, unit));
-                            return;
-                        }
-                    }
-
-                    updateState(channelId, new DecimalType(d));
-                    return;
-                } else if (Boolean.class.isAssignableFrom(value.getClass()) && SWITCH.equals(acceptedItemType)) {
-                    updateState(channelId, OnOffType.from((boolean) value));
-                    return;
-                } else if (value instanceof String && CHANNEL_TYPE_UID_IR_CODE.equals(channelTypeUID)) {
-                    if (channelConfiguration.dp == 2) {
-                        String decoded = convertBase64Code(channelConfiguration, (String) value);
-                        logger.info("thing {} received ir code: {}", thing.getUID(), decoded);
-                        updateState(channelId, new StringType(decoded));
-                        irStartLearning(channelConfiguration.activeListen);
-                    }
-                    return;
-                }
-            } catch (IllegalArgumentException ignored) {
-            }
-            logger.warn("Could not update channel '{}' of thing '{}' with value '{}'. Datatype incompatible.",
-                    channelId, getThing().getUID(), value);
-            updateState(channelId, UnDefType.UNDEF);
-        } else {
-            // try additional channelDps, only OnOffType
-            List<String> channelIds = dp2ToChannelId.get(dp);
-            if (channelIds == null) {
-                logger.debug("Could not find channel for dp '{}' in thing '{}'", dp, thing.getUID());
-            } else {
-                if (Boolean.class.isAssignableFrom(value.getClass())) {
-                    OnOffType state = OnOffType.from((boolean) value);
-                    channelIds.forEach(ch -> updateState(ch, state));
-                    return;
-                }
-                logger.warn("Could not update channel '{}' of thing '{}' with value {}. Datatype incompatible.",
-                        channelIds, getThing().getUID(), value);
-            }
+    @Override
+    protected void requestStatus() {
+        TuyaDevice tuyaDevice = this.tuyaDevice;
+        if (tuyaDevice != null) {
+            tuyaDevice.requestStatus();
         }
+    }
+
+    @Override
+    protected void refreshStatus() {
+        TuyaDevice tuyaDevice = this.tuyaDevice;
+        if (tuyaDevice != null) {
+            tuyaDevice.refreshStatus();
+        }
+    }
+
+    @Override
+    public void processDeviceStatus(@Nullable String cid, Map<Integer, Object> deviceStatus) {
+        if (cid != null) {
+            logger.debug("{}: ignoring status for sub-device '{}', this thing is not a gateway", thing.getUID().getId(),
+                    cid);
+            return;
+        }
+
+        processDeviceStatus(deviceStatus);
     }
 
     @Override
     public void connectionStatus(boolean status, int initialDelay) {
+        connected = status;
+
         if (status) {
             logger.debug("{}: connected", thing.getUID().getId());
 
@@ -329,230 +125,21 @@ public class TuyaDeviceHandler extends BaseThingHandler implements DeviceInfoSub
             // status message here rather than actually setting the Thing online.
             updateStatus(ThingStatus.ONLINE);
 
-            TuyaDevice tuyaDevice = this.tuyaDevice;
-            if (tuyaDevice != null) {
-                synchronized (this) {
-                    if (pollingJob == null) {
-                        // When we first connect the device state is unknown so we want to query for everything.
-                        // Some devices seem to initialize their stacks in the wrong order and
-                        // requests that come too soon can be either ignored completely or responded
-                        // to with a, "not supported". The lower level protocol handler suggests an
-                        // initial delay where it might be advisable.
-                        pollingJob = scheduler.schedule(() -> {
-                            tuyaDevice.requestStatus();
-
-                            // After that we poll for the measurable DPs.
-                            int pollingInterval = configuration.pollingInterval;
-                            if (pollingInterval > 0) {
-                                synchronized (this) {
-                                    // The first refresh request is immediate because we do not know how old
-                                    // the current status might be.
-                                    pollingJob = scheduler.scheduleWithFixedDelay(() -> {
-                                        tuyaDevice.refreshStatus();
-                                    }, 0, pollingInterval, TimeUnit.SECONDS);
-                                }
-                            }
-                        }, initialDelay, TimeUnit.MILLISECONDS);
-                    } else {
-                        logger.debug("{}: polling job already exists?!?", thing.getUID().getId());
-                    }
-                }
-            }
-
-            // start learning code if thing is online and presents 'ir-code' channel
-            channelIdToChannelTypeUID.entrySet().stream().filter(e -> CHANNEL_TYPE_UID_IR_CODE.equals(e.getValue()))
-                    .map(Map.Entry::getKey).findAny().map(channelIdToConfiguration::get)
-                    .ifPresent(irCodeChannelConfig -> irStartLearning(irCodeChannelConfig.activeListen));
+            onCommunicationEstablished(initialDelay);
         } else {
             logger.debug("{}: disconnected", thing.getUID().getId());
 
             updateStatus(ThingStatus.ONLINE, ThingStatusDetail.NONE, "@text/online.wait-for-device");
 
-            synchronized (this) {
-                ScheduledFuture<?> pollingJob = this.pollingJob;
-                if (pollingJob != null) {
-                    this.pollingJob = null;
-                    pollingJob.cancel(true);
-                }
-            }
-
-            if (channelIdToChannelTypeUID.containsValue(CHANNEL_TYPE_UID_IR_CODE)) {
-                irStopLearning();
-            }
-        }
-    }
-
-    @Override
-    public void handleCommand(ChannelUID channelUID, Command command) {
-        if (command instanceof RefreshType) {
-            State state = channelStateCache.get(channelUID.getId());
-            if (state != null) {
-                updateState(channelUID, state);
-            }
-            return;
-        }
-
-        if (getThing().getStatus() != ThingStatus.ONLINE) {
-            logger.warn("Channel '{}' received a command but device is not ONLINE. Discarding command.", channelUID);
-            return;
-        }
-
-        Map<Integer, @Nullable Object> commandRequest = new HashMap<>();
-
-        ChannelTypeUID channelTypeUID = channelIdToChannelTypeUID.get(channelUID.getId());
-        ChannelConfiguration configuration = channelIdToConfiguration.get(channelUID.getId());
-        if (channelTypeUID == null || configuration == null) {
-            logger.warn("Could not determine channel type or configuration for channel '{}'. Discarding command.",
-                    channelUID);
-            return;
-        }
-
-        Channel channel = thing.getChannel(channelUID.getId());
-        String acceptedItemType = (channel != null ? channel.getAcceptedItemType() : "");
-
-        if (COLOR.equals(acceptedItemType)) {
-            if (command instanceof HSBType) {
-                commandRequest.put(configuration.dp, ConversionUtil.hexColorEncode((HSBType) command, oldColorMode));
-                ChannelConfiguration workModeConfig = channelIdToConfiguration.get("work_mode");
-                if (workModeConfig != null) {
-                    commandRequest.put(workModeConfig.dp, "colour");
-                }
-                if (configuration.dp2 != 0) {
-                    commandRequest.put(configuration.dp2, ((HSBType) command).getBrightness().doubleValue() > 0.0);
-                }
-            } else if (command instanceof PercentType percentCommand) {
-                State oldState = channelStateCache.get(channelUID.getId());
-                if (!(oldState instanceof HSBType)) {
-                    logger.debug("Discarding command '{}' to channel '{}', cannot determine old state", command,
-                            channelUID);
-                    return;
-                }
-                HSBType newState = new HSBType(((HSBType) oldState).getHue(), ((HSBType) oldState).getSaturation(),
-                        percentCommand);
-                commandRequest.put(configuration.dp, ConversionUtil.hexColorEncode(newState, oldColorMode));
-                ChannelConfiguration workModeConfig = channelIdToConfiguration.get("work_mode");
-                if (workModeConfig != null) {
-                    commandRequest.put(workModeConfig.dp, "colour");
-                }
-                if (configuration.dp2 != 0) {
-                    commandRequest.put(configuration.dp2, (percentCommand).doubleValue() > 0.0);
-                }
-            } else if (command instanceof OnOffType) {
-                if (configuration.dp2 != 0) {
-                    commandRequest.put(configuration.dp2, OnOffType.ON.equals(command));
-                }
-            }
-        } else if (DIMMER.equals(acceptedItemType)) {
-            if (command instanceof PercentType percentCommand) {
-                int value = ConversionUtil.brightnessEncode(percentCommand, 0, configuration.max);
-                if (configuration.reversed) {
-                    value = configuration.max - value;
-                }
-                if (value >= configuration.min) {
-                    commandRequest.put(configuration.dp, value);
-                }
-                if (configuration.dp2 != 0) {
-                    commandRequest.put(configuration.dp2, value >= configuration.min);
-                }
-                ChannelConfiguration workModeConfig = channelIdToConfiguration.get("work_mode");
-                if (workModeConfig != null) {
-                    commandRequest.put(workModeConfig.dp, "white");
-                }
-            } else if (command instanceof OnOffType) {
-                if (configuration.dp2 != 0) {
-                    commandRequest.put(configuration.dp2, OnOffType.ON.equals(command));
-                }
-            }
-        } else if (STRING.equals(acceptedItemType)) {
-            commandRequest.put(configuration.dp, command.toString());
-        } else if (acceptedItemType != null && acceptedItemType.startsWith(NUMBER)) {
-            if (command instanceof QuantityType quantityType) {
-                SchemaDp schemaDp = schemaDps.get(channelUID.getId());
-
-                if (schemaDp != null && !schemaDp.unit.isEmpty()) {
-                    // If the item type for the channel is not dimensioned the unit is not usable and we
-                    // assume whoever sent a quantity instead of a bare number knows what they are doing.
-                    if (!NUMBER.equals(acceptedItemType)) {
-                        quantityType = quantityType.toUnit(schemaDp.unit);
-                    }
-                }
-
-                if (quantityType != null) {
-                    BigDecimal d = quantityType.toBigDecimal();
-                    if (schemaDp != null) {
-                        d = d.movePointRight(schemaDp.scale);
-                    }
-                    command = new DecimalType(d);
-                }
-            }
-
-            if (command instanceof DecimalType decimalType) {
-                commandRequest.put(configuration.dp,
-                        configuration.sendAsString ? String.format("%d", decimalType.intValue())
-                                : decimalType.intValue());
-            }
-        } else if (SWITCH.equals(acceptedItemType)) {
-            if (command instanceof OnOffType) {
-                commandRequest.put(configuration.dp, OnOffType.ON.equals(command));
-            }
-        } else if (CHANNEL_TYPE_UID_IR_CODE.equals(channelTypeUID)) {
-            if (command instanceof StringType) {
-                switch (configuration.irType) {
-                    case "base64" -> {
-                        commandRequest.put(1, "study_key");
-                        commandRequest.put(7, command.toString());
-                    }
-                    case "tuya-head" -> {
-                        if (!configuration.irCode.isBlank()) {
-                            commandRequest.put(1, "send_ir");
-                            commandRequest.put(3, configuration.irCode);
-                            commandRequest.put(4, command.toString());
-                            commandRequest.put(10, configuration.irSendDelay);
-                            commandRequest.put(13, configuration.irCodeType);
-                        } else {
-                            logger.warn("irCode is not set for channel {}", channelUID);
-                        }
-                    }
-                    case "nec" -> {
-                        long code = convertHexCode(command.toString());
-                        String base64Code = IrUtils.necToBase64(code);
-                        commandRequest.put(1, "study_key");
-                        commandRequest.put(7, base64Code);
-                    }
-                    case "samsung" -> {
-                        long code = convertHexCode(command.toString());
-                        String base64Code = IrUtils.samsungToBase64(code);
-                        commandRequest.put(1, "study_key");
-                        commandRequest.put(7, base64Code);
-                    }
-                }
-                irStopLearning();
-            }
-        }
-
-        TuyaDevice tuyaDevice = this.tuyaDevice;
-        if (!commandRequest.isEmpty() && tuyaDevice != null) {
-            tuyaDevice.set(commandRequest);
-        }
-
-        if (CHANNEL_TYPE_UID_IR_CODE.equals(channelTypeUID)) {
-            if (command instanceof StringType) {
-                irStartLearning(configuration.activeListen);
-            }
+            onCommunicationLost();
         }
     }
 
     @Override
     public void dispose() {
-        logger.debug("{}: dispose", thing.getUID().getId());
+        super.dispose();
 
-        synchronized (this) {
-            ScheduledFuture<?> pollingJob = this.pollingJob;
-            if (pollingJob != null) {
-                this.pollingJob = null;
-                pollingJob.cancel(true);
-            }
-        }
+        connected = false;
 
         udpDiscoveryListener.unregisterListener(this);
 
@@ -561,42 +148,16 @@ public class TuyaDeviceHandler extends BaseThingHandler implements DeviceInfoSub
             this.tuyaDevice = null;
             tuyaDevice.dispose();
         }
-
-        irStopLearning();
-
-        dpToChannelId.clear();
-        dp2ToChannelId.clear();
-        channelIdToChannelTypeUID.clear();
-        channelIdToConfiguration.clear();
     }
 
     @Override
-    public void initialize() {
-        configuration = getConfigAs(DeviceConfiguration.class);
-
-        boolean hasStatusDps = false;
-        for (var e : schemaDps.values()) {
-            if (e.readOnly) {
-                hasStatusDps = true;
-                break;
-            }
-        }
-        if (!hasStatusDps) {
-            logger.debug("{}: no status DPs - polling disabled", thing.getUID().getId());
-            configuration.pollingInterval = 0;
-        }
-
-        // Update the channel list.
-        addChannels();
-
-        thing.getChannels().forEach(this::configureChannel);
-
+    protected void initializeTransport() {
         if (!configuration.ip.isBlank()) {
             updateStatus(ThingStatus.ONLINE, ThingStatusDetail.NONE, "@text/online.wait-for-device");
 
             this.tuyaDevice = new TuyaDevice(gson, this, eventLoopGroup, configuration.deviceId,
                     configuration.localKey.getBytes(StandardCharsets.UTF_8), configuration.ip, configuration.port,
-                    configuration.protocol, schemaDps.values().stream().map(e -> e.id).toList());
+                    configuration.protocol, getAllDpIds());
         } else {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_PENDING, "@text/offline.wait-for-ip");
         }
@@ -628,211 +189,11 @@ public class TuyaDeviceHandler extends BaseThingHandler implements DeviceInfoSub
 
                 this.tuyaDevice = new TuyaDevice(gson, this, eventLoopGroup, configuration.deviceId,
                         configuration.localKey.getBytes(StandardCharsets.UTF_8), configuration.ip, configuration.port,
-                        configuration.protocol, schemaDps.values().stream().map(e -> e.id).toList());
+                        configuration.protocol, getAllDpIds());
             } catch (IllegalArgumentException e) {
                 logger.warn("{}", e.getMessage());
                 updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, e.getMessage());
             }
-        }
-    }
-
-    private void addChannels() {
-        ThingBuilder thingBuilder = editThing();
-        ThingUID thingUID = thing.getUID();
-        ThingHandlerCallback callback = getCallback();
-
-        if (callback == null) {
-            logger.warn("Thing callback not found. Cannot auto-detect thing '{}' channels.", thingUID);
-            return;
-        }
-
-        Map<String, Channel> channels = new LinkedHashMap<>(schemaDps.entrySet().stream().map(e -> {
-            String channelId = e.getKey();
-            SchemaDp schemaDp = e.getValue();
-
-            ChannelTypeUID channeltypeUID = new ChannelTypeUID(BINDING_ID, configuration.productId + "_" + channelId);
-            ChannelUID channelUID = new ChannelUID(thingUID, channelId);
-
-            Map<@Nullable String, @Nullable Object> configuration = new HashMap<>();
-            configuration.put(CONFIG_DP, schemaDp.id);
-
-            if ("enum".equals(schemaDp.type)) {
-                List<String> range = Objects.requireNonNullElse(schemaDp.range, List.of());
-                configuration.put(CONFIG_RANGE, String.join(",", range));
-            } else if ("value".equals(schemaDp.type)) {
-                if (schemaDp.scale > 0) {
-                    Double d = schemaDp.min;
-                    if (d != null) {
-                        configuration.put(CONFIG_MIN, new BigDecimal(d).movePointLeft(schemaDp.scale));
-                    }
-
-                    d = schemaDp.max;
-                    if (d != null) {
-                        configuration.put(CONFIG_MAX, new BigDecimal(d).movePointLeft(schemaDp.scale));
-                    }
-                } else {
-                    configuration.put(CONFIG_MIN, schemaDp.min);
-                    configuration.put(CONFIG_MAX, schemaDp.max);
-                }
-            }
-
-            return Map.entry(channelId, callback.createChannelBuilder(channelUID, channeltypeUID) //
-                    .withConfiguration(new Configuration(configuration)) //
-                    .build());
-        }).filter(c -> !c.getKey().isEmpty())
-                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (e1, e2) -> e1, LinkedHashMap::new)));
-
-        List<String> channelSuffixes = List.of("", "_1", "_2");
-        List<String> switchChannels = List.of("switch_led", "led_switch");
-        channelSuffixes.forEach(suffix -> switchChannels.forEach(channel -> {
-            Channel switchChannel = channels.get(channel + suffix);
-            if (switchChannel != null) {
-                // remove switch channel if brightness or color is present and add to dp2 instead
-                ChannelConfiguration config = switchChannel.getConfiguration().as(ChannelConfiguration.class);
-                Channel colourChannel = channels.get("colour_data" + suffix);
-                Channel brightChannel = channels.get("bright_value" + suffix);
-                boolean remove = false;
-
-                if (colourChannel != null) {
-                    colourChannel.getConfiguration().put(CONFIG_DP2, config.dp);
-                    remove = true;
-                }
-                if (brightChannel != null) {
-                    brightChannel.getConfiguration().put(CONFIG_DP2, config.dp);
-                    remove = true;
-                }
-
-                if (remove) {
-                    channels.remove(channel + suffix);
-                }
-            }
-        }));
-
-        var existingChannels = thing.getChannels();
-
-        // Starting from scratch...
-        thingBuilder.withChannels(List.of());
-
-        // Add the channels from the schema.
-        channels.values().forEach(thingBuilder::withChannel);
-
-        // Add pre-existing channels that weren't in the schema (user-added channels).
-        existingChannels.stream() //
-                .filter(channel -> !channels.containsKey(channel.getUID().getId())) //
-                .forEach(thingBuilder::withChannel);
-
-        updateThing(thingBuilder.build());
-    }
-
-    private void configureChannel(Channel channel) {
-        ChannelConfiguration configuration = channel.getConfiguration().as(ChannelConfiguration.class);
-        ChannelTypeUID channelTypeUID = channel.getChannelTypeUID();
-
-        if (channelTypeUID == null) {
-            logger.warn("Could not determine ChannelTypeUID for '{}'", channel.getUID());
-            return;
-        }
-
-        String channelId = channel.getUID().getId();
-
-        if (!configuration.range.isEmpty()) {
-            List<CommandOption> commandOptions = toCommandOptionList(
-                    Arrays.stream(configuration.range.split(",")).collect(Collectors.toList()));
-            dynamicCommandDescriptionProvider.setCommandOptions(channel.getUID(), commandOptions);
-        }
-
-        dpToChannelId.put(configuration.dp, channelId);
-        channelIdToConfiguration.put(channelId, configuration);
-        channelIdToChannelTypeUID.put(channelId, channelTypeUID);
-
-        // check if we have additional DPs (these are switch DP for color or brightness only)
-        if (configuration.dp2 != 0) {
-            List<String> list = Objects
-                    .requireNonNull(dp2ToChannelId.computeIfAbsent(configuration.dp2, ArrayList::new));
-            list.add(channelId);
-        }
-        if (CHANNEL_TYPE_UID_IR_CODE.equals(channelTypeUID)) {
-            irStartLearning(configuration.activeListen);
-        }
-    }
-
-    private List<CommandOption> toCommandOptionList(List<String> options) {
-        return options.stream()
-                .map(c -> new CommandOption(c, StringUtils.capitalizeByWhitespace(c.replaceAll("_", " ")))).toList();
-    }
-
-    private void addSingleExpiringCache(Integer key, Object value) {
-        ExpiringCache<@Nullable Object> expiringCache = new ExpiringCache<>(Duration.ofSeconds(10), () -> null);
-        expiringCache.putValue(value);
-        deviceStatusCache.put(key, expiringCache);
-    }
-
-    @Override
-    protected void updateState(String channelId, State state) {
-        channelStateCache.put(channelId, state);
-        super.updateState(channelId, state);
-    }
-
-    private long convertHexCode(String code) {
-        String sCode = code.startsWith("0x") ? code.substring(2) : code;
-        return Long.parseLong(sCode, 16);
-    }
-
-    private String convertBase64Code(ChannelConfiguration channelConfig, String encoded) {
-        String decoded = "";
-        try {
-            if (channelConfig.irType.equals("nec")) {
-                decoded = IrUtils.base64ToNec(encoded);
-                IrCode code = Objects.requireNonNull(gson.fromJson(decoded, IrCode.class));
-                decoded = "0x" + code.hex;
-            } else if (channelConfig.irType.equals("samsung")) {
-                decoded = IrUtils.base64ToSamsung(encoded);
-                IrCode code = Objects.requireNonNull(gson.fromJson(decoded, IrCode.class));
-                decoded = "0x" + code.hex;
-            } else {
-                if (encoded.length() > 68) {
-                    decoded = IrUtils.base64ToNec(encoded);
-                    if (decoded.isEmpty()) {
-                        decoded = IrUtils.base64ToSamsung(encoded);
-                    }
-                    IrCode code = Objects.requireNonNull(gson.fromJson(decoded, IrCode.class));
-                    decoded = code.type + ": 0x" + code.hex;
-                } else {
-                    decoded = encoded;
-                }
-            }
-        } catch (JsonSyntaxException e) {
-            logger.warn("Incorrect json response: {}", e.getMessage());
-            decoded = encoded;
-        } catch (RuntimeException e) {
-            logger.warn("Unable decode key code'{}', reason: {}", decoded, e.getMessage());
-        }
-        return decoded;
-    }
-
-    private void repeatStudyCode() {
-        Map<Integer, @Nullable Object> commandRequest = new HashMap<>();
-        commandRequest.put(1, "study");
-        TuyaDevice tuyaDevice = this.tuyaDevice;
-        if (tuyaDevice != null) {
-            tuyaDevice.set(commandRequest);
-        }
-    }
-
-    private void irStopLearning() {
-        logger.debug("[tuya:ir-controller] stop ir learning");
-        ScheduledFuture<?> feature = irLearnJob;
-        if (feature != null) {
-            feature.cancel(true);
-            this.irLearnJob = null;
-        }
-    }
-
-    private void irStartLearning(boolean available) {
-        irStopLearning();
-        if (available) {
-            logger.debug("[tuya:ir-controller] start ir learning");
-            irLearnJob = scheduler.scheduleWithFixedDelay(this::repeatStudyCode, 200, 29000, TimeUnit.MILLISECONDS);
         }
     }
 }

--- a/bundles/org.openhab.binding.tuya/src/main/java/org/openhab/binding/tuya/internal/handler/TuyaGatewayHandler.java
+++ b/bundles/org.openhab.binding.tuya/src/main/java/org/openhab/binding/tuya/internal/handler/TuyaGatewayHandler.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.tuya.internal.handler;
+
+import static org.openhab.binding.tuya.internal.TuyaBindingConstants.TCP_CONNECT_INITIAL_DELAY;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.tuya.internal.TuyaDynamicCommandDescriptionProvider;
+import org.openhab.binding.tuya.internal.TuyaDynamicStateDescriptionProvider;
+import org.openhab.binding.tuya.internal.local.TuyaDevice;
+import org.openhab.binding.tuya.internal.local.UdpDiscoveryListener;
+import org.openhab.core.thing.Bridge;
+import org.openhab.core.thing.Thing;
+import org.openhab.core.thing.binding.BridgeHandler;
+import org.openhab.core.thing.binding.ThingHandler;
+import org.openhab.core.thing.binding.builder.BridgeBuilder;
+
+import com.google.gson.Gson;
+
+import io.netty.channel.EventLoopGroup;
+
+/**
+ * The {@link TuyaGatewayHandler} handles a Tuya device that also relays for sub-devices, e.g. a Bluetooth or ZigBee
+ * gateway. It behaves like any other local device for its own data points and additionally routes messages tagged with
+ * a sub-device node id to and from the {@link TuyaSubDeviceHandler}s of its child things.
+ *
+ * @author Maciej Jarzebowski - Initial contribution
+ */
+@NonNullByDefault
+public class TuyaGatewayHandler extends TuyaDeviceHandler implements BridgeHandler {
+    private final Map<String, TuyaSubDeviceHandler> subDeviceHandlers = new ConcurrentHashMap<>();
+
+    public TuyaGatewayHandler(Bridge bridge, Gson gson,
+            TuyaDynamicCommandDescriptionProvider dynamicCommandDescriptionProvider,
+            TuyaDynamicStateDescriptionProvider dynamicStateDescriptionProvider, EventLoopGroup eventLoopGroup,
+            UdpDiscoveryListener udpDiscoveryListener) {
+        super(bridge, gson, dynamicCommandDescriptionProvider, dynamicStateDescriptionProvider, eventLoopGroup,
+                udpDiscoveryListener);
+    }
+
+    /**
+     * Mirrors {@code BaseBridgeHandler#editThing()}, which this handler cannot inherit because it extends
+     * {@link TuyaDeviceHandler} to share the device implementation. {@code ThingBuilder#build()} produces a plain
+     * thing, so building on it would silently turn this bridge into a non-bridge and orphan its sub-devices.
+     */
+    @Override
+    protected BridgeBuilder editThing() {
+        return BridgeBuilder.create(thing.getThingTypeUID(), thing.getUID()).withBridge(thing.getBridgeUID())
+                .withChannels(thing.getChannels()).withConfiguration(thing.getConfiguration())
+                .withLabel(thing.getLabel()).withLocation(thing.getLocation()).withProperties(thing.getProperties())
+                .withSemanticEquipmentTag(thing.getSemanticEquipmentTag());
+    }
+
+    /**
+     * Registers a sub-device so that traffic tagged with its node id is routed to it.
+     *
+     * A sub-device registers itself rather than being registered from {@link #childHandlerInitialized}, because
+     * editing the configuration of either thing makes the framework dispose and initialize that handler again
+     * without running the bridge child callbacks. Doing it here keeps the routing table in step with the node id a
+     * sub-device actually uses.
+     */
+    void registerSubDevice(String subDeviceId, TuyaSubDeviceHandler subDeviceHandler) {
+        subDeviceHandlers.put(subDeviceId, subDeviceHandler);
+
+        // Registration has to happen before the sub-device queries its state, otherwise the response could not be
+        // routed back to it.
+        subDeviceHandler.gatewayConnectionStatus(isConnected(), TCP_CONNECT_INITIAL_DELAY);
+    }
+
+    void unregisterSubDevice(String subDeviceId, TuyaSubDeviceHandler subDeviceHandler) {
+        subDeviceHandlers.remove(subDeviceId, subDeviceHandler);
+    }
+
+    @Override
+    public void childHandlerInitialized(ThingHandler childHandler, Thing childThing) {
+        // Sub-devices register themselves, see registerSubDevice()
+    }
+
+    @Override
+    public void childHandlerDisposed(ThingHandler childHandler, Thing childThing) {
+        // Sub-devices unregister themselves, see unregisterSubDevice()
+    }
+
+    @Override
+    public void processDeviceStatus(@Nullable String cid, Map<Integer, Object> deviceStatus) {
+        if (cid == null || cid.equals(configuration.deviceId)) {
+            processDeviceStatus(deviceStatus);
+            return;
+        }
+
+        TuyaSubDeviceHandler subDeviceHandler = subDeviceHandlers.get(cid);
+        if (subDeviceHandler == null) {
+            logger.debug("{}: received status for unknown sub-device '{}'", thing.getUID().getId(), cid);
+            return;
+        }
+
+        subDeviceHandler.processDeviceStatus(deviceStatus);
+    }
+
+    @Override
+    public void connectionStatus(boolean status, int initialDelay) {
+        super.connectionStatus(status, initialDelay);
+
+        subDeviceHandlers.values().forEach(handler -> handler.gatewayConnectionStatus(status, initialDelay));
+    }
+
+    @Override
+    public void dispose() {
+        // The routing table is deliberately kept: a configuration change disposes and initializes this handler
+        // again without the children being reinitialized, and they would otherwise never register a second time.
+        super.dispose();
+    }
+
+    /**
+     * Sends data points to a sub-device connected through this gateway.
+     */
+    void sendCommand(String subDeviceId, Map<Integer, @Nullable Object> command) {
+        TuyaDevice tuyaDevice = getTuyaDevice();
+        if (tuyaDevice != null) {
+            tuyaDevice.set(subDeviceId, command);
+        }
+    }
+
+    /**
+     * Queries the status of a sub-device connected through this gateway.
+     */
+    void requestStatus(String subDeviceId) {
+        TuyaDevice tuyaDevice = getTuyaDevice();
+        if (tuyaDevice != null) {
+            tuyaDevice.requestStatus(subDeviceId);
+        }
+    }
+}

--- a/bundles/org.openhab.binding.tuya/src/main/java/org/openhab/binding/tuya/internal/handler/TuyaSubDeviceHandler.java
+++ b/bundles/org.openhab.binding.tuya/src/main/java/org/openhab/binding/tuya/internal/handler/TuyaSubDeviceHandler.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.tuya.internal.handler;
+
+import java.util.Map;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.tuya.internal.TuyaDynamicCommandDescriptionProvider;
+import org.openhab.binding.tuya.internal.TuyaDynamicStateDescriptionProvider;
+import org.openhab.core.thing.Bridge;
+import org.openhab.core.thing.Thing;
+import org.openhab.core.thing.ThingStatus;
+import org.openhab.core.thing.ThingStatusDetail;
+import org.openhab.core.thing.ThingStatusInfo;
+
+import com.google.gson.Gson;
+
+/**
+ * The {@link TuyaSubDeviceHandler} handles commands and state updates for a device that is reached through a gateway.
+ * It has no connection of its own, all traffic is relayed by the {@link TuyaGatewayHandler} of its bridge and tagged
+ * with the sub-device node id.
+ *
+ * @author Maciej Jarzebowski - Initial contribution
+ */
+@NonNullByDefault
+public class TuyaSubDeviceHandler extends BaseTuyaDeviceHandler {
+    // The node id this handler is registered under, which is not necessarily the configured one any more
+    private @Nullable String registeredSubDeviceId;
+
+    public TuyaSubDeviceHandler(Thing thing, Gson gson,
+            TuyaDynamicCommandDescriptionProvider dynamicCommandDescriptionProvider,
+            TuyaDynamicStateDescriptionProvider dynamicStateDescriptionProvider) {
+        super(thing, gson, dynamicCommandDescriptionProvider, dynamicStateDescriptionProvider);
+    }
+
+    /**
+     * @return the node id identifying this device towards its gateway, empty if it is not configured
+     */
+    String getSubDeviceId() {
+        return configuration.subDeviceId;
+    }
+
+    @Override
+    protected void initializeTransport() {
+        if (configuration.subDeviceId.isBlank()) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
+                    "@text/offline.missing-sub-device-id");
+            return;
+        }
+
+        updateStatus(ThingStatus.UNKNOWN);
+
+        TuyaGatewayHandler gatewayHandler = getGatewayHandler();
+        if (gatewayHandler == null) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_UNINITIALIZED);
+            return;
+        }
+
+        // Registering here rather than from the bridge child callback keeps the routing table correct when only the
+        // node id is edited, because that path disposes and initializes this handler without those callbacks.
+        registeredSubDeviceId = configuration.subDeviceId;
+        gatewayHandler.registerSubDevice(configuration.subDeviceId, this);
+    }
+
+    @Override
+    public void dispose() {
+        String registeredSubDeviceId = this.registeredSubDeviceId;
+        TuyaGatewayHandler gatewayHandler = getGatewayHandler();
+        if (registeredSubDeviceId != null && gatewayHandler != null) {
+            gatewayHandler.unregisterSubDevice(registeredSubDeviceId, this);
+        }
+        this.registeredSubDeviceId = null;
+
+        super.dispose();
+    }
+
+    /**
+     * Called by the gateway when the state of its connection changed, and once when this handler is registered as a
+     * child of the gateway.
+     *
+     * @param status whether the gateway is connected
+     * @param initialDelay how long to wait before querying the device, in milliseconds
+     */
+    void gatewayConnectionStatus(boolean status, int initialDelay) {
+        if (status) {
+            updateStatus(ThingStatus.ONLINE);
+
+            onCommunicationEstablished(initialDelay);
+            return;
+        }
+
+        onCommunicationLost();
+
+        Bridge bridge = getBridge();
+        if (bridge != null && bridge.getStatus() == ThingStatus.OFFLINE) {
+            // The gateway cannot connect at all, e.g. because its IP address is not known yet
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE);
+        } else {
+            updateStatus(ThingStatus.ONLINE, ThingStatusDetail.NONE, "@text/online.wait-for-device");
+        }
+    }
+
+    @Override
+    public void bridgeStatusChanged(ThingStatusInfo bridgeStatusInfo) {
+        if (bridgeStatusInfo.getStatus() == ThingStatus.OFFLINE) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE);
+
+            onCommunicationLost();
+        }
+        // Coming back online is driven by the gateway connection, see gatewayConnectionStatus().
+    }
+
+    @Override
+    protected boolean canCommunicate() {
+        TuyaGatewayHandler gatewayHandler = getGatewayHandler();
+        return gatewayHandler != null && gatewayHandler.isConnected();
+    }
+
+    @Override
+    protected void sendCommand(Map<Integer, @Nullable Object> command) {
+        TuyaGatewayHandler gatewayHandler = getGatewayHandler();
+        if (gatewayHandler != null) {
+            gatewayHandler.sendCommand(configuration.subDeviceId, command);
+        } else {
+            logger.warn("{}: Setting {} failed. Gateway is not available.", thing.getUID().getId(), command);
+        }
+    }
+
+    @Override
+    protected void requestStatus() {
+        TuyaGatewayHandler gatewayHandler = getGatewayHandler();
+        if (gatewayHandler != null) {
+            gatewayHandler.requestStatus(configuration.subDeviceId);
+        }
+    }
+
+    @Override
+    protected void refreshStatus() {
+        // Gateways relay DP_QUERY for their sub-devices. DP_REFRESH is not defined for sub-devices, so a full query is
+        // the only way to get up-to-date measurements.
+        requestStatus();
+    }
+
+    @Override
+    protected boolean refreshRepeatsFullQuery() {
+        return true;
+    }
+
+    private @Nullable TuyaGatewayHandler getGatewayHandler() {
+        Bridge bridge = getBridge();
+        if (bridge == null) {
+            return null;
+        }
+
+        return bridge.getHandler() instanceof TuyaGatewayHandler gatewayHandler ? gatewayHandler : null;
+    }
+}

--- a/bundles/org.openhab.binding.tuya/src/main/java/org/openhab/binding/tuya/internal/local/DeviceStatusListener.java
+++ b/bundles/org.openhab.binding.tuya/src/main/java/org/openhab/binding/tuya/internal/local/DeviceStatusListener.java
@@ -15,15 +15,24 @@ package org.openhab.binding.tuya.internal.local;
 import java.util.Map;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 
 /**
  * The {@link DeviceStatusListener} encapsulates device status data
  *
  * @author Jan N. Klug - Initial contribution
+ * @author Maciej Jarzebowski - Report the sub-device a status belongs to
  */
 @NonNullByDefault
 public interface DeviceStatusListener {
-    void processDeviceStatus(Map<Integer, Object> deviceStatus);
+    /**
+     * Called when a status message was received.
+     *
+     * @param cid the node id of the sub-device the status belongs to, or {@code null} if it belongs to the device the
+     *            connection is established with
+     * @param deviceStatus the reported data points
+     */
+    void processDeviceStatus(@Nullable String cid, Map<Integer, Object> deviceStatus);
 
     void connectionStatus(boolean status, int initialDelay);
 }

--- a/bundles/org.openhab.binding.tuya/src/main/java/org/openhab/binding/tuya/internal/local/MessageWrapper.java
+++ b/bundles/org.openhab.binding.tuya/src/main/java/org/openhab/binding/tuya/internal/local/MessageWrapper.java
@@ -13,24 +13,37 @@
 package org.openhab.binding.tuya.internal.local;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 
 /**
  * The {@link MessageWrapper} wraps command type and message content
  *
  * @author Jan N. Klug - Initial contribution
+ * @author Maciej Jarzebowski - Add sub-device (cid) addressing
  */
 @NonNullByDefault
 public class MessageWrapper<T> {
     public CommandType commandType;
     public T content;
 
+    /**
+     * The node id of the sub-device this message is addressed to, or {@code null} if the message is addressed to the
+     * device the connection is established with.
+     */
+    public final @Nullable String cid;
+
     public MessageWrapper(CommandType commandType, T content) {
+        this(commandType, content, null);
+    }
+
+    public MessageWrapper(CommandType commandType, T content, @Nullable String cid) {
         this.commandType = commandType;
         this.content = content;
+        this.cid = cid;
     }
 
     @Override
     public String toString() {
-        return "MessageWrapper{commandType=" + commandType + ", content='" + content + "'}";
+        return "MessageWrapper{commandType=" + commandType + ", content='" + content + "', cid='" + cid + "'}";
     }
 }

--- a/bundles/org.openhab.binding.tuya/src/main/java/org/openhab/binding/tuya/internal/local/TuyaDevice.java
+++ b/bundles/org.openhab.binding.tuya/src/main/java/org/openhab/binding/tuya/internal/local/TuyaDevice.java
@@ -71,6 +71,7 @@ import io.netty.util.concurrent.Future;
  * The {@link TuyaDevice} handles the device connection
  *
  * @author Jan N. Klug - Initial contribution
+ * @author Maciej Jarzebowski - Add sub-device (cid) addressing
  */
 @NonNullByDefault
 public class TuyaDevice implements ChannelFutureListener {
@@ -203,7 +204,10 @@ public class TuyaDevice implements ChannelFutureListener {
                 // the connection does not recover so we do need to reconnect. And finally, since we
                 // always send DP_QUERY and CONTROL in pairs (because some older devices require CONTROL
                 // rather than DP_QUERY) we do not need to set a timeout for DP_QUERY.
+                // A message addressed to a sub-device is only relayed by the gateway. The sub-device may answer
+                // seconds later or not at all, which says nothing about the gateway connection being alive.
                 if (msg != null && msg instanceof MessageWrapper<?> m //
+                        && m.cid == null //
                         && m.commandType != SESS_KEY_NEG_FINISH //
                         && m.commandType != DP_REFRESH //
                         && m.commandType != DP_QUERY && m.commandType != DP_QUERY_NEW //
@@ -323,13 +327,45 @@ public class TuyaDevice implements ChannelFutureListener {
     }
 
     public void set(Map<Integer, @Nullable Object> command) {
+        set(null, command);
+    }
+
+    /**
+     * Sends data points to a device.
+     *
+     * @param cid the node id of the sub-device to address, or {@code null} to address this device
+     * @param command the data points to set
+     */
+    public void set(@Nullable String cid, Map<Integer, @Nullable Object> command) {
         CommandType commandType = (protocolVersion == V3_4 || protocolVersion == V3_5) ? CONTROL_NEW : CONTROL;
         ChannelFuture channelFuture = this.channelFuture;
         if (channelFuture != null) {
-            channelFuture.channel().writeAndFlush(new MessageWrapper<>(commandType, Map.of("dps", command)));
+            channelFuture.channel().writeAndFlush(new MessageWrapper<>(commandType, Map.of("dps", command), cid));
         } else {
             logger.warn("{}: Setting {} failed. Device is not connected.", deviceId, command);
         }
+    }
+
+    /**
+     * Queries the status of a sub-device connected through this gateway.
+     *
+     * A sub-device query carries nothing but the node id: the data points to report are chosen by the gateway, and
+     * unlike {@link #requestStatus()} there is no need for the legacy CONTROL companion message because sub-devices
+     * are served by the gateway firmware, which always implements DP_QUERY.
+     *
+     * @param cid the node id of the sub-device to query
+     */
+    public void requestStatus(String cid) {
+        ChannelFuture channelFuture = this.channelFuture;
+        if (channelFuture == null) {
+            logger.warn("{}/{}: Querying status failed. Device is not connected.", deviceId, cid);
+            return;
+        }
+
+        // 3.4 and 3.5 replaced DP_QUERY with DP_QUERY_NEW. A gateway answers a sub-device query only in the form of
+        // the negotiated protocol and otherwise silently reports its own data points instead.
+        CommandType commandType = (protocolVersion == V3_4 || protocolVersion == V3_5) ? DP_QUERY_NEW : DP_QUERY;
+        channelFuture.channel().writeAndFlush(new MessageWrapper<>(commandType, Map.of(), cid));
     }
 
     public void requestStatus() {

--- a/bundles/org.openhab.binding.tuya/src/main/java/org/openhab/binding/tuya/internal/local/dto/TcpStatusPayload.java
+++ b/bundles/org.openhab.binding.tuya/src/main/java/org/openhab/binding/tuya/internal/local/dto/TcpStatusPayload.java
@@ -20,6 +20,7 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
  * The {@link TcpStatusPayload} encapsulates the payload of a TCP status message
  *
  * @author Jan N. Klug - Initial contribution
+ * @author Maciej Jarzebowski - Add sub-device node id (cid)
  */
 @NonNullByDefault
 public class TcpStatusPayload {
@@ -27,6 +28,8 @@ public class TcpStatusPayload {
     public String devId = "";
     public String gwId = "";
     public String uid = "";
+    // Set by gateways to the node id of the sub-device the status belongs to.
+    public String cid = "";
     public long t = 0;
     public Map<Integer, Object> dps = Map.of();
     public Data data = new Data();
@@ -34,15 +37,16 @@ public class TcpStatusPayload {
     @Override
     public String toString() {
         return "TcpStatusPayload{protocol=" + protocol + ", devId='" + devId + "', gwId='" + gwId + "', uid='" + uid
-                + "', t=" + t + ", dps=" + dps + ", data=" + data + "}";
+                + "', cid='" + cid + "', t=" + t + ", dps=" + dps + ", data=" + data + "}";
     }
 
     public static class Data {
+        public String cid = "";
         public Map<Integer, Object> dps = Map.of();
 
         @Override
         public String toString() {
-            return "Data{dps=" + dps + "}";
+            return "Data{cid='" + cid + "', dps=" + dps + "}";
         }
     }
 }

--- a/bundles/org.openhab.binding.tuya/src/main/java/org/openhab/binding/tuya/internal/local/handlers/TuyaDecoder.java
+++ b/bundles/org.openhab.binding.tuya/src/main/java/org/openhab/binding/tuya/internal/local/handlers/TuyaDecoder.java
@@ -14,6 +14,7 @@ package org.openhab.binding.tuya.internal.local.handlers;
 
 import static org.openhab.binding.tuya.internal.local.CommandType.BROADCAST_LPV34;
 import static org.openhab.binding.tuya.internal.local.CommandType.DP_QUERY;
+import static org.openhab.binding.tuya.internal.local.CommandType.DP_QUERY_NEW;
 import static org.openhab.binding.tuya.internal.local.CommandType.HEART_BEAT;
 import static org.openhab.binding.tuya.internal.local.CommandType.SESS_KEY_NEG_RESPONSE;
 import static org.openhab.binding.tuya.internal.local.CommandType.STATUS;
@@ -238,7 +239,7 @@ public class TuyaDecoder extends ByteToMessageDecoder {
                     // workaround, cf. https://github.com/codetheweb/tuyapi/blob/master/index.js#L156
                     // Since already we sent a CONTROL as well we can ignore this error.
                     return;
-                } else if (commandType == STATUS || commandType == DP_QUERY) {
+                } else if (commandType == STATUS || commandType == DP_QUERY || commandType == DP_QUERY_NEW) {
                     m = new MessageWrapper<>(commandType,
                             Objects.requireNonNull(gson.fromJson(decodedString, TcpStatusPayload.class)));
                 } else if (commandType == UDP_NEW || commandType == BROADCAST_LPV34) {

--- a/bundles/org.openhab.binding.tuya/src/main/java/org/openhab/binding/tuya/internal/local/handlers/TuyaEncoder.java
+++ b/bundles/org.openhab.binding.tuya/src/main/java/org/openhab/binding/tuya/internal/local/handlers/TuyaEncoder.java
@@ -54,6 +54,7 @@ import io.netty.handler.codec.MessageToByteEncoder;
  * Parts of this code are inspired by the TuyAPI project (see notice file)
  *
  * @author Jan N. Klug - Initial contribution
+ * @author Maciej Jarzebowski - Address sub-devices by node id (cid)
  */
 @NonNullByDefault
 public class TuyaEncoder extends MessageToByteEncoder<MessageWrapper<?>> {
@@ -88,24 +89,40 @@ public class TuyaEncoder extends MessageToByteEncoder<MessageWrapper<?>> {
         if (msg.content == null || msg.content instanceof Map<?, ?>) {
             Map<String, Object> content = (Map<String, Object>) msg.content;
             Map<String, Object> payload = new HashMap<>();
+            String cid = msg.cid;
             if (msg.commandType == REQ_DEVINFO || msg.commandType == DP_REFRESH) {
                 if (content != null) {
                     payload.putAll(content);
                 }
+            } else if ((protocol == V3_4 || protocol == V3_5) && cid != null
+                    && (msg.commandType == DP_QUERY || msg.commandType == DP_QUERY_NEW)) {
+                // A sub-device query carries nothing but the node id. Wrapping it in the protocol 5 envelope used
+                // for commands makes a gateway answer for itself instead of for the addressed sub-device.
+                payload.put("cid", cid);
             } else if (protocol == V3_4 || protocol == V3_5) {
                 payload.put("protocol", 5);
                 payload.put("t", System.currentTimeMillis() / 1000);
+                if (cid != null) {
+                    // A sub-device is identified at both levels of the envelope
+                    payload.put("cid", cid);
+                }
                 Map<String, Object> data = new HashMap<>();
-                data.put("cid", deviceId);
+                data.put("cid", Objects.requireNonNullElse(cid, deviceId));
                 data.put("ctype", 0);
                 if (content != null) {
                     data.putAll(content);
                 }
                 payload.put("data", data);
             } else {
-                payload.put("devId", deviceId);
-                payload.put("gwId", deviceId);
-                payload.put("uid", deviceId);
+                if (cid != null) {
+                    // Sub-devices are addressed by their node id only. Gateways reject messages that also
+                    // carry the device identification of the gateway itself.
+                    payload.put("cid", cid);
+                } else {
+                    payload.put("devId", deviceId);
+                    payload.put("gwId", deviceId);
+                    payload.put("uid", deviceId);
+                }
                 payload.put("t", System.currentTimeMillis() / 1000);
                 if (content != null) {
                     payload.putAll(content);

--- a/bundles/org.openhab.binding.tuya/src/main/java/org/openhab/binding/tuya/internal/local/handlers/TuyaMessageHandler.java
+++ b/bundles/org.openhab.binding.tuya/src/main/java/org/openhab/binding/tuya/internal/local/handlers/TuyaMessageHandler.java
@@ -38,6 +38,7 @@ import io.netty.channel.ChannelHandlerContext;
  * The {@link TuyaMessageHandler} is a Netty channel handler
  *
  * @author Jan N. Klug - Initial contribution
+ * @author Maciej Jarzebowski - Report the sub-device a status belongs to
  */
 @NonNullByDefault
 public class TuyaMessageHandler extends ChannelDuplexHandler {
@@ -64,14 +65,21 @@ public class TuyaMessageHandler extends ChannelDuplexHandler {
         ProtocolVersion protocol = ctx.channel().attr(TuyaDevice.PROTOCOL_ATTR).get();
 
         if (msg instanceof MessageWrapper<?> m) {
-            if (m.commandType == CommandType.DP_QUERY || m.commandType == CommandType.STATUS) {
+            if (m.commandType == CommandType.DP_QUERY || m.commandType == CommandType.DP_QUERY_NEW
+                    || m.commandType == CommandType.STATUS) {
                 Map<Integer, Object> stateMap = null;
+                String cid = null;
                 if (m.content instanceof TcpStatusPayload payload) {
-                    stateMap = payload.protocol == 4 ? payload.data.dps : payload.dps;
+                    boolean nested = payload.protocol == 4;
+                    stateMap = nested ? payload.data.dps : payload.dps;
+                    // Gateways report the originating sub-device in "cid". An empty value means the
+                    // status belongs to the gateway itself.
+                    String payloadCid = nested ? payload.data.cid : payload.cid;
+                    cid = payloadCid.isEmpty() ? null : payloadCid;
                 }
 
                 if (stateMap != null && !stateMap.isEmpty()) {
-                    deviceStatusListener.processDeviceStatus(stateMap);
+                    deviceStatusListener.processDeviceStatus(cid, stateMap);
                 }
             } else if (m.commandType == CommandType.SESS_KEY_NEG_RESPONSE) {
                 if (!ctx.channel().hasAttr(TuyaDevice.SESSION_KEY_ATTR)

--- a/bundles/org.openhab.binding.tuya/src/main/resources/OH-INF/i18n/tuya.properties
+++ b/bundles/org.openhab.binding.tuya/src/main/resources/OH-INF/i18n/tuya.properties
@@ -9,6 +9,10 @@ thing-type.tuya.project.label = Tuya Cloud Project
 thing-type.tuya.project.description = This thing represents a single cloud project. Needed for discovery.
 thing-type.tuya.tuyaDevice.label = Generic Tuya Device
 thing-type.tuya.tuyaDevice.description = A generic Tuya device. Can be extended with channels.
+thing-type.tuya.tuyaGateway.label = Tuya Gateway
+thing-type.tuya.tuyaGateway.description = A Tuya device that relays for sub-devices, e.g. a Bluetooth or ZigBee gateway.
+thing-type.tuya.tuyaSubDevice.label = Tuya Sub-Device
+thing-type.tuya.tuyaSubDevice.description = A Tuya device that is reached through a gateway. Can be extended with channels.
 
 # thing types config
 
@@ -48,6 +52,24 @@ thing-type.config.tuya.tuyaDevice.protocol.option.3.1 = 3.1
 thing-type.config.tuya.tuyaDevice.protocol.option.3.3 = 3.3
 thing-type.config.tuya.tuyaDevice.protocol.option.3.4 = 3.4
 thing-type.config.tuya.tuyaDevice.protocol.option.3.5 = 3.5
+thing-type.config.tuya.tuyaGateway.deviceId.label = Device ID
+thing-type.config.tuya.tuyaGateway.ip.label = IP Address
+thing-type.config.tuya.tuyaGateway.ip.description = Auto-detected if device is on same subnet or broadcast forwarding configured.
+thing-type.config.tuya.tuyaGateway.localKey.label = Device Local Key
+thing-type.config.tuya.tuyaGateway.pollingInterval.label = Polling Interval
+thing-type.config.tuya.tuyaGateway.port.label = Port
+thing-type.config.tuya.tuyaGateway.port.description = TCP port used by the device. Change only if the device is reachable through a NAT/port mapping.
+thing-type.config.tuya.tuyaGateway.productId.label = Product ID
+thing-type.config.tuya.tuyaGateway.protocol.label = Protocol Version
+thing-type.config.tuya.tuyaGateway.protocol.option.3.1 = 3.1
+thing-type.config.tuya.tuyaGateway.protocol.option.3.3 = 3.3
+thing-type.config.tuya.tuyaGateway.protocol.option.3.4 = 3.4
+thing-type.config.tuya.tuyaGateway.protocol.option.3.5 = 3.5
+thing-type.config.tuya.tuyaSubDevice.deviceId.label = Device ID
+thing-type.config.tuya.tuyaSubDevice.pollingInterval.label = Polling Interval
+thing-type.config.tuya.tuyaSubDevice.productId.label = Product ID
+thing-type.config.tuya.tuyaSubDevice.subDeviceId.label = Sub-Device ID
+thing-type.config.tuya.tuyaSubDevice.subDeviceId.description = Node ID identifying the device towards its gateway.
 
 # channel types
 
@@ -126,6 +148,7 @@ channel-type.config.tuya.switch.dp.label = DP
 
 # thing status descriptions
 
+offline.missing-sub-device-id = Sub-device ID is not set
 offline.wait-for-ip = Waiting for IP address
 online.wait-for-device = Waiting for device wake up
 

--- a/bundles/org.openhab.binding.tuya/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.tuya/src/main/resources/OH-INF/thing/thing-types.xml
@@ -58,6 +58,80 @@
 		</config-description>
 	</thing-type>
 
+	<!-- Tuya gateway -->
+	<bridge-type id="tuyaGateway" extensible="color,switch,dimmer,number,string,ir-code">
+		<label>Tuya Gateway</label>
+		<description>A Tuya device that relays for sub-devices, e.g. a Bluetooth or ZigBee gateway.</description>
+
+		<config-description>
+			<parameter name="deviceId" type="text" required="true">
+				<label>Device ID</label>
+			</parameter>
+			<parameter name="localKey" type="text" required="true">
+				<label>Device Local Key</label>
+				<context>password</context>
+			</parameter>
+			<parameter name="productId" type="text" required="true">
+				<label>Product ID</label>
+			</parameter>
+			<parameter name="ip" type="text">
+				<label>IP Address</label>
+				<description>Auto-detected if device is on same subnet or broadcast forwarding configured.</description>
+				<advanced>true</advanced>
+			</parameter>
+			<parameter name="port" type="integer" min="1" max="65535">
+				<label>Port</label>
+				<description>TCP port used by the device. Change only if the device is reachable through a NAT/port mapping.</description>
+				<default>6668</default>
+				<advanced>true</advanced>
+			</parameter>
+			<parameter name="protocol" type="text">
+				<label>Protocol Version</label>
+				<options>
+					<option value="3.1">3.1</option>
+					<option value="3.3">3.3</option>
+					<option value="3.4">3.4</option>
+					<option value="3.5">3.5</option>
+				</options>
+				<limitToOptions>true</limitToOptions>
+				<advanced>true</advanced>
+			</parameter>
+			<parameter name="pollingInterval" type="integer" min="0" unit="s">
+				<label>Polling Interval</label>
+				<default>10</default>
+				<advanced>true</advanced>
+			</parameter>
+		</config-description>
+	</bridge-type>
+
+	<!-- Tuya sub-device -->
+	<thing-type id="tuyaSubDevice" extensible="color,switch,dimmer,number,string,ir-code">
+		<supported-bridge-type-refs>
+			<bridge-type-ref id="tuyaGateway"/>
+		</supported-bridge-type-refs>
+
+		<label>Tuya Sub-Device</label>
+		<description>A Tuya device that is reached through a gateway. Can be extended with channels.</description>
+
+		<config-description>
+			<parameter name="deviceId" type="text" required="true">
+				<label>Device ID</label>
+			</parameter>
+			<parameter name="productId" type="text" required="true">
+				<label>Product ID</label>
+			</parameter>
+			<parameter name="subDeviceId" type="text" required="true">
+				<label>Sub-Device ID</label>
+				<description>Node ID identifying the device towards its gateway.</description>
+			</parameter>
+			<parameter name="pollingInterval" type="integer" min="0" unit="s">
+				<label>Polling Interval</label>
+				<default>10</default>
+				<advanced>true</advanced>
+			</parameter>
+		</config-description>
+	</thing-type>
+
 	<!-- Generic Tuya device -->
 	<thing-type id="tuyaDevice" extensible="color,switch,dimmer,number,string,ir-code">
 		<label>Generic Tuya Device</label>

--- a/bundles/org.openhab.binding.tuya/src/test/java/org/openhab/binding/tuya/internal/local/handlers/TuyaEncoderTest.java
+++ b/bundles/org.openhab.binding.tuya/src/test/java/org/openhab/binding/tuya/internal/local/handlers/TuyaEncoderTest.java
@@ -14,13 +14,19 @@ package org.openhab.binding.tuya.internal.local.handlers;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.openhab.binding.tuya.internal.local.TuyaDevice.*;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Objects;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -29,9 +35,11 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.openhab.binding.tuya.internal.local.CommandType;
 import org.openhab.binding.tuya.internal.local.MessageWrapper;
 import org.openhab.binding.tuya.internal.local.ProtocolVersion;
+import org.openhab.binding.tuya.internal.util.CryptoUtil;
 import org.openhab.core.util.HexUtils;
 
 import com.google.gson.Gson;
+import com.google.gson.JsonObject;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.Channel;
@@ -42,10 +50,15 @@ import io.netty.util.Attribute;
  * The {@link TuyaEncoderTest} is a test class for the {@link TuyaEncoder} class
  *
  * @author Jan N. Klug - Initial contribution
+ * @author Maciej Jarzebowski - Add sub-device (cid) tests
  */
 @ExtendWith(MockitoExtension.class)
 @NonNullByDefault
 public class TuyaEncoderTest {
+
+    private static final String DEVICE_ID = "bf5d241ed32f3968eej27a";
+    private static final String SUB_DEVICE_ID = "e0f6bf69791fc50c";
+    private static final byte[] KEY = "5c8c3ccc1f0fbdbb".getBytes(StandardCharsets.UTF_8);
 
     private final Gson gson = new Gson();
     private @Mock @NonNullByDefault({}) ChannelHandlerContext ctxMock;
@@ -86,5 +99,136 @@ public class TuyaEncoderTest {
         byte[] result = (byte[]) captor.getValue();
         assertThat(result.length, is(expectedResult.length));
         assertThat(result, is(expectedResult));
+    }
+
+    @Test
+    public void testDeviceIsAddressedByDeviceId33() throws Exception {
+        JsonObject payload = encodeControl33(null);
+
+        assertThat(payload.get("devId").getAsString(), is(DEVICE_ID));
+        assertThat(payload.get("gwId").getAsString(), is(DEVICE_ID));
+        assertThat(payload.get("uid").getAsString(), is(DEVICE_ID));
+        assertThat(payload.get("cid"), is(nullValue()));
+        assertThat(payload.get("dps"), is(not(nullValue())));
+    }
+
+    @Test
+    public void testSubDeviceIsAddressedByNodeIdOnly33() throws Exception {
+        JsonObject payload = encodeControl33(SUB_DEVICE_ID);
+
+        assertThat(payload.get("cid").getAsString(), is(SUB_DEVICE_ID));
+        // A gateway does not accept a sub-device message that also carries the identification of the gateway itself.
+        assertThat(payload.get("devId"), is(nullValue()));
+        assertThat(payload.get("gwId"), is(nullValue()));
+        assertThat(payload.get("uid"), is(nullValue()));
+        assertThat(payload.get("dps"), is(not(nullValue())));
+    }
+
+    @Test
+    public void testSubDeviceIsAddressedByNodeIdInData34() throws Exception {
+        JsonObject payload = encodeControl34(SUB_DEVICE_ID);
+
+        assertThat(payload.getAsJsonObject("data").get("cid").getAsString(), is(SUB_DEVICE_ID));
+        // the node id identifies the sub-device at both levels of the envelope
+        assertThat(payload.get("cid").getAsString(), is(SUB_DEVICE_ID));
+    }
+
+    @Test
+    public void testDeviceIsAddressedByDeviceIdInData34() throws Exception {
+        JsonObject payload = encodeControl34(null);
+
+        assertThat(payload.getAsJsonObject("data").get("cid").getAsString(), is(DEVICE_ID));
+        assertThat(payload.get("cid"), is(nullValue()));
+    }
+
+    @Test
+    public void testSubDeviceQueryCarriesOnlyNodeId34() throws Exception {
+        mockChannel(ProtocolVersion.V3_4);
+
+        TuyaEncoder encoder = new TuyaEncoder(gson);
+        encoder.encode(ctxMock, new MessageWrapper<>(CommandType.DP_QUERY_NEW, Map.of(), SUB_DEVICE_ID), out);
+
+        // a query is not prefixed with the protocol version header, so the payload starts right after the header
+        byte[] frame = captureFrame();
+        JsonObject payload = decrypt(Arrays.copyOfRange(frame, 16, frame.length - 36));
+
+        assertThat(payload.get("cid").getAsString(), is(SUB_DEVICE_ID));
+        // the protocol 5 envelope is for commands; a gateway answers for itself when a query is wrapped in it
+        assertThat(payload.get("data"), is(nullValue()));
+        assertThat(payload.get("protocol"), is(nullValue()));
+    }
+
+    @Test
+    public void testSubDeviceQueryCarriesOnlyNodeId33() throws Exception {
+        mockChannel(ProtocolVersion.V3_3);
+
+        TuyaEncoder encoder = new TuyaEncoder(gson);
+        encoder.encode(ctxMock, new MessageWrapper<>(CommandType.DP_QUERY, Map.of(), SUB_DEVICE_ID), out);
+
+        byte[] frame = captureFrame();
+        JsonObject payload = decrypt(Arrays.copyOfRange(frame, 16, frame.length - 8));
+
+        assertThat(payload.get("cid").getAsString(), is(SUB_DEVICE_ID));
+        assertThat(payload.get("devId"), is(nullValue()));
+        assertThat(payload.get("gwId"), is(nullValue()));
+    }
+
+    private JsonObject encodeControl33(@Nullable String cid) throws Exception {
+        mockChannel(ProtocolVersion.V3_3);
+
+        TuyaEncoder encoder = new TuyaEncoder(gson);
+        encoder.encode(ctxMock, new MessageWrapper<>(CommandType.CONTROL, Map.of("dps", Map.of(1, true)), cid), out);
+
+        // prefix, sequence, command and length take 16 bytes, the trailing checksum and suffix another 8
+        byte[] frame = captureFrame();
+        byte[] encrypted = Arrays.copyOfRange(frame, 16, frame.length - 8);
+
+        // CONTROL messages carry a 15 byte version header in front of the encrypted payload
+        return decrypt(Arrays.copyOfRange(encrypted, 15, encrypted.length));
+    }
+
+    private JsonObject encodeControl34(@Nullable String cid) throws Exception {
+        mockChannel(ProtocolVersion.V3_4);
+
+        TuyaEncoder encoder = new TuyaEncoder(gson);
+        encoder.encode(ctxMock, new MessageWrapper<>(CommandType.CONTROL_NEW, Map.of("dps", Map.of(1, true)), cid),
+                out);
+
+        // prefix, sequence, command and length take 16 bytes, the trailing HMAC and suffix another 36
+        byte[] frame = captureFrame();
+        byte[] decrypted = Objects
+                .requireNonNull(CryptoUtil.decryptAesEcb(Arrays.copyOfRange(frame, 16, frame.length - 36), KEY, true));
+
+        // the decrypted payload carries a 15 byte version header in front of the JSON
+        return Objects.requireNonNull(
+                gson.fromJson(new String(Arrays.copyOfRange(decrypted, 15, decrypted.length), StandardCharsets.UTF_8),
+                        JsonObject.class));
+    }
+
+    private void mockChannel(ProtocolVersion protocol) {
+        when(ctxMock.channel()).thenReturn(channelMock);
+
+        when(channelMock.hasAttr(DEVICE_ID_ATTR)).thenReturn(true);
+        when(channelMock.attr(DEVICE_ID_ATTR)).thenReturn(deviceIdAttrMock);
+        when(deviceIdAttrMock.get()).thenReturn(DEVICE_ID);
+
+        when(channelMock.hasAttr(PROTOCOL_ATTR)).thenReturn(true);
+        when(channelMock.attr(PROTOCOL_ATTR)).thenReturn(protocolAttrMock);
+        when(protocolAttrMock.get()).thenReturn(protocol);
+
+        when(channelMock.hasAttr(SESSION_KEY_ATTR)).thenReturn(true);
+        when(channelMock.attr(SESSION_KEY_ATTR)).thenReturn(sessionKeyAttrMock);
+        when(sessionKeyAttrMock.get()).thenReturn(KEY);
+    }
+
+    private byte[] captureFrame() {
+        ArgumentCaptor<Object> captor = ArgumentCaptor.forClass(Object.class);
+        verify(out).writeBytes((byte[]) captor.capture());
+        return (byte[]) captor.getValue();
+    }
+
+    private JsonObject decrypt(byte[] encrypted) {
+        byte[] decrypted = Objects.requireNonNull(CryptoUtil.decryptAesEcb(encrypted, KEY, true));
+        return Objects.requireNonNull(gson.fromJson(new String(decrypted, StandardCharsets.UTF_8), JsonObject.class));
     }
 }

--- a/bundles/org.openhab.binding.tuya/src/test/java/org/openhab/binding/tuya/internal/local/handlers/TuyaMessageHandlerTest.java
+++ b/bundles/org.openhab.binding.tuya/src/test/java/org/openhab/binding/tuya/internal/local/handlers/TuyaMessageHandlerTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.tuya.internal.local.handlers;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.openhab.binding.tuya.internal.local.TuyaDevice.*;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.openhab.binding.tuya.internal.local.CommandType;
+import org.openhab.binding.tuya.internal.local.DeviceStatusListener;
+import org.openhab.binding.tuya.internal.local.MessageWrapper;
+import org.openhab.binding.tuya.internal.local.ProtocolVersion;
+import org.openhab.binding.tuya.internal.local.dto.TcpStatusPayload;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.util.Attribute;
+
+/**
+ * The {@link TuyaMessageHandlerTest} is a test class for the {@link TuyaMessageHandler} class
+ *
+ * @author Maciej Jarzebowski - Initial contribution
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@NonNullByDefault
+public class TuyaMessageHandlerTest {
+    private static final String SUB_DEVICE_ID = "e0f6bf69791fc50c";
+    private static final Map<Integer, Object> DPS = Map.of(1, Boolean.TRUE);
+
+    private @Mock @NonNullByDefault({}) ChannelHandlerContext ctxMock;
+    private @Mock @NonNullByDefault({}) Channel channelMock;
+    private @Mock @NonNullByDefault({}) Attribute<String> deviceIdAttrMock;
+    private @Mock @NonNullByDefault({}) Attribute<ProtocolVersion> protocolAttrMock;
+    private @Mock @NonNullByDefault({}) Attribute<byte[]> sessionKeyAttrMock;
+    private @Mock @NonNullByDefault({}) DeviceStatusListener deviceStatusListenerMock;
+
+    @BeforeEach
+    public void setUp() {
+        when(ctxMock.channel()).thenReturn(channelMock);
+
+        when(channelMock.hasAttr(DEVICE_ID_ATTR)).thenReturn(true);
+        when(channelMock.attr(DEVICE_ID_ATTR)).thenReturn(deviceIdAttrMock);
+        when(deviceIdAttrMock.get()).thenReturn("bf5d241ed32f3968eej27a");
+
+        when(channelMock.hasAttr(PROTOCOL_ATTR)).thenReturn(true);
+        when(channelMock.attr(PROTOCOL_ATTR)).thenReturn(protocolAttrMock);
+        when(protocolAttrMock.get()).thenReturn(ProtocolVersion.V3_3);
+
+        when(channelMock.hasAttr(SESSION_KEY_ATTR)).thenReturn(true);
+        when(channelMock.attr(SESSION_KEY_ATTR)).thenReturn(sessionKeyAttrMock);
+        when(sessionKeyAttrMock.get()).thenReturn("5c8c3ccc1f0fbdbb".getBytes(StandardCharsets.UTF_8));
+    }
+
+    @Test
+    public void deviceStatusIsReportedWithoutSubDeviceId() throws Exception {
+        TcpStatusPayload payload = new TcpStatusPayload();
+        payload.dps = DPS;
+
+        new TuyaMessageHandler(deviceStatusListenerMock).channelRead(ctxMock,
+                new MessageWrapper<>(CommandType.STATUS, payload));
+
+        verify(deviceStatusListenerMock).processDeviceStatus(null, DPS);
+    }
+
+    @Test
+    public void subDeviceStatusIsReportedWithSubDeviceId() throws Exception {
+        TcpStatusPayload payload = new TcpStatusPayload();
+        payload.cid = SUB_DEVICE_ID;
+        payload.dps = DPS;
+
+        new TuyaMessageHandler(deviceStatusListenerMock).channelRead(ctxMock,
+                new MessageWrapper<>(CommandType.STATUS, payload));
+
+        verify(deviceStatusListenerMock).processDeviceStatus(SUB_DEVICE_ID, DPS);
+    }
+
+    @Test
+    public void subDeviceStatusIsReportedWithSubDeviceIdForNestedPayload() throws Exception {
+        TcpStatusPayload payload = new TcpStatusPayload();
+        payload.protocol = 4;
+        payload.data.cid = SUB_DEVICE_ID;
+        payload.data.dps = DPS;
+
+        new TuyaMessageHandler(deviceStatusListenerMock).channelRead(ctxMock,
+                new MessageWrapper<>(CommandType.STATUS, payload));
+
+        verify(deviceStatusListenerMock).processDeviceStatus(SUB_DEVICE_ID, DPS);
+    }
+}


### PR DESCRIPTION
## Description

**Classification: Improvement.** Resolves #19464.

Tuya Bluetooth and ZigBee gateways relay for the devices paired to them over the local protocol, tagging each message with the sub-device node id (`cid`). The binding had no notion of this, so devices behind a gateway could not be used at all.

Prior art for this exists against the older SmartHome/J fork ([presidentio/addons@8bc34a4](https://github.com/presidentio/addons/commit/8bc34a468f5c974be1cf63ad266f0a20eb2ea4b6) and [presidentio/addons#1](https://github.com/presidentio/addons/pull/1)), referenced in the issue. It could not be applied directly — this binding has since diverged considerably (static `TuyaSchemaDB`, the `port` parameter, `allDpIds`-driven queries, burst polling, protocol 3.5, IR channels) — so this is a fresh implementation of the same idea.

### For the end user

Two new thing types:

- **`tuyaGateway`** — a bridge. Configured exactly like a `tuyaDevice` and behaves like one for its own channels; it additionally routes traffic for its children.
- **`tuyaSubDevice`** — a device reached through a gateway. It has no connection of its own, so no `ip`, `port`, `protocol` or `localKey`; instead it has a `subDeviceId` (the node id). Its bridge is the gateway.

Discovery classifies the account automatically: a device that reports children becomes a `tuyaGateway`, its children become `tuyaSubDevice`s nested under it, and everything else stays a `tuyaDevice`. Accounts with no sub-devices behave exactly as before and make no extra cloud requests.

### Noteworthy changes in usage

- A gateway previously added as a `tuyaDevice` must be **deleted and re-added** as a `tuyaGateway` before its sub-devices can be used. Such things have almost no data points of their own today, so little is lost.
- Sub-devices are only offered in the inbox **once their gateway exists as a thing** — a `tuyaSubDevice` cannot be created without its bridge. Add the gateway, then scan again.

Both are documented in the add-on README, which is updated along with the i18n properties.

### Implementation notes

- The transport-independent half of `TuyaDeviceHandler` moves unchanged into a new `BaseTuyaDeviceHandler`, shared by the plain device, gateway and sub-device handlers. `TuyaGatewayHandler` extends `TuyaDeviceHandler` and implements `BridgeHandler`; because it therefore cannot inherit `BaseBridgeHandler`, it overrides `editThing()` to return a `BridgeBuilder` — otherwise `updateThing()` would silently replace the bridge with a plain thing.
- `MessageWrapper` carries an optional `cid`. The encoder addresses sub-devices by node id alone on 3.1/3.3 (dropping `devId`/`gwId`/`uid`) and via `data.cid` on 3.4/3.5, matching tinytuya's payload templates. `TcpStatusPayload` reads `cid` both flat and nested.
- Sub-devices have no partial refresh, so `refreshStatus()` is a full `DP_QUERY`. Since its reply is itself a status report, the burst-refresh-on-function-change is disabled for them (`refreshRepeatsFullQuery()`), otherwise reply and refresh trigger each other indefinitely.
- The response-timeout watchdog is not armed for cid-addressed messages: a gateway acknowledges immediately but relays asynchronously, and a slow sub-device reply says nothing about the gateway link.
- The device list does not name the gateway of a sub-device, so each device is asked for its children. A device flagged `sub` can itself be a gateway (a "Multi-mode Gateway" in my account is), so no device is excluded from that query. The requests are chained rather than issued at once, because the cloud API rejects bursts.

## Testing

Verified against real hardware on openHAB 5.x: two ZigBee gateways and one Bluetooth/multi-mode gateway, with several sub-devices each.

- Discovery of gateways and sub-devices, including a gateway that the cloud flags as a sub-device
- Sub-devices nested under their bridge, reaching ONLINE
- Inbound `cid` routing — live sensor updates through the gateway, mapped to schema channels with units
- Outbound commands to a sub-device, confirmed by the device reporting the new value back
- Regression: existing plain `tuyaDevice` things still initialise, connect and update

Unit tests added for the encoder (`cid` payloads on 3.3 and 3.4, plus a no-`cid` regression case) and for the inbound `cid`, flat and nested. `mvn clean install` on the binding is green, 24/24 tests, and static analysis reports no new findings.

### Pre-existing behaviour noticed while testing

Neither is introduced by this PR, and both affect plain `tuyaDevice` things too. Mentioning them so they are not attributed to this change; happy to file them separately.

- `requestStatus()` sends a legacy `CONTROL` companion, which arms the 200 ms response deadline. Devices that do not answer it get their connection recycled roughly once a second.
- `TuyaDevice` reconnects with no backoff after a close, so a device that responds with TCP RST produces a hot reconnect loop.
