### PR TITLE
[yamlcomposer] Add output formatting configuration and force recompilation on settings change

### DIFF
--- a/bundles/org.openhab.io.yamlcomposer/src/main/java/org/openhab/io/yamlcomposer/internal/ComposerUtils.java
+++ b/bundles/org.openhab.io.yamlcomposer/src/main/java/org/openhab/io/yamlcomposer/internal/ComposerUtils.java
@@ -42,7 +42,6 @@ import org.snakeyaml.engine.v2.api.Dump;
 import org.snakeyaml.engine.v2.api.DumpSettings;
 import org.snakeyaml.engine.v2.api.Load;
 import org.snakeyaml.engine.v2.api.LoadSettings;
-import org.snakeyaml.engine.v2.common.FlowStyle;
 import org.snakeyaml.engine.v2.resolver.ScalarResolver;
 import org.snakeyaml.engine.v2.schema.CoreSchema;
 import org.snakeyaml.engine.v2.schema.Schema;
@@ -90,7 +89,18 @@ final class ComposerUtils {
      */
     static void writeCompiledOutput(Object dataMap, Path sourcePath, Path outputPath, Set<String> trackedEnvVars)
             throws IOException {
-        writeCompiledOutput(dataMap, sourcePath, outputPath, trackedEnvVars, System.getenv());
+        writeCompiledOutput(dataMap, sourcePath, outputPath, trackedEnvVars, System.getenv(),
+                YamlOutputConfig.defaultConfig());
+    }
+
+    static void writeCompiledOutput(Object dataMap, Path sourcePath, Path outputPath, Set<String> trackedEnvVars,
+            YamlOutputConfig outputConfig) throws IOException {
+        writeCompiledOutput(dataMap, sourcePath, outputPath, trackedEnvVars, System.getenv(), outputConfig);
+    }
+
+    static void writeCompiledOutput(Object dataMap, Path sourcePath, Path outputPath, Set<String> trackedEnvVars,
+            Map<String, String> envMap) throws IOException {
+        writeCompiledOutput(dataMap, sourcePath, outputPath, trackedEnvVars, envMap, YamlOutputConfig.defaultConfig());
     }
 
     /**
@@ -104,25 +114,36 @@ final class ComposerUtils {
      * @param outputPath the absolute path of the compiled output file
      * @param trackedEnvVars the set of environment variables referenced during composition
      * @param envMap the environment variable map to compute the initial hash against
+     * @param outputConfig the YAML output configuration to use for dumping
      * @throws IOException if writing to the file fails
      */
     static void writeCompiledOutput(Object dataMap, Path sourcePath, Path outputPath, Set<String> trackedEnvVars,
-            Map<String, String> envMap) throws IOException {
+            Map<String, String> envMap, YamlOutputConfig outputConfig) throws IOException {
         Path outputDir = outputPath.getParent();
         if (outputDir != null) {
             Files.createDirectories(outputDir);
         }
 
         DumpSettings dumpSettings = DumpSettings.builder() //
-                .setDefaultFlowStyle(FlowStyle.BLOCK) //
-                .setIndentWithIndicator(true) //
-                .setIndicatorIndent(2) //
+                .setDefaultFlowStyle(YamlOutputConfig.DEFAULT_FLOW_STYLE) //
+                .setDefaultScalarStyle(YamlOutputConfig.DEFAULT_SCALAR_STYLE) //
+                .setIndent(YamlOutputConfig.DEFAULT_INDENT) //
+                .setIndicatorIndent(YamlOutputConfig.DEFAULT_INDICATOR_INDENT) //
+                .setIndentWithIndicator(YamlOutputConfig.DEFAULT_INDENT_WITH_INDICATOR) //
+                .setWidth(outputConfig.maxLineWidth()) //
+                .setSplitLines(outputConfig.splitLines()) //
+                .setExplicitStart(false) //
+                .setExplicitEnd(false) //
                 .setMultiLineFlow(true) //
                 .build();
+
         Dump yaml = new Dump(dumpSettings);
         Object unaliasedData = breakAliases(dataMap);
         String compiledYaml = yaml.dumpToString(unaliasedData);
-        compiledYaml = formatYamlSpacing(compiledYaml);
+
+        if (outputConfig.sectionSpacing() > 0) {
+            compiledYaml = formatYamlSpacing(compiledYaml, outputConfig.sectionSpacing());
+        }
 
         List<String> sortedEnvVars = new ArrayList<>(trackedEnvVars);
         Collections.sort(sortedEnvVars);
@@ -367,13 +388,15 @@ final class ComposerUtils {
      * and it safely handles both Map keys (e.g., {@code   Key:}) and List items (e.g., {@code   - Item}).
      *
      * @param yaml The raw YAML string to be formatted.
+     * @param spacingLines The number of blank lines to insert between sections or sibling nodes.
      * @return A formatted YAML string with injected "breathing room."
      */
-    private static @Nullable String formatYamlSpacing(@Nullable String yaml) {
+    private static @Nullable String formatYamlSpacing(@Nullable String yaml, int spacingLines) {
         if (yaml == null || yaml.isEmpty()) {
             return yaml;
         }
 
+        String padding = "\n".repeat(spacingLines);
         String[] lines = yaml.split("\n");
         StringBuilder sb = new StringBuilder();
 
@@ -385,7 +408,7 @@ final class ComposerUtils {
             // Matches lines starting with a character (not space, not comment)
             if (!line.startsWith(" ") && !line.startsWith("#")) {
                 if (hasSeenLevel0) {
-                    sb.append("\n");
+                    sb.append(padding);
                 }
                 hasSeenLevel0 = true;
                 hasSeenLevel2 = false; // Reset level 2 tracker for the new section
@@ -396,7 +419,7 @@ final class ComposerUtils {
             // This targets siblings within a top-level section.
             else if (line.matches("^ {2}[^ \\t\\-].*")) {
                 if (hasSeenLevel2) {
-                    sb.append("\n");
+                    sb.append(padding);
                 }
                 hasSeenLevel2 = true;
             }

--- a/bundles/org.openhab.io.yamlcomposer/src/main/java/org/openhab/io/yamlcomposer/internal/YamlComposerSettings.java
+++ b/bundles/org.openhab.io.yamlcomposer/src/main/java/org/openhab/io/yamlcomposer/internal/YamlComposerSettings.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.io.yamlcomposer.internal;
+
+import java.util.Map;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * Composite container for all YAML Composer configuration domains.
+ *
+ * @author Jimmy Tanagra - Initial contribution
+ */
+@NonNullByDefault
+public record YamlComposerSettings(YamlOutputConfig output
+// Future domains (e.g. FolderFilterConfig filter) will be added here
+) {
+    public static YamlComposerSettings fromMap(Map<String, Object> configMap) {
+        return new YamlComposerSettings(YamlOutputConfig.fromMap(configMap));
+    }
+
+    public static YamlComposerSettings defaultConfig() {
+        return new YamlComposerSettings(YamlOutputConfig.defaultConfig());
+    }
+}

--- a/bundles/org.openhab.io.yamlcomposer/src/main/java/org/openhab/io/yamlcomposer/internal/YamlComposerWatchService.java
+++ b/bundles/org.openhab.io.yamlcomposer/src/main/java/org/openhab/io/yamlcomposer/internal/YamlComposerWatchService.java
@@ -20,15 +20,19 @@ import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.nio.file.attribute.FileTime;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.core.config.core.ConfigurableService;
 import org.openhab.core.service.WatchService;
 import org.openhab.core.service.WatchService.Kind;
+import org.osgi.framework.Constants;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Modified;
 import org.osgi.service.component.annotations.Reference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -39,7 +43,9 @@ import org.slf4j.LoggerFactory;
  * @author Jimmy Tanagra - Initial contribution
  */
 @NonNullByDefault
-@Component(immediate = true, service = YamlComposerWatchService.class)
+@Component(immediate = true, service = YamlComposerWatchService.class, configurationPid = "org.openhab.io.yamlcomposer", property = Constants.SERVICE_PID
+        + "=org.openhab.io.yamlcomposer")
+@ConfigurableService(category = "io", label = "YAML Composer", description_uri = "io:yamlcomposer")
 public class YamlComposerWatchService implements WatchService.WatchEventListener {
     private static final Path WATCHED_SOURCE_PATH = ComposerConfig.SOURCE_ROOT_DIRECTORY;
 
@@ -53,9 +59,15 @@ public class YamlComposerWatchService implements WatchService.WatchEventListener
     private final IncludeRegistry includeRegistry = new IncludeRegistry();
     private final WatchService watchService;
 
+    private volatile YamlComposerSettings settings = YamlComposerSettings.defaultConfig();
+
     @Activate
-    public YamlComposerWatchService(@Reference(target = WatchService.CONFIG_WATCHER_FILTER) WatchService watchService) {
+    public YamlComposerWatchService(@Reference(target = WatchService.CONFIG_WATCHER_FILTER) WatchService watchService,
+            Map<String, Object> config) {
         this.watchService = watchService;
+        this.settings = YamlComposerSettings.fromMap(config);
+
+        logger.debug("YamlComposer settings: {}, config map: {}", this.settings, config);
 
         try {
             Path outputRoot = ComposerConfig.outputRoot();
@@ -67,7 +79,7 @@ public class YamlComposerWatchService implements WatchService.WatchEventListener
             if (brandNew) {
                 Files.writeString(outputRoot.resolve("readme.txt"), OUTPUT_ROOT_README);
             }
-            processDirectory(ComposerConfig.sourceRoot());
+            processDirectory(ComposerConfig.sourceRoot(), false);
         } catch (IOException e) {
             logger.warn("Cannot prepare yaml composer directories: {}", e.getMessage());
         }
@@ -81,8 +93,20 @@ public class YamlComposerWatchService implements WatchService.WatchEventListener
         includeRegistry.clear();
     }
 
+    @Modified
+    public void modified(Map<String, Object> config) {
+        this.settings = YamlComposerSettings.fromMap(config);
+        logger.info("YAML Composer settings updated, recompiling source files");
+        logger.debug("YamlComposer settings: {}, config map: {}", this.settings, config);
+        processDirectory(ComposerConfig.sourceRoot(), true);
+    }
+
     @Override
-    public synchronized void processWatchEvent(Kind kind, Path fullPath) {
+    public void processWatchEvent(Kind kind, Path fullPath) {
+        processWatchEventInternal(kind, fullPath, false);
+    }
+
+    private synchronized void processWatchEventInternal(Kind kind, Path fullPath, boolean force) {
         Path sourcePath = fullPath;
         if (kind != Kind.DELETE && (Files.isDirectory(sourcePath) || !Files.isReadable(sourcePath))) {
             return;
@@ -130,9 +154,10 @@ public class YamlComposerWatchService implements WatchService.WatchEventListener
             }
 
             Set<Path> includePaths = includeRegistry.getIncludesForMain(sourcePath);
-            if (isSourceModified(sourcePath, includePaths, outputPath)
+            if (force || isSourceModified(sourcePath, includePaths, outputPath)
                     || ComposerUtils.isEnvironmentChanged(outputPath)) {
-                ComposerUtils.writeCompiledOutput(yamlObject, sourcePath, outputPath, trackedEnvVars);
+                ComposerUtils.writeCompiledOutput(yamlObject, sourcePath, outputPath, trackedEnvVars,
+                        settings.output());
                 logger.info("YAML Composer: {} -> {}", relativeSourcePath, relativeOutputPath);
             }
         } catch (IOException e) {
@@ -166,7 +191,7 @@ public class YamlComposerWatchService implements WatchService.WatchEventListener
         }
     }
 
-    private void processDirectory(Path sourceDirectory) {
+    private void processDirectory(Path sourceDirectory, boolean force) {
         try {
             Files.walkFileTree(sourceDirectory, new SimpleFileVisitor<>() {
                 @Override
@@ -180,7 +205,7 @@ public class YamlComposerWatchService implements WatchService.WatchEventListener
                     String fileName = sourcePath.getFileName().toString();
 
                     if (YamlComposer.isYamlFile(fileName) && !YamlComposer.isIncludeFile(fileName)) {
-                        processWatchEvent(Kind.CREATE, sourcePath);
+                        processWatchEventInternal(Kind.CREATE, sourcePath, force);
                     }
 
                     return FileVisitResult.CONTINUE;

--- a/bundles/org.openhab.io.yamlcomposer/src/main/java/org/openhab/io/yamlcomposer/internal/YamlOutputConfig.java
+++ b/bundles/org.openhab.io.yamlcomposer/src/main/java/org/openhab/io/yamlcomposer/internal/YamlOutputConfig.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.io.yamlcomposer.internal;
+
+import java.util.Map;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.snakeyaml.engine.v2.common.FlowStyle;
+import org.snakeyaml.engine.v2.common.ScalarStyle;
+
+/**
+ * YamlOutputConfig holds the configuration options for YAML output.
+ *
+ * @param maxLineWidth the maximum line width before text wrapping occurs
+ * @param splitLines whether to split long lines that exceed the maximum line width
+ * @param sectionSpacing the number of blank lines to insert between sections
+ *
+ * @author Jimmy Tanagra - Initial contribution
+ */
+@NonNullByDefault
+public record YamlOutputConfig(int maxLineWidth, boolean splitLines, int sectionSpacing) {
+
+    // Sane, non-configurable defaults for openHAB YAML
+    public static final FlowStyle DEFAULT_FLOW_STYLE = FlowStyle.BLOCK;
+    public static final ScalarStyle DEFAULT_SCALAR_STYLE = ScalarStyle.PLAIN;
+    public static final int DEFAULT_INDENT = 2;
+    public static final int DEFAULT_INDICATOR_INDENT = 2;
+    public static final boolean DEFAULT_INDENT_WITH_INDICATOR = true;
+
+    public static YamlOutputConfig fromMap(Map<String, Object> config) {
+        int maxLineWidth = parseInt(config.get("maxLineWidth"), 80, 20);
+        boolean splitLines = parseBoolean(config.get("splitLines"), true);
+        int sectionSpacing = parseInt(config.get("sectionSpacing"), 1, 0);
+
+        return new YamlOutputConfig(maxLineWidth, splitLines, sectionSpacing);
+    }
+
+    private static int parseInt(@Nullable Object val, int defaultValue, int minVal) {
+        if (val instanceof Number n) {
+            return Math.max(minVal, n.intValue());
+        } else if (val instanceof String s) {
+            try {
+                return Math.max(minVal, Integer.parseInt(s.trim()));
+            } catch (NumberFormatException ignored) {
+            }
+        }
+        return defaultValue;
+    }
+
+    private static boolean parseBoolean(@Nullable Object val, boolean defaultValue) {
+        if (val instanceof Boolean b) {
+            return b;
+        } else if (val instanceof String s) {
+            return Boolean.parseBoolean(s.trim());
+        }
+        return defaultValue;
+    }
+
+    public static YamlOutputConfig defaultConfig() {
+        return fromMap(Map.of());
+    }
+}

--- a/bundles/org.openhab.io.yamlcomposer/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.io.yamlcomposer/src/main/resources/OH-INF/addon/addon.xml
@@ -10,4 +10,5 @@
 	<connection>local</connection>
 
 	<service-id>org.openhab.io.yamlcomposer</service-id>
+	<config-description-ref uri="io:yamlcomposer"/>
 </addon:addon>

--- a/bundles/org.openhab.io.yamlcomposer/src/main/resources/OH-INF/config/config.xml
+++ b/bundles/org.openhab.io.yamlcomposer/src/main/resources/OH-INF/config/config.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<config-description:config-descriptions
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:config-description="https://openhab.org/schemas/config-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/config-description/v1.0.0 https://openhab.org/schemas/config-description-1.0.0.xsd">
+
+	<config-description uri="io:yamlcomposer">
+
+		<parameter name="maxLineWidth" type="integer" min="20">
+			<label>Maximum Line Width</label>
+			<description>Maximum line length before text wrapping occurs.</description>
+			<default>80</default>
+		</parameter>
+
+		<parameter name="splitLines" type="boolean">
+			<label>Split Long Lines</label>
+			<description>Split long string scalar lines that exceed the maximum line width.</description>
+			<default>true</default>
+		</parameter>
+
+		<parameter name="sectionSpacing" type="integer" min="0" max="5">
+			<label>Section and Entity Spacing</label>
+			<description>Number of blank lines to inject before top-level section keys and individual entities (0 to disable).</description>
+			<default>1</default>
+		</parameter>
+
+	</config-description>
+</config-description:config-descriptions>

--- a/bundles/org.openhab.io.yamlcomposer/src/main/resources/OH-INF/i18n/yamlcomposer.properties
+++ b/bundles/org.openhab.io.yamlcomposer/src/main/resources/OH-INF/i18n/yamlcomposer.properties
@@ -2,3 +2,12 @@
 
 addon.yamlcomposer.name = YAML Composer
 addon.yamlcomposer.description = This add-on processes YAML with extended syntax (includes, packages, variables) and outputs fully resolved plain YAML for openHAB YAML Configuration.
+
+# add-on config
+
+io.config.yamlcomposer.maxLineWidth.label = Maximum Line Width
+io.config.yamlcomposer.maxLineWidth.description = Maximum line length before text wrapping occurs.
+io.config.yamlcomposer.sectionSpacing.label = Section and Entity Spacing
+io.config.yamlcomposer.sectionSpacing.description = Number of blank lines to inject before top-level section keys and individual entities (0 to disable).
+io.config.yamlcomposer.splitLines.label = Split Long Lines
+io.config.yamlcomposer.splitLines.description = Split long string scalar lines that exceed the maximum line width.


### PR DESCRIPTION
- Add configuration parameters for maxLineWidth, splitLines, and sectionSpacing
- Make the number of lines injected between top-level YAML sections and nested entities configurable
- Force recompilation of all YAML source files when add-on configuration is modified
