### PR TITLE
[pidcontroller] Stop calculating after the handler is retired

### DIFF
--- a/bundles/org.openhab.automation.pidcontroller/src/main/java/org/openhab/automation/pidcontroller/internal/handler/PIDControllerTriggerHandler.java
+++ b/bundles/org.openhab.automation.pidcontroller/src/main/java/org/openhab/automation/pidcontroller/internal/handler/PIDControllerTriggerHandler.java
@@ -144,6 +144,10 @@ public class PIDControllerTriggerHandler extends BaseTriggerModuleHandler implem
     public synchronized void setCallback(ModuleHandlerCallback callback) {
         super.setCallback(callback);
 
+        // cancel(false), not cancel(true): the running calculation holds this monitor, so
+        // interrupting it would only raise an interrupt this code never observes, while the
+        // synchronized calculate() already guarantees the in-flight invocation completes
+        // before a replacement can start or the callback can be cleared.
         cancelCalculationJob();
         calculationJob = getCallback().getScheduler().scheduleWithFixedDelay(this::calculate, 0, loopTimeMs,
                 TimeUnit.MILLISECONDS);
@@ -166,7 +170,23 @@ public class PIDControllerTriggerHandler extends BaseTriggerModuleHandler implem
         return ((BigDecimal) rawValue).doubleValue();
     }
 
-    private void calculate() {
+    /**
+     * Runs one control cycle.
+     *
+     * <p>
+     * Synchronized on the same monitor as {@link #setCallback} and {@link #dispose}, which is
+     * what makes retirement safe. Reading the inherited {@code callback} field without it gives
+     * no visibility guarantee, and a calculation that passed the check would still hold its
+     * reference through the inspector updates and the {@code triggered()} call, so a handler
+     * retired mid-cycle could publish a stale output. {@code PIDController} is not thread safe
+     * either, so two overlapping invocations would corrupt the accumulators.
+     *
+     * <p>
+     * Holding the monitor for the whole cycle means a retirement waits for the in-flight
+     * calculation rather than racing it, and the callback cannot be cleared between the check
+     * and the publication.
+     */
+    private synchronized void calculate() {
         ModuleHandlerCallback currentCallback = callback;
         if (!(currentCallback instanceof TriggerHandlerCallback triggerCallback)) {
             logger.debug("Tried to calculate, but callback isn't available!");
@@ -301,7 +321,7 @@ public class PIDControllerTriggerHandler extends BaseTriggerModuleHandler implem
     private void cancelCalculationJob() {
         ScheduledFuture<?> job = calculationJob;
         if (job != null) {
-            job.cancel(true);
+            job.cancel(false);
             calculationJob = null;
         }
     }

--- a/bundles/org.openhab.automation.pidcontroller/src/main/java/org/openhab/automation/pidcontroller/internal/handler/PIDControllerTriggerHandler.java
+++ b/bundles/org.openhab.automation.pidcontroller/src/main/java/org/openhab/automation/pidcontroller/internal/handler/PIDControllerTriggerHandler.java
@@ -18,6 +18,7 @@ import java.math.BigDecimal;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -71,6 +72,7 @@ public class PIDControllerTriggerHandler extends BaseTriggerModuleHandler implem
     private @Nullable String iInspector;
     private @Nullable String dInspector;
     private @Nullable String eInspector;
+    private @Nullable ScheduledFuture<?> calculationJob;
     private ItemRegistry itemRegistry;
 
     public PIDControllerTriggerHandler(Trigger module, ItemRegistry itemRegistry, EventPublisher eventPublisher,
@@ -139,9 +141,12 @@ public class PIDControllerTriggerHandler extends BaseTriggerModuleHandler implem
     }
 
     @Override
-    public void setCallback(ModuleHandlerCallback callback) {
+    public synchronized void setCallback(ModuleHandlerCallback callback) {
         super.setCallback(callback);
-        getCallback().getScheduler().scheduleWithFixedDelay(this::calculate, 0, loopTimeMs, TimeUnit.MILLISECONDS);
+
+        cancelCalculationJob();
+        calculationJob = getCallback().getScheduler().scheduleWithFixedDelay(this::calculate, 0, loopTimeMs,
+                TimeUnit.MILLISECONDS);
     }
 
     private <T> T requireNonNull(T obj, String message) {
@@ -162,6 +167,12 @@ public class PIDControllerTriggerHandler extends BaseTriggerModuleHandler implem
     }
 
     private void calculate() {
+        ModuleHandlerCallback currentCallback = callback;
+        if (!(currentCallback instanceof TriggerHandlerCallback triggerCallback)) {
+            logger.debug("Tried to calculate, but callback isn't available!");
+            return;
+        }
+
         double input;
         double setpoint;
 
@@ -189,7 +200,7 @@ public class PIDControllerTriggerHandler extends BaseTriggerModuleHandler implem
         updateItem(dInspector, output.getDerivativePart());
         updateItem(eInspector, output.getError());
 
-        getCallback().triggered(module, Map.of(COMMAND, new DecimalType(output.getOutput())));
+        triggerCallback.triggered(module, Map.of(COMMAND, new DecimalType(output.getOutput())));
     }
 
     private void updateItem(@Nullable String itemName, double value) {
@@ -280,9 +291,18 @@ public class PIDControllerTriggerHandler extends BaseTriggerModuleHandler implem
     }
 
     @Override
-    public void dispose() {
+    public synchronized void dispose() {
+        cancelCalculationJob();
         eventSubscriberRegistration.unregister();
 
         super.dispose();
+    }
+
+    private void cancelCalculationJob() {
+        ScheduledFuture<?> job = calculationJob;
+        if (job != null) {
+            job.cancel(true);
+            calculationJob = null;
+        }
     }
 }

--- a/bundles/org.openhab.automation.pidcontroller/src/test/java/org/openhab/automation/pidcontroller/internal/handler/PIDControllerTriggerHandlerRetirementTest.java
+++ b/bundles/org.openhab.automation.pidcontroller/src/test/java/org/openhab/automation/pidcontroller/internal/handler/PIDControllerTriggerHandlerRetirementTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.automation.pidcontroller.internal.handler;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Retirement must not race an in-flight calculation.
+ *
+ * <p>
+ * The handler needs an OSGi BundleContext and a live ItemRegistry to construct, which is more
+ * than a unit test can reasonably stand up, so this exercises the locking contract directly:
+ * the calculation and the retirement must serialise on one monitor. Without that, a
+ * calculation that has already passed its callback check goes on to write the inspector Items
+ * and call triggered(), so a handler retired mid-cycle can still publish a stale output, and
+ * two overlapping invocations can corrupt the non-thread-safe PIDController.
+ *
+ * @author Vlad Kolotoff - Initial contribution
+ */
+@NonNullByDefault
+public class PIDControllerTriggerHandlerRetirementTest {
+
+    /**
+     * Models the handler: a guarded, multi-step calculation and a retirement that clears the
+     * guard. Both synchronize on the same monitor, as calculate()/setCallback()/dispose() do.
+     */
+    private static class SerialisedHandler {
+        private final Object monitor = new Object();
+        private volatile boolean retired;
+        final AtomicBoolean publishedAfterRetirement = new AtomicBoolean();
+
+        void calculate(CountDownLatch reachedGuard, CountDownLatch releaseAfterGuard) {
+            synchronized (monitor) {
+                if (retired) {
+                    return;
+                }
+                reachedGuard.countDown();
+                try {
+                    // Stand in for the work between the guard and the publication: reading the
+                    // items, running the controller, updating the inspectors.
+                    releaseAfterGuard.await(2, TimeUnit.SECONDS);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+                if (retired) {
+                    publishedAfterRetirement.set(true);
+                }
+            }
+        }
+
+        void retire() {
+            synchronized (monitor) {
+                retired = true;
+            }
+        }
+    }
+
+    @Test
+    void retirementWaitsForAnInFlightCalculation() throws Exception {
+        SerialisedHandler handler = new SerialisedHandler();
+        CountDownLatch reachedGuard = new CountDownLatch(1);
+        CountDownLatch releaseAfterGuard = new CountDownLatch(1);
+
+        Thread calculating = new Thread(() -> handler.calculate(reachedGuard, releaseAfterGuard));
+        calculating.start();
+        assertTrue(reachedGuard.await(2, TimeUnit.SECONDS), "the calculation should reach its guard");
+
+        // Retire while the calculation sits between its guard and its publication. This is the
+        // window the unsynchronized version left open.
+        Thread retiring = new Thread(handler::retire);
+        retiring.start();
+
+        // The retirement must block on the monitor rather than take effect mid-calculation.
+        retiring.join(200);
+        assertTrue(retiring.isAlive(), "retirement must wait for the in-flight calculation, not race it");
+
+        releaseAfterGuard.countDown();
+        calculating.join(2000);
+        retiring.join(2000);
+
+        assertFalse(handler.publishedAfterRetirement.get(),
+                "a calculation must not observe retirement partway through and publish anyway");
+    }
+}


### PR DESCRIPTION
## Description

`setCallback()` schedules the periodic calculation but discards the returned `ScheduledFuture`, and `dispose()` only unregisters the event subscriber. Nothing ever cancels the task, so it keeps running for the lifetime of the runtime.

`calculate()` reaches the callback through a private getter that throws when it is null, so the usual "am I still in use" check never happens on that path either.

This becomes visible when a rule is updated rather than deleted. The old handler is not always disposed in that case, and a retired handler and its replacement then write the same inspector items from their own `PIDController` instances. The retired one keeps the configuration it was created with, so the two disagree. On a loop that uses an integral hold the effect is an I part that appears to ignore its settings and drifts to its clamp, because only one of the two controllers honours the hold.

I hit this on a set of zone damper loops: the I part was written roughly every 28 seconds against a 60 second loop time, which is what gave the second controller away.

## Changes

- keep the `ScheduledFuture` and cancel it in `dispose()`
- cancel any previous job in `setCallback()` so a repeated callback cannot schedule twice
- check the callback at the start of `calculate()` and return if it is gone, matching what the core trigger handlers do
- `setCallback()` and `dispose()` are synchronized, again matching the core handlers

No functional change for a handler that is in use.

## Testing

Built and tested locally, and running on my own installation across repeated rule updates. Before the change each update left another calculation task behind, visible as a second periodic write to the inspector items; afterwards there is one.