### PR TITLE
[pidcontroller] Add integral decay to release a stuck I part

### DIFF
--- a/bundles/org.openhab.automation.pidcontroller/README.md
+++ b/bundles/org.openhab.automation.pidcontroller/README.md
@@ -39,6 +39,7 @@ This is then transferred to the action module.
 | `loopTime`       | Decimal | The interval the output value will be updated in milliseconds. Note: the output will also be updated when the input value or the setpoint changes. | Y        |
 | `integralMinValue` | Decimal | The I-part will be limited (min) to this value.                                                                                                    | N        |
 | `integralMaxValue` | Decimal | The I-part will be limited (max) to this value.                                                                                                    | N        |
+| `integralDecayTime` | Decimal | Time constant in seconds for fading out the I-part while the deviation is not growing. 0 (default) disables the fade-out.                          | N        |
 | `pInspector`     | Item    | Name of the inspector Item for the current P-part                                                                                                  | N        |
 | `iInspector`     | Item    | Name of the inspector Item for the current I-part                                                                                                  | N        |
 | `dInspector`     | Item    | Name of the inspector Item for the current D-part                                                                                                  | N        |
@@ -52,6 +53,20 @@ The I-part can be limited via `integralMinValue`/`integralMaxValue`.
 This is useful if the regulation cannot meet its setpoint from time to time.
 E.g. a heating controller in the summer, which can not cool (min limit) or when the heating valve is already at 100% and the room is only slowly heating up (max limit).
 When controlling a heating valve, reasonable values are 0% (min limit) and 100% (max limit).
+
+### Integral Decay
+
+A plain integrator only unwinds on an error of the opposite sign.
+A process that settles slightly off its setpoint, because the actuator is discrete or because the load cannot be fully served, therefore holds a saturated I-part indefinitely: the error never changes sign, so nothing ever reduces it.
+Limiting the I-part does not help here, because it bounds the value but not how long it stays there.
+
+`integralDecayTime` fades the I-part towards zero while the deviation is no longer growing.
+After one decay time the I-part has fallen to about 37% of its value, after three decay times to about 5%.
+While the deviation is still increasing in the direction the I-part is already pushing, which is when integral action is actually needed, the I-part accumulates normally and is not faded out.
+
+Choose the decay time from how long the I-part should be allowed to stay saturated once the demand has gone, and keep it well above the `loopTime`.
+A decay that is too fast caps the I-part the controller can build up at all: for a constant error the I-part settles near `ki * error * integralDecayTime`, so a control loop that needs a large steady-state I-part to hold its actuator open needs a correspondingly long decay time.
+0 (the default) disables the fade-out and keeps the classic behaviour.
 
 You can view the internal P-, I- and D-parts of the controller with the inspector Items.
 These values are useful when tuning the controller.

--- a/bundles/org.openhab.automation.pidcontroller/src/main/java/org/openhab/automation/pidcontroller/internal/PIDControllerConstants.java
+++ b/bundles/org.openhab.automation.pidcontroller/src/main/java/org/openhab/automation/pidcontroller/internal/PIDControllerConstants.java
@@ -34,6 +34,7 @@ public class PIDControllerConstants {
     public static final String CONFIG_KD_TIMECONSTANT = "kdTimeConstant";
     public static final String CONFIG_I_MAX = "integralMaxValue";
     public static final String CONFIG_I_MIN = "integralMinValue";
+    public static final String CONFIG_I_DECAY_TIME = "integralDecayTime";
     public static final String P_INSPECTOR = "pInspector";
     public static final String I_INSPECTOR = "iInspector";
     public static final String D_INSPECTOR = "dInspector";

--- a/bundles/org.openhab.automation.pidcontroller/src/main/java/org/openhab/automation/pidcontroller/internal/handler/PIDController.java
+++ b/bundles/org.openhab.automation.pidcontroller/src/main/java/org/openhab/automation/pidcontroller/internal/handler/PIDController.java
@@ -35,14 +35,16 @@ class PIDController {
     private double derivativeTimeConstantSec;
     private double iMinResult;
     private double iMaxResult;
+    private double integralDecayTimeSec;
 
     public PIDController(double kpAdjuster, double kiAdjuster, double kdAdjuster, double derivativeTimeConstantSec,
-            double iMinValue, double iMaxValue, double previousIntegralPart, double previousDerivativePart,
-            double previousError) {
+            double iMinValue, double iMaxValue, double integralDecayTimeSec, double previousIntegralPart,
+            double previousDerivativePart, double previousError) {
         this.kp = kpAdjuster;
         this.ki = kiAdjuster;
         this.kd = kdAdjuster;
         this.derivativeTimeConstantSec = derivativeTimeConstantSec;
+        this.integralDecayTimeSec = integralDecayTimeSec;
         this.iMinResult = Double.NaN;
         this.iMaxResult = Double.NaN;
 
@@ -75,16 +77,38 @@ class PIDController {
     public PIDOutputDTO calculate(double input, double setpoint, long lastInvocationMs, int loopTimeMs) {
         final double lastInvocationSec = lastInvocationMs / 1000d;
         final double error = setpoint - input;
+        final double errorChange = error - previousError;
 
         // derivative T1 calculation
         final double timeQuotient = lastInvocationSec / derivativeTimeConstantSec;
         if (derivativeTimeConstantSec != 0) {
-            derivativeResult = LowpassFilter.calculate(derivativeResult, error - previousError, timeQuotient);
-            previousError = error;
+            derivativeResult = LowpassFilter.calculate(derivativeResult, errorChange, timeQuotient);
         }
+        previousError = error;
 
         // integral calculation
         integralResult += error * lastInvocationMs / loopTimeMs;
+
+        // Integral decay: bleed the accumulator towards zero while the error is no longer moving away from the
+        // setpoint.
+        //
+        // A plain integrator only unwinds on an error of the opposite sign. A process that settles slightly off its
+        // setpoint (discrete actuators, or a load the plant cannot fully serve) therefore holds a saturated I-part
+        // indefinitely, because the error never changes sign. Decaying releases that accumulation without requiring
+        // an overshoot first.
+        //
+        // The decay is suppressed while the error is still growing in the direction the I-part is already pushing,
+        // which is exactly when the integral action is needed. That is tested as the product of the error change and
+        // the accumulator: a positive product means both have the same sign, i.e. the deviation is still increasing.
+        // Using the product keeps the behaviour symmetric for negative setpoint deviations.
+        //
+        // The unfiltered error change is used here on purpose. The filtered derivative approaches zero only
+        // asymptotically, so it never becomes exactly zero for a constant error, which is the very case this decay
+        // addresses.
+        if (integralDecayTimeSec > 0 && errorChange * integralResult <= 0) {
+            integralResult *= Math.exp(-lastInvocationSec / integralDecayTimeSec);
+        }
+
         if (Double.isFinite(iMinResult)) {
             integralResult = Math.max(integralResult, iMinResult);
         }

--- a/bundles/org.openhab.automation.pidcontroller/src/main/java/org/openhab/automation/pidcontroller/internal/handler/PIDControllerTriggerHandler.java
+++ b/bundles/org.openhab.automation.pidcontroller/src/main/java/org/openhab/automation/pidcontroller/internal/handler/PIDControllerTriggerHandler.java
@@ -109,6 +109,7 @@ public class PIDControllerTriggerHandler extends BaseTriggerModuleHandler implem
         double kdTimeConstant = getDoubleFromConfig(config, CONFIG_KD_TIMECONSTANT);
         double iMinValue = getDoubleFromConfig(config, CONFIG_I_MIN);
         double iMaxValue = getDoubleFromConfig(config, CONFIG_I_MAX);
+        double integralDecayTime = getDoubleFromConfig(config, CONFIG_I_DECAY_TIME);
         pInspector = (String) config.get(P_INSPECTOR);
         iInspector = (String) config.get(I_INSPECTOR);
         dInspector = (String) config.get(D_INSPECTOR);
@@ -122,7 +123,7 @@ public class PIDControllerTriggerHandler extends BaseTriggerModuleHandler implem
         double previousError = getItemNameValueAsNumberOrZero(itemRegistry, eInspector);
 
         controller = new PIDController(kpAdjuster, kiAdjuster, kdAdjuster, kdTimeConstant, iMinValue, iMaxValue,
-                previousIntegralPart, previousDerivativePart, previousError);
+                integralDecayTime, previousIntegralPart, previousDerivativePart, previousError);
 
         eventFilter = event -> {
             String topic = event.getTopic();

--- a/bundles/org.openhab.automation.pidcontroller/src/main/java/org/openhab/automation/pidcontroller/internal/type/PIDControllerTriggerType.java
+++ b/bundles/org.openhab.automation.pidcontroller/src/main/java/org/openhab/automation/pidcontroller/internal/type/PIDControllerTriggerType.java
@@ -106,6 +106,21 @@ public class PIDControllerTriggerType extends TriggerType {
                 .withLabel("I-part Upper Limit") //
                 .withDescription("The I-part will be max this value. Can be left empty for no limit.") //
                 .build());
+        configDescriptions.add(ConfigDescriptionParameterBuilder.create(CONFIG_I_DECAY_TIME, Type.DECIMAL) //
+                .withRequired(false) //
+                .withMultiple(false) //
+                .withMinimum(BigDecimal.ZERO) //
+                .withDefault("0") //
+                .withLabel("I-part Decay Time") //
+                .withDescription("Time constant in seconds for fading out the I-part while the deviation from the "
+                        + "setpoint is no longer growing. After one decay time the I-part has fallen to about 37% of "
+                        + "its value, after three decay times to about 5%. Use this if the I-part stays at its limit "
+                        + "long after the demand has gone, which happens when the process settles slightly off the "
+                        + "setpoint and the error never changes sign, so the I-part is never unwound. While the "
+                        + "deviation is still growing the I-part accumulates normally and is not faded out. "
+                        + "0 (the default) disables the fade-out.") //
+                .withUnit("s") //
+                .build());
         configDescriptions.add(ConfigDescriptionParameterBuilder.create(P_INSPECTOR, Type.TEXT) //
                 .withRequired(false) //
                 .withMultiple(false) //

--- a/bundles/org.openhab.automation.pidcontroller/src/test/java/org/openhab/automation/pidcontroller/internal/handler/PIDControllerIntegralDecayTest.java
+++ b/bundles/org.openhab.automation.pidcontroller/src/test/java/org/openhab/automation/pidcontroller/internal/handler/PIDControllerIntegralDecayTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.automation.pidcontroller.internal.handler;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests the integral decay of the PID controller.
+ *
+ * @author Vlad Kolotov - Initial contribution
+ *
+ */
+@NonNullByDefault
+class PIDControllerIntegralDecayTest {
+    private static final int LOOP_TIME_MS = 1000;
+    private static final double KD_TIME_CONSTANT_SEC = 10;
+    private static final double DECAY_TIME_SEC = 100;
+
+    private PIDController createController(double decayTimeSec) {
+        return new PIDController(1, 1, 0, KD_TIME_CONSTANT_SEC, Double.NaN, Double.NaN, decayTimeSec, Double.NaN,
+                Double.NaN, Double.NaN);
+    }
+
+    private double settle(PIDController controller, double input, double setpoint, int invocations) {
+        double integralPart = 0;
+        for (int i = 0; i < invocations; i++) {
+            integralPart = controller.calculate(input, setpoint, LOOP_TIME_MS, LOOP_TIME_MS).getIntegralPart();
+        }
+        return integralPart;
+    }
+
+    @Test
+    void constantErrorIsFadedOutWhenEnabled() {
+        // the deviation is not growing, so the I-part must not keep accumulating without bound
+        double withoutDecay = settle(createController(0), 0, 1, 500);
+        double withDecay = settle(createController(DECAY_TIME_SEC), 0, 1, 500);
+
+        assertTrue(withDecay < withoutDecay,
+                "the I-part must be smaller with decay enabled, was " + withDecay + " vs " + withoutDecay);
+        // it converges towards the decay time constant instead of growing with every invocation
+        assertEquals(DECAY_TIME_SEC, withDecay, DECAY_TIME_SEC * 0.1);
+    }
+
+    @Test
+    void disabledByDefaultKeepsAccumulating() {
+        // an unset decay time is passed through as NaN and must not enable the fade-out
+        double integralPart = settle(createController(Double.NaN), 0, 1, 100);
+
+        assertEquals(100, integralPart, 0.001);
+    }
+
+    @Test
+    void zeroDecayTimeKeepsAccumulating() {
+        double integralPart = settle(createController(0), 0, 1, 100);
+
+        assertEquals(100, integralPart, 0.001);
+    }
+
+    @Test
+    void growingDeviationIsNotFadedOut() {
+        PIDController withDecay = createController(DECAY_TIME_SEC);
+        PIDController withoutDecay = createController(0);
+
+        // the error grows on every invocation, so the integral action is still required
+        double withDecayPart = 0;
+        double withoutDecayPart = 0;
+        for (int i = 1; i <= 50; i++) {
+            withDecayPart = withDecay.calculate(0, i, LOOP_TIME_MS, LOOP_TIME_MS).getIntegralPart();
+            withoutDecayPart = withoutDecay.calculate(0, i, LOOP_TIME_MS, LOOP_TIME_MS).getIntegralPart();
+        }
+
+        assertEquals(withoutDecayPart, withDecayPart, 0.001);
+    }
+
+    @Test
+    void fadeOutIsSymmetricForNegativeDeviations() {
+        double positive = settle(createController(DECAY_TIME_SEC), 0, 1, 500);
+        double negative = settle(createController(DECAY_TIME_SEC), 0, -1, 500);
+
+        assertEquals(positive, -negative, 0.001);
+    }
+
+    @Test
+    void growingNegativeDeviationIsNotFadedOut() {
+        PIDController withDecay = createController(DECAY_TIME_SEC);
+        PIDController withoutDecay = createController(0);
+
+        double withDecayPart = 0;
+        double withoutDecayPart = 0;
+        for (int i = 1; i <= 50; i++) {
+            withDecayPart = withDecay.calculate(0, -i, LOOP_TIME_MS, LOOP_TIME_MS).getIntegralPart();
+            withoutDecayPart = withoutDecay.calculate(0, -i, LOOP_TIME_MS, LOOP_TIME_MS).getIntegralPart();
+        }
+
+        assertEquals(withoutDecayPart, withDecayPart, 0.001);
+    }
+
+    @Test
+    void fadeOutWorksWithoutDerivativeTimeConstant() {
+        // the fade-out uses the unfiltered error change, so it does not depend on the derivative configuration
+        PIDController withoutKdTimeConstant = new PIDController(1, 1, 0, 0, Double.NaN, Double.NaN, DECAY_TIME_SEC,
+                Double.NaN, Double.NaN, Double.NaN);
+
+        assertEquals(DECAY_TIME_SEC, settle(withoutKdTimeConstant, 0, 1, 500), DECAY_TIME_SEC * 0.1);
+    }
+}


### PR DESCRIPTION
#21543 builds on this one and should be reviewed after it.

## Problem

A plain integrator only unwinds on an error of the opposite sign. A process that settles slightly off its setpoint, because the actuator is discrete or because the load cannot be fully served, therefore holds a saturated I part indefinitely: the error never changes sign, so nothing ever brings the accumulator back. The loop stops responding until something forces an overshoot.

Clamping the I part with `integralMinValue` / `integralMaxValue` does not solve this. It bounds the value, but not how long it stays there.

## Change

A new optional `integralDecayTime` parameter fades the I part towards zero while the deviation is no longer growing. The fade is suppressed while the deviation is still increasing in the direction the I part is already pushing, which is when integral action is genuinely needed, so it does not fight a real load.

Off by default (`0` keeps the classic behaviour), so existing controllers are unaffected.

## This is a standard technique, not a workaround

This is the [leaky integrator](https://en.wikipedia.org/wiki/Leaky_integrator), also called integration with a forgetting factor or exponential forgetting: `dx/dt = -Ax + C`, whose solution for a constant input is `x(t) = k*e^(-At) + C/A`, so past inputs leak away exponentially. It is a textbook first order lag applied to the accumulator rather than anything invented here.

The implementation follows directly from that:

- the accumulator is multiplied by `exp(-dt / integralDecayTime)` each step, so `integralDecayTime` is the time constant `1/A` in the equation above and behaves as one: about 37% of the value left after one decay time, about 5% after three
- for a constant error the I part settles at `C/A`, that is `ki * error * integralDecayTime`. The README documents this explicitly, because it is the property that decides how to choose the value: a loop that needs a large steady state I part needs a correspondingly long decay time
- `0` disables it, giving an ideal (non leaky) integrator, which is the current behaviour

The one deliberate refinement over a plain leaky integrator is that the leak is gated: it is suspended while the deviation is still growing in the direction the I part is pushing. Without that gate the leak would degrade the controller's ability to reject a genuine sustained load, since it would fight the integrator exactly when integral action is wanted. The gate is tested as the product of the error change and the accumulator, which keeps the behaviour symmetric for negative deviations.

The unfiltered error change is used for that test on purpose. The filtered derivative only approaches zero asymptotically, so it never becomes exactly zero for a constant error, which is precisely the case this addresses.
