### PR TITLE
[tuya] Backoff heartbeat if DP_REFRESH is acknowledged.

### DIFF
--- a/bundles/org.openhab.binding.tuya/src/main/java/org/openhab/binding/tuya/internal/local/TuyaDevice.java
+++ b/bundles/org.openhab.binding.tuya/src/main/java/org/openhab/binding/tuya/internal/local/TuyaDevice.java
@@ -141,10 +141,13 @@ public class TuyaDevice implements ChannelFutureListener {
         @Override
         public void channelRead(@Nullable ChannelHandlerContext ctx, @Nullable Object msg) throws Exception {
             if (ctx != null) {
-                if (msg != null && msg instanceof MessageWrapper<?> m && m.commandType == STATUS) {
+                if (msg != null && msg instanceof MessageWrapper<?> m
+                        && (m.commandType == STATUS || m.commandType == DP_REFRESH)) {
                     // The next heartbeat will be one heartbeat interval from now.
                     resetWriteTimeout();
-                    statusSeen = true;
+                    if (m.commandType == STATUS) {
+                        statusSeen = true;
+                    }
                 } else if (statusSeen && msg != null && msg instanceof MessageWrapper<?> m
                         && m.commandType == HEART_BEAT) {
                     // A heartbeat acknowledgement after a status message is proof-of-life


### PR DESCRIPTION
DP_REFRESH triggers resampling of measurables. If we send a heartbeat too soon after a DP_REFRESH the device can be too busy to give a timely response leading to unwanted disconnects. So if our DP_REFRESH is acknowledged we treat it as proof-of-life and backoff the heartbeat.
