### PR TITLE
[astro] Fix timezone related issues

### DIFF
--- a/bundles/org.openhab.binding.astro/src/main/java/org/openhab/binding/astro/internal/calc/MoonCalc.java
+++ b/bundles/org.openhab.binding.astro/src/main/java/org/openhab/binding/astro/internal/calc/MoonCalc.java
@@ -16,7 +16,6 @@ import static org.openhab.binding.astro.internal.util.MathUtils.*;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
-import java.time.InstantSource;
 import java.util.Calendar;
 import java.util.Set;
 import java.util.TimeZone;
@@ -45,17 +44,6 @@ import org.openhab.binding.astro.internal.util.MathUtils;
 public class MoonCalc {
     private static final double FL = 1.0 - AstroConstants.WGS84_EARTH_FLATTENING;
     private static final EclipseCalc ECLIPSE_CALC = new MoonEclipseCalc();
-
-    private final InstantSource instantSource;
-
-    /**
-     * Creates a new instance using the specified {@link InstantSource}.
-     *
-     * @param instantSource the source of the current time.
-     */
-    public MoonCalc(InstantSource instantSource) {
-        this.instantSource = instantSource;
-    }
 
     /**
      * Calculates all moon data at the specified coordinates
@@ -102,7 +90,7 @@ public class MoonCalc {
     public void setPositionalInfo(Calendar calendar, double latitude, double longitude, Moon moon, TimeZone zone) {
         double julianDate = DateTimeUtils.dateToJulianDate(calendar);
 
-        moon.setPhaseSet(MoonPhaseCalc.calculate(instantSource, julianDate, moon.getPhaseSet(), zone.toZoneId()));
+        moon.setPhaseSet(MoonPhaseCalc.calculate(julianDate, moon.getPhaseSet(), zone.toZoneId()));
 
         MoonPosition moonPosition = getMoonPosition(julianDate, latitude, longitude);
         moon.setPosition(moonPosition);

--- a/bundles/org.openhab.binding.astro/src/main/java/org/openhab/binding/astro/internal/calc/MoonPhaseCalc.java
+++ b/bundles/org.openhab.binding.astro/src/main/java/org/openhab/binding/astro/internal/calc/MoonPhaseCalc.java
@@ -14,7 +14,6 @@ package org.openhab.binding.astro.internal.calc;
 
 import static org.openhab.binding.astro.internal.util.MathUtils.*;
 
-import java.time.InstantSource;
 import java.time.ZoneId;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -24,6 +23,7 @@ import org.openhab.binding.astro.internal.calc.moon.LunarArguments;
 import org.openhab.binding.astro.internal.calc.moon.LunationArguments;
 import org.openhab.binding.astro.internal.model.MoonPhase;
 import org.openhab.binding.astro.internal.model.MoonPhaseSet;
+import org.openhab.binding.astro.internal.util.DateTimeUtils;
 
 /**
  * Moon Phase Calculator
@@ -32,20 +32,21 @@ import org.openhab.binding.astro.internal.model.MoonPhaseSet;
  */
 @NonNullByDefault
 public class MoonPhaseCalc {
-    public static MoonPhaseSet calculate(InstantSource instantSource, double julianDate, MoonPhaseSet previousMP,
-            ZoneId zone) {
+    public static MoonPhaseSet calculate(double julianDate, MoonPhaseSet previousMP, ZoneId zone) {
         final MoonPhaseSet result;
 
         if (previousMP.needsRecalc(julianDate)) {
-            double julianDateMidnight = Math.floor(julianDate + 0.5) - 0.5;
-            double parentNewMoon = getPhase(julianDateMidnight, MoonPhase.NEW, false);
+            double localMidnight = DateTimeUtils.instantToJulianDay(
+                    DateTimeUtils.jdToInstant(julianDate).atZone(zone).toLocalDate().atStartOfDay(zone).toInstant());
+            double previousNewMoon = getPhase(julianDate, MoonPhase.NEW, false);
+            double nextNewMoon = getPhase(julianDate, MoonPhase.NEW, true);
 
             Map<MoonPhase, Double> comingPhases = MoonPhase.remarkables().stream()
-                    .collect(Collectors.toMap(phase -> phase, phase -> getPhase(julianDateMidnight, phase, true)));
+                    .collect(Collectors.toMap(phase -> phase, phase -> getPhase(localMidnight, phase, true)));
 
-            result = new MoonPhaseSet(instantSource, parentNewMoon, comingPhases);
+            result = new MoonPhaseSet(julianDate, previousNewMoon, nextNewMoon, comingPhases);
         } else {
-            result = previousMP;
+            result = previousMP.withJulianDate(julianDate);
         }
 
         result.setIllumination(getIllumination(julianDate));

--- a/bundles/org.openhab.binding.astro/src/main/java/org/openhab/binding/astro/internal/handler/MoonHandler.java
+++ b/bundles/org.openhab.binding.astro/src/main/java/org/openhab/binding/astro/internal/handler/MoonHandler.java
@@ -63,7 +63,7 @@ public class MoonHandler extends AstroThingHandler {
     public MoonHandler(Thing thing, final CronScheduler scheduler, final TimeZoneProvider timeZoneProvider,
             LocaleProvider localeProvider, InstantSource instantSource) {
         super(thing, scheduler, timeZoneProvider, localeProvider, instantSource, POSITIONAL_CHANNELS);
-        moonCalc = new MoonCalc(instantSource);
+        moonCalc = new MoonCalc();
     }
 
     @Override

--- a/bundles/org.openhab.binding.astro/src/main/java/org/openhab/binding/astro/internal/model/MoonPhaseSet.java
+++ b/bundles/org.openhab.binding.astro/src/main/java/org/openhab/binding/astro/internal/model/MoonPhaseSet.java
@@ -14,7 +14,6 @@ package org.openhab.binding.astro.internal.model;
 
 import java.time.Duration;
 import java.time.Instant;
-import java.time.InstantSource;
 import java.time.ZoneId;
 import java.util.Map;
 import java.util.Objects;
@@ -45,26 +44,35 @@ public class MoonPhaseSet {
     public static final MoonPhaseSet NONE = new MoonPhaseSet();
 
     private final Map<MoonPhase, Instant> phases;
-    private final Instant parentNewMoon;
-    private final InstantSource instantSource;
+    private final Instant currentInstant;
+    private final Instant previousNewMoon;
+    private final Instant nextNewMoon;
 
     private double illumination;
     private @Nullable MoonPhase name;
 
-    private MoonPhaseSet(InstantSource instantSource, Instant parentNewMoon, Map<MoonPhase, Instant> phases) {
+    private MoonPhaseSet(Instant currentInstant, Instant previousNewMoon, Instant nextNewMoon,
+            Map<MoonPhase, Instant> phases) {
         this.phases = phases;
-        this.parentNewMoon = parentNewMoon;
-        this.instantSource = instantSource;
+        this.currentInstant = currentInstant;
+        this.previousNewMoon = previousNewMoon;
+        this.nextNewMoon = nextNewMoon;
     }
 
     private MoonPhaseSet() {
-        this(InstantSource.system(), Instant.MIN, Map.of());
+        this(Instant.MIN, Instant.MIN, Instant.MAX, Map.of());
     }
 
-    public MoonPhaseSet(InstantSource instantSource, double parentNewMoon, Map<MoonPhase, Double> comingPhases) {
-        this(instantSource, DateTimeUtils.jdToInstant(parentNewMoon),
+    public MoonPhaseSet(double julianDate, double previousNewMoon, double nextNewMoon,
+            Map<MoonPhase, Double> comingPhases) {
+        this(DateTimeUtils.jdToInstant(julianDate), DateTimeUtils.jdToInstant(previousNewMoon),
+                DateTimeUtils.jdToInstant(nextNewMoon),
                 comingPhases.keySet().stream().collect(Collectors.toMap(Function.identity(),
                         k -> DateTimeUtils.jdToInstant(Objects.requireNonNull(comingPhases.get(k))))));
+    }
+
+    public MoonPhaseSet withJulianDate(double julianDate) {
+        return new MoonPhaseSet(DateTimeUtils.jdToInstant(julianDate), previousNewMoon, nextNewMoon, phases);
     }
 
     public Instant getPhase(MoonPhase phase) {
@@ -86,7 +94,7 @@ public class MoonPhaseSet {
     }
 
     public double getAgePercentDouble() {
-        return ((double) Duration.between(parentNewMoon, instantSource.instant()).getSeconds()) / getMonthDuration();
+        return ((double) Duration.between(previousNewMoon, currentInstant).getSeconds()) / getMonthDuration();
     }
 
     /**
@@ -142,10 +150,10 @@ public class MoonPhaseSet {
         Instant instant = DateTimeUtils.jdToInstant(julianDate);
         Instant phaseDate = getPhase(phaseName);
         return DateTimeUtils.isSameDay(instant, phaseDate, zone)
-                || (MoonPhase.NEW.equals(phaseName) && DateTimeUtils.isSameDay(instant, parentNewMoon, zone));
+                || (MoonPhase.NEW.equals(phaseName) && DateTimeUtils.isSameDay(instant, previousNewMoon, zone));
     }
 
     private long getMonthDuration() {
-        return Duration.between(parentNewMoon, getPhase(MoonPhase.NEW)).getSeconds();
+        return Duration.between(previousNewMoon, nextNewMoon).getSeconds();
     }
 }

--- a/bundles/org.openhab.binding.astro/src/test/java/org/openhab/binding/astro/internal/calc/MoonCalcTest.java
+++ b/bundles/org.openhab.binding.astro/src/test/java/org/openhab/binding/astro/internal/calc/MoonCalcTest.java
@@ -14,8 +14,6 @@ package org.openhab.binding.astro.internal.calc;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import java.time.Instant;
-import java.time.InstantSource;
 import java.util.Calendar;
 import java.util.GregorianCalendar;
 import java.util.Locale;
@@ -58,7 +56,7 @@ public class MoonCalcTest {
 
     @BeforeEach
     public void init() {
-        moonCalc = new MoonCalc(InstantSource.fixed(Instant.ofEpochMilli(1551225600000L)));
+        moonCalc = new MoonCalc();
     }
 
     @Test

--- a/bundles/org.openhab.binding.astro/src/test/java/org/openhab/binding/astro/internal/calc/MoonPhaseCalcTest.java
+++ b/bundles/org.openhab.binding.astro/src/test/java/org/openhab/binding/astro/internal/calc/MoonPhaseCalcTest.java
@@ -15,7 +15,6 @@ package org.openhab.binding.astro.internal.calc;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.time.Instant;
-import java.time.InstantSource;
 import java.time.ZoneId;
 import java.util.Calendar;
 import java.util.GregorianCalendar;
@@ -59,7 +58,7 @@ public class MoonPhaseCalcTest {
 
     @BeforeEach
     public void init() {
-        moonCalc = new MoonCalc(InstantSource.fixed(Instant.ofEpochMilli(1551225600000L)));
+        moonCalc = new MoonCalc();
     }
 
     @Test
@@ -73,9 +72,8 @@ public class MoonPhaseCalcTest {
 
     @Test
     public void testGetMoonInfoForMoonPhaseAccuracy() {
-        InstantSource instantSource = InstantSource.fixed(Instant.ofEpochMilli(1551225600000L));
-        MoonPhaseSet moonPhase = MoonPhaseCalc.calculate(instantSource, DateTimeUtils.dateToJulianDate(FEB_27_2019),
-                MoonPhaseSet.NONE, ZONE);
+        MoonPhaseSet moonPhase = MoonPhaseCalc.calculate(DateTimeUtils.dateToJulianDate(FEB_27_2019), MoonPhaseSet.NONE,
+                ZONE);
 
         // New moon 06 March 2019 17:04 - jd : 2458549.1702492456
         // First quarter 14 March 2019 11:27 - jd : 2458556.936169754
@@ -98,21 +96,34 @@ public class MoonPhaseCalcTest {
         assertEquals(newCalendar(2019, Calendar.MARCH, 28, 05, 10, TIME_ZONE).getTimeInMillis(), phaseTQ.toEpochMilli(),
                 ACCURACY_IN_MILLIS);
 
-        moonPhase = MoonPhaseCalc.calculate(InstantSource.fixed(phaseNew), DateTimeUtils.instantToJulianDay(phaseNew),
-                MoonPhaseSet.NONE, ZONE);
+        moonPhase = MoonPhaseCalc.calculate(DateTimeUtils.instantToJulianDay(phaseNew), MoonPhaseSet.NONE, ZONE);
         assertEquals(0, moonPhase.getIllumination().doubleValue(), 0.01);
 
-        moonPhase = MoonPhaseCalc.calculate(InstantSource.fixed(phaseFull), DateTimeUtils.instantToJulianDay(phaseFull),
-                MoonPhaseSet.NONE, ZONE);
+        moonPhase = MoonPhaseCalc.calculate(DateTimeUtils.instantToJulianDay(phaseFull), MoonPhaseSet.NONE, ZONE);
         assertEquals(1, moonPhase.getIllumination().doubleValue(), 0.01);
 
-        moonPhase = MoonPhaseCalc.calculate(InstantSource.fixed(phaseTQ), DateTimeUtils.instantToJulianDay(phaseTQ),
-                MoonPhaseSet.NONE, ZONE);
+        moonPhase = MoonPhaseCalc.calculate(DateTimeUtils.instantToJulianDay(phaseTQ), MoonPhaseSet.NONE, ZONE);
         assertEquals(0.5, moonPhase.getIllumination().doubleValue(), 0.01);
 
-        moonPhase = MoonPhaseCalc.calculate(InstantSource.fixed(phaseFQ), DateTimeUtils.instantToJulianDay(phaseFQ),
-                MoonPhaseSet.NONE, ZONE);
+        moonPhase = MoonPhaseCalc.calculate(DateTimeUtils.instantToJulianDay(phaseFQ), MoonPhaseSet.NONE, ZONE);
         assertEquals(0.5, moonPhase.getIllumination().doubleValue(), 0.01);
+    }
+
+    @Test
+    public void testMoonAgeAfterNewMoonAcrossUtcDateBoundary() {
+        Instant instant = newCalendar(2019, Calendar.MARCH, 7, 0, 30, TIME_ZONE).toInstant();
+
+        MoonPhaseSet moonPhase = MoonPhaseCalc.calculate(DateTimeUtils.instantToJulianDay(instant), MoonPhaseSet.NONE,
+                ZONE);
+
+        double agePercent = moonPhase.getAgePercent().doubleValue();
+        assertTrue(agePercent >= 0 && agePercent <= 1);
+        assertEquals(MoonPhase.WAXING_CRESCENT.toString(), moonPhase.getName().toString());
+
+        Instant nextDay = newCalendar(2019, Calendar.MARCH, 8, 0, 30, TIME_ZONE).toInstant();
+        MoonPhaseSet updatedMoonPhase = MoonPhaseCalc.calculate(DateTimeUtils.instantToJulianDay(nextDay), moonPhase,
+                ZONE);
+        assertTrue(updatedMoonPhase.getAgePercent().doubleValue() > agePercent);
     }
 
     /***


### PR DESCRIPTION
Fixes #20586.

This bug fix prevents moon positional updates from failing with `agePercent must be in [0,1]` around local midnight.

Moon phase dates were previously bound to UTC midnight, while phase-day matching used the configured time zone. This potentially calculates an invalid moon age.

The calculation now:

- Uses local midnight for calendar-day phase names and scheduled phase events.
- Calculates moon age from the previous and next new moons surrounding the requested timestamp.
- Uses the calculation date as the single time source.

A regression tests added with Europe/Amsterdam timezone.