### PR TITLE
[amazonechocontrol] Add MAC address to discovery

### DIFF
--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/connection/Connection.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/connection/Connection.java
@@ -89,6 +89,7 @@ import org.openhab.binding.amazonechocontrol.internal.dto.response.CustomerHisto
 import org.openhab.binding.amazonechocontrol.internal.dto.response.CustomerHistoryRecordsTO;
 import org.openhab.binding.amazonechocontrol.internal.dto.response.DeviceListTO;
 import org.openhab.binding.amazonechocontrol.internal.dto.response.DeviceNotificationStatesTO;
+import org.openhab.binding.amazonechocontrol.internal.dto.response.DeviceWifiDetailsTO;
 import org.openhab.binding.amazonechocontrol.internal.dto.response.DoNotDisturbDeviceStatusesTO;
 import org.openhab.binding.amazonechocontrol.internal.dto.response.EndpointTO;
 import org.openhab.binding.amazonechocontrol.internal.dto.response.ListItemTO;
@@ -554,6 +555,22 @@ public class Connection {
         Set<@Nullable String> serialNumbers = ConcurrentHashMap.newKeySet();
         return devices.devices.stream().filter(d -> d.serialNumber != null && serialNumbers.add(d.serialNumber))
                 .toList();
+    }
+
+    public @Nullable String getDeviceMacAddress(DeviceTO device) {
+        String serialNumber = device.serialNumber;
+        String deviceType = device.deviceType;
+        if (serialNumber == null || deviceType == null) {
+            return null;
+        }
+
+        try {
+            return requestBuilder.get(getAlexaServer() + "/api/device-wifi-details?deviceSerialNumber=" + serialNumber
+                    + "&deviceType=" + deviceType).syncSend(DeviceWifiDetailsTO.class).macAddress;
+        } catch (ConnectionException e) {
+            logger.debug("Getting Wi-Fi details failed for device {}", serialNumber, e);
+            return null;
+        }
     }
 
     public Map<String, JsonArray> getSmartHomeDeviceStatesJson(Set<SmartHomeBaseDevice> devices)

--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/discovery/AmazonEchoDiscovery.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/discovery/AmazonEchoDiscovery.java
@@ -71,11 +71,7 @@ public class AmazonEchoDiscovery extends AbstractThingHandlerDiscoveryService<Ac
         }
         Connection connection = thingHandler.getConnection();
         List<DeviceTO> devices = thingHandler.updateDeviceList();
-        devices.forEach(device -> {
-            if (device.macAddress == null) {
-                device.macAddress = connection.getDeviceMacAddress(device);
-            }
-        });
+        addMacAddresses(devices, connection);
         setDevices(devices);
 
         List<EnabledFeedTO> currentFlashBriefingConfiguration = thingHandler.updateFlashBriefingHandlers();
@@ -132,23 +128,10 @@ public class AmazonEchoDiscovery extends AbstractThingHandlerDiscoveryService<Ac
             if (serialNumber != null) {
                 String deviceFamily = device.deviceFamily;
                 if (deviceFamily != null) {
-                    ThingTypeUID thingTypeId;
-                    switch (deviceFamily) {
-                        case "ECHO":
-                            thingTypeId = THING_TYPE_ECHO;
-                            break;
-                        case "ROOK":
-                            thingTypeId = THING_TYPE_ECHO_SPOT;
-                            break;
-                        case "KNIGHT":
-                            thingTypeId = THING_TYPE_ECHO_SHOW;
-                            break;
-                        case "WHA":
-                            thingTypeId = THING_TYPE_ECHO_WHA;
-                            break;
-                        default:
-                            logger.debug("Unknown thing type '{}'", deviceFamily);
-                            continue;
+                    ThingTypeUID thingTypeId = getThingTypeId(deviceFamily);
+                    if (thingTypeId == null) {
+                        logger.debug("Unknown thing type '{}'", deviceFamily);
+                        continue;
                     }
 
                     ThingUID bridgeThingUID = thingHandler.getThing().getUID();
@@ -171,6 +154,28 @@ public class AmazonEchoDiscovery extends AbstractThingHandlerDiscoveryService<Ac
                 }
             }
         }
+    }
+
+    static void addMacAddresses(List<DeviceTO> devices, Connection connection) {
+        devices.forEach(device -> {
+            if (device.macAddress == null && getThingTypeId(device.deviceFamily) != null) {
+                device.macAddress = connection.getDeviceMacAddress(device);
+            }
+        });
+    }
+
+    private static @Nullable ThingTypeUID getThingTypeId(@Nullable String deviceFamily) {
+        if (deviceFamily == null) {
+            return null;
+        }
+
+        return switch (deviceFamily) {
+            case "ECHO" -> THING_TYPE_ECHO;
+            case "ROOK" -> THING_TYPE_ECHO_SPOT;
+            case "KNIGHT" -> THING_TYPE_ECHO_SHOW;
+            case "WHA" -> THING_TYPE_ECHO_WHA;
+            default -> null;
+        };
     }
 
     static void addMacAddressProperty(DiscoveryResultBuilder resultBuilder, @Nullable String macAddress) {

--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/discovery/AmazonEchoDiscovery.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/discovery/AmazonEchoDiscovery.java
@@ -18,6 +18,7 @@ import java.time.Instant;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ScheduledFuture;
@@ -32,6 +33,7 @@ import org.openhab.binding.amazonechocontrol.internal.handler.AccountHandler;
 import org.openhab.core.config.discovery.AbstractThingHandlerDiscoveryService;
 import org.openhab.core.config.discovery.DiscoveryResult;
 import org.openhab.core.config.discovery.DiscoveryResultBuilder;
+import org.openhab.core.thing.Thing;
 import org.openhab.core.thing.ThingTypeUID;
 import org.openhab.core.thing.ThingUID;
 import org.osgi.service.component.annotations.Component;
@@ -67,7 +69,14 @@ public class AmazonEchoDiscovery extends AbstractThingHandlerDiscoveryService<Ac
         if (activateTimeStamp != null) {
             removeOlderResults(activateTimeStamp);
         }
-        setDevices(thingHandler.updateDeviceList());
+        Connection connection = thingHandler.getConnection();
+        List<DeviceTO> devices = thingHandler.updateDeviceList();
+        devices.forEach(device -> {
+            if (device.macAddress == null) {
+                device.macAddress = connection.getDeviceMacAddress(device);
+            }
+        });
+        setDevices(devices);
 
         List<EnabledFeedTO> currentFlashBriefingConfiguration = thingHandler.updateFlashBriefingHandlers();
         discoverFlashBriefingProfiles(currentFlashBriefingConfiguration);
@@ -145,13 +154,15 @@ public class AmazonEchoDiscovery extends AbstractThingHandlerDiscoveryService<Ac
                     ThingUID bridgeThingUID = thingHandler.getThing().getUID();
                     ThingUID thingUID = new ThingUID(thingTypeId, bridgeThingUID, serialNumber);
 
-                    DiscoveryResult result = DiscoveryResultBuilder.create(thingUID).withLabel(device.accountName)
-                            .withProperty(DEVICE_PROPERTY_SERIAL_NUMBER, serialNumber)
+                    DiscoveryResultBuilder resultBuilder = DiscoveryResultBuilder.create(thingUID)
+                            .withLabel(device.accountName).withProperty(DEVICE_PROPERTY_SERIAL_NUMBER, serialNumber)
                             .withProperty(DEVICE_PROPERTY_FAMILY, deviceFamily)
                             .withProperty(DEVICE_PROPERTY_DEVICE_TYPE_ID,
                                     Objects.requireNonNullElse(device.deviceType, "<unknown>"))
-                            .withRepresentationProperty(DEVICE_PROPERTY_SERIAL_NUMBER).withBridge(bridgeThingUID)
-                            .build();
+                            .withRepresentationProperty(DEVICE_PROPERTY_SERIAL_NUMBER).withBridge(bridgeThingUID);
+
+                    addMacAddressProperty(resultBuilder, device.macAddress);
+                    DiscoveryResult result = resultBuilder.build();
 
                     logger.debug("Device [{}: {}] found. Mapped to thing type {}", device.deviceFamily, serialNumber,
                             thingTypeId.getAsString());
@@ -160,6 +171,28 @@ public class AmazonEchoDiscovery extends AbstractThingHandlerDiscoveryService<Ac
                 }
             }
         }
+    }
+
+    static void addMacAddressProperty(DiscoveryResultBuilder resultBuilder, @Nullable String macAddress) {
+        String normalizedMacAddress = normalizeMacAddress(macAddress);
+        if (!normalizedMacAddress.isEmpty()) {
+            resultBuilder.withProperty(Thing.PROPERTY_MAC_ADDRESS, normalizedMacAddress);
+        }
+    }
+
+    private static String normalizeMacAddress(@Nullable String macAddress) {
+        if (macAddress == null) {
+            return "";
+        }
+
+        String hex = macAddress.replace(":", "").replace("-", "").trim();
+        if (!hex.matches("(?i)[0-9a-f]{12}") || "000000000000".equals(hex)) {
+            return "";
+        }
+
+        String normalized = hex.toLowerCase(Locale.ROOT);
+        return String.join(":", normalized.substring(0, 2), normalized.substring(2, 4), normalized.substring(4, 6),
+                normalized.substring(6, 8), normalized.substring(8, 10), normalized.substring(10, 12));
     }
 
     private synchronized void discoverFlashBriefingProfiles(List<EnabledFeedTO> enabledFeeds) {

--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/dto/DeviceTO.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/dto/DeviceTO.java
@@ -28,6 +28,7 @@ public class DeviceTO {
     public String deviceAccountId;
     public String deviceFamily;
     public String deviceType;
+    public String macAddress;
     public String softwareVersion;
     public boolean online;
     public Set<String> capabilities = Set.of();
@@ -36,7 +37,7 @@ public class DeviceTO {
     public @NonNull String toString() {
         return "Device{accountName='" + accountName + "', serialNumber='" + serialNumber + "', deviceOwnerCustomerId='"
                 + deviceOwnerCustomerId + "', deviceAccountId='" + deviceAccountId + "', deviceFamily='" + deviceFamily
-                + "', deviceType='" + deviceType + "', softwareVersion='" + softwareVersion + "', online=" + online
-                + ", capabilities=" + capabilities + "}";
+                + "', deviceType='" + deviceType + "', macAddress='" + macAddress + "', softwareVersion='"
+                + softwareVersion + "', online=" + online + ", capabilities=" + capabilities + "}";
     }
 }

--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/dto/response/DeviceWifiDetailsTO.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/dto/response/DeviceWifiDetailsTO.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.amazonechocontrol.internal.dto.response;
+
+/**
+ * The {@link DeviceWifiDetailsTO} encapsulates the response of /api/device-wifi-details.
+ *
+ * @author Lee Ballard - Initial contribution
+ */
+public class DeviceWifiDetailsTO {
+    public String macAddress;
+}

--- a/bundles/org.openhab.binding.amazonechocontrol/src/test/java/org/openhab/binding/amazonechocontrol/internal/discovery/AmazonEchoDiscoveryTest.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/test/java/org/openhab/binding/amazonechocontrol/internal/discovery/AmazonEchoDiscoveryTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.amazonechocontrol.internal.discovery;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.openhab.binding.amazonechocontrol.internal.AmazonEchoControlBindingConstants.THING_TYPE_ECHO;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.openhab.core.config.discovery.DiscoveryResultBuilder;
+import org.openhab.core.thing.Thing;
+import org.openhab.core.thing.ThingUID;
+
+/**
+ * Tests for {@link AmazonEchoDiscovery}.
+ *
+ * @author Lee Ballard - Initial contribution
+ */
+class AmazonEchoDiscoveryTest {
+
+    @ParameterizedTest
+    @CsvSource(value = { //
+            "40B4CD10B295, 40:b4:cd:10:b2:95", //
+            "40:B4:CD:10:B2:95, 40:b4:cd:10:b2:95", //
+            "40-B4-CD-10-B2-95, 40:b4:cd:10:b2:95" //
+    })
+    void testMacAddressIsAddedToDiscoveryProperties(String input, String expected) {
+        DiscoveryResultBuilder builder = newDiscoveryResultBuilder();
+
+        AmazonEchoDiscovery.addMacAddressProperty(builder, input);
+
+        assertEquals(expected, builder.build().getProperties().get(Thing.PROPERTY_MAC_ADDRESS));
+    }
+
+    @ParameterizedTest
+    @NullSource
+    @ValueSource(strings = { "", "invalid", "000000000000" })
+    void testInvalidMacAddressIsNotAddedToDiscoveryProperties(String input) {
+        DiscoveryResultBuilder builder = newDiscoveryResultBuilder();
+
+        AmazonEchoDiscovery.addMacAddressProperty(builder, input);
+
+        assertFalse(builder.build().getProperties().containsKey(Thing.PROPERTY_MAC_ADDRESS));
+    }
+
+    private DiscoveryResultBuilder newDiscoveryResultBuilder() {
+        return DiscoveryResultBuilder.create(new ThingUID(THING_TYPE_ECHO, "account", "echo")).withLabel("Echo");
+    }
+}

--- a/bundles/org.openhab.binding.amazonechocontrol/src/test/java/org/openhab/binding/amazonechocontrol/internal/discovery/AmazonEchoDiscoveryTest.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/test/java/org/openhab/binding/amazonechocontrol/internal/discovery/AmazonEchoDiscoveryTest.java
@@ -14,12 +14,21 @@ package org.openhab.binding.amazonechocontrol.internal.discovery;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static org.openhab.binding.amazonechocontrol.internal.AmazonEchoControlBindingConstants.THING_TYPE_ECHO;
 
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.NullSource;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.openhab.binding.amazonechocontrol.internal.connection.Connection;
+import org.openhab.binding.amazonechocontrol.internal.dto.DeviceTO;
 import org.openhab.core.config.discovery.DiscoveryResultBuilder;
 import org.openhab.core.thing.Thing;
 import org.openhab.core.thing.ThingUID;
@@ -30,6 +39,22 @@ import org.openhab.core.thing.ThingUID;
  * @author Lee Ballard - Initial contribution
  */
 class AmazonEchoDiscoveryTest {
+
+    @Test
+    void testMacAddressLookupSkipsUnsupportedDevices() {
+        DeviceTO supportedDevice = new DeviceTO();
+        supportedDevice.deviceFamily = "ECHO";
+        DeviceTO unsupportedDevice = new DeviceTO();
+        unsupportedDevice.deviceFamily = "THIRD_PARTY_AVS_MEDIA_DISPLAY";
+        Connection connection = mock(Connection.class);
+        when(connection.getDeviceMacAddress(supportedDevice)).thenReturn("40:B4:CD:10:B2:95");
+
+        AmazonEchoDiscovery.addMacAddresses(List.of(supportedDevice, unsupportedDevice), connection);
+
+        assertEquals("40:B4:CD:10:B2:95", supportedDevice.macAddress);
+        verify(connection).getDeviceMacAddress(supportedDevice);
+        verify(connection, never()).getDeviceMacAddress(unsupportedDevice);
+    }
 
     @ParameterizedTest
     @CsvSource(value = { //


### PR DESCRIPTION
This improvement adds each Echo device MAC address to its discovery result using the standard Thing.PROPERTY_MAC_ADDRESS property.

Amazon no longer includes the MAC address in the devices-v2 response, so discovery retrieves it from the per-device device-wifi-details endpoint. MAC values are normalized to lowercase colon-separated form. Missing, invalid, or unavailable values are omitted without failing the discovery scan.

This allows general correlation of Echo account names with local network inventory. For example, it enables DD-WRT discovery to enrich a matched client name from the Echo label, but the discovery property is not specific to DD-WRT.

Fixes #21556

### Testing

- mvn clean install for org.openhab.binding.amazonechocontrol
- 194 tests passed with no failures
- Spotless, Checkstyle, PMD, SpotBugs, and Karaf feature verification passed
- Validated in a local openHAB development runtime: nine Echo discovery results received normalized MAC properties
- A subsequent DD-WRT discovery refresh matched four active clients by MAC and used the Echo labels for client-name enrichment