### PR TITLE
[freeathome] Resolve channel types at boot

### DIFF
--- a/bundles/org.openhab.binding.freeathome/src/main/java/org/openhab/binding/freeathome/internal/datamodel/FreeAtHomeDeviceChannel.java
+++ b/bundles/org.openhab.binding.freeathome/src/main/java/org/openhab/binding/freeathome/internal/datamodel/FreeAtHomeDeviceChannel.java
@@ -366,7 +366,7 @@ public class FreeAtHomeDeviceChannel {
             case FID_BLIND_SENSOR: {
                 this.channelId = channelId;
 
-                logger.warn("Blind sensor channel - Channel FID: 0x{}, not implemented yet", channelFunctionID);
+                logger.debug("Blind sensor channel - Channel FID: 0x{}, not implemented yet", channelFunctionID);
 
                 break;
             }
@@ -565,7 +565,7 @@ public class FreeAtHomeDeviceChannel {
             case FID_SCENE_SENSOR: {
                 this.channelId = channelId;
 
-                logger.warn("Scene sensor channel - Channel FID: 0x{} is not yet implemented", channelFunctionID);
+                logger.debug("Scene sensor channel - Channel FID: 0x{} is not yet implemented", channelFunctionID);
 
                 break;
             }
@@ -620,11 +620,8 @@ public class FreeAtHomeDeviceChannel {
             logger.debug("Datapoint group is added");
             datapointGroups.add(DatapointGroup);
         } else {
-            /*
-             * There is no constantrelationship between Function IDs and the required pairing IDs. As a result, a
-             * "needed" pairing ID may sometimes not exist. In such cases, we avoid adding an invalid datapoint group.
-             */
-            logger.warn("Datapoint group is not added, because it is not valid");
+            logger.debug("Skipping datapoint group for channel {} (FID 0x{}): the needed pairing IDs do not exist here",
+                    channelId, channelFunctionID);
         }
     }
 }

--- a/bundles/org.openhab.binding.freeathome/src/main/java/org/openhab/binding/freeathome/internal/handler/FreeAtHomeBridgeHandler.java
+++ b/bundles/org.openhab.binding.freeathome/src/main/java/org/openhab/binding/freeathome/internal/handler/FreeAtHomeBridgeHandler.java
@@ -544,8 +544,8 @@ public class FreeAtHomeBridgeHandler extends BaseBridgeHandler implements WebSoc
         mapEventListeners.put(deviceID, deviceHandler);
     }
 
-    public void unregisterDeviceStateListener(String deviceID) {
-        mapEventListeners.remove(deviceID);
+    public void unregisterDeviceStateListener(String deviceID, FreeAtHomeDeviceHandler listener) {
+        mapEventListeners.remove(deviceID, listener);
     }
 
     /**

--- a/bundles/org.openhab.binding.freeathome/src/main/java/org/openhab/binding/freeathome/internal/handler/FreeAtHomeDeviceHandler.java
+++ b/bundles/org.openhab.binding.freeathome/src/main/java/org/openhab/binding/freeathome/internal/handler/FreeAtHomeDeviceHandler.java
@@ -13,16 +13,17 @@
 package org.openhab.binding.freeathome.internal.handler;
 
 import java.math.BigDecimal;
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Future;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.freeathome.internal.configuration.FreeAtHomeDeviceHandlerConfiguration;
 import org.openhab.binding.freeathome.internal.datamodel.FreeAtHomeDatapoint;
 import org.openhab.binding.freeathome.internal.datamodel.FreeAtHomeDatapointGroup;
@@ -43,6 +44,7 @@ import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.Thing;
 import org.openhab.core.thing.ThingStatus;
 import org.openhab.core.thing.ThingStatusDetail;
+import org.openhab.core.thing.ThingStatusInfo;
 import org.openhab.core.thing.ThingUID;
 import org.openhab.core.thing.binding.BaseThingHandler;
 import org.openhab.core.thing.binding.ThingHandler;
@@ -73,8 +75,6 @@ import org.slf4j.LoggerFactory;
 @NonNullByDefault
 public class FreeAtHomeDeviceHandler extends BaseThingHandler implements FreeAtHomeDeviceStateListener {
 
-    private static final String CHANNEL_URI = "channel-type:freeathome:config";
-
     private final Logger logger = LoggerFactory.getLogger(FreeAtHomeDeviceHandler.class);
     private FreeAtHomeDeviceDescription device = new FreeAtHomeDeviceDescription();
     private final FreeAtHomeChannelTypeProvider channelTypeProvider;
@@ -82,8 +82,12 @@ public class FreeAtHomeDeviceHandler extends BaseThingHandler implements FreeAtH
     private final Locale locale;
     private Bundle bundle;
 
-    private final Map<ChannelUID, FreeAtHomeDatapointGroup> mapChannelUID = new HashMap<ChannelUID, FreeAtHomeDatapointGroup>();
-    private final Map<String, ChannelUID> mapEventToChannelUID = new HashMap<String, ChannelUID>();
+    private final Map<ChannelUID, FreeAtHomeDatapointGroup> mapChannelUID = new ConcurrentHashMap<>();
+    private final Map<String, ChannelUID> mapEventToChannelUID = new ConcurrentHashMap<>();
+
+    private volatile boolean disposed = false;
+    private @Nullable Future<?> initializeJob;
+    private final Object initializeLock = new Object();
 
     public FreeAtHomeDeviceHandler(Thing thing, FreeAtHomeChannelTypeProvider channelTypeProvider,
             TranslationProvider i18nProvider, LocaleProvider localeProvider) {
@@ -97,59 +101,127 @@ public class FreeAtHomeDeviceHandler extends BaseThingHandler implements FreeAtH
 
     @Override
     public void initialize() {
-        updateStatus(ThingStatus.UNKNOWN);
+        synchronized (initializeLock) {
+            disposed = false;
+            updateStatus(ThingStatus.UNKNOWN);
 
-        scheduler.execute(() -> {
-            FreeAtHomeDeviceHandlerConfiguration config = getConfigAs(FreeAtHomeDeviceHandlerConfiguration.class);
+            Future<?> previousJob = initializeJob;
+            if (previousJob != null) {
+                previousJob.cancel(true);
+            }
+            initializeJob = scheduler.submit(this::initializeDevice);
+        }
+    }
 
-            Bridge bridge = this.getBridge();
-            String locDeviceId = config.deviceId;
+    private boolean initializationAborted() {
+        return disposed || Thread.currentThread().isInterrupted();
+    }
 
-            if (bridge != null) {
-                ThingHandler handler = bridge.getHandler();
+    private void initializeDevice() {
+        FreeAtHomeDeviceHandlerConfiguration config = getConfigAs(FreeAtHomeDeviceHandlerConfiguration.class);
 
-                if (handler instanceof FreeAtHomeBridgeHandler bridgeHandler) {
-                    if (!locDeviceId.isBlank()) {
-                        try {
-                            device = bridgeHandler.getFreeatHomeDeviceDescription(locDeviceId);
+        Bridge bridge = this.getBridge();
+        String locDeviceId = config.deviceId;
 
-                            updateChannels();
-                        } catch (FreeAtHomeHttpCommunicationException e) {
-                            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
-                                    "@text/comm-error.error-in-sysap-com");
-                        } catch (FreeAtHomeGeneralException e) {
-                            logger.debug("General error in the binding - during initialization {}",
-                                    device.getDeviceId());
+        if (bridge != null) {
+            ThingHandler handler = bridge.getHandler();
 
-                            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
-                                    "@text/conf-error.general-binding-error");
+            if (handler instanceof FreeAtHomeBridgeHandler bridgeHandler) {
+                if (initializationAborted()) {
+                    return;
+                }
+                if (bridge.getStatus() != ThingStatus.ONLINE) {
+                    updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE);
+                    return;
+                }
+                if (!locDeviceId.isBlank()) {
+                    try {
+                        device = bridgeHandler.getFreeatHomeDeviceDescription(locDeviceId);
+
+                        updateChannels();
+
+                        if (initializationAborted()) {
+                            return;
                         }
-
-                        // register device for status updates
-                        bridgeHandler.registerDeviceStateListener(device.getDeviceId(), this);
+                        String registeredDeviceId = device.getDeviceId();
+                        bridgeHandler.registerDeviceStateListener(registeredDeviceId, this);
+                        if (initializationAborted()) {
+                            synchronized (initializeLock) {
+                                if (disposed) {
+                                    bridgeHandler.unregisterDeviceStateListener(registeredDeviceId);
+                                }
+                            }
+                            return;
+                        }
 
                         updateStatus(ThingStatus.ONLINE);
 
                         logger.debug("Device created - device id: {}", device.getDeviceId());
-                    } else {
-                        updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
-                                "@text/conf-error.invalid-deviceconfig");
+                    } catch (FreeAtHomeHttpCommunicationException e) {
+                        if (initializationAborted()) {
+                            return;
+                        }
+                        updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
+                                "@text/comm-error.error-in-sysap-com");
+                    } catch (FreeAtHomeGeneralException e) {
+                        logger.debug("General error in the binding - during initialization {}", device.getDeviceId());
 
-                        logger.debug("Device cannot be created: device ID is null!");
+                        if (initializationAborted()) {
+                            return;
+                        }
+                        updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
+                                "@text/conf-error.general-binding-error");
                     }
+                } else {
+                    updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
+                            "@text/conf-error.invalid-deviceconfig");
+
+                    logger.debug("Device cannot be created: device ID is null!");
                 }
             } else {
-                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.OFFLINE.CONFIGURATION_ERROR,
+                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
                         "@text/conf-error.bridge-not-configured");
+            }
+        } else {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
+                    "@text/conf-error.bridge-not-configured");
 
-                logger.debug("Device cannot be created: no bridge is configured!");
+            logger.debug("Device cannot be created: no bridge is configured!");
+        }
+    }
+
+    @Override
+    public void bridgeStatusChanged(ThingStatusInfo bridgeStatusInfo) {
+        synchronized (initializeLock) {
+            if (disposed) {
                 return;
             }
-        });
+            if (bridgeStatusInfo.getStatus() == ThingStatus.ONLINE) {
+                if (getThing().getStatus() != ThingStatus.ONLINE) {
+                    initialize();
+                }
+            } else {
+                Future<?> pendingJob = initializeJob;
+                if (pendingJob != null) {
+                    pendingJob.cancel(true);
+                }
+                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE);
+            }
+        }
     }
 
     @Override
     public void dispose() {
+        synchronized (initializeLock) {
+            disposed = true;
+
+            Future<?> pendingJob = initializeJob;
+            if (pendingJob != null) {
+                pendingJob.cancel(true);
+                initializeJob = null;
+            }
+        }
+
         Bridge bridge = this.getBridge();
 
         // Unregister device and specific channel for event based state updated
@@ -417,32 +489,25 @@ public class FreeAtHomeDeviceHandler extends BaseThingHandler implements FreeAtH
             stateFragment.withMinimum(min).withMaximum(max);
         }
 
-        try {
-            URI configDescriptionUriChannel = new URI(CHANNEL_URI);
+        ChannelTypeBuilder<?> channelTypeBuilder = ChannelTypeBuilder
+                .state(channelTypeUID,
+                        String.format("%s-%s-%s-%s", dpg.getLabel(), dpg.getOpenHabItemType(), dpg.getOpenHabCategory(),
+                                "type"),
+                        dpg.getOpenHabItemType())
+                .withCategory(dpg.getOpenHabCategory()).withStateDescriptionFragment(stateFragment.build());
 
-            ChannelTypeBuilder<?> channelTypeBuilder = ChannelTypeBuilder
-                    .state(channelTypeUID,
-                            String.format("%s-%s-%s-%s", dpg.getLabel(), dpg.getOpenHabItemType(),
-                                    dpg.getOpenHabCategory(), "type"),
-                            dpg.getOpenHabItemType())
-                    .withCategory(dpg.getOpenHabCategory()).withStateDescriptionFragment(stateFragment.build());
+        ChannelType channelType = channelTypeBuilder.isAdvanced(false)
+                .withDescription(String.format("Type for channel - %s ", dpg.getLabel())).build();
 
-            ChannelType channelType = channelTypeBuilder.isAdvanced(false)
-                    .withConfigDescriptionURI(configDescriptionUriChannel)
-                    .withDescription(String.format("Type for channel - %s ", dpg.getLabel())).build();
+        channelTypeProvider.addChannelType(channelType);
 
-            channelTypeProvider.addChannelType(channelType);
-
-            logger.debug("Channel type created {} - label: {} - category: {}", channelTypeUID.getAsString(),
-                    dpg.getLabel(), dpg.getOpenHabCategory());
-        } catch (URISyntaxException e) {
-            logger.debug("Channel config URI cannot created for datapoint - datapoint group: {}", dpg.getLabel());
-        }
+        logger.debug("Channel type created {} - label: {} - category: {}", channelTypeUID.getAsString(), dpg.getLabel(),
+                dpg.getOpenHabCategory());
 
         return channelTypeUID;
     }
 
-    public void updateChannels() throws FreeAtHomeGeneralException {
+    public void updateChannels() throws FreeAtHomeGeneralException, FreeAtHomeHttpCommunicationException {
         // define update policy
         AutoUpdatePolicy policy = AutoUpdatePolicy.DEFAULT;
 
@@ -541,22 +606,17 @@ public class FreeAtHomeDeviceHandler extends BaseThingHandler implements FreeAtH
         });
     }
 
-    private void reloadChannelTypes() throws FreeAtHomeGeneralException {
+    private void reloadChannelTypes() throws FreeAtHomeGeneralException, FreeAtHomeHttpCommunicationException {
         Bridge bridge = this.getBridge();
 
         ThingUID thingUID = thing.getUID();
 
-        try {
-            if (bridge != null) {
-                ThingHandler handler = bridge.getHandler();
+        if (bridge != null) {
+            ThingHandler handler = bridge.getHandler();
 
-                if (handler instanceof FreeAtHomeBridgeHandler bridgeHandler) {
-                    device = bridgeHandler.getFreeatHomeDeviceDescription(device.getDeviceId());
-                }
+            if (handler instanceof FreeAtHomeBridgeHandler bridgeHandler) {
+                device = bridgeHandler.getFreeatHomeDeviceDescription(device.getDeviceId());
             }
-        } catch (FreeAtHomeHttpCommunicationException e) {
-            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
-                    "@text/comm-error.error-in-sysap-com");
         }
 
         for (int i = 0; i < device.getNumberOfChannels(); i++) {

--- a/bundles/org.openhab.binding.freeathome/src/main/java/org/openhab/binding/freeathome/internal/handler/FreeAtHomeDeviceHandler.java
+++ b/bundles/org.openhab.binding.freeathome/src/main/java/org/openhab/binding/freeathome/internal/handler/FreeAtHomeDeviceHandler.java
@@ -12,7 +12,6 @@
  */
 package org.openhab.binding.freeathome.internal.handler;
 
-import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -29,6 +28,7 @@ import org.openhab.binding.freeathome.internal.datamodel.FreeAtHomeDatapoint;
 import org.openhab.binding.freeathome.internal.datamodel.FreeAtHomeDatapointGroup;
 import org.openhab.binding.freeathome.internal.datamodel.FreeAtHomeDeviceChannel;
 import org.openhab.binding.freeathome.internal.datamodel.FreeAtHomeDeviceDescription;
+import org.openhab.binding.freeathome.internal.type.FreeAtHomeChannelTypeFactory;
 import org.openhab.binding.freeathome.internal.type.FreeAtHomeChannelTypeProvider;
 import org.openhab.binding.freeathome.internal.util.FreeAtHomeGeneralException;
 import org.openhab.binding.freeathome.internal.util.FreeAtHomeHttpCommunicationException;
@@ -52,13 +52,10 @@ import org.openhab.core.thing.binding.builder.ChannelBuilder;
 import org.openhab.core.thing.binding.builder.ThingBuilder;
 import org.openhab.core.thing.type.AutoUpdatePolicy;
 import org.openhab.core.thing.type.ChannelKind;
-import org.openhab.core.thing.type.ChannelType;
-import org.openhab.core.thing.type.ChannelTypeBuilder;
 import org.openhab.core.thing.type.ChannelTypeUID;
 import org.openhab.core.types.Command;
 import org.openhab.core.types.RefreshType;
 import org.openhab.core.types.State;
-import org.openhab.core.types.StateDescriptionFragmentBuilder;
 import org.openhab.core.util.StringUtils;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.FrameworkUtil;
@@ -76,7 +73,7 @@ import org.slf4j.LoggerFactory;
 public class FreeAtHomeDeviceHandler extends BaseThingHandler implements FreeAtHomeDeviceStateListener {
 
     private final Logger logger = LoggerFactory.getLogger(FreeAtHomeDeviceHandler.class);
-    private FreeAtHomeDeviceDescription device = new FreeAtHomeDeviceDescription();
+    private volatile FreeAtHomeDeviceDescription device = new FreeAtHomeDeviceDescription();
     private final FreeAtHomeChannelTypeProvider channelTypeProvider;
     private final TranslationProvider i18nProvider;
     private final Locale locale;
@@ -86,6 +83,7 @@ public class FreeAtHomeDeviceHandler extends BaseThingHandler implements FreeAtH
     private final Map<String, ChannelUID> mapEventToChannelUID = new ConcurrentHashMap<>();
 
     private volatile boolean disposed = false;
+    private long initializationGeneration = 0;
     private @Nullable Future<?> initializeJob;
     private final Object initializeLock = new Object();
 
@@ -103,90 +101,89 @@ public class FreeAtHomeDeviceHandler extends BaseThingHandler implements FreeAtH
     public void initialize() {
         synchronized (initializeLock) {
             disposed = false;
+            long generation = ++initializationGeneration;
             updateStatus(ThingStatus.UNKNOWN);
 
             Future<?> previousJob = initializeJob;
             if (previousJob != null) {
                 previousJob.cancel(true);
             }
-            initializeJob = scheduler.submit(this::initializeDevice);
+            initializeJob = scheduler.submit(() -> initializeDevice(generation));
         }
     }
 
-    private boolean initializationAborted() {
-        return disposed || Thread.currentThread().isInterrupted();
+    long currentInitializationGeneration() {
+        synchronized (initializeLock) {
+            return initializationGeneration;
+        }
     }
 
-    private void initializeDevice() {
+    private boolean isCurrentRun(long generation) {
+        return !disposed && generation == initializationGeneration;
+    }
+
+    private void publishStatus(long generation, ThingStatus status, ThingStatusDetail detail,
+            @Nullable String description) {
+        synchronized (initializeLock) {
+            if (isCurrentRun(generation)) {
+                updateStatus(status, detail, description);
+            }
+        }
+    }
+
+    void initializeDevice(long generation) {
         FreeAtHomeDeviceHandlerConfiguration config = getConfigAs(FreeAtHomeDeviceHandlerConfiguration.class);
 
         Bridge bridge = this.getBridge();
         String locDeviceId = config.deviceId;
 
-        if (bridge != null) {
-            ThingHandler handler = bridge.getHandler();
-
-            if (handler instanceof FreeAtHomeBridgeHandler bridgeHandler) {
-                if (initializationAborted()) {
-                    return;
-                }
-                if (bridge.getStatus() != ThingStatus.ONLINE) {
-                    updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE);
-                    return;
-                }
-                if (!locDeviceId.isBlank()) {
-                    try {
-                        device = bridgeHandler.getFreeatHomeDeviceDescription(locDeviceId);
-
-                        updateChannels();
-
-                        if (initializationAborted()) {
-                            return;
-                        }
-                        String registeredDeviceId = device.getDeviceId();
-                        bridgeHandler.registerDeviceStateListener(registeredDeviceId, this);
-                        if (initializationAborted()) {
-                            synchronized (initializeLock) {
-                                if (disposed) {
-                                    bridgeHandler.unregisterDeviceStateListener(registeredDeviceId);
-                                }
-                            }
-                            return;
-                        }
-
-                        updateStatus(ThingStatus.ONLINE);
-
-                        logger.debug("Device created - device id: {}", device.getDeviceId());
-                    } catch (FreeAtHomeHttpCommunicationException e) {
-                        if (initializationAborted()) {
-                            return;
-                        }
-                        updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
-                                "@text/comm-error.error-in-sysap-com");
-                    } catch (FreeAtHomeGeneralException e) {
-                        logger.debug("General error in the binding - during initialization {}", device.getDeviceId());
-
-                        if (initializationAborted()) {
-                            return;
-                        }
-                        updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
-                                "@text/conf-error.general-binding-error");
-                    }
-                } else {
-                    updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
-                            "@text/conf-error.invalid-deviceconfig");
-
-                    logger.debug("Device cannot be created: device ID is null!");
-                }
-            } else {
-                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
-                        "@text/conf-error.bridge-not-configured");
-            }
-        } else {
-            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
+        if (bridge == null) {
+            publishStatus(generation, ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
                     "@text/conf-error.bridge-not-configured");
 
             logger.debug("Device cannot be created: no bridge is configured!");
+            return;
+        }
+        if (!(bridge.getHandler() instanceof FreeAtHomeBridgeHandler bridgeHandler)) {
+            publishStatus(generation, ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
+                    "@text/conf-error.bridge-not-configured");
+            return;
+        }
+        if (bridge.getStatus() != ThingStatus.ONLINE) {
+            publishStatus(generation, ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE, null);
+            return;
+        }
+        if (locDeviceId.isBlank()) {
+            publishStatus(generation, ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
+                    "@text/conf-error.invalid-deviceconfig");
+
+            logger.debug("Device cannot be created: device ID is null!");
+            return;
+        }
+
+        try {
+            FreeAtHomeDeviceDescription description = bridgeHandler.getFreeatHomeDeviceDescription(locDeviceId);
+
+            synchronized (initializeLock) {
+                if (!isCurrentRun(generation)) {
+                    return;
+                }
+                device = description;
+                updateChannels();
+                bridgeHandler.registerDeviceStateListener(description.getDeviceId(), this);
+                updateStatus(ThingStatus.ONLINE);
+            }
+            refreshLinkedChannels(generation);
+
+            logger.debug("Device created - device id: {}", description.getDeviceId());
+        } catch (FreeAtHomeHttpCommunicationException e) {
+            publishStatus(generation, ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
+                    "@text/comm-error.error-in-sysap-com");
+        } catch (FreeAtHomeGeneralException e) {
+            logger.debug("General error in the binding - during initialization {}", locDeviceId);
+
+            publishStatus(generation, ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
+                    "@text/conf-error.general-binding-error");
         }
     }
 
@@ -201,6 +198,7 @@ public class FreeAtHomeDeviceHandler extends BaseThingHandler implements FreeAtH
                     initialize();
                 }
             } else {
+                initializationGeneration++;
                 Future<?> pendingJob = initializeJob;
                 if (pendingJob != null) {
                     pendingJob.cancel(true);
@@ -212,6 +210,7 @@ public class FreeAtHomeDeviceHandler extends BaseThingHandler implements FreeAtH
 
     @Override
     public void dispose() {
+        String registeredDeviceId;
         synchronized (initializeLock) {
             disposed = true;
 
@@ -220,6 +219,7 @@ public class FreeAtHomeDeviceHandler extends BaseThingHandler implements FreeAtH
                 pendingJob.cancel(true);
                 initializeJob = null;
             }
+            registeredDeviceId = device.getDeviceId();
         }
 
         Bridge bridge = this.getBridge();
@@ -229,7 +229,7 @@ public class FreeAtHomeDeviceHandler extends BaseThingHandler implements FreeAtH
             ThingHandler handler = bridge.getHandler();
 
             if (handler instanceof FreeAtHomeBridgeHandler bridgeHandler) {
-                bridgeHandler.unregisterDeviceStateListener(device.getDeviceId());
+                bridgeHandler.unregisterDeviceStateListener(registeredDeviceId, this);
             }
         }
 
@@ -238,7 +238,7 @@ public class FreeAtHomeDeviceHandler extends BaseThingHandler implements FreeAtH
 
         mapEventToChannelUID.clear();
 
-        logger.debug("Device removed - device id: {}", device.getDeviceId());
+        logger.debug("Device removed - device id: {}", registeredDeviceId);
     }
 
     private void handleRefreshCommand(FreeAtHomeBridgeHandler freeAtHomeBridge, FreeAtHomeDatapointGroup dpg,
@@ -272,6 +272,9 @@ public class FreeAtHomeDeviceHandler extends BaseThingHandler implements FreeAtH
 
             updateState(channelUID, vsc.convertToState(valueStr));
         } catch (FreeAtHomeHttpCommunicationException e) {
+            if (Thread.currentThread().isInterrupted()) {
+                return;
+            }
             logger.debug("Communication error during refresh command {} - at channel {} - Error string {}",
                     device.getDeviceId(), channelUID.getAsString(), e.getMessage());
 
@@ -478,28 +481,7 @@ public class FreeAtHomeDeviceHandler extends BaseThingHandler implements FreeAtH
 
     public ChannelTypeUID createChannelTypeForDatapointgroup(FreeAtHomeDatapointGroup dpg,
             ChannelTypeUID channelTypeUID) throws FreeAtHomeGeneralException {
-        StateDescriptionFragmentBuilder stateFragment = StateDescriptionFragmentBuilder.create();
-
-        stateFragment.withReadOnly(dpg.isReadOnly());
-        stateFragment.withPattern(dpg.getTypePattern());
-
-        if (dpg.isDecimal() || dpg.isInteger()) {
-            BigDecimal min = new BigDecimal(dpg.getMin());
-            BigDecimal max = new BigDecimal(dpg.getMax());
-            stateFragment.withMinimum(min).withMaximum(max);
-        }
-
-        ChannelTypeBuilder<?> channelTypeBuilder = ChannelTypeBuilder
-                .state(channelTypeUID,
-                        String.format("%s-%s-%s-%s", dpg.getLabel(), dpg.getOpenHabItemType(), dpg.getOpenHabCategory(),
-                                "type"),
-                        dpg.getOpenHabItemType())
-                .withCategory(dpg.getOpenHabCategory()).withStateDescriptionFragment(stateFragment.build());
-
-        ChannelType channelType = channelTypeBuilder.isAdvanced(false)
-                .withDescription(String.format("Type for channel - %s ", dpg.getLabel())).build();
-
-        channelTypeProvider.addChannelType(channelType);
+        channelTypeProvider.addChannelType(FreeAtHomeChannelTypeFactory.createChannelType(dpg, channelTypeUID));
 
         logger.debug("Channel type created {} - label: {} - category: {}", channelTypeUID.getAsString(), dpg.getLabel(),
                 dpg.getOpenHabCategory());
@@ -507,7 +489,7 @@ public class FreeAtHomeDeviceHandler extends BaseThingHandler implements FreeAtH
         return channelTypeUID;
     }
 
-    public void updateChannels() throws FreeAtHomeGeneralException, FreeAtHomeHttpCommunicationException {
+    public void updateChannels() throws FreeAtHomeGeneralException {
         // define update policy
         AutoUpdatePolicy policy = AutoUpdatePolicy.DEFAULT;
 
@@ -598,26 +580,23 @@ public class FreeAtHomeDeviceHandler extends BaseThingHandler implements FreeAtH
         } else {
             reloadChannelTypes();
         }
+    }
 
-        thingChannels.forEach(channel -> {
+    private void refreshLinkedChannels(long generation) {
+        for (Channel channel : getThing().getChannels()) {
+            synchronized (initializeLock) {
+                if (!isCurrentRun(generation)) {
+                    return;
+                }
+            }
             if (isLinked(channel.getUID())) {
                 channelLinked(channel.getUID());
             }
-        });
+        }
     }
 
-    private void reloadChannelTypes() throws FreeAtHomeGeneralException, FreeAtHomeHttpCommunicationException {
-        Bridge bridge = this.getBridge();
-
+    private void reloadChannelTypes() throws FreeAtHomeGeneralException {
         ThingUID thingUID = thing.getUID();
-
-        if (bridge != null) {
-            ThingHandler handler = bridge.getHandler();
-
-            if (handler instanceof FreeAtHomeBridgeHandler bridgeHandler) {
-                device = bridgeHandler.getFreeatHomeDeviceDescription(device.getDeviceId());
-            }
-        }
 
         for (int i = 0; i < device.getNumberOfChannels(); i++) {
             FreeAtHomeDeviceChannel channel = device.getChannel(i);

--- a/bundles/org.openhab.binding.freeathome/src/main/java/org/openhab/binding/freeathome/internal/type/FreeAtHomeChannelTypeFactory.java
+++ b/bundles/org.openhab.binding.freeathome/src/main/java/org/openhab/binding/freeathome/internal/type/FreeAtHomeChannelTypeFactory.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.freeathome.internal.type;
+
+import java.math.BigDecimal;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.binding.freeathome.internal.datamodel.FreeAtHomeDatapointGroup;
+import org.openhab.binding.freeathome.internal.util.FreeAtHomeGeneralException;
+import org.openhab.core.thing.type.ChannelType;
+import org.openhab.core.thing.type.ChannelTypeBuilder;
+import org.openhab.core.thing.type.ChannelTypeUID;
+import org.openhab.core.types.StateDescriptionFragmentBuilder;
+
+/**
+ * Builds the channel type a datapoint group is represented by, without a configuration description URI so that the type
+ * stays resolvable after a restore from storage.
+ *
+ * @author Martin Littkovsky - Initial contribution
+ */
+@NonNullByDefault
+public final class FreeAtHomeChannelTypeFactory {
+
+    private FreeAtHomeChannelTypeFactory() {
+    }
+
+    public static ChannelType createChannelType(FreeAtHomeDatapointGroup dpg, ChannelTypeUID channelTypeUID)
+            throws FreeAtHomeGeneralException {
+        StateDescriptionFragmentBuilder stateFragment = StateDescriptionFragmentBuilder.create();
+
+        stateFragment.withReadOnly(dpg.isReadOnly());
+        stateFragment.withPattern(dpg.getTypePattern());
+
+        if (dpg.isDecimal() || dpg.isInteger()) {
+            BigDecimal min = new BigDecimal(dpg.getMin());
+            BigDecimal max = new BigDecimal(dpg.getMax());
+            stateFragment.withMinimum(min).withMaximum(max);
+        }
+
+        ChannelTypeBuilder<?> channelTypeBuilder = ChannelTypeBuilder
+                .state(channelTypeUID,
+                        String.format("%s-%s-%s-%s", dpg.getLabel(), dpg.getOpenHabItemType(), dpg.getOpenHabCategory(),
+                                "type"),
+                        dpg.getOpenHabItemType())
+                .withCategory(dpg.getOpenHabCategory()).withStateDescriptionFragment(stateFragment.build());
+
+        return channelTypeBuilder.isAdvanced(false)
+                .withDescription(String.format("Type for channel - %s ", dpg.getLabel())).build();
+    }
+}

--- a/bundles/org.openhab.binding.freeathome/src/main/java/org/openhab/binding/freeathome/internal/type/FreeAtHomeChannelTypeFactory.java
+++ b/bundles/org.openhab.binding.freeathome/src/main/java/org/openhab/binding/freeathome/internal/type/FreeAtHomeChannelTypeFactory.java
@@ -23,8 +23,8 @@ import org.openhab.core.thing.type.ChannelTypeUID;
 import org.openhab.core.types.StateDescriptionFragmentBuilder;
 
 /**
- * Builds the channel type a datapoint group is represented by, without a configuration description URI so that the type
- * stays resolvable after a restore from storage.
+ * Builds the channel type a datapoint group is represented by. The type references no configuration description: the
+ * binding registers none, and a dangling reference makes the framework warn on every boot.
  *
  * @author Martin Littkovsky - Initial contribution
  */

--- a/bundles/org.openhab.binding.freeathome/src/main/java/org/openhab/binding/freeathome/internal/type/FreeAtHomeChannelTypeProviderImpl.java
+++ b/bundles/org.openhab.binding.freeathome/src/main/java/org/openhab/binding/freeathome/internal/type/FreeAtHomeChannelTypeProviderImpl.java
@@ -12,18 +12,14 @@
  */
 package org.openhab.binding.freeathome.internal.type;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Locale;
-import java.util.Map;
-
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.core.storage.StorageService;
+import org.openhab.core.thing.binding.AbstractStorageBasedTypeProvider;
 import org.openhab.core.thing.type.ChannelType;
 import org.openhab.core.thing.type.ChannelTypeProvider;
-import org.openhab.core.thing.type.ChannelTypeUID;
+import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  *
@@ -32,34 +28,16 @@ import org.osgi.service.component.annotations.Component;
  */
 @Component(service = { FreeAtHomeChannelTypeProvider.class, ChannelTypeProvider.class })
 @NonNullByDefault
-public class FreeAtHomeChannelTypeProviderImpl implements FreeAtHomeChannelTypeProvider {
+public class FreeAtHomeChannelTypeProviderImpl extends AbstractStorageBasedTypeProvider
+        implements FreeAtHomeChannelTypeProvider {
 
-    private final Map<ChannelTypeUID, ChannelType> channelTypesByUID = new HashMap<>();
-
-    @Override
-    public Collection<ChannelType> getChannelTypes(@Nullable Locale locale) {
-        Collection<ChannelType> result = new ArrayList<>();
-
-        for (ChannelTypeUID uid : channelTypesByUID.keySet()) {
-            ChannelType channelType = channelTypesByUID.get(uid);
-
-            if (channelType != null) {
-                result.add(channelType);
-            }
-        }
-
-        return result;
+    @Activate
+    public FreeAtHomeChannelTypeProviderImpl(@Reference StorageService storageService) {
+        super(storageService);
     }
 
     @Override
-    public @Nullable ChannelType getChannelType(@Nullable ChannelTypeUID channelTypeUID, @Nullable Locale locale) {
-        return channelTypesByUID.get(channelTypeUID);
-    }
-
-    @Override
-    public void addChannelType(@Nullable ChannelType channelType) {
-        if (channelType != null) {
-            channelTypesByUID.put(channelType.getUID(), channelType);
-        }
+    public void addChannelType(ChannelType channelType) {
+        putChannelType(channelType);
     }
 }

--- a/bundles/org.openhab.binding.freeathome/src/test/java/org/openhab/binding/freeathome/internal/handler/FreeAtHomeDeviceHandlerInitializationTest.java
+++ b/bundles/org.openhab.binding.freeathome/src/test/java/org/openhab/binding/freeathome/internal/handler/FreeAtHomeDeviceHandlerInitializationTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.freeathome.internal.handler;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.openhab.binding.freeathome.internal.FreeAtHomeBindingConstants.BRIDGE_TYPE_UID;
+import static org.openhab.binding.freeathome.internal.FreeAtHomeBindingConstants.DEVICE_TYPE_UID;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openhab.binding.freeathome.internal.datamodel.FreeAtHomeDeviceDescription;
+import org.openhab.binding.freeathome.internal.type.FreeAtHomeChannelTypeProvider;
+import org.openhab.binding.freeathome.internal.util.FreeAtHomeHttpCommunicationException;
+import org.openhab.core.config.core.Configuration;
+import org.openhab.core.i18n.LocaleProvider;
+import org.openhab.core.i18n.TranslationProvider;
+import org.openhab.core.thing.Bridge;
+import org.openhab.core.thing.Thing;
+import org.openhab.core.thing.ThingStatus;
+import org.openhab.core.thing.ThingStatusDetail;
+import org.openhab.core.thing.ThingStatusInfo;
+import org.openhab.core.thing.ThingUID;
+import org.openhab.core.thing.binding.ThingHandlerCallback;
+
+/**
+ * Tests that only the current initialization run reaches the outside world, because a run left over from a previous
+ * configuration would otherwise keep the old device id registered on the bridge, and a later devicesRemoved event for
+ * that id then marks the reconfigured thing GONE.
+ *
+ * @author Martin Littkovsky - Initial contribution
+ */
+@NonNullByDefault
+public class FreeAtHomeDeviceHandlerInitializationTest {
+
+    private static final ThingUID BRIDGE_UID = new ThingUID(BRIDGE_TYPE_UID, "bridge");
+    private static final ThingUID DEVICE_UID = new ThingUID(DEVICE_TYPE_UID, "test");
+    private static final String DEVICE_ID = "ABB0001";
+
+    private @NonNullByDefault({}) Thing thing;
+    private @NonNullByDefault({}) ThingHandlerCallback callback;
+    private @NonNullByDefault({}) FreeAtHomeBridgeHandler bridgeHandler;
+    private @NonNullByDefault({}) FreeAtHomeDeviceHandler handler;
+
+    @BeforeEach
+    public void setUp() throws FreeAtHomeHttpCommunicationException {
+        thing = mock(Thing.class);
+        when(thing.getUID()).thenReturn(DEVICE_UID);
+        when(thing.getThingTypeUID()).thenReturn(DEVICE_TYPE_UID);
+        when(thing.getBridgeUID()).thenReturn(BRIDGE_UID);
+        when(thing.getConfiguration()).thenReturn(new Configuration(Map.of("deviceId", DEVICE_ID)));
+        when(thing.getChannels()).thenReturn(List.of());
+        when(thing.getStatus()).thenReturn(ThingStatus.UNKNOWN);
+        when(thing.getLabel()).thenReturn("test");
+
+        FreeAtHomeDeviceDescription descriptionWithoutChannels = new FreeAtHomeDeviceDescription();
+        descriptionWithoutChannels.deviceId = DEVICE_ID;
+
+        bridgeHandler = mock(FreeAtHomeBridgeHandler.class);
+        when(bridgeHandler.getFreeatHomeDeviceDescription(DEVICE_ID)).thenReturn(descriptionWithoutChannels);
+
+        Bridge bridge = mock(Bridge.class);
+        when(bridge.getUID()).thenReturn(BRIDGE_UID);
+        when(bridge.getStatus()).thenReturn(ThingStatus.ONLINE);
+        when(bridge.getHandler()).thenReturn(bridgeHandler);
+
+        callback = mock(ThingHandlerCallback.class);
+        when(callback.getBridge(BRIDGE_UID)).thenReturn(bridge);
+
+        LocaleProvider localeProvider = mock(LocaleProvider.class);
+        when(localeProvider.getLocale()).thenReturn(Locale.GERMAN);
+
+        handler = new FreeAtHomeDeviceHandler(thing, mock(FreeAtHomeChannelTypeProvider.class),
+                mock(TranslationProvider.class), localeProvider);
+        handler.setCallback(callback);
+    }
+
+    @Test
+    public void staleInitializationRunNeitherRegistersNorPublishesStatus() {
+        long staleGeneration = handler.currentInitializationGeneration() - 1;
+
+        handler.initializeDevice(staleGeneration);
+
+        verify(bridgeHandler, never()).registerDeviceStateListener(any(), any());
+        verify(callback, never()).statusUpdated(any(), any());
+    }
+
+    @Test
+    public void bridgeGoingOfflineOutdatesTheRunningInitialization() {
+        long generation = handler.currentInitializationGeneration();
+
+        handler.bridgeStatusChanged(new ThingStatusInfo(ThingStatus.OFFLINE, ThingStatusDetail.NONE, null));
+        handler.initializeDevice(generation);
+
+        verify(bridgeHandler, never()).registerDeviceStateListener(any(), any());
+        verify(callback, never()).statusUpdated(eq(thing),
+                argThat(statusInfo -> statusInfo.getStatus() == ThingStatus.ONLINE));
+    }
+
+    @Test
+    public void currentInitializationRunRegistersOnceAndGoesOnline() {
+        handler.initializeDevice(handler.currentInitializationGeneration());
+
+        verify(bridgeHandler, times(1)).registerDeviceStateListener(DEVICE_ID, handler);
+        verify(callback).statusUpdated(eq(thing), argThat(statusInfo -> statusInfo.getStatus() == ThingStatus.ONLINE));
+    }
+
+    @Test
+    public void initializationRunAfterDisposeNeitherRegistersNorPublishesStatus() {
+        handler.dispose();
+
+        handler.initializeDevice(handler.currentInitializationGeneration());
+
+        verify(bridgeHandler, never()).registerDeviceStateListener(any(), any());
+        verify(callback, never()).statusUpdated(any(), any());
+    }
+}

--- a/bundles/org.openhab.binding.freeathome/src/test/java/org/openhab/binding/freeathome/internal/type/FreeAtHomeChannelTypeFactoryTest.java
+++ b/bundles/org.openhab.binding.freeathome/src/test/java/org/openhab/binding/freeathome/internal/type/FreeAtHomeChannelTypeFactoryTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.freeathome.internal.type;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.jupiter.api.Test;
+import org.openhab.binding.freeathome.internal.datamodel.FreeAtHomeDatapointGroup;
+import org.openhab.binding.freeathome.internal.util.FreeAtHomeGeneralException;
+import org.openhab.binding.freeathome.internal.util.PidTranslationUtils;
+import org.openhab.binding.freeathome.internal.util.UidUtils;
+import org.openhab.core.library.CoreItemFactory;
+import org.openhab.core.test.storage.VolatileStorageService;
+import org.openhab.core.thing.type.ChannelType;
+import org.openhab.core.thing.type.ChannelTypeUID;
+import org.openhab.core.types.StateDescription;
+
+/**
+ * Tests that the channel type the binding generates for a datapoint group carries no configuration description, so that
+ * it still resolves after the provider restored it from storage.
+ *
+ * @author Martin Littkovsky - Initial contribution
+ */
+@NonNullByDefault
+public class FreeAtHomeChannelTypeFactoryTest {
+
+    private static final String MEASURED_TEMPERATURE_LABEL = "pid-measured-temperature";
+    private static final String WINDOW_POSITION_LABEL = "pid-window-door-position";
+
+    private final VolatileStorageService storageService = new VolatileStorageService();
+
+    @Test
+    public void channelTypeBuiltFromADatapointGroupCarriesNoConfigDescription() throws FreeAtHomeGeneralException {
+        FreeAtHomeDatapointGroup dpg = readOnlyDecimalDatapointGroup();
+        ChannelTypeUID uid = UidUtils.generateChannelTypeUID(PidTranslationUtils.PID_VALUETYPE_DECIMAL, true);
+
+        ChannelType channelType = FreeAtHomeChannelTypeFactory.createChannelType(dpg, uid);
+
+        assertNull(channelType.getConfigDescriptionURI());
+        assertEquals(uid, channelType.getUID());
+        assertEquals(MEASURED_TEMPERATURE_LABEL + "-" + CoreItemFactory.NUMBER + "-"
+                + PidTranslationUtils.CATEGORY_TEMPERATURE + "-type", channelType.getLabel());
+        assertEquals(CoreItemFactory.NUMBER, channelType.getItemType());
+        assertEquals(PidTranslationUtils.CATEGORY_TEMPERATURE, channelType.getCategory());
+        StateDescription state = channelType.getState();
+        assertNotNull(state);
+        assertTrue(state.isReadOnly());
+    }
+
+    @Test
+    public void channelTypeBuiltFromADatapointGroupSurvivesTheProviderStorageWithoutConfigDescription()
+            throws FreeAtHomeGeneralException {
+        FreeAtHomeDatapointGroup dpg = writableBooleanDatapointGroup();
+        ChannelTypeUID uid = UidUtils.generateChannelTypeUID(PidTranslationUtils.PID_VALUETYPE_BOOLEAN, false);
+        ChannelType channelType = FreeAtHomeChannelTypeFactory.createChannelType(dpg, uid);
+
+        new FreeAtHomeChannelTypeProviderImpl(storageService).addChannelType(channelType);
+        ChannelType restoredType = new FreeAtHomeChannelTypeProviderImpl(storageService).getChannelType(uid, null);
+
+        assertNotNull(restoredType);
+        assertNull(restoredType.getConfigDescriptionURI());
+        assertEquals(uid, restoredType.getUID());
+        assertEquals(CoreItemFactory.SWITCH, restoredType.getItemType());
+    }
+
+    private FreeAtHomeDatapointGroup readOnlyDecimalDatapointGroup() throws FreeAtHomeGeneralException {
+        FreeAtHomeDatapointGroup dpg = mock(FreeAtHomeDatapointGroup.class);
+        when(dpg.isReadOnly()).thenReturn(true);
+        when(dpg.getTypePattern()).thenReturn("%.1f");
+        when(dpg.isDecimal()).thenReturn(true);
+        when(dpg.getMin()).thenReturn(7);
+        when(dpg.getMax()).thenReturn(30);
+        when(dpg.getLabel()).thenReturn(MEASURED_TEMPERATURE_LABEL);
+        when(dpg.getOpenHabItemType()).thenReturn(CoreItemFactory.NUMBER);
+        when(dpg.getOpenHabCategory()).thenReturn(PidTranslationUtils.CATEGORY_TEMPERATURE);
+        return dpg;
+    }
+
+    private FreeAtHomeDatapointGroup writableBooleanDatapointGroup() throws FreeAtHomeGeneralException {
+        FreeAtHomeDatapointGroup dpg = mock(FreeAtHomeDatapointGroup.class);
+        when(dpg.isReadOnly()).thenReturn(false);
+        when(dpg.getTypePattern()).thenReturn("");
+        when(dpg.isDecimal()).thenReturn(false);
+        when(dpg.isInteger()).thenReturn(false);
+        when(dpg.getLabel()).thenReturn(WINDOW_POSITION_LABEL);
+        when(dpg.getOpenHabItemType()).thenReturn(CoreItemFactory.SWITCH);
+        when(dpg.getOpenHabCategory()).thenReturn(PidTranslationUtils.CATEGORY_CONTACT);
+        return dpg;
+    }
+}

--- a/bundles/org.openhab.binding.freeathome/src/test/java/org/openhab/binding/freeathome/internal/type/FreeAtHomeChannelTypeFactoryTest.java
+++ b/bundles/org.openhab.binding.freeathome/src/test/java/org/openhab/binding/freeathome/internal/type/FreeAtHomeChannelTypeFactoryTest.java
@@ -32,8 +32,8 @@ import org.openhab.core.thing.type.ChannelTypeUID;
 import org.openhab.core.types.StateDescription;
 
 /**
- * Tests that the channel type the binding generates for a datapoint group carries no configuration description, so that
- * it still resolves after the provider restored it from storage.
+ * Tests that the channel type the binding generates for a datapoint group references no configuration description -
+ * neither when built nor after the provider restored it from storage - because the binding registers none.
  *
  * @author Martin Littkovsky - Initial contribution
  */

--- a/bundles/org.openhab.binding.freeathome/src/test/java/org/openhab/binding/freeathome/internal/type/FreeAtHomeChannelTypeProviderImplTest.java
+++ b/bundles/org.openhab.binding.freeathome/src/test/java/org/openhab/binding/freeathome/internal/type/FreeAtHomeChannelTypeProviderImplTest.java
@@ -14,7 +14,6 @@ package org.openhab.binding.freeathome.internal.type;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -57,17 +56,5 @@ public class FreeAtHomeChannelTypeProviderImplTest {
         assertNotNull(state);
         assertTrue(state.isReadOnly());
         assertTrue(restartedProvider.getChannelTypes(null).stream().anyMatch(type -> uid.equals(type.getUID())));
-    }
-
-    @Test
-    public void restoredChannelTypeReferencesNoConfigDescription() {
-        FreeAtHomeChannelTypeProviderImpl provider = new FreeAtHomeChannelTypeProviderImpl(storageService);
-        ChannelTypeUID uid = UidUtils.generateChannelTypeUID("decimal", false);
-        provider.addChannelType(ChannelTypeBuilder.state(uid, "Setpoint", CoreItemFactory.NUMBER).build());
-
-        ChannelType restoredType = new FreeAtHomeChannelTypeProviderImpl(storageService).getChannelType(uid, null);
-
-        assertNotNull(restoredType);
-        assertNull(restoredType.getConfigDescriptionURI());
     }
 }

--- a/bundles/org.openhab.binding.freeathome/src/test/java/org/openhab/binding/freeathome/internal/type/FreeAtHomeChannelTypeProviderImplTest.java
+++ b/bundles/org.openhab.binding.freeathome/src/test/java/org/openhab/binding/freeathome/internal/type/FreeAtHomeChannelTypeProviderImplTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.freeathome.internal.type;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.jupiter.api.Test;
+import org.openhab.binding.freeathome.internal.util.UidUtils;
+import org.openhab.core.library.CoreItemFactory;
+import org.openhab.core.test.storage.VolatileStorageService;
+import org.openhab.core.thing.type.ChannelType;
+import org.openhab.core.thing.type.ChannelTypeBuilder;
+import org.openhab.core.thing.type.ChannelTypeUID;
+import org.openhab.core.types.StateDescription;
+import org.openhab.core.types.StateDescriptionFragmentBuilder;
+
+/**
+ * Tests that a generated channel type outlives the provider that created it, so things restored from storage
+ * resolve their channel types at boot, before the SysAP has answered.
+ *
+ * @author Martin Littkovsky - Initial contribution
+ */
+@NonNullByDefault
+public class FreeAtHomeChannelTypeProviderImplTest {
+
+    private final VolatileStorageService storageService = new VolatileStorageService();
+
+    @Test
+    public void addedChannelTypeSurvivesAProviderRestart() {
+        FreeAtHomeChannelTypeProviderImpl provider = new FreeAtHomeChannelTypeProviderImpl(storageService);
+        ChannelTypeUID uid = UidUtils.generateChannelTypeUID("boolean", true);
+        provider.addChannelType(ChannelTypeBuilder.state(uid, "Window position", CoreItemFactory.SWITCH)
+                .withStateDescriptionFragment(StateDescriptionFragmentBuilder.create().withReadOnly(true).build())
+                .build());
+
+        FreeAtHomeChannelTypeProviderImpl restartedProvider = new FreeAtHomeChannelTypeProviderImpl(storageService);
+        ChannelType restoredType = restartedProvider.getChannelType(uid, null);
+
+        assertNotNull(restoredType);
+        assertEquals(uid, restoredType.getUID());
+        assertEquals(CoreItemFactory.SWITCH, restoredType.getItemType());
+        StateDescription state = restoredType.getState();
+        assertNotNull(state);
+        assertTrue(state.isReadOnly());
+        assertTrue(restartedProvider.getChannelTypes(null).stream().anyMatch(type -> uid.equals(type.getUID())));
+    }
+
+    @Test
+    public void restoredChannelTypeReferencesNoConfigDescription() {
+        FreeAtHomeChannelTypeProviderImpl provider = new FreeAtHomeChannelTypeProviderImpl(storageService);
+        ChannelTypeUID uid = UidUtils.generateChannelTypeUID("decimal", false);
+        provider.addChannelType(ChannelTypeBuilder.state(uid, "Setpoint", CoreItemFactory.NUMBER).build());
+
+        ChannelType restoredType = new FreeAtHomeChannelTypeProviderImpl(storageService).getChannelType(uid, null);
+
+        assertNotNull(restoredType);
+        assertNull(restoredType.getConfigDescriptionURI());
+    }
+}


### PR DESCRIPTION
The binding builds its channel types from SysAP data. After a restart those types do not exist yet: they only appear once the bridge has connected and every device handler has run. The framework therefore holds all stored things for up to 120s and then logs two warnings per thing - channel types missing, and a failed configuration normalize. The second warning has an extra cause: the generated types carried a config description URI (channel-type:freeathome:config) that nothing in the bundle registers.

- the channel type provider now extends AbstractStorageBasedTypeProvider, the mechanism mqtt, matter, homematic and nine other bindings with generated channel types already use: generated types persist across restarts, so stored things resolve them right at boot. The first boot after the update generates them once more; every boot after that is warning-free
- the unregistered config description URI is gone from the generated types - the binding defines no channel config parameters, and the dangling URI was what kept the normalize warning alive
- device things no longer call the SysAP before the bridge is ONLINE (previously the 120s hold masked that race), go ONLINE only after a successful initialization instead of unconditionally, and re-initialize when the bridge comes online
- three warnings that fire on every boot of installations with the affected channels (unimplemented blind/scene sensor channels, datapoint groups whose pairing IDs do not exist on a channel - a normal combination) log at debug now, matching how completely unknown function IDs are already logged (the missing FID support behind the blind sensor line is tracked in #19468); the datapoint group message names channel and function ID
- new FreeAtHomeChannelTypeProviderImplTest covers that a generated channel type survives a provider restart and that a restored type references no config description

Note for review: the generated types keep their existing labels, patterns and plain Number item types unchanged on purpose - switching numeric channels to unit-bearing item types would change item semantics for existing links and belongs in a separate change.

Tested on a production system (openHAB 5.2.1, a gateway and 22 device things): the first boot after the update fills the storage and behaves like before; on the next boot the log carries zero of the 120s/normalize warnings and zero binding warnings, and all device things are online within 23 seconds of the gateway instead of two minutes later. The persisted types carry no config description reference (verified in the storage file). Further testing on other free@home installations is very welcome - the [test build for 5.2.x](https://github.com/ML19821/openhab-addons/releases/tag/freeathome-bootwarnings-test-1) matches this PR exactly.

**Transparency:** this patch and the comments on this PR were written with AI assistance (Claude); every commit carries an `AI-assisted-by` trailer. All changes were built, tested and verified on a production system by the author. Reviewed against wborn/github-review-policy at `ca8d3f4d0` (2026-08-19) before submission.

Fixes #21558
