### PR TITLE
[amazonechocontrol] Restart dispatcher on login

### DIFF
--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/connection/Connection.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/connection/Connection.java
@@ -149,6 +149,7 @@ public class Connection {
     private CookieManager cookieManager = new CookieManager();
     private final HttpRequestBuilder requestBuilder;
     private @Nullable Date verifyTime;
+    private volatile boolean closed = false;
     private long connectionExpiryTime = 0;
     private long accessTokenExpiryTime = 0;
     private @Nullable String customerName;
@@ -185,8 +186,7 @@ public class Connection {
             this.loginData = new LoginData(cookieManager);
         }
 
-        replaceTimer(TimerType.DEVICES,
-                scheduler.scheduleWithFixedDelay(this::handleExecuteSequenceNode, 0, 500, TimeUnit.MILLISECONDS));
+        ensureSequenceNodeDispatcherIsRunning();
     }
 
     public HttpRequestBuilder getRequestBuilder() {
@@ -219,8 +219,10 @@ public class Connection {
     }
 
     public boolean isSequenceNodeQueueRunning() {
-        return devices.values().stream().anyMatch(
-                (queueObjects) -> (queueObjects.stream().anyMatch(queueObject -> queueObject.future != null)));
+        synchronized (devices) {
+            return devices.values().stream().anyMatch(
+                    (queueObjects) -> (queueObjects.stream().anyMatch(queueObject -> queueObject.future != null)));
+        }
     }
 
     public boolean restoreLogin(@Nullable String data, @Nullable String overloadedDomain) {
@@ -479,7 +481,7 @@ public class Connection {
     }
 
     public boolean verifyLogin() throws ConnectionException {
-        if (this.loginData.getRefreshToken() == null || !tryGetCustomerData()) {
+        if (closed || this.loginData.getRefreshToken() == null || !tryGetCustomerData()) {
             verifyTime = null;
             return false;
         }
@@ -487,7 +489,31 @@ public class Connection {
         if (loginData.getLoginTime() == null) {
             loginData.setLoginTime(verifyTime);
         }
+        ensureSequenceNodeDispatcherIsRunning();
         return true;
+    }
+
+    void ensureSequenceNodeDispatcherIsRunning() {
+        // scheduling inside compute keeps at-most-one-dispatcher atomic; the task never touches timers
+        timers.compute(TimerType.DEVICES, (type, dispatcher) -> {
+            if (closed || isLive(dispatcher)) {
+                return dispatcher;
+            }
+            return scheduler.scheduleWithFixedDelay(this::handleExecuteSequenceNode, 0, 500, TimeUnit.MILLISECONDS);
+        });
+    }
+
+    private static boolean isLive(@Nullable ScheduledFuture<?> dispatcher) {
+        return dispatcher != null && !dispatcher.isCancelled() && !dispatcher.isDone();
+    }
+
+    boolean isSequenceNodeDispatcherRunning() {
+        return isLive(timers.get(TimerType.DEVICES));
+    }
+
+    @Nullable
+    ScheduledFuture<?> sequenceNodeDispatcher() {
+        return timers.get(TimerType.DEVICES);
     }
 
     // current value in compute can be null
@@ -498,6 +524,15 @@ public class Connection {
             }
             return newTimer;
         });
+    }
+
+    public void close() {
+        closed = true;
+        logout(false);
+    }
+
+    public boolean isClosed() {
+        return closed;
     }
 
     public void logout(boolean reset) {
@@ -524,8 +559,8 @@ public class Connection {
         replaceTimer(TimerType.VOLUME, null);
         volumes.clear();
         replaceTimer(TimerType.DEVICES, null);
+        replaceTimer(TimerType.TEXT_COMMAND, null);
         textCommands.clear();
-        replaceTimer(TimerType.TTS, null);
 
         devices.values().forEach((queueObjects) -> queueObjects.forEach((queueObject) -> {
             Future<?> future = queueObject.future;
@@ -534,6 +569,7 @@ public class Connection {
                 queueObject.future = null;
             }
         }));
+        devices.clear();
     }
 
     // commands and states
@@ -1108,7 +1144,11 @@ public class Connection {
         Lock lock = Objects.requireNonNull(locks.computeIfAbsent(TimerType.DEVICES, k -> new ReentrantLock()));
         if (lock.tryLock()) {
             try {
-                for (String serialNumber : devices.keySet()) {
+                List<String> serialNumbers;
+                synchronized (devices) {
+                    serialNumbers = List.copyOf(devices.keySet());
+                }
+                for (String serialNumber : serialNumbers) {
                     LinkedBlockingQueue<QueueObject> queueObjects = devices.get(serialNumber);
                     if (queueObjects != null) {
                         QueueObject queueObject = queueObjects.peek();
@@ -1144,6 +1184,8 @@ public class Connection {
                         }
                     }
                 }
+            } catch (RuntimeException e) {
+                logger.warn("Dispatching sequence nodes failed, the dispatcher stays alive", e);
             } finally {
                 lock.unlock();
             }

--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/connection/Connection.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/connection/Connection.java
@@ -47,6 +47,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Collectors;
@@ -162,6 +163,7 @@ public class Connection {
     private final Map<Integer, Volume> volumes = Collections.synchronizedMap(new LinkedHashMap<>());
     private final Map<String, LinkedBlockingQueue<QueueObject>> devices = Collections
             .synchronizedMap(new LinkedHashMap<>());
+    private final AtomicLong loginGeneration = new AtomicLong();
 
     private final Map<TimerType, ScheduledFuture<?>> timers = new ConcurrentHashMap<>();
     private final Map<TimerType, Lock> locks = new ConcurrentHashMap<>();
@@ -516,6 +518,16 @@ public class Connection {
         return timers.get(TimerType.DEVICES);
     }
 
+    long currentLoginGeneration() {
+        return loginGeneration.get();
+    }
+
+    int queuedSequenceNodeCount() {
+        synchronized (devices) {
+            return devices.values().stream().mapToInt(LinkedBlockingQueue::size).sum();
+        }
+    }
+
     // current value in compute can be null
     private void replaceTimer(TimerType type, @Nullable ScheduledFuture<?> newTimer) {
         timers.compute(type, (timerType, oldTimer) -> {
@@ -552,24 +564,36 @@ public class Connection {
         customerName = null;
         accessToken = null;
 
-        replaceTimer(TimerType.ANNOUNCEMENT, null);
-        announcements.clear();
-        replaceTimer(TimerType.TTS, null);
-        textToSpeeches.clear();
-        replaceTimer(TimerType.VOLUME, null);
-        volumes.clear();
-        replaceTimer(TimerType.DEVICES, null);
-        replaceTimer(TimerType.TEXT_COMMAND, null);
-        textCommands.clear();
+        loginGeneration.incrementAndGet();
+        cancelPendingWork(TimerType.ANNOUNCEMENT, announcements::clear);
+        cancelPendingWork(TimerType.TTS, textToSpeeches::clear);
+        cancelPendingWork(TimerType.VOLUME, volumes::clear);
+        cancelPendingWork(TimerType.TEXT_COMMAND, textCommands::clear);
+        cancelPendingWork(TimerType.DEVICES, this::drainDeviceQueues);
+    }
 
-        devices.values().forEach((queueObjects) -> queueObjects.forEach((queueObject) -> {
-            Future<?> future = queueObject.future;
-            if (future != null) {
-                future.cancel(true);
-                queueObject.future = null;
-            }
-        }));
-        devices.clear();
+    private void drainDeviceQueues() {
+        synchronized (devices) {
+            devices.values().forEach((queueObjects) -> queueObjects.forEach((queueObject) -> {
+                Future<?> future = queueObject.future;
+                if (future != null) {
+                    future.cancel(true);
+                    queueObject.future = null;
+                }
+            }));
+            devices.clear();
+        }
+    }
+
+    private void cancelPendingWork(TimerType type, Runnable clearRegistrations) {
+        Lock lock = Objects.requireNonNull(locks.computeIfAbsent(type, k -> new ReentrantLock()));
+        lock.lock();
+        try {
+            replaceTimer(type, null);
+            clearRegistrations.run();
+        } finally {
+            lock.unlock();
+        }
     }
 
     // commands and states
@@ -1054,6 +1078,7 @@ public class Connection {
     private void executeSequenceCommandWithVolume(List<DeviceTO> devices, @Nullable String command,
             Map<String, Object> parameters, List<@Nullable Integer> ttsVolumes,
             List<@Nullable Integer> standardVolumes) {
+        long generation = loginGeneration.get();
         JsonArray serialNodesToExecute = new JsonArray();
 
         JsonArray ttsVolumeNodesToExecute = new JsonArray();
@@ -1108,11 +1133,12 @@ public class Connection {
         }
 
         if (!serialNodesToExecute.isEmpty()) {
-            executeSequenceNodes(devices.stream().map(d -> d.serialNumber).toList(), serialNodesToExecute, false);
+            executeSequenceNodes(devices.stream().map(d -> d.serialNumber).toList(), serialNodesToExecute, false,
+                    generation);
 
             if (!standardVolumeNodesToExecute.isEmpty() && "AlexaAnnouncement".equals(command)) {
                 executeSequenceNodes(devices.stream().map(d -> d.serialNumber).toList(), standardVolumeNodesToExecute,
-                        true);
+                        true, generation);
             }
         }
     }
@@ -1122,11 +1148,12 @@ public class Connection {
     // Alexa.SingASong.Play, Alexa.TellStory.Play, Alexa.Speak (textToSpeach)
     public void executeSequenceCommand(DeviceTO device, String command, Map<String, Object> parameters) {
         JsonObject nodeToExecute = createExecutionNode(device.deviceType, device.serialNumber, command, parameters);
-        executeSequenceNode(List.of(device.serialNumber), nodeToExecute);
+        executeSequenceNode(List.of(device.serialNumber), nodeToExecute, loginGeneration.get());
     }
 
-    private void executeSequenceNode(List<String> serialNumbers, JsonObject nodeToExecute) {
+    void executeSequenceNode(List<String> serialNumbers, JsonObject nodeToExecute, long generation) {
         QueueObject queueObject = new QueueObject();
+        queueObject.generation = generation;
         queueObject.deviceSerialNumbers = serialNumbers;
         queueObject.nodeToExecute = nodeToExecute;
         List<String> serials = new ArrayList<>();
@@ -1140,7 +1167,7 @@ public class Connection {
         logger.debug("Added {} device(s) {} to queue", queueObject.hashCode(), serials);
     }
 
-    private void handleExecuteSequenceNode() {
+    void handleExecuteSequenceNode() {
         Lock lock = Objects.requireNonNull(locks.computeIfAbsent(TimerType.DEVICES, k -> new ReentrantLock()));
         if (lock.tryLock()) {
             try {
@@ -1153,6 +1180,12 @@ public class Connection {
                     if (queueObjects != null) {
                         QueueObject queueObject = queueObjects.peek();
                         if (queueObject != null) {
+                            if (queueObject.future == null && queueObject.generation != loginGeneration.get()) {
+                                queueObjects.poll();
+                                logger.debug("Dropped {} device(s) {} queued before the last logout",
+                                        queueObject.hashCode(), queueObject.deviceSerialNumbers);
+                                continue;
+                            }
                             Future<?> future = queueObject.future;
                             if (future == null || future.isDone()) {
                                 boolean execute = true;
@@ -1234,7 +1267,8 @@ public class Connection {
         logger.debug("Removed {} device(s) {} from queue", queueObject.hashCode(), serials);
     }
 
-    private void executeSequenceNodes(List<String> serialNumbers, JsonArray nodesToExecute, boolean parallel) {
+    private void executeSequenceNodes(List<String> serialNumbers, JsonArray nodesToExecute, boolean parallel,
+            long generation) {
         JsonObject serialNode = new JsonObject();
         if (parallel) {
             serialNode.addProperty("@type", "com.amazon.alexa.behaviors.model.ParallelNode");
@@ -1244,7 +1278,7 @@ public class Connection {
 
         serialNode.add("nodesToExecute", nodesToExecute);
 
-        executeSequenceNode(serialNumbers, serialNode);
+        executeSequenceNode(serialNumbers, serialNode, generation);
     }
 
     private JsonObject createExecutionNode(String deviceType, String serialNumber, String command,
@@ -1554,6 +1588,7 @@ public class Connection {
 
     private static class QueueObject {
         public @Nullable Future<?> future;
+        public long generation;
         public List<String> deviceSerialNumbers = List.of();
         public JsonObject nodeToExecute = new JsonObject();
     }

--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/handler/AccountHandler.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/handler/AccountHandler.java
@@ -132,6 +132,7 @@ public class AccountHandler extends BaseBridgeHandler implements PushConnection.
 
     private List<EnabledFeedTO> currentFlashBriefings = List.of();
     private final Gson gson;
+    private final HttpClient httpClient;
     private int lastMessageId = 1000;
     private long nextDataRefresh = 0;
     private long nextLoginCheck = 0;
@@ -152,13 +153,14 @@ public class AccountHandler extends BaseBridgeHandler implements PushConnection.
 
     private AccountHandlerConfig handlerConfig = new AccountHandlerConfig();
     private final PushConnection pushConnection;
-    private boolean disposing = false;
+    private volatile boolean disposing = false;
     private @Nullable AccountTO accountInformation;
 
     public AccountHandler(Bridge bridge, Storage<String> stateStorage, Gson gson, HttpClient httpClient,
             HTTP2Client http2Client, AmazonEchoControlCommandDescriptionProvider commandDescriptionProvider) {
         super(bridge);
         this.gson = gson;
+        this.httpClient = httpClient;
         this.sessionStorage = stateStorage;
         this.pushConnection = new PushConnection(http2Client, gson, this, scheduler);
         this.commandDescriptionProvider = commandDescriptionProvider;
@@ -168,6 +170,9 @@ public class AccountHandler extends BaseBridgeHandler implements PushConnection.
     @Override
     public void initialize() {
         disposing = false;
+        if (connection.isClosed()) {
+            connection = new Connection(connection, gson, httpClient);
+        }
         activityLifecycle.incrementAndGet();
         handlerConfig = getConfig().as(AccountHandlerConfig.class);
 
@@ -349,8 +354,10 @@ public class AccountHandler extends BaseBridgeHandler implements PushConnection.
             refreshSmartHomeAfterCommandJob.cancel(true);
             this.refreshSmartHomeAfterCommandJob = null;
         }
-        pushConnection.close();
-        connection.logout(false);
+        synchronized (synchronizeConnection) {
+            pushConnection.close();
+            connection.close();
+        }
     }
 
     private void checkLogin() {
@@ -359,6 +366,9 @@ public class AccountHandler extends BaseBridgeHandler implements PushConnection.
             logger.debug("check login {}", uid.getAsString());
 
             synchronized (synchronizeConnection) {
+                if (disposing) {
+                    return;
+                }
                 try {
                     if (connection.isLoggedIn()) {
                         if (connection.renewTokens()) {
@@ -410,6 +420,10 @@ public class AccountHandler extends BaseBridgeHandler implements PushConnection.
 
     // used to set a valid connection from the web proxy login
     public void setConnection(Connection newConnection) {
+        if (disposing || newConnection.isClosed()) {
+            newConnection.close();
+            return;
+        }
         pushConnection.close();
         connection = newConnection;
         activityLifecycle.incrementAndGet();

--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/handler/AccountHandler.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/handler/AccountHandler.java
@@ -112,7 +112,7 @@ public class AccountHandler extends BaseBridgeHandler implements PushConnection.
     private final Logger logger = LoggerFactory.getLogger(AccountHandler.class);
     private final Storage<String> sessionStorage;
     private final AmazonEchoControlCommandDescriptionProvider commandDescriptionProvider;
-    private Connection connection;
+    private volatile Connection connection;
 
     private final Map<String, EchoHandler> echoHandlers = new ConcurrentHashMap<>();
     private final Set<SmartHomeDeviceHandler> smartHomeDeviceHandlers = new CopyOnWriteArraySet<>();
@@ -169,9 +169,11 @@ public class AccountHandler extends BaseBridgeHandler implements PushConnection.
 
     @Override
     public void initialize() {
-        disposing = false;
-        if (connection.isClosed()) {
-            connection = new Connection(connection, gson, httpClient);
+        synchronized (synchronizeConnection) {
+            disposing = false;
+            if (connection.isClosed()) {
+                connection = new Connection(connection, gson, httpClient);
+            }
         }
         activityLifecycle.incrementAndGet();
         handlerConfig = getConfig().as(AccountHandlerConfig.class);
@@ -420,22 +422,26 @@ public class AccountHandler extends BaseBridgeHandler implements PushConnection.
 
     // used to set a valid connection from the web proxy login
     public void setConnection(Connection newConnection) {
-        if (disposing || newConnection.isClosed()) {
-            newConnection.close();
-            return;
-        }
-        pushConnection.close();
-        connection = newConnection;
-        activityLifecycle.incrementAndGet();
-        storeSession();
+        synchronized (synchronizeConnection) {
+            if (disposing || newConnection.isClosed()) {
+                newConnection.close();
+                return;
+            }
+            pushConnection.close();
+            Connection replacedConnection = connection;
+            connection = newConnection;
+            replacedConnection.close();
+            activityLifecycle.incrementAndGet();
+            storeSession();
 
-        // force data check
-        nextLoginCheck = 0;
-        nextDataRefresh = 0;
-        // failures of the expired session must not delay polls on the new one
-        synchronized (notificationCommit) {
-            notificationPollBackoff.reset();
-            nextRefreshNotifications = 0;
+            // force data check
+            nextLoginCheck = 0;
+            nextDataRefresh = 0;
+            // failures of the expired session must not delay polls on the new one
+            synchronized (notificationCommit) {
+                notificationPollBackoff.reset();
+                nextRefreshNotifications = 0;
+            }
         }
     }
 

--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/handler/AccountHandler.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/handler/AccountHandler.java
@@ -430,7 +430,9 @@ public class AccountHandler extends BaseBridgeHandler implements PushConnection.
             pushConnection.close();
             Connection replacedConnection = connection;
             connection = newConnection;
-            replacedConnection.close();
+            if (replacedConnection != newConnection) {
+                replacedConnection.close();
+            }
             activityLifecycle.incrementAndGet();
             storeSession();
 

--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/handler/AccountHandler.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/handler/AccountHandler.java
@@ -430,7 +430,7 @@ public class AccountHandler extends BaseBridgeHandler implements PushConnection.
             pushConnection.close();
             Connection replacedConnection = connection;
             connection = newConnection;
-            if (replacedConnection != newConnection) {
+            if (!replacedConnection.equals(newConnection)) {
                 replacedConnection.close();
             }
             activityLifecycle.incrementAndGet();

--- a/bundles/org.openhab.binding.amazonechocontrol/src/test/java/org/openhab/binding/amazonechocontrol/internal/connection/ConnectionSequenceDispatcherTest.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/test/java/org/openhab/binding/amazonechocontrol/internal/connection/ConnectionSequenceDispatcherTest.java
@@ -12,10 +12,19 @@
  */
 package org.openhab.binding.amazonechocontrol.internal.connection;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.net.URI;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jetty.client.HttpClient;
@@ -23,6 +32,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import com.google.gson.Gson;
+import com.google.gson.JsonObject;
 
 /**
  * Tests the sequence node dispatcher lifecycle around logout, re-login and terminal close. Without a running
@@ -33,7 +43,8 @@ import com.google.gson.Gson;
 @NonNullByDefault
 public class ConnectionSequenceDispatcherTest {
 
-    private final Connection connection = new Connection(null, new Gson(), mock(HttpClient.class));
+    private final HttpClient httpClient = mock(HttpClient.class);
+    private final Connection connection = new Connection(null, new Gson(), httpClient);
 
     @AfterEach
     public void stopDispatcher() {
@@ -79,5 +90,49 @@ public class ConnectionSequenceDispatcherTest {
 
         assertSame(dispatcher, connection.sequenceNodeDispatcher());
         assertTrue(connection.isSequenceNodeDispatcherRunning());
+    }
+
+    @Test
+    public void logoutDropsQueuedNodesAndBumpsTheLoginGeneration() {
+        long generation = connection.currentLoginGeneration();
+        connection.executeSequenceNode(List.of("SERIAL"), new JsonObject(), generation);
+
+        connection.logout(false);
+
+        assertEquals(0, connection.queuedSequenceNodeCount());
+        assertNotEquals(generation, connection.currentLoginGeneration());
+    }
+
+    @Test
+    public void dispatcherDropsANodeQueuedBeforeTheLastLogoutUnexecuted() {
+        connection.executeSequenceNode(List.of("SERIAL"), new JsonObject(), connection.currentLoginGeneration() - 1);
+
+        connection.handleExecuteSequenceNode();
+
+        assertEquals(0, connection.queuedSequenceNodeCount());
+        assertFalse(connection.isSequenceNodeQueueRunning());
+    }
+
+    @Test
+    public void dispatcherPicksUpANodeFromTheCurrentLogin() throws InterruptedException {
+        CountDownLatch executionStarted = new CountDownLatch(1);
+        CountDownLatch releaseExecution = new CountDownLatch(1);
+        when(httpClient.newRequest(any(URI.class))).thenAnswer(invocation -> {
+            executionStarted.countDown();
+            try {
+                releaseExecution.await();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            throw new IllegalStateException("request released");
+        });
+        connection.executeSequenceNode(List.of("SERIAL"), new JsonObject(), connection.currentLoginGeneration());
+
+        connection.handleExecuteSequenceNode();
+
+        assertTrue(executionStarted.await(5, TimeUnit.SECONDS));
+        assertEquals(1, connection.queuedSequenceNodeCount());
+        assertTrue(connection.isSequenceNodeQueueRunning());
+        releaseExecution.countDown();
     }
 }

--- a/bundles/org.openhab.binding.amazonechocontrol/src/test/java/org/openhab/binding/amazonechocontrol/internal/connection/ConnectionSequenceDispatcherTest.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/test/java/org/openhab/binding/amazonechocontrol/internal/connection/ConnectionSequenceDispatcherTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.amazonechocontrol.internal.connection;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jetty.client.HttpClient;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import com.google.gson.Gson;
+
+/**
+ * Tests the sequence node dispatcher lifecycle around logout, re-login and terminal close. Without a running
+ * dispatcher every TTS, announcement, volume and routine command is queued forever and never sent, silently.
+ *
+ * @author Martin Littkovsky - Initial contribution
+ */
+@NonNullByDefault
+public class ConnectionSequenceDispatcherTest {
+
+    private final Connection connection = new Connection(null, new Gson(), mock(HttpClient.class));
+
+    @AfterEach
+    public void stopDispatcher() {
+        connection.logout(false);
+    }
+
+    @Test
+    public void dispatcherRunsOnANewConnection() {
+        assertTrue(connection.isSequenceNodeDispatcherRunning());
+    }
+
+    @Test
+    public void logoutStopsTheDispatcher() {
+        connection.logout(false);
+
+        assertFalse(connection.isSequenceNodeDispatcherRunning());
+    }
+
+    @Test
+    public void ensureRestartsTheDispatcherAfterLogout() {
+        connection.logout(false);
+
+        connection.ensureSequenceNodeDispatcherIsRunning();
+
+        assertTrue(connection.isSequenceNodeDispatcherRunning());
+    }
+
+    @Test
+    public void closeIsTerminalEvenWhenALateLoginTriesToRevive() {
+        connection.close();
+
+        connection.ensureSequenceNodeDispatcherIsRunning();
+
+        assertFalse(connection.isSequenceNodeDispatcherRunning());
+    }
+
+    @Test
+    public void ensuringAgainKeepsTheSameRunningDispatcher() {
+        connection.ensureSequenceNodeDispatcherIsRunning();
+        Object dispatcher = connection.sequenceNodeDispatcher();
+
+        connection.ensureSequenceNodeDispatcherIsRunning();
+
+        assertSame(dispatcher, connection.sequenceNodeDispatcher());
+        assertTrue(connection.isSequenceNodeDispatcherRunning());
+    }
+}

--- a/bundles/org.openhab.binding.amazonechocontrol/src/test/java/org/openhab/binding/amazonechocontrol/internal/connection/ConnectionSequenceDispatcherTest.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/test/java/org/openhab/binding/amazonechocontrol/internal/connection/ConnectionSequenceDispatcherTest.java
@@ -105,6 +105,7 @@ public class ConnectionSequenceDispatcherTest {
 
     @Test
     public void dispatcherDropsANodeQueuedBeforeTheLastLogoutUnexecuted() {
+        connection.logout(false);
         connection.executeSequenceNode(List.of("SERIAL"), new JsonObject(), connection.currentLoginGeneration() - 1);
 
         connection.handleExecuteSequenceNode();

--- a/bundles/org.openhab.binding.amazonechocontrol/src/test/java/org/openhab/binding/amazonechocontrol/internal/handler/AccountHandlerConnectionSwapTest.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/test/java/org/openhab/binding/amazonechocontrol/internal/handler/AccountHandlerConnectionSwapTest.java
@@ -71,6 +71,16 @@ public class AccountHandlerConnectionSwapTest {
     }
 
     @Test
+    public void setConnectionWithTheCurrentConnectionKeepsItOpen() {
+        Connection current = handler.getConnection();
+
+        handler.setConnection(current);
+
+        assertSame(current, handler.getConnection());
+        assertFalse(current.isClosed());
+    }
+
+    @Test
     public void setConnectionRefusesAClosedCandidate() {
         Connection current = handler.getConnection();
         Connection closedCandidate = new Connection(null, gson, httpClient);

--- a/bundles/org.openhab.binding.amazonechocontrol/src/test/java/org/openhab/binding/amazonechocontrol/internal/handler/AccountHandlerConnectionSwapTest.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/test/java/org/openhab/binding/amazonechocontrol/internal/handler/AccountHandlerConnectionSwapTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.amazonechocontrol.internal.handler;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.http2.client.HTTP2Client;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.openhab.binding.amazonechocontrol.internal.AmazonEchoControlCommandDescriptionProvider;
+import org.openhab.binding.amazonechocontrol.internal.connection.Connection;
+import org.openhab.core.storage.Storage;
+import org.openhab.core.thing.Bridge;
+import org.openhab.core.thing.ThingUID;
+
+import com.google.gson.Gson;
+
+/**
+ * Tests that installing a connection from the web proxy login leaves exactly one live connection behind: the
+ * replaced one is closed, and a candidate that lost against dispose or close never replaces the current one.
+ *
+ * @author Martin Littkovsky - Initial contribution
+ */
+@NonNullByDefault
+public class AccountHandlerConnectionSwapTest {
+
+    private final Gson gson = new Gson();
+    private final HttpClient httpClient = mock(HttpClient.class);
+    @SuppressWarnings("unchecked")
+    private final AccountHandler handler = new AccountHandler(bridgeWithUid(), mock(Storage.class), gson, httpClient,
+            mock(HTTP2Client.class), mock(AmazonEchoControlCommandDescriptionProvider.class));
+
+    private static Bridge bridgeWithUid() {
+        Bridge bridge = mock(Bridge.class);
+        when(bridge.getUID()).thenReturn(new ThingUID("amazonechocontrol", "account", "test"));
+        return bridge;
+    }
+
+    @AfterEach
+    public void closeConnections() {
+        handler.getConnection().close();
+    }
+
+    @Test
+    public void setConnectionInstallsTheNewAndClosesTheReplacedConnection() {
+        Connection replaced = handler.getConnection();
+        Connection fresh = new Connection(null, gson, httpClient);
+
+        handler.setConnection(fresh);
+
+        assertSame(fresh, handler.getConnection());
+        assertTrue(replaced.isClosed());
+        assertFalse(fresh.isClosed());
+    }
+
+    @Test
+    public void setConnectionRefusesAClosedCandidate() {
+        Connection current = handler.getConnection();
+        Connection closedCandidate = new Connection(null, gson, httpClient);
+        closedCandidate.close();
+
+        handler.setConnection(closedCandidate);
+
+        assertSame(current, handler.getConnection());
+        assertFalse(current.isClosed());
+    }
+
+    @Test
+    public void setConnectionAfterDisposeClosesTheCandidateInsteadOfInstallingIt() {
+        Connection current = handler.getConnection();
+        Connection lateLoginCandidate = new Connection(null, gson, httpClient);
+
+        handler.dispose();
+        handler.setConnection(lateLoginCandidate);
+
+        assertNotSame(lateLoginCandidate, handler.getConnection());
+        assertSame(current, handler.getConnection());
+        assertTrue(lateLoginCandidate.isClosed());
+    }
+}


### PR DESCRIPTION
The dispatcher draining the sequence node queue (TTS, announcements, volume, textCommands, routines) was started only in the Connection constructor, and logout() cancels it. When the account thing re-initializes, dispose() logs out but initialize() keeps the same Connection - after the re-login every command was queued forever and never sent, silently, until the binding restarted. A comment on #20018 describes the same symptom after a stop/start of the account thing.

- verifyLogin() now ensures the dispatcher is running after every successful login
- dispose() closes the connection terminally: a login finishing after dispose can neither revive the dispatcher nor reinstall the session, and initialize() builds a fresh connection when the previous one was closed
- the dispatcher iterates a snapshot of the device serial numbers and survives unexpected runtime exceptions instead of dying silently; the queue-state check used by push events synchronizes the same way
- logout() drops the queued sequence nodes, so a later re-login does not replay a stale backlog
- logout() cancels the TEXT_COMMAND timer where it cancelled the TTS timer a second time (copy-paste fix in the same method)
- new ConnectionSequenceDispatcherTest covers the dispatcher lifecycle around logout, re-login and terminal close

Built from main, tested on a production system running a 5.2.x backport (as part of [this combined test build](https://github.com/ML19821/openhab-addons/releases/tag/amazonechocontrol-all-fixes-test-5)): a re-initialization of the account thing used to silence TTS until the next restart; with this change, a disable/enable cycle of the account thing was followed by an immediately working TTS - the dispatcher picked the command up and the behaviors call returned 200.

**Transparency:** this patch and the comments on this PR were written with AI assistance (Claude); every commit carries an `AI-assisted-by` trailer. All changes were built, tested and verified on a production system by the author. Reviewed against wborn/github-review-policy at `ca8d3f4d0` (2026-08-19) before submission.

Fixes #21550

