### PR TITLE
[yamlcomposer] Fix a serialization error when using the `enumerate` filter or function on maps.

### DIFF
--- a/bundles/org.openhab.io.yamlcomposer/doc/variables.md
+++ b/bundles/org.openhab.io.yamlcomposer/doc/variables.md
@@ -301,7 +301,7 @@ items_mapped:
   !for "index, item in enumerate(items)":
     "item_${index}": "${item}"
 
-# Enumerating maps yields index and Map.Entry pairs (.key and .value)
+# Enumerating maps yields index and map entry pairs (.key and .value)
 map_results:
   !for "idx, entry in enumerate(mapping)":
     "item_${idx}_${entry.key}": "${entry.value}"
@@ -375,11 +375,9 @@ enumerated_list: ${items | enumerate}
 enumerated_list_func: ${enumerate(items)}
 # Result: [[0, "alpha"], [1, "beta"], [2, "gamma"]]
 
-# Enumerating maps yields indexed Map.Entry objects.
-# Each entry wraps the original key-value pair and provides explicit
-# property accessors: .key (for the map key) and .value (for the map value).
+# Enumerating maps yields indexed map entry objects (default starting index 0)
 enumerated_map: ${enumerate(mapping)}
-# Result Structure: [[0, alpha=one], [1, beta=two]]
+# Result Structure: [[0, {key=alpha, value=one}], [1, {key=beta, value=two}]]
 #
 # Accessing properties from a specific index (e.g., the first item):
 #   - Key access:   ${enumerated_map[0][1].key}   -> "alpha"

--- a/bundles/org.openhab.io.yamlcomposer/src/main/java/org/openhab/io/yamlcomposer/internal/expression/filters/EnumerateFilter.java
+++ b/bundles/org.openhab.io.yamlcomposer/src/main/java/org/openhab/io/yamlcomposer/internal/expression/filters/EnumerateFilter.java
@@ -14,6 +14,7 @@ package org.openhab.io.yamlcomposer.internal.expression.filters;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -59,7 +60,10 @@ public class EnumerateFilter implements Filter {
             }
         } else if (var instanceof Map) {
             for (Map.Entry<?, ?> entry : ((Map<?, ?>) var).entrySet()) {
-                addPair(enumeratedList, index++, entry);
+                Map<String, Object> mapEntry = new LinkedHashMap<>();
+                mapEntry.put("key", entry.getKey());
+                mapEntry.put("value", entry.getValue());
+                addPair(enumeratedList, index++, mapEntry);
             }
         } else if (var.getClass().isArray()) {
             Object[] array = (Object[]) var;

--- a/bundles/org.openhab.io.yamlcomposer/src/test/java/org/openhab/io/yamlcomposer/internal/YamlComposerVariablesAndSubstitutionsTest.java
+++ b/bundles/org.openhab.io.yamlcomposer/src/test/java/org/openhab/io/yamlcomposer/internal/YamlComposerVariablesAndSubstitutionsTest.java
@@ -27,9 +27,13 @@ import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.eclipse.jdt.annotation.Nullable;
 import org.junit.jupiter.api.DisplayName;
@@ -39,9 +43,12 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
+import org.openhab.core.OpenHAB;
+import org.openhab.io.yamlcomposer.internal.YamlComposer.CacheEntry;
 
 /**
  * The {@link YamlComposerVariablesAndSubstitutionsTest} contains tests for the variables and substitutions
@@ -691,8 +698,8 @@ class YamlComposerVariablesAndSubstitutionsTest extends AbstractYamlComposerTest
                         """;
 
                 Map<Object, Object> data = loadYaml(yaml);
-                List<?> resultList = (List<?>) data.get("result");
-                assertThat(resultList, not(empty()));
+                assertThat(data.get("result"), equalTo(List.of(List.of(0, Map.of("key", "a", "value", "apple")),
+                        List.of(1, Map.of("key", "b", "value", "banana")))));
             }
 
             @Test
@@ -705,8 +712,33 @@ class YamlComposerVariablesAndSubstitutionsTest extends AbstractYamlComposerTest
                         """;
 
                 Map<Object, Object> data = loadYaml(yaml);
-                List<?> resultList = (List<?>) data.get("result");
-                assertThat(resultList, not(empty()));
+                assertThat(data.get("result"), equalTo(List.of(List.of(0, Map.of("key", "a", "value", "apple")),
+                        List.of(1, Map.of("key", "b", "value", "banana")))));
+            }
+
+            @Test
+            @DisplayName("Writes compiled output for enumerated map without serialization errors")
+            void writesCompiledOutputForEnumeratedMap() throws IOException {
+                Path main = writeFixture("enumerate_map.yaml", """
+                        variables:
+                          mapping: { a: "apple", b: "banana" }
+                        result: ${enumerate(mapping)}
+                        """);
+                Path output = Objects.requireNonNull(sharedTempDir).resolve("output.yaml");
+
+                Set<String> trackedEnv = ConcurrentHashMap.newKeySet();
+                ConcurrentHashMap<Path, CacheEntry> includeCache = new ConcurrentHashMap<>();
+                Object yamlObject = Objects.requireNonNull(YamlComposer.load(main, p -> {
+                }, trackedEnv::add, logSession, includeCache));
+
+                try (MockedStatic<OpenHAB> openHABMock = mockOpenHabMetadata()) {
+                    ComposerUtils.writeCompiledOutput(yamlObject, main, output, trackedEnv);
+                }
+
+                assertThat(Files.exists(output), is(true));
+                String content = Files.readString(output);
+                assertThat(content, containsString("apple"));
+                assertThat(content, containsString("banana"));
             }
         }
 


### PR DESCRIPTION
Bug introduced in #21408 

Fix a `YamlEngineException` when enumerating maps. `Map.Entry` instances are 
not natively serializable by SnakeYAML and broke Jinjava property access. 

Map entries are now converted into maps with explicit "key" and "value" properties, 
allowing both SnakeYAML serialization and Jinjava `entry.key` / `entry.value` 
access to work correctly.