### PR TITLE
[yamlcomposer] Add optional start index parameter to `enumerate` filter and function

### DIFF
--- a/bundles/org.openhab.io.yamlcomposer/doc/variables.md
+++ b/bundles/org.openhab.io.yamlcomposer/doc/variables.md
@@ -266,11 +266,11 @@ label: ${room_label | default('Kitchen')}
 
 ### Custom Filters
 
-| Filter      | Description                                                                         |
-|:------------|:------------------------------------------------------------------------------------|
-| `label`     | Converts identifiers (camelCase, snake_case) into human-friendly titles.            |
-| `dig`       | Safely navigates deep maps; returns `null` instead of an error if a key is missing. |
-| `enumerate` | Maps collections, arrays, or maps into an indexed list of `[index, item]` pairs.    |
+| Filter      | Description                                                                                                                           |
+|:------------|:--------------------------------------------------------------------------------------------------------------------------------------|
+| `label`     | Converts identifiers (camelCase, snake_case) into human-friendly titles.                                                              |
+| `dig`       | Safely navigates deep maps; returns `null` instead of an error if a key is missing.                                                   |
+| `enumerate` | Maps collections, arrays, or maps into an indexed list of `[index, item]` pairs. Accepts an optional starting index (default is `0`). |
 
 **`dig` Example:**
 
@@ -283,6 +283,7 @@ host: ${ VARS | dig('config', 'servers', 1, 'host') | default('localhost') }
 **`enumerate` Example:**
 
 The `enumerate` filter and function map any collection, array, or map into a list of index-item pairs, making them fully compatible with `!for` loops and tuple unpacking.
+You can supply an optional starting index parameter (default is `0`).
 
 ```yaml
 variables:
@@ -296,14 +297,14 @@ devices:
   !for "index, item in items | enumerate":
     "dev_${index}": "${item}"
 
-# Using the function syntax with a !for loop
-items_mapped:
-  !for "index, item in enumerate(items)":
-    "item_${index}": "${item}"
+# Filter syntax with a custom starting index
+devices_one_indexed:
+  !for "index, item in items | enumerate(1)":
+    "dev_${index}": "${item}"
 
 # Enumerating maps yields index and Map.Entry pairs (.key and .value)
 map_results:
-  !for "idx, entry in enumerate(mapping)":
+  !for "idx, entry in mapping | enumerate":
     "item_${idx}_${entry.key}": "${entry.value}"
 ```
 
@@ -356,7 +357,9 @@ Use whichever form is clearer for your template.
 
 **Syntax:**
 
-**`enumerate(target)`**: Maps collections, arrays, or maps into a list of indexed `[index, item]` pairs. When used with maps, it yields entry objects supporting `.key` and `.value` accessors.
+**`enumerate(target[, start])`**: Maps collections, arrays, or maps into a list of indexed `[index, item]` pairs.
+The optional `start` argument sets the initial index (defaults to `0`).
+When used with maps, it yields entry objects supporting `.key` and `.value` accessors.
 
 **Example:**
 
@@ -367,13 +370,13 @@ variables:
     alpha: "one"
     beta: "two"
 
-# Using the enumerate filter
-enumerated_list: ${items | enumerate}
+# Using the enumerate function (default starting index 0)
+enumerated_list: ${enumerate(items)}
 # Result: [[0, "alpha"], [1, "beta"], [2, "gamma"]]
 
-# Using the enumerate function
-enumerated_list_func: ${enumerate(items)}
-# Result: [[0, "alpha"], [1, "beta"], [2, "gamma"]]
+# Using the enumerate function with a custom starting index (1)
+enumerated_list_from_1: ${enumerate(items, 1)}
+# Result: [[1, "alpha"], [2, "beta"], [3, "gamma"]]
 
 # Enumerating maps yields indexed Map.Entry objects.
 # Each entry wraps the original key-value pair and provides explicit

--- a/bundles/org.openhab.io.yamlcomposer/src/main/java/org/openhab/io/yamlcomposer/internal/expression/ExpressionEvaluator.java
+++ b/bundles/org.openhab.io.yamlcomposer/src/main/java/org/openhab/io/yamlcomposer/internal/expression/ExpressionEvaluator.java
@@ -72,7 +72,7 @@ public class ExpressionEvaluator {
         context.registerFilter(new EnumerateFilter());
 
         context.registerFunction(
-                new ELFunctionDefinition("", "enumerate", EnumerateFilter.class, "staticEnumerate", Object.class));
+                new ELFunctionDefinition("", "enumerate", EnumerateFilter.class, "staticEnumerate", Object[].class));
     }
 
     /**

--- a/bundles/org.openhab.io.yamlcomposer/src/main/java/org/openhab/io/yamlcomposer/internal/expression/filters/EnumerateFilter.java
+++ b/bundles/org.openhab.io.yamlcomposer/src/main/java/org/openhab/io/yamlcomposer/internal/expression/filters/EnumerateFilter.java
@@ -25,9 +25,13 @@ import com.hubspot.jinjava.lib.filter.Filter;
 
 /**
  * Custom Jinjava filter to enumerate elements of a collection, iterable, or array.
- * It returns a list of pairs, where each pair consists of the index and the corresponding element
+ * It returns a list of pairs, where each pair consists of the index and the corresponding element.
  *
- * Usage: {@code variable|enumerate} to get a list of {@code [index, element]} pairs.
+ * Usage:
+ * <ul>
+ * <li>{@code variable|enumerate} — starting at index 0</li>
+ * <li>{@code variable|enumerate(1)} — starting at index 1</li>
+ * </ul>
  *
  * @author Jimmy Tanagra - Initial contribution
  */
@@ -46,8 +50,17 @@ public class EnumerateFilter implements Filter {
             return new ArrayList<>();
         }
 
+        int start = 0;
+        if (args.length > 0 && args[0] != null) {
+            try {
+                start = Integer.parseInt(args[0].trim());
+            } catch (NumberFormatException e) {
+                // Fallback to index 0 if the argument is not a valid integer
+            }
+        }
+
         List<Object> enumeratedList = new ArrayList<>();
-        int index = 0;
+        int index = start;
 
         if (var instanceof Collection) {
             for (Object item : (Collection<?>) var) {
@@ -67,7 +80,7 @@ public class EnumerateFilter implements Filter {
                 addPair(enumeratedList, index++, item);
             }
         } else {
-            addPair(enumeratedList, 0, var);
+            addPair(enumeratedList, start, var);
         }
 
         return enumeratedList;
@@ -80,7 +93,15 @@ public class EnumerateFilter implements Filter {
         list.add(pair);
     }
 
-    public static Object staticEnumerate(Object target) {
-        return new EnumerateFilter().filter(target, null);
+    public static Object staticEnumerate(Object... args) {
+        if (args.length == 0 || args[0] == null) {
+            return new ArrayList<>();
+        }
+        Object target = args[0];
+        String startStr = "0";
+        if (args.length > 1 && args[1] != null) {
+            startStr = String.valueOf(args[1]);
+        }
+        return new EnumerateFilter().filter(target, null, startStr);
     }
 }

--- a/bundles/org.openhab.io.yamlcomposer/src/test/java/org/openhab/io/yamlcomposer/internal/YamlComposerVariablesAndSubstitutionsTest.java
+++ b/bundles/org.openhab.io.yamlcomposer/src/test/java/org/openhab/io/yamlcomposer/internal/YamlComposerVariablesAndSubstitutionsTest.java
@@ -668,6 +668,20 @@ class YamlComposerVariablesAndSubstitutionsTest extends AbstractYamlComposerTest
             }
 
             @Test
+            @DisplayName("Enumerates list elements using the enumerate filter with a custom start index")
+            void enumeratesListWithFilterAndStartIndex() throws IOException {
+                String yaml = """
+                        variables:
+                          items: ["apple", "banana", "cherry"]
+                        result: ${items | enumerate(1)}
+                        """;
+
+                Map<Object, Object> data = loadYaml(yaml);
+                assertThat(data.get("result"),
+                        equalTo(List.of(List.of(1, "apple"), List.of(2, "banana"), List.of(3, "cherry"))));
+            }
+
+            @Test
             @DisplayName("Enumerates list elements using the enumerate function")
             void enumeratesListWithFunction() throws IOException {
                 String yaml = """
@@ -679,6 +693,20 @@ class YamlComposerVariablesAndSubstitutionsTest extends AbstractYamlComposerTest
                 Map<Object, Object> data = loadYaml(yaml);
                 assertThat(data.get("result"),
                         equalTo(List.of(List.of(0, "apple"), List.of(1, "banana"), List.of(2, "cherry"))));
+            }
+
+            @Test
+            @DisplayName("Enumerates list elements using the enumerate function with a custom start index")
+            void enumeratesListWithFunctionAndStartIndex() throws IOException {
+                String yaml = """
+                        variables:
+                          items: ["apple", "banana", "cherry"]
+                        result: ${enumerate(items, 10)}
+                        """;
+
+                Map<Object, Object> data = loadYaml(yaml);
+                assertThat(data.get("result"),
+                        equalTo(List.of(List.of(10, "apple"), List.of(11, "banana"), List.of(12, "cherry"))));
             }
 
             @Test


### PR DESCRIPTION
Enhance the `enumerate` filter and custom function to accept an optional starting index (defaulting to 0).

Examples:
- Filter syntax: `${items | enumerate(1)}`
- Function syntax: `${enumerate(items, 1)}`

Updates unit tests and documentation to cover custom start indices.