### PR TITLE
[amazonechocontrol] Fix the servlet login after a logout

### DIFF
--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/AmazonEchoControlBindingConstants.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/AmazonEchoControlBindingConstants.java
@@ -115,6 +115,8 @@ public class AmazonEchoControlBindingConstants {
     public static final String DI_OS_VERSION = "16.6";
     public static final String DI_SDK_VERSION = "6.12.4";
     public static final String DEFAULT_RETAIL_DOMAIN = "amazon.com";
+    // every login dialog starts here, before the account's own retail host is known
+    public static final String SIGN_IN_HOST = "www.amazon.com";
 
     public static final Map<String, String> DEVICE_TYPES = ResourceUtil
             .readProperties(AmazonEchoControlBindingConstants.class, "device_type.properties");

--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/AmazonEchoControlServlet.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/AmazonEchoControlServlet.java
@@ -338,7 +338,8 @@ public class AmazonEchoControlServlet extends HttpServlet {
             LoginDialogPage signInPage = LoginDialogPage.signIn();
             returnHtml(resp, uriParts, html, signInPage.host(), signInPage.linkBase(uriParts));
         } catch (ConnectionException e) {
-            logger.warn("get failed with uri syntax error", e);
+            logger.warn("Failed to load the sign-in page: {}", e.getMessage());
+            logger.debug("Failed to load the sign-in page", e);
         }
     }
 

--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/AmazonEchoControlServlet.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/AmazonEchoControlServlet.java
@@ -32,8 +32,11 @@ import java.nio.charset.StandardCharsets;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import javax.servlet.Servlet;
@@ -82,8 +85,10 @@ import org.slf4j.LoggerFactory;
 public class AmazonEchoControlServlet extends HttpServlet {
     public static final String SERVLET_PATH = "/" + BINDING_ID;
     private static final long serialVersionUID = -9158865063627039237L;
-    private static final String FORWARD_URI_PART = "/FORWARD/";
     private static final String PROXY_URI_PART = "/PROXY/";
+    private static final String MAP_LANDING_PATH = "/ap/maplanding";
+    private static final Pattern LINK_TARGET = Pattern.compile("(?<=\\s)(href|action|formaction)=\"([^\"]*)\"",
+            Pattern.CASE_INSENSITIVE);
 
     private final Logger logger = LoggerFactory.getLogger(AmazonEchoControlServlet.class);
     private final VelocityEngine velocityEngine = new VelocityEngine();
@@ -187,8 +192,8 @@ public class AmazonEchoControlServlet extends HttpServlet {
                 postData = req.getReader().lines().collect(Collectors.joining());
             }
 
-            this.handleProxyRequest(accountHandler, connection, resp, uriParts, method, proxyUrl, null, postData,
-                    postData != null, connection.getRetailDomain());
+            this.handleProxyRequest(accountHandler, connection, resp, uriParts, method, proxyUrl, Map.of(), postData,
+                    postData != null, null);
             return;
         }
 
@@ -215,24 +220,42 @@ public class AmazonEchoControlServlet extends HttpServlet {
             } else {
                 String[] strings = map.get(name);
                 if (strings != null && strings.length > 0) {
-                    value = strings[0];
+                    value = LoginDialogPage.unrewrite(strings[0], uriParts);
                 }
             }
             postDataBuilder.append(URLEncoder.encode(value, StandardCharsets.UTF_8));
         }
 
-        String relativeUrl = uriParts.request().replace(FORWARD_URI_PART, "/");
-
-        String retailDomain = relativeUrl.startsWith("/ap/signin") ? "amazon.com" : connection.getRetailDomain();
-        String postUrl = "https://www." + retailDomain + relativeUrl;
-        queryString = req.getQueryString();
-        if (isNotBlank(queryString)) {
-            postUrl += "?" + queryString;
+        LoginDialogPage page = LoginDialogPage.fromRequest(LoginDialogPage.unrewrite(uri, uriParts),
+                dialogHosts(connection.getRetailUrl()));
+        if (page == null) {
+            returnError(resp, uriParts, "Refusing to post to '" + uri + "'");
+            return;
         }
-        String referer = "https://www." + retailDomain;
         String postData = postDataBuilder.toString();
-        handleProxyRequest(accountHandler, connection, resp, uriParts, method, postUrl, referer, postData, false,
-                retailDomain);
+        handleProxyRequest(accountHandler, connection, resp, uriParts, method, page.url(),
+                browserHeaders(req, page, method), postData, false, page);
+    }
+
+    /** Amazon rejects the sign-in post unless it carries the identity of the browser the page was served to */
+    static Map<String, String> browserHeaders(HttpServletRequest req) {
+        Map<String, String> headers = new HashMap<>();
+        for (HttpHeader header : List.of(HttpHeader.USER_AGENT, HttpHeader.ACCEPT_LANGUAGE)) {
+            String value = req.getHeader(header.asString());
+            if (value != null && !value.isBlank()) {
+                headers.put(header.asString(), value);
+            }
+        }
+        return headers;
+    }
+
+    static Map<String, String> browserHeaders(HttpServletRequest req, LoginDialogPage page, HttpMethod method) {
+        Map<String, String> headers = browserHeaders(req);
+        headers.put(HttpHeader.REFERER.asString(), page.origin());
+        if (!HttpMethod.GET.equals(method)) {
+            headers.put(HttpHeader.ORIGIN.asString(), page.origin());
+        }
+        return headers;
     }
 
     private void doAccountGet(ServletUri uriParts, HttpServletRequest req, HttpServletResponse resp)
@@ -250,11 +273,19 @@ public class AmazonEchoControlServlet extends HttpServlet {
             }
 
             Connection connection = accountHandler.getConnection();
-            if (uri.startsWith(FORWARD_URI_PART)) {
-                String getUrl = connection.getRetailUrl() + "/" + uri.substring(FORWARD_URI_PART.length());
-
-                this.handleProxyRequest(accountHandler, connection, resp, uriParts, HttpMethod.GET, getUrl, null, null,
-                        false, connection.getRetailDomain());
+            if (uri.startsWith(LoginDialogPage.FORWARD_URI_PART)) {
+                if (connection.isLoggedIn()) {
+                    returnError(resp, uriParts, "Connection not in initialize mode.");
+                    return;
+                }
+                LoginDialogPage page = LoginDialogPage.fromRequest(LoginDialogPage.unrewrite(uri, uriParts),
+                        dialogHosts(connection.getRetailUrl()));
+                if (page == null) {
+                    returnError(resp, uriParts, "Refusing to forward to '" + uri + "'");
+                    return;
+                }
+                this.handleProxyRequest(accountHandler, connection, resp, uriParts, HttpMethod.GET, page.url(),
+                        browserHeaders(req, page, HttpMethod.GET), null, false, page);
                 return;
             }
 
@@ -262,8 +293,8 @@ public class AmazonEchoControlServlet extends HttpServlet {
                 // handle proxy request
                 String proxyUrl = connection.getAlexaServer() + "/" + uri.substring(PROXY_URI_PART.length());
 
-                this.handleProxyRequest(accountHandler, connection, resp, uriParts, HttpMethod.GET, proxyUrl, null,
-                        null, false, connection.getRetailDomain());
+                this.handleProxyRequest(accountHandler, connection, resp, uriParts, HttpMethod.GET, proxyUrl, Map.of(),
+                        null, false, null);
                 return;
             }
 
@@ -303,8 +334,9 @@ public class AmazonEchoControlServlet extends HttpServlet {
                 return;
             }
 
-            String html = connection.getLoginPage();
-            returnHtml(resp, uriParts, html, "amazon.com");
+            String html = connection.getLoginPage(browserHeaders(req));
+            LoginDialogPage signInPage = LoginDialogPage.signIn();
+            returnHtml(resp, uriParts, html, signInPage.host(), signInPage.linkBase(uriParts));
         } catch (ConnectionException e) {
             logger.warn("get failed with uri syntax error", e);
         }
@@ -368,55 +400,44 @@ public class AmazonEchoControlServlet extends HttpServlet {
     }
 
     private void handleProxyRequest(AccountHandler accountHandler, Connection connection, HttpServletResponse resp,
-            ServletUri uriParts, HttpMethod method, String url, @Nullable String referer, @Nullable Object postData,
-            boolean isJson, String retailDomain) throws IOException {
+            ServletUri uriParts, HttpMethod method, String url, Map<String, String> headers, @Nullable Object postData,
+            boolean isJson, @Nullable LoginDialogPage page) throws IOException {
+        String retailUrl = connection.getRetailUrl();
+        List<String> dialogHosts = dialogHosts(retailUrl);
+        String host = page == null ? dialogHosts.get(dialogHosts.size() - 1) : page.host();
         try {
-            Map<String, String> headers = new HashMap<>();
-            if (referer != null) {
-                headers.put(HttpHeader.REFERER.asString(), referer);
-            }
-
             HttpRequestBuilder.HttpResponse response = connection.getRequestBuilder().builder(method, url)
                     .withContent(postData).withJson(isJson).withHeaders(headers).retry(false).redirect(false)
                     .syncSend();
-            if (response.statusCode() == HttpStatus.FOUND_302) {
-                String location = response.headers().get("location");
-                if (location.contains("/ap/maplanding")) {
+            if (HttpStatus.isRedirection(response.statusCode())) {
+                String location = LoginDialogPage.unrewrite(response.headers().get("location"), uriParts);
+                LoginDialogPage target = page == null ? null
+                        : LoginDialogPage.fromLocation(location, page, dialogHosts);
+                if (target != null && target.pathAndQuery().startsWith(MAP_LANDING_PATH)) {
                     try {
                         URI oAuthRedirectUri = new URI(location);
                         String accessToken = getQueryMap(oAuthRedirectUri.getQuery()).get("openid.oa2.access_token");
                         if (accessToken == null) {
                             returnError(resp, uriParts,
-                                    "Login to '" + retailDomain + "' failed: Could not extract accessToken.");
+                                    "Login to '" + host + "' failed: Could not extract accessToken.");
                         } else if (connection.registerConnectionAsApp(accessToken)) {
                             accountHandler.setConnection(connection);
                             resp.sendRedirect(SERVLET_PATH + "/" + uriParts.account());
                             // createAccountPage(resp, uriParts, accountHandler, connection);
                         } else {
-                            returnError(resp, uriParts,
-                                    "Login to '" + retailDomain + "' failed: Could not register as app.");
+                            returnError(resp, uriParts, "Login to '" + host + "' failed: Could not register as app.");
                         }
                         return;
                     } catch (URISyntaxException e) {
-                        returnError(resp, uriParts,
-                                "Login to '" + retailDomain + "' failed: " + e.getLocalizedMessage());
+                        returnError(resp, uriParts, "Login to '" + host + "' failed: " + e.getLocalizedMessage());
                         accountHandler.resetConnection(false);
                         return;
                     }
                 }
 
-                String startString = connection.getRetailUrl() + "/";
-                String newLocation = null;
-                if (location.startsWith(startString) && connection.isLoggedIn()) {
-                    newLocation = uriParts.buildFor(PROXY_URI_PART + location.substring(startString.length()));
-                } else if (location.startsWith(startString)) {
-                    newLocation = uriParts.buildFor(FORWARD_URI_PART + location.substring(startString.length()));
-                } else {
-                    startString = "/";
-                    if (location.startsWith(startString)) {
-                        newLocation = uriParts.buildFor(FORWARD_URI_PART + location.substring(startString.length()));
-                    }
-                }
+                String newLocation = page == null
+                        ? proxyRedirectTarget(location, retailUrl, connection.isLoggedIn(), uriParts)
+                        : target == null ? null : target.servletPath(uriParts);
                 if (newLocation != null) {
                     logger.debug("Redirect mapped from {} to {}", location, newLocation);
                     resp.sendRedirect(newLocation);
@@ -425,25 +446,68 @@ public class AmazonEchoControlServlet extends HttpServlet {
                 returnError(resp, uriParts, "Invalid redirect to '" + location + "'");
                 return;
             }
-            returnHtml(resp, uriParts, response.content(), retailDomain);
+            String linkBase = page == null ? uriParts.buildFor("/") : page.linkBase(uriParts);
+            returnHtml(resp, uriParts, response.content(), host, linkBase);
         } catch (ConnectionException e) {
             returnError(resp, uriParts, e.getLocalizedMessage());
         }
     }
 
-    private void returnHtml(HttpServletResponse resp, ServletUri uriParts, String html, String retailDomain)
+    /** the sign-in host first, the account's retail host last */
+    static List<String> dialogHosts(String retailUrl) {
+        String retailHost;
+        try {
+            retailHost = URI.create(retailUrl).getHost();
+        } catch (IllegalArgumentException e) {
+            retailHost = null;
+        }
+        if (retailHost == null || SIGN_IN_HOST.equalsIgnoreCase(retailHost)) {
+            return List.of(SIGN_IN_HOST);
+        }
+        return List.of(SIGN_IN_HOST, retailHost.toLowerCase(Locale.ROOT));
+    }
+
+    static @Nullable String proxyRedirectTarget(String location, String retailUrl, boolean loggedIn,
+            ServletUri uriParts) {
+        String retailUrlWithSlash = retailUrl + "/";
+        if (loggedIn && location.startsWith(retailUrlWithSlash)) {
+            return uriParts.buildFor(PROXY_URI_PART + location.substring(retailUrlWithSlash.length()));
+        }
+        return null;
+    }
+
+    private void returnHtml(HttpServletResponse resp, ServletUri uriParts, String html, String host, String linkBase)
             throws IOException {
-        String servletUrl = uriParts.buildFor("/");
-        String resultHtml = html.replace("action=\"/", "action=\"" + servletUrl)
-                .replace("action=\"&#x2F;", "action=\"" + servletUrl)
-                .replace("https://www." + retailDomain + "/", servletUrl)
-                .replace("https://www." + retailDomain + ":443" + "/", servletUrl)
-                .replace("https:&#x2F;&#x2F;www." + retailDomain + "&#x2F;", servletUrl)
-                .replace("https:&#x2F;&#x2F;www." + retailDomain + ":443" + "&#x2F;", servletUrl)
-                .replace("http://www." + retailDomain + "/", servletUrl)
-                .replace("http:&#x2F;&#x2F;www." + retailDomain + "&#x2F;", servletUrl);
         resp.addHeader(HttpHeader.CONTENT_TYPE.asString(), MimeTypes.Type.TEXT_HTML_UTF_8.asString());
-        resp.getWriter().write(resultHtml);
+        resp.getWriter().write(rewriteLinks(html, host, linkBase));
+    }
+
+    static String rewriteLinks(String html, String host, String linkBase) {
+        Matcher matcher = LINK_TARGET.matcher(html);
+        StringBuilder rewritten = new StringBuilder();
+        while (matcher.find()) {
+            matcher.appendReplacement(rewritten, Matcher.quoteReplacement(
+                    matcher.group(1) + "=\"" + rewriteLinkTarget(matcher.group(2), host, linkBase) + "\""));
+        }
+        matcher.appendTail(rewritten);
+        return rewritten.toString();
+    }
+
+    private static String rewriteLinkTarget(String target, String host, String linkBase) {
+        for (String prefix : List.of("https://" + host + "/", "https://" + host + ":443/", "http://" + host + "/",
+                "https:&#x2F;&#x2F;" + host + "&#x2F;", "https:&#x2F;&#x2F;" + host + ":443&#x2F;",
+                "http:&#x2F;&#x2F;" + host + "&#x2F;")) {
+            if (target.startsWith(prefix)) {
+                return linkBase + target.substring(prefix.length());
+            }
+        }
+        if (target.startsWith("/") && !target.startsWith("//")) {
+            return linkBase + target.substring(1);
+        }
+        if (target.startsWith("&#x2F;") && !target.startsWith("&#x2F;&#x2F;")) {
+            return linkBase + target.substring("&#x2F;".length());
+        }
+        return target;
     }
 
     void returnError(HttpServletResponse resp, @Nullable ServletUri uriParts, @Nullable String errorMessage)

--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/LoginDialogPage.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/LoginDialogPage.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.amazonechocontrol.internal;
+
+import java.net.URI;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Collection;
+import java.util.Locale;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
+/**
+ * The {@link LoginDialogPage} is one page of Amazon's login dialog as the servlet forwards it to the browser, addressed
+ * as {@code /FORWARD/<host>/<pathAndQuery>} below the account path. The dialog starts on
+ * {@link AmazonEchoControlBindingConstants#SIGN_IN_HOST} and may continue on the account's retail host; pages on any
+ * other host are not forwarded.
+ *
+ * @author Martin Littkovsky - Initial contribution
+ */
+@NonNullByDefault
+record LoginDialogPage(String host, String pathAndQuery) {
+    static final String FORWARD_URI_PART = "/FORWARD/";
+    private static final String SCHEME = "https";
+
+    static LoginDialogPage signIn() {
+        return new LoginDialogPage(AmazonEchoControlBindingConstants.SIGN_IN_HOST, "/ap/signin");
+    }
+
+    static @Nullable LoginDialogPage fromRequest(String request, Collection<String> dialogHosts) {
+        if (!request.startsWith(FORWARD_URI_PART)) {
+            return null;
+        }
+        String hostAndPath = request.substring(FORWARD_URI_PART.length());
+        int pathStart = hostAndPath.indexOf('/');
+        String host = pathStart < 0 ? hostAndPath : hostAndPath.substring(0, pathStart);
+        String pathAndQuery = pathStart < 0 ? "/" : hostAndPath.substring(pathStart);
+        return dialogHosts.contains(host) ? new LoginDialogPage(host, pathAndQuery) : null;
+    }
+
+    static @Nullable LoginDialogPage fromLocation(String location, LoginDialogPage current,
+            Collection<String> dialogHosts) {
+        if (location.startsWith("/") && !location.startsWith("//")) {
+            return new LoginDialogPage(current.host, location);
+        }
+        URI uri;
+        try {
+            uri = URI.create(location);
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
+        String host = uri.getHost();
+        if (host == null || uri.getUserInfo() != null || !SCHEME.equalsIgnoreCase(uri.getScheme())
+                || (uri.getPort() != -1 && uri.getPort() != 443)) {
+            return null;
+        }
+        host = host.toLowerCase(Locale.ROOT);
+        if (!dialogHosts.contains(host)) {
+            return null;
+        }
+        String path = uri.getRawPath().isEmpty() ? "/" : uri.getRawPath();
+        String query = uri.getRawQuery();
+        return new LoginDialogPage(host, query == null ? path : path + "?" + query);
+    }
+
+    /**
+     * Amazon echoes rewritten links back as data (a hidden {@code openid.return_to}, a query parameter, a redirect), so
+     * everything that goes back to Amazon is translated to the page URL first
+     */
+    static String unrewrite(String text, ServletUri uriParts) {
+        String forwardBase = uriParts.buildFor(FORWARD_URI_PART);
+        String originPrefix = SCHEME + "://";
+        return text.replace(forwardBase, originPrefix).replace(URLEncoder.encode(forwardBase, StandardCharsets.UTF_8),
+                URLEncoder.encode(originPrefix, StandardCharsets.UTF_8));
+    }
+
+    String origin() {
+        return SCHEME + "://" + host;
+    }
+
+    String url() {
+        return origin() + pathAndQuery;
+    }
+
+    String servletPath(ServletUri uriParts) {
+        return uriParts.buildFor(FORWARD_URI_PART + host + pathAndQuery);
+    }
+
+    /** the servlet path that links of this page are rewritten to, so that they stay on the page's host */
+    String linkBase(ServletUri uriParts) {
+        return uriParts.buildFor(FORWARD_URI_PART + host + "/");
+    }
+}

--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/connection/Connection.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/connection/Connection.java
@@ -135,6 +135,7 @@ import com.google.gson.JsonObject;
 public class Connection {
     private static final String THING_THREADPOOL_NAME = "thingHandler";
     private static final long EXPIRES_IN = 432000; // five days
+    private static final String SIGN_IN_URL = "https://" + AmazonEchoControlBindingConstants.SIGN_IN_HOST;
     // Amazon answers /api/notifications with 400 ThrottlingException for the app agent the binding otherwise
     // sends, and with 200 for a browser agent; a quiet window of hours does not clear the 400.
     private static final String NOTIFICATIONS_USER_AGENT = "Mozilla/5.0 (iPhone; CPU iPhone OS 16_6 like Mac OS X) "
@@ -299,8 +300,8 @@ public class Connection {
 
     public boolean registerConnectionAsApp(String accessToken) {
         try {
-            List<CookieTO> webSiteCookies = cookieManager.getCookieStore().get(URI.create("https://www.amazon.com"))
-                    .stream().map(TOMapper::mapCookie).toList();
+            List<CookieTO> webSiteCookies = cookieManager.getCookieStore().get(URI.create(SIGN_IN_URL)).stream()
+                    .map(TOMapper::mapCookie).toList();
 
             AuthRegisterTO registerAppRequest = new AuthRegisterTO();
             registerAppRequest.registrationData.deviceSerial = loginData.getSerial();
@@ -448,7 +449,7 @@ public class Connection {
         return loginData.getLoginTime() != null;
     }
 
-    public String getLoginPage() throws ConnectionException {
+    public String getLoginPage(Map<String, String> browserHeaders) throws ConnectionException {
         // clear session data
         logout(false);
 
@@ -457,12 +458,11 @@ public class Connection {
         String mapMdJson = "{\"device_user_dictionary\":[],\"device_registration_data\":{\"software_version\":\"1\"},\"app_identifier\":{\"app_version\":\"2.2.443692\",\"bundle_id\":\"com.amazon.echo\"}}";
         String mapMdCookie = Base64.getEncoder().encodeToString(mapMdJson.getBytes());
 
-        cookieManager.getCookieStore().add(URI.create("https://www.amazon.com"), new HttpCookie("map-md", mapMdCookie));
-        cookieManager.getCookieStore().add(URI.create("https://www.amazon.com"),
-                new HttpCookie("frc", loginData.getFrc()));
+        cookieManager.getCookieStore().add(URI.create(SIGN_IN_URL), new HttpCookie("map-md", mapMdCookie));
+        cookieManager.getCookieStore().add(URI.create(SIGN_IN_URL), new HttpCookie("frc", loginData.getFrc()));
 
-        String url = "https://www.amazon.com/ap/signin" //
-                + "?openid.return_to=https://www.amazon.com/ap/maplanding" //
+        String url = SIGN_IN_URL + "/ap/signin" //
+                + "?openid.return_to=" + SIGN_IN_URL + "/ap/maplanding" //
                 + "&openid.assoc_handle=amzn_dp_project_dee_ios" //
                 + "&openid.identity=http://specs.openid.net/auth/2.0/identifier_select" //
                 + "&pageId=amzn_dp_project_dee_ios" //
@@ -476,7 +476,8 @@ public class Connection {
                 + "&openid.ns=http://specs.openid.net/auth/2.0&openid.pape.max_auth_age=0" //
                 + "&openid.oa2.scope=device_auth_access";
 
-        return requestBuilder.get(url).withHeader("authority", "www.amazon.com").syncSend(String.class);
+        return requestBuilder.get(url).withHeaders(browserHeaders)
+                .withHeader("authority", AmazonEchoControlBindingConstants.SIGN_IN_HOST).syncSend(String.class);
     }
 
     public boolean verifyLogin() throws ConnectionException {

--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/util/HttpRequestBuilder.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/util/HttpRequestBuilder.java
@@ -28,6 +28,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Semaphore;
@@ -45,6 +46,7 @@ import org.eclipse.jetty.client.api.Result;
 import org.eclipse.jetty.client.util.BufferingResponseListener;
 import org.eclipse.jetty.client.util.BytesContentProvider;
 import org.eclipse.jetty.http.HttpFields;
+import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpMethod;
 import org.eclipse.jetty.http.HttpStatus;
 import org.openhab.binding.amazonechocontrol.internal.ConnectionException;
@@ -104,16 +106,20 @@ public class HttpRequestBuilder {
         return new Builder(httpMethod, uriString);
     }
 
+    private static Optional<String> customHeader(RequestParams params, HttpHeader header) {
+        return params.customHeaders().entrySet().stream().filter(entry -> header.is(entry.getKey()))
+                .map(Map.Entry::getValue).filter(value -> !value.isBlank()).findFirst();
+    }
+
     private void createRequest(URI uri, RequestParams params, HttpResponseListener responseListener) {
         Request request = httpClient.newRequest(uri).method(params.method());
-        request.header(ACCEPT_LANGUAGE, "en-US");
+        request.header(ACCEPT_LANGUAGE, customHeader(params, ACCEPT_LANGUAGE).orElse("en-US"));
         request.header("DNT", "1");
         request.header("Upgrade-Insecure-Requests", "1");
-        String customUserAgent = params.customHeaders().entrySet().stream()
-                .filter(header -> USER_AGENT.is(header.getKey())).map(Map.Entry::getValue).findFirst().orElse("");
-        request.agent(customUserAgent.isBlank() ? DEFAULT_USER_AGENT : customUserAgent);
+        request.agent(customHeader(params, USER_AGENT).orElse(DEFAULT_USER_AGENT));
         params.customHeaders().entrySet().stream()
-                .filter(header -> !header.getValue().isBlank() && !USER_AGENT.is(header.getKey()))
+                .filter(header -> !header.getValue().isBlank() && !USER_AGENT.is(header.getKey())
+                        && !ACCEPT_LANGUAGE.is(header.getKey()))
                 .forEach(header -> request.header(header.getKey(), header.getValue()));
 
         // handle re-directs in response listener manually

--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/util/HttpRequestBuilder.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/util/HttpRequestBuilder.java
@@ -383,9 +383,11 @@ public class HttpRequestBuilder {
                 logger.debug("Redirected to {}", location);
                 if (!autoRedirect) {
                     httpResponse.complete(new HttpResponse(responseStatus, headers, content));
+                    return;
                 }
                 if (redirectCounter == 0) {
                     httpResponse.completeExceptionally(new ConnectionException("Too many redirects"));
+                    return;
                 }
                 createRequest(URI.create(location), params,
                         new HttpResponseListener(this, retryCounter, redirectCounter - 1));

--- a/bundles/org.openhab.binding.amazonechocontrol/src/test/java/org/openhab/binding/amazonechocontrol/internal/AmazonEchoControlServletTest.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/test/java/org/openhab/binding/amazonechocontrol/internal/AmazonEchoControlServletTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.amazonechocontrol.internal;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jetty.http.HttpMethod;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The {@link AmazonEchoControlServletTest} contains tests for the login dialog handling of the
+ * {@link AmazonEchoControlServlet}
+ *
+ * @author Martin Littkovsky - Initial contribution
+ */
+@NonNullByDefault
+public class AmazonEchoControlServletTest {
+    private static final ServletUri ACCOUNT = new ServletUri("account1", "");
+    private static final String RETAIL_URL = "https://www.amazon.de";
+    private static final String SIGN_IN_LINK_BASE = "/amazonechocontrol/account1/FORWARD/www.amazon.com/";
+
+    @Test
+    public void testTheDialogHostsAreTheSignInHostAndTheRetailHost() {
+        assertThat(AmazonEchoControlServlet.dialogHosts(RETAIL_URL), contains("www.amazon.com", "www.amazon.de"));
+        assertThat(AmazonEchoControlServlet.dialogHosts("https://WWW.Amazon.DE"),
+                contains("www.amazon.com", "www.amazon.de"));
+        assertThat(AmazonEchoControlServlet.dialogHosts("https://www.amazon.com"), contains("www.amazon.com"));
+        assertThat(AmazonEchoControlServlet.dialogHosts("amazon.de"), contains("www.amazon.com"));
+        assertThat(AmazonEchoControlServlet.dialogHosts("http://exa mple"), contains("www.amazon.com"));
+    }
+
+    @Test
+    public void testAProxyRedirectOnTheRetailHostStaysOnTheProxyWhileLoggedIn() {
+        String target = AmazonEchoControlServlet.proxyRedirectTarget(RETAIL_URL + "/spa/index.html?x=1", RETAIL_URL,
+                true, ACCOUNT);
+        assertThat(target, is("/amazonechocontrol/account1/PROXY/spa/index.html?x=1"));
+    }
+
+    @Test
+    public void testOtherProxyRedirectsAreRefused() {
+        assertThat(AmazonEchoControlServlet.proxyRedirectTarget(RETAIL_URL + "/spa/index.html", RETAIL_URL, false,
+                ACCOUNT), is(nullValue()));
+        assertThat(AmazonEchoControlServlet.proxyRedirectTarget("https://www.amazon.com/ap/signin", RETAIL_URL, true,
+                ACCOUNT), is(nullValue()));
+        assertThat(AmazonEchoControlServlet.proxyRedirectTarget("/api/devices-v2/device", RETAIL_URL, true, ACCOUNT),
+                is(nullValue()));
+    }
+
+    @Test
+    public void testTheBrowsersIdentityIsPassedOnAndThePageOriginIsTheReferer() {
+        HttpServletRequest req = mock(HttpServletRequest.class);
+        when(req.getHeader("User-Agent")).thenReturn("Mozilla/5.0 (Windows NT 10.0) Chrome/140.0");
+        when(req.getHeader("Accept-Language")).thenReturn("de-DE,de;q=0.9");
+        LoginDialogPage page = new LoginDialogPage("www.amazon.com", "/ap/signin");
+
+        Map<String, String> get = AmazonEchoControlServlet.browserHeaders(req, page, HttpMethod.GET);
+        assertThat(get, is(Map.of("User-Agent", "Mozilla/5.0 (Windows NT 10.0) Chrome/140.0", "Accept-Language",
+                "de-DE,de;q=0.9", "Referer", "https://www.amazon.com")));
+
+        Map<String, String> post = AmazonEchoControlServlet.browserHeaders(req, page, HttpMethod.POST);
+        assertThat(post.get("Origin"), is("https://www.amazon.com"));
+        assertThat(post.get("Referer"), is("https://www.amazon.com"));
+
+        assertThat(AmazonEchoControlServlet.browserHeaders(req).keySet(), contains("User-Agent", "Accept-Language"));
+    }
+
+    @Test
+    public void testMissingBrowserHeadersAreLeftToTheDefaults() {
+        HttpServletRequest req = mock(HttpServletRequest.class);
+        when(req.getHeader("Accept-Language")).thenReturn(" ");
+
+        assertThat(AmazonEchoControlServlet.browserHeaders(req), is(Map.of()));
+    }
+
+    @Test
+    public void testDataAttributesAreNotRewrittenAndFormactionIs() {
+        String html = "<a data-href=\"/x\" href=\"/y\">1</a><button formaction=\"/z\">2</button>";
+        assertThat(AmazonEchoControlServlet.rewriteLinks(html, "www.amazon.com", SIGN_IN_LINK_BASE),
+                is("<a data-href=\"/x\" href=\"" + SIGN_IN_LINK_BASE + "y\">1</a><button formaction=\""
+                        + SIGN_IN_LINK_BASE + "z\">2</button>"));
+    }
+
+    @Test
+    public void testOnlyLinkAndFormTargetsOfThePageHostAreRewritten() {
+        String html = "<form action=\"/ap/signin\"><a href=\"https://www.amazon.com/ap/forgotpassword\">x</a>"
+                + "<a HREF=\"https:&#x2F;&#x2F;www.amazon.com&#x2F;gp&#x2F;help\">y</a>"
+                + "<a href=\"https://www.amazon.com:443/gp/css\">z</a>" + "<a href=\"/gp/help\">root relative</a>"
+                + "<a href=\"//evil.example/x\">protocol relative</a>"
+                + "<a href=\"https://www.amazon.de/ap/signin\">other host</a>"
+                + "<input type=\"hidden\" name=\"openid.return_to\" value=\"https://www.amazon.com/ap/maplanding\"/>"
+                + "<script>var u = \"https://www.amazon.com/ap/x\";</script>";
+        String rewritten = AmazonEchoControlServlet.rewriteLinks(html, "www.amazon.com", SIGN_IN_LINK_BASE);
+        assertThat(rewritten, is("<form action=\"" + SIGN_IN_LINK_BASE + "ap/signin\"><a href=\"" + SIGN_IN_LINK_BASE
+                + "ap/forgotpassword\">x</a><a HREF=\"" + SIGN_IN_LINK_BASE + "gp&#x2F;help\">y</a>" + "<a href=\""
+                + SIGN_IN_LINK_BASE + "gp/css\">z</a>" + "<a href=\"" + SIGN_IN_LINK_BASE
+                + "gp/help\">root relative</a>" + "<a href=\"//evil.example/x\">protocol relative</a>"
+                + "<a href=\"https://www.amazon.de/ap/signin\">other host</a>"
+                + "<input type=\"hidden\" name=\"openid.return_to\" value=\"https://www.amazon.com/ap/maplanding\"/>"
+                + "<script>var u = \"https://www.amazon.com/ap/x\";</script>"));
+    }
+}

--- a/bundles/org.openhab.binding.amazonechocontrol/src/test/java/org/openhab/binding/amazonechocontrol/internal/LoginDialogPageTest.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/test/java/org/openhab/binding/amazonechocontrol/internal/LoginDialogPageTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.amazonechocontrol.internal;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * The {@link LoginDialogPageTest} contains tests for the {@link LoginDialogPage} record
+ *
+ * @author Martin Littkovsky - Initial contribution
+ */
+@NonNullByDefault
+public class LoginDialogPageTest {
+    private static final List<String> HOSTS = List.of("www.amazon.com", "www.amazon.de");
+    private static final ServletUri ACCOUNT = new ServletUri("account1", "");
+    private static final LoginDialogPage SIGN_IN_PAGE = new LoginDialogPage("www.amazon.com", "/ap/signin");
+    private static final LoginDialogPage RETAIL_PAGE = new LoginDialogPage("www.amazon.de", "/ap/cvf/verify");
+
+    private static Stream<Arguments> testFromRequest() {
+        return Stream.of( //
+                Arguments.of("/FORWARD/www.amazon.com/ap/signin", new LoginDialogPage("www.amazon.com", "/ap/signin")), //
+                Arguments.of("/FORWARD/www.amazon.de/ap/cvf/verify?arb=1&openid.mode=checkid_setup",
+                        new LoginDialogPage("www.amazon.de", "/ap/cvf/verify?arb=1&openid.mode=checkid_setup")), //
+                Arguments.of("/FORWARD/www.amazon.de", new LoginDialogPage("www.amazon.de", "/")), //
+                Arguments.of("/FORWARD/www.amazon.com", new LoginDialogPage("www.amazon.com", "/")), //
+                Arguments.of("/FORWARD/WWW.AMAZON.COM/ap/signin", null), //
+                Arguments.of("/FORWARD/www.amazon.co.uk/ap/signin", null), //
+                Arguments.of("/FORWARD/na.account.amazon.com/ap/cvf/request", null), //
+                Arguments.of("/FORWARD/evil.example/ap/signin", null), //
+                Arguments.of("/FORWARD/www.amazon.com@evil.example/ap/signin", null), //
+                Arguments.of("/FORWARD/www.amazon.com:443/ap/signin", null), //
+                Arguments.of("/FORWARD/ap/signin", null), //
+                Arguments.of("/FORWARD/", null), //
+                Arguments.of("/ap/signin", null), //
+                Arguments.of("", null));
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    public void testFromRequest(String request, @Nullable LoginDialogPage expected) {
+        assertThat(request, LoginDialogPage.fromRequest(request, HOSTS), is(expected));
+    }
+
+    private static Stream<Arguments> testFromLocation() {
+        return Stream.of( //
+                Arguments.of("/ap/forgotpassword/reverification?arb=1", SIGN_IN_PAGE,
+                        new LoginDialogPage("www.amazon.com", "/ap/forgotpassword/reverification?arb=1")), //
+                Arguments.of("/ap/cvf/approval/poll", RETAIL_PAGE,
+                        new LoginDialogPage("www.amazon.de", "/ap/cvf/approval/poll")), //
+                Arguments.of("https://www.amazon.com/ap/cvf/transactionapproval?arb=2", RETAIL_PAGE,
+                        new LoginDialogPage("www.amazon.com", "/ap/cvf/transactionapproval?arb=2")), //
+                Arguments.of("https://www.amazon.de/ap/signin", SIGN_IN_PAGE,
+                        new LoginDialogPage("www.amazon.de", "/ap/signin")), //
+                Arguments.of("https://www.amazon.de/", SIGN_IN_PAGE, new LoginDialogPage("www.amazon.de", "/")), //
+                Arguments.of("https://www.amazon.de", SIGN_IN_PAGE, new LoginDialogPage("www.amazon.de", "/")), //
+                Arguments.of("https://www.amazon.de:443/ap/signin", SIGN_IN_PAGE,
+                        new LoginDialogPage("www.amazon.de", "/ap/signin")), //
+                Arguments.of("HTTPS://WWW.AMAZON.DE/ap/signin", SIGN_IN_PAGE,
+                        new LoginDialogPage("www.amazon.de", "/ap/signin")), //
+                Arguments.of("https://www.amazon.co.uk/ap/signin", SIGN_IN_PAGE, null), //
+                Arguments.of("https://na.account.amazon.com/ap/cvf/request", SIGN_IN_PAGE, null), //
+                Arguments.of("https://www.amazon.de.evil.example/ap/signin", SIGN_IN_PAGE, null), //
+                Arguments.of("https://www.amazon.com@evil.example/ap/signin", SIGN_IN_PAGE, null), //
+                Arguments.of("https://www.amazon.com:8443/ap/signin", SIGN_IN_PAGE, null), //
+                Arguments.of("http://www.amazon.com/ap/signin", SIGN_IN_PAGE, null), //
+                Arguments.of("//evil.example/ap/signin", SIGN_IN_PAGE, null), //
+                Arguments.of("ap/signin", SIGN_IN_PAGE, null), //
+                Arguments.of("https://www.amazon.com/ap/sig nin", SIGN_IN_PAGE, null), //
+                Arguments.of("", SIGN_IN_PAGE, null));
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    public void testFromLocation(String location, LoginDialogPage current, @Nullable LoginDialogPage expected) {
+        assertThat(location, LoginDialogPage.fromLocation(location, current, HOSTS), is(expected));
+    }
+
+    @Test
+    public void testEchoedServletPathsAreTranslatedBackToThePageUrl() {
+        String plain = "/amazonechocontrol/account1/FORWARD/www.amazon.com/ap/maplanding?openid.oa2.access_token=x";
+        assertThat(LoginDialogPage.unrewrite(plain, ACCOUNT),
+                is("https://www.amazon.com/ap/maplanding?openid.oa2.access_token=x"));
+        String encoded = "/ap/cvf/approval?openid.return_to=%2Famazonechocontrol%2Faccount1%2FFORWARD%2Fwww.amazon.com%2Fap%2Fsignin";
+        assertThat(LoginDialogPage.unrewrite(encoded, ACCOUNT),
+                is("/ap/cvf/approval?openid.return_to=https%3A%2F%2Fwww.amazon.com%2Fap%2Fsignin"));
+        assertThat(LoginDialogPage.unrewrite("https://www.amazon.com/ap/signin", ACCOUNT),
+                is("https://www.amazon.com/ap/signin"));
+        assertThat(LoginDialogPage.unrewrite("/amazonechocontrol/other/FORWARD/www.amazon.com/x", ACCOUNT),
+                is("/amazonechocontrol/other/FORWARD/www.amazon.com/x"));
+    }
+
+    @Test
+    public void testAddresses() {
+        LoginDialogPage page = new LoginDialogPage("www.amazon.de", "/ap/cvf/verify?arb=1");
+        assertThat(page.origin(), is("https://www.amazon.de"));
+        assertThat(page.url(), is("https://www.amazon.de/ap/cvf/verify?arb=1"));
+        assertThat(page.servletPath(ACCOUNT),
+                is("/amazonechocontrol/account1/FORWARD/www.amazon.de/ap/cvf/verify?arb=1"));
+        assertThat(page.linkBase(ACCOUNT), is("/amazonechocontrol/account1/FORWARD/www.amazon.de/"));
+        assertThat(LoginDialogPage.signIn().host(), is("www.amazon.com"));
+    }
+}

--- a/bundles/org.openhab.binding.amazonechocontrol/src/test/java/org/openhab/binding/amazonechocontrol/internal/util/HttpRequestBuilderTest.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/test/java/org/openhab/binding/amazonechocontrol/internal/util/HttpRequestBuilderTest.java
@@ -123,6 +123,24 @@ public class HttpRequestBuilderTest {
     }
 
     @Test
+    public void testARedirectIsHandedToTheCallerAndNotFollowedWhenAutoRedirectIsOff() throws Exception {
+        HttpClient httpClient = mock(HttpClient.class);
+        when(httpClient.newRequest(any(URI.class))).thenReturn(mock(Request.class, RETURNS_SELF));
+        HttpRequestBuilder requestBuilder = new HttpRequestBuilder(httpClient, new CookieManager(), new Gson());
+
+        HttpFields headers = new HttpFields();
+        headers.add("Location", "https://www.amazon.com/ap/cvf/request?arb=1");
+
+        CompletableFuture<HttpResponse> httpResponse = new CompletableFuture<>();
+        RequestParams params = new RequestParams(HttpMethod.POST, "email=x&password=y", false, Map.of());
+        requestBuilder.new HttpResponseListener(httpResponse, params, false, FailMode.RETRY)
+                .onComplete(resultWithStatus(302, headers));
+
+        verify(httpClient, never()).newRequest(any(URI.class));
+        assertThat(httpResponse.get().statusCode(), is(302));
+    }
+
+    @Test
     public void testACustomUserAgentReplacesTheClientAgentInsteadOfAddingASecondOne() {
         Request request = mock(Request.class, RETURNS_SELF);
 
@@ -158,11 +176,15 @@ public class HttpRequestBuilderTest {
     }
 
     private Result throttledResult(HttpFields headers) {
+        return resultWithStatus(400, headers);
+    }
+
+    private Result resultWithStatus(int status, HttpFields headers) {
         Request request = mock(Request.class);
         when(request.getURI()).thenReturn(REQUEST_URI);
         Response response = mock(Response.class);
         when(response.getRequest()).thenReturn(request);
-        when(response.getStatus()).thenReturn(400);
+        when(response.getStatus()).thenReturn(status);
         when(response.getHeaders()).thenReturn(headers);
         when(response.getReason()).thenReturn("Bad Request");
         Result result = mock(Result.class);

--- a/bundles/org.openhab.binding.amazonechocontrol/src/test/java/org/openhab/binding/amazonechocontrol/internal/util/HttpRequestBuilderTest.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/test/java/org/openhab/binding/amazonechocontrol/internal/util/HttpRequestBuilderTest.java
@@ -40,6 +40,7 @@ import org.eclipse.jetty.client.api.Request;
 import org.eclipse.jetty.client.api.Response;
 import org.eclipse.jetty.client.api.Result;
 import org.eclipse.jetty.http.HttpFields;
+import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpMethod;
 import org.junit.jupiter.api.Test;
 import org.openhab.binding.amazonechocontrol.internal.util.HttpRequestBuilder.FailMode;
@@ -161,12 +162,24 @@ public class HttpRequestBuilderTest {
     }
 
     @Test
+    public void testACustomAcceptLanguageReplacesTheDefaultInsteadOfAddingASecondOne() {
+        Request request = mock(Request.class, RETURNS_SELF);
+
+        requestBuilderFor(request).get(REQUEST_URI.toString()).withHeader("Accept-Language", "de-DE,de;q=0.9").send();
+
+        verify(request).header(HttpHeader.ACCEPT_LANGUAGE, "de-DE,de;q=0.9");
+        verify(request, never()).header(HttpHeader.ACCEPT_LANGUAGE, "en-US");
+        verify(request, never()).header(eq("Accept-Language"), anyString());
+    }
+
+    @Test
     public void testARequestWithoutAnOverrideKeepsTheAppUserAgent() {
         Request request = mock(Request.class, RETURNS_SELF);
 
         requestBuilderFor(request).get(REQUEST_URI.toString()).send();
 
         verify(request).agent(contains("AmazonWebView"));
+        verify(request).header(HttpHeader.ACCEPT_LANGUAGE, "en-US");
     }
 
     private HttpRequestBuilder requestBuilderFor(Request request) {


### PR DESCRIPTION
After a Logout on the servlet page, or once a stored session had expired, the re-login of a non-US account ended in a 404 as soon as Amazon interposed a verification page (`/ap/forgotpassword/reverification`, `/ap/cvf/...`). The dialog starts on `www.amazon.com`, but the servlet fetched every following page from the retail domain of the previous login, where those pages do not exist. Fresh installations were not affected, their retail domain still defaults to `amazon.com`.

- A dialog page is addressed as `/FORWARD/<host>/<path>` and stays on the host of the page that produced it. Absolute redirects are followed only to the sign-in host and the account's retail host (taken from `retailUrl`, `retailDomain` holds a host on some accounts), the `Location` header is parsed as a URI, and the `/ap/maplanding` token redirect is accepted from those two hosts only.
- Only `href`, `action` and `formaction` targets are rewritten, and everything sent back to Amazon is translated to the page URL first. Amazon echoes rewritten links back as data (`openid.return_to`), which doubled the path and ended in another 404. ioBroker's alexa-cookie fixed the same trap on 2026-08-15 ("do not replace amazon URLs inside parameters").
- Dialog requests carry the browser's `User-Agent` and `Accept-Language`, with `Referer` and `Origin` set to the page. Without them Amazon answered the sign-in post with "Enter a valid email or mobile number", while the same URL opened directly in the browser logged in fine. `HttpRequestBuilder` replaces its default `Accept-Language` when a custom one is given, as it already did for the user agent.
- `redirect(false)` in `HttpRequestBuilder` now really stops at the redirect. It handed the 3xx to the caller and followed it anyway, with the same method and body.
- `FORWARD` is refused while logged in, redirects of `PROXY` responses map only to the proxy, and root-relative links on dialog pages go through the servlet instead of restarting the login.

Testing: Logout on the servlet page, then sign in again with e-mail and password (or the Shopping App approval), the account page comes back ONLINE. With `log:set DEBUG org.openhab.binding.amazonechocontrol` every redirect shows up as `Redirect mapped from ... to /amazonechocontrol/<account>/FORWARD/www.amazon.com/...`. TRACE logs the form bodies including the password, so please do not post those. Test build for 5.2.x with everything merged since 5.2.0 plus #21561 and this PR: https://github.com/ML19821/openhab-addons/releases/tag/amazonechocontrol-all-fixes-test-6

@jaywiseman1971 (US account) and @DV-STUDIOS-DE (the German account from #21475), would you give this a try? Before the Logout, copy `userdata/jsondb/amazonechocontrol%3Aaccount%3A<your account>.json` aside: with openHAB stopped, putting it back restores the old session should anything go wrong.

Fixes #21475

**Transparency:** this patch and the comments on this PR were written with AI assistance (Claude); every commit carries an `AI-assisted-by` trailer. All changes were built, tested and verified on a production system by the author. Reviewed against wborn/github-review-policy at `ca8d3f4d0` (2026-08-19) before submission.

