### PR TITLE
[enphase] Add energy channels to inverter things

### DIFF
--- a/bundles/org.openhab.binding.enphase/README.md
+++ b/bundles/org.openhab.binding.enphase/README.md
@@ -90,11 +90,17 @@ The `wattHoursToday` and `wattHoursSevenDays` consumption channels are not avail
 
 The `inverter` thing has the following channels:
 
-| channel         | type         | description                          |
-|-----------------|--------------|--------------------------------------|
-| lastReportWatts | Number:Power | Last reported power delivery         |
-| maxReportWatts  | Number:Power | Maximum reported power               |
-| lastReportDate  | DateTime     | Date of last reported power delivery |
+| channel            | type          | description                           |
+|--------------------|---------------|---------------------------------------|
+| lastReportWatts    | Number:Power  | Last reported power delivery          |
+| maxReportWatts     | Number:Power  | Maximum reported power                |
+| lastReportDate     | DateTime      | Date of last reported power delivery  |
+| wattHoursToday     | Number:Energy | Watt hours produced today             |
+| wattHoursSevenDays | Number:Energy | Watt hours produced the last 7 days   |
+| wattHoursLifetime  | Number:Energy | Watt hours produced over the lifetime |
+| wattsNow           | Number:Power  | Latest watts produced                 |
+
+The `wattHoursToday`, `wattHoursSevenDays`, `wattHoursLifetime` and `wattsNow` inverter channels are only available if the Envoy gateway supports the per-device energy data endpoint.
 
 The following channels are only available if supported by the Envoy gateway:
 
@@ -136,9 +142,13 @@ Number:Energy envoyWattHoursToday    "Watt Hours Today [%d %unit%]"   { channel=
 Number:Energy envoyWattHours7Days    "Watt Hours 7 Days [%.1f kWh]"   { channel="enphase:envoy:789012:production#wattHoursSevenDays" }
 Number:Energy envoyWattHoursLifetime "Watt Hours Lifetime [%.1f kWh]" { channel="enphase:envoy:789012:production#wattHoursLifetime" }
 
-Number:Power i1LastReportWatts "Last Report [%d %unit%]"                          { channel="enphase:inverter:789012:123456:lastReportWatts" }
-Number:Power i1MaxReportWatts  "Max Report [%d %unit%]"                           { channel="enphase:inverter:789012:123456:maxReportWatts" }
-DateTime     i1LastReportDate  "Last Report Date [%1$tY-%1$tm-%1$td %1$tH:%1$tM]" { channel="enphase:inverter:789012:123456:lastReportDate" }
+Number:Power  i1LastReportWatts    "Last Report [%d %unit%]"                          { channel="enphase:inverter:789012:123456:lastReportWatts" }
+Number:Power  i1MaxReportWatts     "Max Report [%d %unit%]"                           { channel="enphase:inverter:789012:123456:maxReportWatts" }
+DateTime      i1LastReportDate     "Last Report Date [%1$tY-%1$tm-%1$td %1$tH:%1$tM]" { channel="enphase:inverter:789012:123456:lastReportDate" }
+Number:Energy i1WattHoursToday     "Watt Hours Today [%d %unit%]"                     { channel="enphase:inverter:789012:123456:wattHoursToday" }
+Number:Energy i1WattHoursSevenDays "Watt Hours 7 Days [%.1f kWh]"                    { channel="enphase:inverter:789012:123456:wattHoursSevenDays" }
+Number:Energy i1WattHoursLifetime  "Watt Hours Lifetime [%.1f kWh]"                   { channel="enphase:inverter:789012:123456:wattHoursLifetime" }
+Number:Power  i1WattsNow           "Watts Now [%d %unit%]"                            { channel="enphase:inverter:789012:123456:wattsNow" }
 
 Number:Power i2LastReportWatts "Last Report [%d %unit%]"                          { channel="enphase:inverter:789012:223456:lastReportWatts" }
 Number:Power i21MaxReportWatts "Max Report [%d %unit%]"                           { channel="enphase:inverter:789012:223456:maxReportWatts" }

--- a/bundles/org.openhab.binding.enphase/src/main/java/org/openhab/binding/enphase/internal/EnphaseBindingConstants.java
+++ b/bundles/org.openhab.binding.enphase/src/main/java/org/openhab/binding/enphase/internal/EnphaseBindingConstants.java
@@ -21,6 +21,7 @@ import org.openhab.core.thing.ThingTypeUID;
  * used across the whole binding.
  *
  * @author Hilbrand Bouwkamp - Initial contribution
+ * @author Cedric Boon - Added support for detailed inverter stats
  */
 @NonNullByDefault
 public class EnphaseBindingConstants {
@@ -58,6 +59,10 @@ public class EnphaseBindingConstants {
     public static final String INVERTER_CHANNEL_LAST_REPORT_WATTS = "lastReportWatts";
     public static final String INVERTER_CHANNEL_MAX_REPORT_WATTS = "maxReportWatts";
     public static final String INVERTER_CHANNEL_LAST_REPORT_DATE = "lastReportDate";
+    public static final String INVERTER_CHANNEL_WATT_HOURS_TODAY = "wattHoursToday";
+    public static final String INVERTER_CHANNEL_WATT_HOURS_SEVEN_DAYS = "wattHoursSevenDays";
+    public static final String INVERTER_CHANNEL_WATT_HOURS_LIFETIME = "wattHoursLifetime";
+    public static final String INVERTER_CHANNEL_WATTS_NOW = "wattsNow";
 
     // Relay channels
     public static final String RELAY_CHANNEL_RELAY = "relay";

--- a/bundles/org.openhab.binding.enphase/src/main/java/org/openhab/binding/enphase/internal/dto/PdmDeviceDataDTO.java
+++ b/bundles/org.openhab.binding.enphase/src/main/java/org/openhab/binding/enphase/internal/dto/PdmDeviceDataDTO.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.enphase.internal.dto;
+
+/**
+ * Data class for a single device entry of the Envoy {@code /ivp/pdm/device_data} response.
+ *
+ * @author Cedric Boon - Added support for detailed inverter stats
+ */
+public class PdmDeviceDataDTO {
+
+    public static class WattHoursDTO {
+        public int today;
+        public int week;
+    }
+
+    public static class WattsDTO {
+        public int now;
+    }
+
+    public static class LifetimeDTO {
+        public long joulesProduced;
+    }
+
+    public static class ChannelDataDTO {
+        public WattHoursDTO wattHours;
+        public WattsDTO watts;
+        public LifetimeDTO lifetime;
+    }
+
+    public String sn;
+    public ChannelDataDTO[] channels;
+}

--- a/bundles/org.openhab.binding.enphase/src/main/java/org/openhab/binding/enphase/internal/handler/EnphaseInverterHandler.java
+++ b/bundles/org.openhab.binding.enphase/src/main/java/org/openhab/binding/enphase/internal/handler/EnphaseInverterHandler.java
@@ -20,6 +20,8 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.enphase.internal.MessageTranslator;
 import org.openhab.binding.enphase.internal.dto.InverterDTO;
+import org.openhab.binding.enphase.internal.dto.PdmDeviceDataDTO;
+import org.openhab.binding.enphase.internal.dto.PdmDeviceDataDTO.ChannelDataDTO;
 import org.openhab.core.library.types.DateTimeType;
 import org.openhab.core.library.types.QuantityType;
 import org.openhab.core.library.unit.Units;
@@ -35,11 +37,15 @@ import org.openhab.core.types.UnDefType;
  * sent to one of the channels.
  *
  * @author Hilbrand Bouwkamp - Initial contribution
+ * @author Cedric Boon - Added support for detailed inverter stats
  */
 @NonNullByDefault
 public class EnphaseInverterHandler extends EnphaseDeviceHandler {
 
+    private static final int SECONDS_PER_HOUR = 3600;
+
     private @Nullable InverterDTO lastKnownState;
+    private @Nullable ChannelDataDTO lastKnownEnergyState;
 
     public EnphaseInverterHandler(final Thing thing, MessageTranslator messageTranslator) {
         super(thing, messageTranslator);
@@ -59,6 +65,18 @@ public class EnphaseInverterHandler extends EnphaseDeviceHandler {
                     break;
                 case INVERTER_CHANNEL_LAST_REPORT_DATE:
                     refreshLastReportDate(lastKnownState);
+                    break;
+                case INVERTER_CHANNEL_WATT_HOURS_TODAY:
+                    refreshWattHoursToday(lastKnownEnergyState);
+                    break;
+                case INVERTER_CHANNEL_WATT_HOURS_SEVEN_DAYS:
+                    refreshWattHoursSevenDays(lastKnownEnergyState);
+                    break;
+                case INVERTER_CHANNEL_WATT_HOURS_LIFETIME:
+                    refreshWattHoursLifetime(lastKnownEnergyState);
+                    break;
+                case INVERTER_CHANNEL_WATTS_NOW:
+                    refreshWattsNow(lastKnownEnergyState);
                     break;
                 default:
                     super.handleCommandRefresh(channelId);
@@ -93,5 +111,45 @@ public class EnphaseInverterHandler extends EnphaseDeviceHandler {
             state = new DateTimeType(Instant.ofEpochSecond(inverterDTO.lastReportDate));
         }
         updateState(INVERTER_CHANNEL_LAST_REPORT_DATE, state);
+    }
+
+    /**
+     * Updates the watt-hours today/7-days/lifetime and current watts channels from the Envoy per-device energy data
+     * ({@code /ivp/pdm/device_data}).
+     *
+     * @param deviceData the device data of this inverter, or null if not (yet) available.
+     */
+    public void refreshInverterEnergyChannels(final @Nullable PdmDeviceDataDTO deviceData) {
+        final ChannelDataDTO channel = deviceData == null || deviceData.channels == null
+                || deviceData.channels.length == 0 ? null : deviceData.channels[0];
+
+        refreshWattHoursToday(channel);
+        refreshWattHoursSevenDays(channel);
+        refreshWattHoursLifetime(channel);
+        refreshWattsNow(channel);
+        lastKnownEnergyState = channel;
+    }
+
+    private void refreshWattHoursToday(final @Nullable ChannelDataDTO channel) {
+        updateState(INVERTER_CHANNEL_WATT_HOURS_TODAY, channel == null || channel.wattHours == null ? UnDefType.UNDEF
+                : new QuantityType<>(channel.wattHours.today, Units.WATT_HOUR));
+    }
+
+    private void refreshWattHoursSevenDays(final @Nullable ChannelDataDTO channel) {
+        updateState(INVERTER_CHANNEL_WATT_HOURS_SEVEN_DAYS,
+                channel == null || channel.wattHours == null ? UnDefType.UNDEF
+                        : new QuantityType<>(channel.wattHours.week, Units.WATT_HOUR));
+    }
+
+    private void refreshWattHoursLifetime(final @Nullable ChannelDataDTO channel) {
+        updateState(INVERTER_CHANNEL_WATT_HOURS_LIFETIME,
+                channel == null || channel.lifetime == null ? UnDefType.UNDEF
+                        : new QuantityType<>(Math.round(channel.lifetime.joulesProduced / (double) SECONDS_PER_HOUR),
+                                Units.WATT_HOUR));
+    }
+
+    private void refreshWattsNow(final @Nullable ChannelDataDTO channel) {
+        updateState(INVERTER_CHANNEL_WATTS_NOW, channel == null || channel.watts == null ? UnDefType.UNDEF
+                : new QuantityType<>(channel.watts.now, Units.WATT));
     }
 }

--- a/bundles/org.openhab.binding.enphase/src/main/java/org/openhab/binding/enphase/internal/handler/EnvoyBridgeHandler.java
+++ b/bundles/org.openhab.binding.enphase/src/main/java/org/openhab/binding/enphase/internal/handler/EnvoyBridgeHandler.java
@@ -45,6 +45,7 @@ import org.openhab.binding.enphase.internal.discovery.EnphaseDevicesDiscoverySer
 import org.openhab.binding.enphase.internal.dto.EnvoyEnergyDTO;
 import org.openhab.binding.enphase.internal.dto.InventoryJsonDTO.DeviceDTO;
 import org.openhab.binding.enphase.internal.dto.InverterDTO;
+import org.openhab.binding.enphase.internal.dto.PdmDeviceDataDTO;
 import org.openhab.binding.enphase.internal.exception.EnphaseException;
 import org.openhab.binding.enphase.internal.exception.EntrezConnectionException;
 import org.openhab.binding.enphase.internal.exception.EntrezJwtInvalidException;
@@ -77,6 +78,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Thomas Hentschel - Initial contribution
  * @author Hilbrand Bouwkamp - Initial contribution
+ * @author Cedric Boon - Added support for detailed inverter stats
  */
 @NonNullByDefault
 public class EnvoyBridgeHandler extends BaseBridgeHandler {
@@ -103,10 +105,12 @@ public class EnvoyBridgeHandler extends BaseBridgeHandler {
     private int consecutiveConnectionErrors;
     private @Nullable ExpiringCache<Map<String, @Nullable InverterDTO>> invertersCache;
     private @Nullable ExpiringCache<Map<String, @Nullable DeviceDTO>> devicesCache;
+    private @Nullable ExpiringCache<Map<String, PdmDeviceDataDTO>> deviceDataCache;
     private @Nullable EnvoyEnergyDTO productionDTO;
     private @Nullable EnvoyEnergyDTO consumptionDTO;
     private FeatureStatus consumptionSupported = FeatureStatus.UNKNOWN;
     private FeatureStatus jsonSupported = FeatureStatus.UNKNOWN;
+    private FeatureStatus deviceDataSupported = FeatureStatus.UNKNOWN;
 
     public EnvoyBridgeHandler(final Bridge thing, final HttpClient httpClient,
             final EnvoyHostAddressCache envoyHostAddressCache) {
@@ -169,10 +173,13 @@ public class EnvoyBridgeHandler extends BaseBridgeHandler {
         updateStatus(ThingStatus.UNKNOWN);
         consumptionSupported = FeatureStatus.UNKNOWN;
         jsonSupported = FeatureStatus.UNKNOWN;
+        deviceDataSupported = FeatureStatus.UNKNOWN;
         invertersCache = new ExpiringCache<>(Duration.of(configuration.refresh, ChronoUnit.MINUTES),
                 this::refreshInverters);
         devicesCache = new ExpiringCache<>(Duration.of(configuration.refresh, ChronoUnit.MINUTES),
                 this::refreshDevices);
+        deviceDataCache = new ExpiringCache<>(Duration.of(configuration.refresh, ChronoUnit.MINUTES),
+                this::refreshDeviceData);
         connectorWrapper.setVersion(getVersion());
         updataDataFuture = scheduler.scheduleWithFixedDelay(() -> updateData(false), 0, configuration.refresh,
                 TimeUnit.MINUTES);
@@ -231,6 +238,38 @@ public class EnvoyBridgeHandler extends BaseBridgeHandler {
     }
 
     /**
+     * Method called by the ExpiringCache when no per-device energy data is present to get the data from the Envoy
+     * gateway. This data is not available on all envoy devices.
+     *
+     * @return the per-device energy data from the Envoy gateway, keyed by serial number, or null if no data is
+     *         available.
+     */
+    private @Nullable Map<String, PdmDeviceDataDTO> refreshDeviceData() {
+        try {
+            if (deviceDataSupported != FeatureStatus.UNSUPPORTED) {
+                final Map<String, PdmDeviceDataDTO> data = connectorWrapper.getConnector().getDeviceData();
+
+                deviceDataSupported = FeatureStatus.SUPPORTED;
+                return data;
+            }
+        } catch (final EnvoyNoHostnameException e) {
+            // ignore hostname exception here. It's already handled by others.
+        } catch (final EnvoyConnectionException e) {
+            if (deviceDataSupported == FeatureStatus.UNKNOWN) {
+                logger.info(
+                        "This Enphase Envoy device ({}) doesn't seem to support per-device energy data. So no inverter energy channels are set.",
+                        getThing().getUID());
+                deviceDataSupported = FeatureStatus.UNSUPPORTED;
+            } else {
+                logger.trace("refreshDeviceData connection problem", e);
+            }
+        } catch (final EnphaseException e) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, e.getMessage());
+        }
+        return null;
+    }
+
+    /**
      * Returns the data for the inverters. It get the data from cache or updates the cache if possible in case no data
      * is available.
      *
@@ -267,6 +306,26 @@ public class EnvoyBridgeHandler extends BaseBridgeHandler {
                 devicesCache.invalidateValue();
             }
             return devicesCache.getValue();
+        }
+    }
+
+    /**
+     * Returns the per-device energy data. It get the data from cache or updates the cache if possible in case no
+     * data is available.
+     *
+     * @param force force a cache refresh
+     * @return data if present or null
+     */
+    public @Nullable Map<String, PdmDeviceDataDTO> getDeviceData(final boolean force) {
+        final ExpiringCache<Map<String, PdmDeviceDataDTO>> deviceDataCache = this.deviceDataCache;
+
+        if (deviceDataCache == null || !isOnline()) {
+            return null;
+        } else {
+            if (force) {
+                deviceDataCache.invalidateValue();
+            }
+            return deviceDataCache.getValue();
         }
     }
 
@@ -396,22 +455,26 @@ public class EnvoyBridgeHandler extends BaseBridgeHandler {
      */
     private void updateInverters(final boolean forceUpdate) {
         final Map<String, @Nullable InverterDTO> inverters = getInvertersData(forceUpdate);
+        final Map<String, PdmDeviceDataDTO> deviceData = getDeviceData(forceUpdate);
 
         if (inverters != null) {
             getThing().getThings().stream().map(Thing::getHandler).filter(h -> h instanceof EnphaseInverterHandler)
                     .map(EnphaseInverterHandler.class::cast)
-                    .forEach(invHandler -> updateInverter(inverters, invHandler));
+                    .forEach(invHandler -> updateInverter(inverters, deviceData, invHandler));
         }
     }
 
     private void updateInverter(final @Nullable Map<String, @Nullable InverterDTO> inverters,
-            final EnphaseInverterHandler invHandler) {
+            final @Nullable Map<String, PdmDeviceDataDTO> deviceData, final EnphaseInverterHandler invHandler) {
         if (inverters == null) {
             return;
         }
         final InverterDTO inverterDTO = inverters.get(invHandler.getSerialNumber());
 
         invHandler.refreshInverterChannels(inverterDTO);
+        if (deviceData != null) {
+            invHandler.refreshInverterEnergyChannels(deviceData.get(invHandler.getSerialNumber()));
+        }
         if (jsonSupported == FeatureStatus.UNSUPPORTED) {
             // if inventory json is supported device status is set in #updateDevices
             invHandler.refreshDeviceStatus(inverterDTO != null);
@@ -449,7 +512,7 @@ public class EnvoyBridgeHandler extends BaseBridgeHandler {
     @Override
     public void childHandlerInitialized(final ThingHandler childHandler, final Thing childThing) {
         if (childHandler instanceof EnphaseInverterHandler handler) {
-            updateInverter(getInvertersData(false), handler);
+            updateInverter(getInvertersData(false), getDeviceData(false), handler);
         }
         if (childHandler instanceof EnphaseDeviceHandler handler) {
             final Map<String, @Nullable DeviceDTO> devices = getDevices(false);

--- a/bundles/org.openhab.binding.enphase/src/main/java/org/openhab/binding/enphase/internal/handler/EnvoyBridgeHandler.java
+++ b/bundles/org.openhab.binding.enphase/src/main/java/org/openhab/binding/enphase/internal/handler/EnvoyBridgeHandler.java
@@ -256,7 +256,7 @@ public class EnvoyBridgeHandler extends BaseBridgeHandler {
             // ignore hostname exception here. It's already handled by others.
         } catch (final EnvoyConnectionException e) {
             if (deviceDataSupported == FeatureStatus.UNKNOWN) {
-                logger.info(
+                logger.debug(
                         "This Enphase Envoy device ({}) doesn't seem to support per-device energy data. So no inverter energy channels are set.",
                         getThing().getUID());
                 deviceDataSupported = FeatureStatus.UNSUPPORTED;

--- a/bundles/org.openhab.binding.enphase/src/main/java/org/openhab/binding/enphase/internal/handler/EnvoyConnector.java
+++ b/bundles/org.openhab.binding.enphase/src/main/java/org/openhab/binding/enphase/internal/handler/EnvoyConnector.java
@@ -14,7 +14,9 @@ package org.openhab.binding.enphase.internal.handler;
 
 import java.net.URI;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -38,6 +40,7 @@ import org.openhab.binding.enphase.internal.dto.EnvoyEnergyDTO;
 import org.openhab.binding.enphase.internal.dto.EnvoyErrorDTO;
 import org.openhab.binding.enphase.internal.dto.InventoryJsonDTO;
 import org.openhab.binding.enphase.internal.dto.InverterDTO;
+import org.openhab.binding.enphase.internal.dto.PdmDeviceDataDTO;
 import org.openhab.binding.enphase.internal.dto.ProductionJsonDTO;
 import org.openhab.binding.enphase.internal.exception.EnphaseException;
 import org.openhab.binding.enphase.internal.exception.EnvoyConnectionException;
@@ -47,12 +50,15 @@ import org.slf4j.LoggerFactory;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
 import com.google.gson.JsonSyntaxException;
 
 /**
  * Methods to make API calls to the Envoy gateway.
  *
  * @author Hilbrand Bouwkamp - Initial contribution
+ * @author Cedric Boon - Added support for detailed inverter stats
  */
 @NonNullByDefault
 public class EnvoyConnector {
@@ -65,7 +71,9 @@ public class EnvoyConnector {
     private static final String PRODUCTION_URL = "/api/v1/production";
     private static final String CONSUMPTION_URL = "/api/v1/consumption";
     private static final String INVERTERS_URL = PRODUCTION_URL + "/inverters";
+    private static final String DEVICE_DATA_URL = "/ivp/pdm/device_data";
     private static final String INFO_XML = "/info.xml";
+    private static final String JSON_KEY_SERIAL_NUMBER = "sn";
 
     private static final String INFO_SOFTWARE_BEGIN = "<software>";
     private static final String INFO_SOFTWARE_END = "</software>";
@@ -203,6 +211,36 @@ public class EnvoyConnector {
             }
         }
         return retrieveData(INVERTERS_URL, json -> Arrays.asList(gson.fromJson(json, InverterDTO[].class)));
+    }
+
+    /**
+     * @return Returns the per-device energy data (watt-hours today/7-days, lifetime and current watts) for the
+     *         inverters and other Envoy devices, keyed by serial number.
+     */
+    public Map<String, PdmDeviceDataDTO> getDeviceData() throws EnphaseException {
+        return retrieveData(DEVICE_DATA_URL, this::jsonToDeviceData);
+    }
+
+    private @Nullable Map<String, PdmDeviceDataDTO> jsonToDeviceData(final String json) {
+        final JsonElement parsed = JsonParser.parseString(json);
+
+        if (!parsed.isJsonObject()) {
+            return null;
+        }
+        final Map<String, PdmDeviceDataDTO> result = new HashMap<>();
+
+        for (final Map.Entry<String, JsonElement> entry : parsed.getAsJsonObject().entrySet()) {
+            final JsonElement value = entry.getValue();
+
+            if (value.isJsonObject() && value.getAsJsonObject().has(JSON_KEY_SERIAL_NUMBER)) {
+                final @Nullable PdmDeviceDataDTO dto = gson.fromJson(value, PdmDeviceDataDTO.class);
+
+                if (dto != null) {
+                    result.put(dto.sn, dto);
+                }
+            }
+        }
+        return result;
     }
 
     protected synchronized <T> T retrieveData(final String urlPath, final Function<String, @Nullable T> jsonConverter)

--- a/bundles/org.openhab.binding.enphase/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.enphase/src/main/resources/OH-INF/thing/thing-types.xml
@@ -84,6 +84,10 @@
 			<channel id="lastReportWatts" typeId="last-report-watts"/>
 			<channel id="maxReportWatts" typeId="max-report-watts"/>
 			<channel id="lastReportDate" typeId="last-report-date"/>
+			<channel id="wattHoursToday" typeId="watt-hours-today"/>
+			<channel id="wattHoursSevenDays" typeId="watt-hours-seven-days"/>
+			<channel id="wattHoursLifetime" typeId="watt-hours-lifetime"/>
+			<channel id="wattsNow" typeId="watts-now"/>
 			<channel id="status" typeId="status"/>
 			<channel id="producing" typeId="producing"/>
 			<channel id="communicating" typeId="communicating"/>


### PR DESCRIPTION
## Description

This is an enhancement to the `inverter` thing: it adds the `wattHoursToday`,
`wattHoursSevenDays`, `wattHoursLifetime` and `wattsNow` channels, mirroring
the channels already available on the `envoy` bridge's `production` channel
group.

Previously the `inverter` thing only exposed `lastReportWatts`,
`maxReportWatts` and `lastReportDate` (from `/api/v1/production/inverters`).
That endpoint has no per-inverter energy totals. The new channels are
populated from the Envoy's `/ivp/pdm/device_data` endpoint, which returns
per-device watt-hours (today/week) and lifetime energy (in joules, converted
to watt-hours) and instantaneous watts, keyed by device serial number.

This endpoint is treated as an optional feature, the same way consumption
data and inventory data already are: if the Envoy doesn't support it, the
new channels simply stay undefined and the rest of the binding keeps
working as before.

The README has been updated with the new channels and example items.

## Testing

Tested against an Envoy running firmware D8.3.5289.

Built JAR for testing: https://github.com/cedricboon/openhab-addons/raw/refs/heads/enphase-inverters-detailed-data-compiled/bundles/org.openhab.binding.enphase/target/org.openhab.binding.enphase-5.3.0-SNAPSHOT.jar
