### PR TITLE
[amazonechocontrol] Browser agent on all notification calls

### DIFF
--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/connection/Connection.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/connection/Connection.java
@@ -56,6 +56,7 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.jetty.http.HttpHeader;
+import org.eclipse.jetty.http.HttpMethod;
 import org.openhab.binding.amazonechocontrol.internal.AmazonEchoControlBindingConstants;
 import org.openhab.binding.amazonechocontrol.internal.ConnectionException;
 import org.openhab.binding.amazonechocontrol.internal.dto.AscendingAlarmModelTO;
@@ -1406,16 +1407,18 @@ public class Connection {
         }
     }
 
+    private HttpRequestBuilder.Builder notificationsRequest(HttpMethod method, String subPath) {
+        return requestBuilder.builder(method, getAlexaServer() + "/api/notifications" + subPath)
+                .withHeader("User-Agent", NOTIFICATIONS_USER_AGENT);
+    }
+
     public List<NotificationTO> getNotifications() throws ConnectionException {
         // propagates the exception: an empty list is indistinguishable from "no notifications set"
-        return requestBuilder.get(getAlexaServer() + "/api/notifications")
-                .withHeader("User-Agent", NOTIFICATIONS_USER_AGENT)
-                .syncSend(NotificationListResponseTO.class).notifications;
+        return notificationsRequest(HttpMethod.GET, "").syncSend(NotificationListResponseTO.class).notifications;
     }
 
     public NotificationTO getNotification(String notificationId) throws ConnectionException {
-        String url = getAlexaServer() + "/api/notifications/" + notificationId;
-        return requestBuilder.get(url).syncSend(NotificationTO.class);
+        return notificationsRequest(HttpMethod.GET, "/" + notificationId).syncSend(NotificationTO.class);
     }
 
     public @Nullable NotificationTO createNotification(DeviceTO device, String type, @Nullable String label,
@@ -1441,13 +1444,13 @@ public class Connection {
         request.isSaveInFlight = true;
         request.isRecurring = false;
 
-        String url = getAlexaServer() + "/api/notifications/createReminder";
-        return requestBuilder.put(url).withContent(request).syncSend(NotificationTO.class);
+        return notificationsRequest(HttpMethod.PUT, "/createReminder").withContent(request)
+                .syncSend(NotificationTO.class);
     }
 
     public void deleteNotification(String notificationId) {
         try {
-            requestBuilder.delete(getAlexaServer() + "/api/notifications/" + notificationId).syncSend();
+            notificationsRequest(HttpMethod.DELETE, "/" + notificationId).syncSend();
         } catch (ConnectionException e) {
             logger.warn("Failed to delete notification {}: {}", notificationId, e.getMessage());
         }

--- a/bundles/org.openhab.binding.amazonechocontrol/src/test/java/org/openhab/binding/amazonechocontrol/internal/connection/ConnectionNotificationAgentTest.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/test/java/org/openhab/binding/amazonechocontrol/internal/connection/ConnectionNotificationAgentTest.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.amazonechocontrol.internal.connection;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.mockito.Answers.RETURNS_SELF;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.startsWith;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.net.URI;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.api.Request;
+import org.eclipse.jetty.client.api.Response;
+import org.eclipse.jetty.client.api.Result;
+import org.eclipse.jetty.client.util.BufferingResponseListener;
+import org.eclipse.jetty.http.HttpFields;
+import org.eclipse.jetty.http.HttpMethod;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.openhab.binding.amazonechocontrol.internal.ConnectionException;
+import org.openhab.binding.amazonechocontrol.internal.dto.DeviceTO;
+import org.openhab.binding.amazonechocontrol.internal.dto.NotificationTO;
+
+import com.google.gson.Gson;
+
+/**
+ * The {@link ConnectionNotificationAgentTest} checks that every request to Amazon's notifications API goes out with
+ * the browser user agent and the expected URL
+ *
+ * @author Martin Littkovsky - Initial contribution
+ */
+@NonNullByDefault
+@Timeout(10)
+public class ConnectionNotificationAgentTest {
+    private static final String BROWSER_AGENT_PREFIX = "Mozilla/5.0";
+    private static final String NOTIFICATIONS_URL = "https://alexa.amazon.com/api/notifications";
+    private static final String RESPONSE_BODY = "{\"id\":\"id\",\"notifications\":[]}";
+
+    private final HttpClient httpClient = mock(HttpClient.class);
+    private final Request request = mock(Request.class, RETURNS_SELF);
+    private @NonNullByDefault({}) Connection connection;
+
+    @BeforeEach
+    public void setUp() {
+        when(request.getURI()).thenReturn(URI.create(NOTIFICATIONS_URL));
+        doAnswer(invocation -> {
+            BufferingResponseListener listener = invocation.getArgument(0);
+            Response response = okJsonResponse();
+            listener.onHeaders(response);
+            listener.onContent(response, ByteBuffer.wrap(RESPONSE_BODY.getBytes(StandardCharsets.UTF_8)));
+            listener.onComplete(resultOf(response));
+            return null;
+        }).when(request).send(any(Response.CompleteListener.class));
+        when(httpClient.newRequest(any(URI.class))).thenReturn(request);
+        connection = new Connection(null, new Gson(), httpClient);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        connection.logout(false);
+    }
+
+    @Test
+    public void testPollingTheNotificationsSendsTheBrowserUserAgent() throws ConnectionException {
+        assertThat(connection.getNotifications(), is(empty()));
+
+        verify(httpClient).newRequest(URI.create(NOTIFICATIONS_URL));
+        verify(request).method(HttpMethod.GET);
+        verify(request).agent(startsWith(BROWSER_AGENT_PREFIX));
+    }
+
+    @Test
+    public void testReadingOneNotificationSendsTheBrowserUserAgent() throws ConnectionException {
+        assertThat(connection.getNotification("id").id, is("id"));
+
+        verify(httpClient).newRequest(URI.create(NOTIFICATIONS_URL + "/id"));
+        verify(request).method(HttpMethod.GET);
+        verify(request).agent(startsWith(BROWSER_AGENT_PREFIX));
+    }
+
+    @Test
+    public void testCreatingAReminderSendsTheBrowserUserAgent() throws ConnectionException {
+        DeviceTO device = new DeviceTO();
+        device.serialNumber = "SERIAL";
+        device.deviceType = "TYPE";
+
+        NotificationTO created = connection.createNotification(device, "Reminder", "test", null);
+
+        assertThat(created, is(notNullValue()));
+        verify(httpClient).newRequest(URI.create(NOTIFICATIONS_URL + "/createReminder"));
+        verify(request).method(HttpMethod.PUT);
+        verify(request).agent(startsWith(BROWSER_AGENT_PREFIX));
+    }
+
+    @Test
+    public void testDeletingANotificationSendsTheBrowserUserAgent() {
+        connection.deleteNotification("id");
+
+        verify(httpClient).newRequest(URI.create(NOTIFICATIONS_URL + "/id"));
+        verify(request).method(HttpMethod.DELETE);
+        verify(request).agent(startsWith(BROWSER_AGENT_PREFIX));
+    }
+
+    private Response okJsonResponse() {
+        HttpFields headers = new HttpFields();
+        headers.add("Content-Type", "application/json");
+        Response response = mock(Response.class);
+        when(response.getRequest()).thenReturn(request);
+        when(response.getStatus()).thenReturn(200);
+        when(response.getHeaders()).thenReturn(headers);
+        when(response.getReason()).thenReturn("OK");
+        return response;
+    }
+
+    private Result resultOf(Response response) {
+        Result result = mock(Result.class);
+        when(result.getResponse()).thenReturn(response);
+        return result;
+    }
+}


### PR DESCRIPTION
Amazon rejects the binding's app user agent on `/api/notifications` with 400 ThrottlingException. #21515 introduced the browser agent for that, but only on the poll. Creating a reminder, reading a single notification and deleting one still went out with the app agent, so `createReminder` failed with the same endpoint and status as in #19711. The `remind` channel needs all three steps, it creates the reminder, polls its status once a second and deletes it afterwards, and every step goes through the same throttled API.

- One helper builds every request to `/api/notifications` with the browser agent, the four callers use it.
- A test checks agent and URL for poll, single read, create and delete.

Verified before and after on a production system through the `remind` channel: with the app agent 400 ThrottlingException, with the browser agent Amazon creates and fires the reminder. Test build for 5.2.x with everything merged since 5.2.0, #21561, #21573 and this PR: https://github.com/ML19821/openhab-addons/releases/tag/amazonechocontrol-all-fixes-test-6

Fixes #19711

**Transparency:** this patch and the comments on this PR were written with AI assistance (Claude); every commit carries an `AI-assisted-by` trailer. All changes were built, tested and verified on a production system by the author. Reviewed against wborn/github-review-policy at `ca8d3f4d0` (2026-08-19) before submission.
