### PR TITLE
[unifi] Add sidebar entries to documentation #21290

### DIFF
--- a/bundles/org.openhab.binding.unifi/README.md
+++ b/bundles/org.openhab.binding.unifi/README.md
@@ -1,3 +1,10 @@
+---
+children:
+  - ["doc/network", "UniFi Network"]
+  - ["doc/protect", "UniFi Protect"]
+  - ["doc/access", "UniFi Access"]
+---
+
 # UniFi Binding
 
 The UniFi Binding integrates Ubiquiti UniFi devices into openHAB, covering the UniFi Network, UniFi Protect, and UniFi Access product families.


### PR DESCRIPTION
Adds sidebar children on the UniFi README so the Network, Protect, and Access pages show in the docs site nav. Same pattern as hue.

See #21290