### PR TITLE
[linky] Add sidebar entries to documentation #21290

### DIFF
--- a/bundles/org.openhab.binding.linky/README.md
+++ b/bundles/org.openhab.binding.linky/README.md
@@ -1,3 +1,9 @@
+---
+children:
+  - ["doc/myelectricaldata/index", "MyElectricalData"]
+  - ["doc/enedis/index", "Enedis"]
+---
+
 # Linky Binding
 
 This binding enables the exploitation of electricity consumption data, mainly for the French market.


### PR DESCRIPTION
Adds sidebar children on the Linky README so the MyElectricalData and Enedis setup pages show in the docs site nav. Same pattern as hue.

See #21290