### PR TITLE
[lutron] Add sidebar entries to documentation #21290

### DIFF
--- a/bundles/org.openhab.binding.lutron/README.md
+++ b/bundles/org.openhab.binding.lutron/README.md
@@ -1,3 +1,8 @@
+---
+children:
+  - ["doc/leapnotes", "Configuring LEAP Authentication"]
+---
+
 # Lutron Binding
 
 This binding integrates with [Lutron](https://www.lutron.com) lighting control and home automation systems.


### PR DESCRIPTION
Adds sidebar children on the Lutron README so the LEAP authentication page shows in the docs site nav. Same pattern as hue.

See #21290