### PR TITLE
[shelly] Add sidebar entries to documentation #21290

### DIFF
--- a/bundles/org.openhab.binding.shelly/README.md
+++ b/bundles/org.openhab.binding.shelly/README.md
@@ -1,3 +1,10 @@
+---
+children:
+  - ["doc/ShellyManager", "Shelly Manager"]
+  - ["doc/AdvancedUsers", "Advanced Users"]
+  - ["doc/UseCaseSmartRoller", "Smartify Roller Shutters with openHAB and Shelly"]
+---
+
 # Shelly Binding
 
 This Binding integrates [Shelly devices](https://shelly.cloud) developed by Allterco.


### PR DESCRIPTION
Adds sidebar children on the Shelly README so Shelly Manager, Advanced Users, and the roller shutter use case show in the docs site nav. Same pattern as hue.

See #21290