### PR TITLE
[smartthings] Add sidebar entries to documentation #21290

### DIFF
--- a/bundles/org.openhab.binding.smartthings/README.md
+++ b/bundles/org.openhab.binding.smartthings/README.md
@@ -1,3 +1,9 @@
+---
+children:
+  - ["doc/SmartthingsInstallation", "Installation of Smartthings code"]
+  - ["doc/Troubleshooting", "Smartthings Binding Troubleshooting Guidelines"]
+---
+
 # Samsung Smartthings Binding
 
 This binding integrates the Samsung Smartthings Hub into openHAB.


### PR DESCRIPTION
Adds sidebar children on the SmartThings README so the installation and troubleshooting pages show in the docs site nav. Same pattern as hue.

See #21290
