### PR TITLE
[amazonechocontrol] Fix status of Sonos media devices

### DIFF
--- a/bundles/org.openhab.binding.amazonechocontrol/README.md
+++ b/bundles/org.openhab.binding.amazonechocontrol/README.md
@@ -114,6 +114,8 @@ After configuration of the account thing with the login data, the echo devices r
 If the device type is not known by the binding, the device will not be discovered.
 But you can define any device listed in your Alexa app with the best matching existing device (e.g. echo).
 You will find the required serial number in settings of the device in the Alexa app.
+Sonos speakers appear twice in the account, once as family `THIRD_PARTY_AVS_SONOS_BOOTLEG` for voice and text and once as family `THIRD_PARTY_AVS_MEDIA_DISPLAY` for playback state and player control, the media entry only if the speaker has no built-in Alexa.
+Both serial numbers are listed on the account page of the binding at `http://<openhab>:8080/amazonechocontrol`, create one `echo` thing per entry you need.
 
 ### Discover Smart Home Devices
 

--- a/bundles/org.openhab.binding.amazonechocontrol/README.md
+++ b/bundles/org.openhab.binding.amazonechocontrol/README.md
@@ -114,8 +114,9 @@ After configuration of the account thing with the login data, the echo devices r
 If the device type is not known by the binding, the device will not be discovered.
 But you can define any device listed in your Alexa app with the best matching existing device (e.g. echo).
 You will find the required serial number in settings of the device in the Alexa app.
-Sonos speakers appear twice in the account, once as family `THIRD_PARTY_AVS_SONOS_BOOTLEG` for voice and text and once as family `THIRD_PARTY_AVS_MEDIA_DISPLAY` for playback state and player control, the media entry only if the speaker has no built-in Alexa.
-Both serial numbers are listed on the account page of the binding at `http://<openhab>:8080/amazonechocontrol`, create one `echo` thing per entry you need.
+Sonos speakers with built-in Alexa appear twice in the account: once as family `THIRD_PARTY_AVS_SONOS_BOOTLEG` for voice and text and once as family `THIRD_PARTY_AVS_MEDIA_DISPLAY` for playback state and player control.
+Sonos speakers without built-in Alexa have only the `THIRD_PARTY_AVS_MEDIA_DISPLAY` entry.
+The available serial numbers are listed on the account page of the binding at `http://<openhab>:8080/amazonechocontrol`; create one `echo` thing per entry you need.
 
 ### Discover Smart Home Devices
 

--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/AmazonEchoControlBindingConstants.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/AmazonEchoControlBindingConstants.java
@@ -99,6 +99,8 @@ public class AmazonEchoControlBindingConstants {
     public static final String CHANNEL_ACTIVE = "active";
     public static final String CHANNEL_PLAY_ON_DEVICE = "playOnDevice";
 
+    public static final String DEVICE_FAMILY_THIRD_PARTY_AVS_MEDIA_DISPLAY = "THIRD_PARTY_AVS_MEDIA_DISPLAY";
+
     // List of all Properties
     public static final String DEVICE_PROPERTY_SERIAL_NUMBER = "serialNumber";
     public static final String DEVICE_PROPERTY_FAMILY = "deviceFamily";

--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/handler/EchoHandler.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/handler/EchoHandler.java
@@ -168,12 +168,16 @@ public class EchoHandler extends BaseThingHandler {
 
         this.device = device;
         this.capabilities = device.capabilities;
-        if (!device.online) {
+        if (!device.online && !amazonAlwaysReportsOffline(device)) {
             updateStatus(ThingStatus.OFFLINE);
             return false;
         }
         updateStatus(ThingStatus.ONLINE);
         return true;
+    }
+
+    private static boolean amazonAlwaysReportsOffline(DeviceTO device) {
+        return DEVICE_FAMILY_THIRD_PARTY_AVS_MEDIA_DISPLAY.equals(device.deviceFamily);
     }
 
     @Override

--- a/bundles/org.openhab.binding.amazonechocontrol/src/test/java/org/openhab/binding/amazonechocontrol/internal/handler/EchoHandlerDeviceStatusTest.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/test/java/org/openhab/binding/amazonechocontrol/internal/handler/EchoHandlerDeviceStatusTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.amazonechocontrol.internal.handler;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.openhab.binding.amazonechocontrol.internal.AmazonEchoControlBindingConstants.DEVICE_FAMILY_THIRD_PARTY_AVS_MEDIA_DISPLAY;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.junit.jupiter.api.Test;
+import org.openhab.binding.amazonechocontrol.internal.AmazonEchoControlStateDescriptionProvider;
+import org.openhab.binding.amazonechocontrol.internal.dto.DeviceTO;
+import org.openhab.core.thing.Thing;
+import org.openhab.core.thing.ThingStatus;
+import org.openhab.core.thing.ThingStatusDetail;
+import org.openhab.core.thing.ThingStatusInfo;
+import org.openhab.core.thing.binding.ThingHandlerCallback;
+
+import com.google.gson.Gson;
+
+/**
+ * The {@link EchoHandlerDeviceStatusTest} checks how the thing status follows the online flag Amazon reports for a
+ * device
+ *
+ * @author Martin Littkovsky - Initial contribution
+ */
+@NonNullByDefault
+public class EchoHandlerDeviceStatusTest {
+    private static final ThingStatusInfo ONLINE = new ThingStatusInfo(ThingStatus.ONLINE, ThingStatusDetail.NONE, null);
+    private static final ThingStatusInfo OFFLINE = new ThingStatusInfo(ThingStatus.OFFLINE, ThingStatusDetail.NONE,
+            null);
+
+    private final Thing thing = mock(Thing.class);
+    private final ThingHandlerCallback callback = mock(ThingHandlerCallback.class);
+
+    @Test
+    public void anOfflineEchoTakesTheThingOffline() {
+        EchoHandler handler = createHandler();
+
+        boolean online = handler.setDeviceAndUpdateThingStatus(device("ECHO", false), null);
+
+        assertThat(online, is(false));
+        verify(callback).statusUpdated(thing, OFFLINE);
+    }
+
+    @Test
+    public void anOnlineEchoTakesTheThingOnline() {
+        EchoHandler handler = createHandler();
+
+        boolean online = handler.setDeviceAndUpdateThingStatus(device("ECHO", true), null);
+
+        assertThat(online, is(true));
+        verify(callback).statusUpdated(thing, ONLINE);
+    }
+
+    @Test
+    public void aThirdPartyMediaDeviceIsOnlineAlthoughAmazonReportsItOffline() {
+        EchoHandler handler = createHandler();
+
+        boolean online = handler
+                .setDeviceAndUpdateThingStatus(device(DEVICE_FAMILY_THIRD_PARTY_AVS_MEDIA_DISPLAY, false), null);
+
+        assertThat(online, is(true));
+        verify(callback).statusUpdated(thing, ONLINE);
+    }
+
+    @Test
+    public void anOfflineDeviceWithoutFamilyTakesTheThingOffline() {
+        EchoHandler handler = createHandler();
+
+        boolean online = handler.setDeviceAndUpdateThingStatus(device(null, false), null);
+
+        assertThat(online, is(false));
+        verify(callback).statusUpdated(thing, OFFLINE);
+    }
+
+    private static DeviceTO device(@Nullable String family, boolean online) {
+        DeviceTO device = new DeviceTO();
+        device.serialNumber = "SERIAL";
+        device.deviceFamily = family;
+        device.online = online;
+        return device;
+    }
+
+    private EchoHandler createHandler() {
+        EchoHandler handler = new EchoHandler(thing, new Gson(), mock(AmazonEchoControlStateDescriptionProvider.class));
+        handler.setCallback(callback);
+        return handler;
+    }
+}


### PR DESCRIPTION
Amazon lists a Sonos speaker twice: the `THIRD_PARTY_AVS_SONOS_BOOTLEG` entry takes voice and text, the `THIRD_PARTY_AVS_MEDIA_DISPLAY` entry carries the playback state and the player commands. Amazon reports the media entry as offline permanently, so a thing on its serial never went ONLINE and the polled state update aborted before it filled a single media channel. Sonos speakers without built-in Alexa only have the media entry and could not be used at all.

- Family `THIRD_PARTY_AVS_MEDIA_DISPLAY` counts as online in `EchoHandler.setDeviceAndUpdateThingStatus`.
- A test covers an offline Echo, an online Echo, an offline media device and a device without family.
- README: under Discovery, which entries a Sonos speaker has and where their serial numbers are listed.

Verified on a production system with a hand-made thing on the media serial of a Sonos Move: ONLINE, player, title, subtitle, providerDisplayName, imageUrl, mediaProgressTime and volume fill through the normal poll path. Known limit: a switched-off speaker stays ONLINE, `np/player` then answers without error with PAUSED and the last title, Amazon offers no better signal. The device list on the servlet page keeps showing Amazon's flag, so OFFLINE appears next to the ONLINE thing there, which is useful for diagnosis. Manual thing for now, discovery is a separate step. Test build for 5.2.x: https://github.com/ML19821/openhab-addons/releases/tag/amazonechocontrol-all-fixes-test-9

@lsiepel you mentioned Sonos devices of your own in #14328: the servlet page of your account should show the pair.

Refs #21591, the issue stays open for the remaining points (discovery, the larger channel question) and for device reports from other users.

**Transparency:** this patch and the comments on this PR were written with AI assistance (Claude); every commit carries an `AI-assisted-by` trailer. All changes were built, tested and verified on a production system by the author. Reviewed against wborn/github-review-policy@ca8d3f4d07b33d3df9abe5989d0d8ae1b3fc2529 (2026-08-19) before submission.


