### PR TITLE
[shelly] Fix Gen1 Bulb color/white mode switching

### DIFF
--- a/bundles/org.openhab.binding.shelly/README.md
+++ b/bundles/org.openhab.binding.shelly/README.md
@@ -69,8 +69,7 @@ See section [Discovery](#discovery) for details.
 | shellyem3         | Shelly 3EM with 3 integrated Power Meter               | SHEM-3    |
 | shellyrgbw2-color | Shelly RGBW2 Controller in Color Mode                  | SHRGBW2   |
 | shellyrgbw2-white | Shelly RGBW2 Controller in White Mode                  | SHRGBW2   |
-| shellybulb-color  | Shelly Bulb in Color Mode                              | SHBLB-1   |
-| shellybulb-white  | Shelly Bulb in White Mode                              | SHBLB-1   |
+| shellybulb        | Shelly Bulb (Color and White Mode)                     | SHBLB-1   |
 | shellybulbduo     | Shelly Duo White                                       | SHBDUO-1  |
 | shellybulbduo     | Shelly Duo White G10                                   | SHBDUO-1  |
 | shellycolorbulb   | Shelly Duo Color G10                                   | SHCB-1    |

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/handler/ShellyColorUtils.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/handler/ShellyColorUtils.java
@@ -54,6 +54,8 @@ public class ShellyColorUtils {
     }
 
     public ShellyColorUtils(ShellyColorUtils col) {
+        power = col.power;
+        mode = col.mode;
         minTemp = col.minTemp;
         maxTemp = col.maxTemp;
         setRed(col.red);
@@ -63,6 +65,7 @@ public class ShellyColorUtils {
         setGain(col.gain);
         setBrightness(col.brightness);
         setTemp(col.temp);
+        setEffect(col.effect);
     }
 
     public void setMode(String mode) {

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/handler/ShellyLightHandler.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/handler/ShellyLightHandler.java
@@ -151,6 +151,10 @@ public class ShellyLightHandler extends ShellyBaseHandler {
                         break;
                     }
 
+                    if (profile.isBulb) {
+                        // setting the white-mode brightness implies white mode, switch if currently in color mode
+                        col.setMode(SHELLY_MODE_WHITE);
+                    }
                     if (command instanceof PercentType percentCommand) {
                         Float percent = percentCommand.floatValue();
                         value = percent.intValue(); // 0..100% = 0..100
@@ -232,6 +236,8 @@ public class ShellyLightHandler extends ShellyBaseHandler {
                     logger.debug("{}: Color mode changed from {} to {}, set new mode", thingName, oldCol.mode,
                             col.mode);
                     api.setLightMode(col.mode);
+                    // make sure the UI promptly reflects the new mode rather than waiting for the next poll
+                    requestUpdates(1, false);
                 }
 
                 // send changed colors to the device
@@ -265,6 +271,10 @@ public class ShellyLightHandler extends ShellyBaseHandler {
             col.setGreen(getColorFromHSB(hsb.getGreen()));
             col.setBrightness(getColorFromHSB(hsb.getBrightness(), BRIGHTNESS_FACTOR));
             // white, gain and temp are not part of the HSB color scheme
+            if (profile.isBulb) {
+                // picking a color implies color mode, switch if the bulb is currently in white mode
+                col.setMode(SHELLY_MODE_COLOR);
+            }
             updated = true;
         } else if (command instanceof PercentType percentCommand) {
             if (!profile.hasColorTag(lightId) || profile.isBulb) {

--- a/bundles/org.openhab.binding.shelly/src/main/resources/OH-INF/i18n/shelly.properties
+++ b/bundles/org.openhab.binding.shelly/src/main/resources/OH-INF/i18n/shelly.properties
@@ -857,7 +857,7 @@ channel-type.shelly.uptime.description = Number of seconds since the device was 
 channel-type.shelly.whiteBrightness.label = Brightness
 channel-type.shelly.whiteBrightness.description = Brightness (0-100%, 0=OFF)
 channel-type.shelly.whiteTemp.label = Light Temperature
-channel-type.shelly.whiteTemp.description = Light Temperature (Bulb/RGBW2: 3000K-6500K; Duo: 2700K-6500K)
+channel-type.shelly.whiteTemp.description = Light Temperature (Bulb/RGBW2: 3000K-6500K; Duo: 2700K-6500K). Link a Number item, not the default Dimmer, or the slider will send an out-of-range command.
 
 # config status messages
 

--- a/bundles/org.openhab.binding.shelly/src/main/resources/OH-INF/thing/shellyGen1_lights.xml
+++ b/bundles/org.openhab.binding.shelly/src/main/resources/OH-INF/thing/shellyGen1_lights.xml
@@ -264,7 +264,9 @@
 	<channel-type id="whiteTemp">
 		<item-type>Dimmer</item-type>
 		<label>Light Temperature</label>
-		<description>Light Temperature (Bulb/RGBW2: 3000K-6500K; Duo/Pro RGBWW PM: 2700K-6500K)</description>
+		<description>Light Temperature (Bulb/RGBW2: 3000K-6500K; Duo/Pro RGBWW PM: 2700K-6500K). Link a Number item,
+			not the
+			default Dimmer, or the slider will send an out-of-range command.</description>
 		<tags>
 			<tag>Control</tag>
 			<tag>ColorTemperature</tag>

--- a/bundles/org.openhab.binding.shelly/src/test/java/org/openhab/binding/shelly/internal/handler/ShellyColorUtilsTest.java
+++ b/bundles/org.openhab.binding.shelly/src/test/java/org/openhab/binding/shelly/internal/handler/ShellyColorUtilsTest.java
@@ -69,4 +69,18 @@ public class ShellyColorUtilsTest {
         assertEquals(new PercentType(100), ShellyColorUtils.toPercent(300));
         assertEquals(new PercentType(0), ShellyColorUtils.toPercent(-10));
     }
+
+    @Test
+    void copyConstructorPreservesPowerModeAndEffect() {
+        ShellyColorUtils col = new ShellyColorUtils();
+        col.power = org.openhab.core.library.types.OnOffType.ON;
+        col.setMode("color");
+        col.setEffect(3);
+
+        ShellyColorUtils copy = new ShellyColorUtils(col);
+
+        assertEquals(col.power, copy.power);
+        assertEquals(col.mode, copy.mode);
+        assertEquals(col.effect, copy.effect);
+    }
 }


### PR DESCRIPTION
### Fix
- Shelly Bulb (Gen1, SHBLB-1): `control#mode` now reliably switches the bulb between color and white mode and the UI reflects the new mode immediately.
- Shelly Bulb (Gen1, SHBLB-1): `color#hsb` now correctly switches the bulb into color mode before applying the picked color, instead of silently having no effect while the bulb was in white mode.
- Shelly Bulb (Gen1, SHBLB-1): `white#brightness` now correctly switches the bulb into white mode before applying the brightness, instead of silently having no effect while the bulb was in color mode.
- Shelly Bulb (Gen1, SHBLB-1) and other Gen1 devices with a `white#temperature` channel: documented that a Number item, not the default Dimmer, must be linked to this channel - linking the default Dimmer and using its slider sent an out-of-range command that the UI rejected as invalid.

Reported by @matmai on #20909.
