### PR TITLE
[tesla] Link README to official Fleet API docs #15759

### DIFF
--- a/bundles/org.openhab.binding.tesla/README.md
+++ b/bundles/org.openhab.binding.tesla/README.md
@@ -1,7 +1,7 @@
 # Tesla Binding
 
 This binding integrates [Tesla Electrical Vehicles](https://www.tesla.com).
-The integration happens through the Tesla Owners Remote API.
+The integration happens through the [Tesla FleetAPI](https://developer.tesla.com/docs/fleet-api).
 
 ## Supported Things
 


### PR DESCRIPTION
The tesla README still named the unlinked Owners Remote API. I pointed that sentence at Tesla's official Fleet API docs.

Fixes #15759