### PR TITLE
[shelly] Preserve Gen2 Cover detached in_mode instead of mapping it to onebutton

### DIFF
--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api1/Shelly1ApiJsonDTO.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api1/Shelly1ApiJsonDTO.java
@@ -144,6 +144,7 @@ public class Shelly1ApiJsonDTO {
 
     public static final String SHELLY_INP_MODE_OPENCLOSE = "openclose";
     public static final String SHELLY_INP_MODE_ONEBUTTON = "onebutton";
+    public static final String SHELLY_INP_MODE_DETACHED = "detached"; // Gen2+ Cover in_mode only, no Gen1 equivalent
 
     public static final String SHELLY_OBSTMODE_DISABLED = "disabled";
     public static final String SHELLY_SAFETYM_WHILEOPENING = "while_opening";

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/Shelly2ApiClient.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/Shelly2ApiClient.java
@@ -174,7 +174,7 @@ public class Shelly2ApiClient extends ShellyHttpClient implements ShellyDiscover
     protected static final Map<String, String> MAP_INPUT_MODE = Map.of(//
             SHELLY2_RMODE_SINGLE, SHELLY_INP_MODE_ONEBUTTON, //
             SHELLY2_RMODE_DUAL, SHELLY_INP_MODE_OPENCLOSE, //
-            SHELLY2_RMODE_DETACHED, SHELLY_INP_MODE_ONEBUTTON);
+            SHELLY2_RMODE_DETACHED, SHELLY_INP_MODE_DETACHED);
 
     protected static final Map<String, String> MAP_ROLLER_STATE = Map.of(//
             SHELLY2_RSTATE_OPEN, SHELLY_RSTATE_OPEN, //


### PR DESCRIPTION
### Purpose

Fixes the Gen2 Cover `in_mode: detached` configuration being mapped to `onebutton`, losing the distinct detached-input mode.

### Fixes

- Preserve `detached` as its own input mode value for Gen2+ Covers instead of collapsing it into `onebutton`.
