### PR TITLE
[amazonechocontrol] Fix the announcement delay check and document the volume restore

### DIFF
--- a/bundles/org.openhab.binding.amazonechocontrol/README.md
+++ b/bundles/org.openhab.binding.amazonechocontrol/README.md
@@ -571,6 +571,10 @@ then
 end
 ```
 
+When a `textToSpeechVolume` or an announcement `volume` is set, the binding raises the volume for the speech and afterwards sets it back to the volume it last knew for the device.
+Volume changes made outside Alexa, for example in the Sonos app or on the speaker itself, often do not reach the binding, so the value it returns to can be outdated.
+Send the current volume to the `volume` channel before speaking to give the binding the value to return to.
+
 ### Show an announcement on the echo show or echo spot
 
 1) Create a rule with a trigger of your choice

--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/connection/Connection.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/connection/Connection.java
@@ -1249,7 +1249,7 @@ public class Connection {
         ExecutionNodeObject executionNodeObject = getExecutionNodeObject(nodeToExecute);
         List<String> types = executionNodeObject.types;
         long delay = types.contains("Alexa.DeviceControls.Volume") ? 2000 : 0;
-        delay += types.contains("Announcement") ? 3000 : 2000;
+        delay += types.contains("AlexaAnnouncement") ? 3000 : 2000;
 
         try {
             JsonObject sequenceJson = new JsonObject();


### PR DESCRIPTION
Two small things from testing the volume handling around text-to-speech and announcements.

The delay before the volume restore after an announcement checks `types.contains("Announcement")`, but the node type is `AlexaAnnouncement`, so announcements always got the 2 s base of a plain speak instead of the intended 3 s. One word. Measured on a Sonos Move with the fix: 7.88 s between the announcement request and the restore request for a 19-character text, which matches the 2 s + 3 s + 150 ms per character the code adds up to. Without the fix the same sum gives 6.85 s.

The README now says what the binding does when a speech volume is set: it raises the volume for the speech and afterwards returns to the volume it last knew for the device. On a Sonos speaker a volume change made in the Sonos app did not reach the binding in my tests (no PUSH_VOLUME_CHANGE arrived), so the restored value can be stale. The documented way out is to send the current volume to the `volume` channel before speaking. Refs #14328.

**Transparency:** this patch and the comments on this PR were written with AI assistance (Claude); every commit carries an `AI-assisted-by` trailer. All changes were built, tested and verified on a production system by the author. Reviewed against wborn/github-review-policy@ca8d3f4d07b33d3df9abe5989d0d8ae1b3fc2529 (2026-08-19) before submission.


