### PR TITLE
[shelly] Handle ConfigurationAdmin unregistration during mDNS discovery

### DIFF
--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/discovery/ShellyMDNSDiscoveryParticipant.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/discovery/ShellyMDNSDiscoveryParticipant.java
@@ -169,6 +169,11 @@ public class ShellyMDNSDiscoveryParticipant implements MDNSDiscoveryParticipant 
         } catch (IOException e) {
             logger.debug("{}: Exception on processing serviceInfo '{}'", serviceName, service.getNiceTextString(), e);
             return null;
+        } catch (IllegalStateException e) {
+            // ConfigurationAdmin is unregistered while the framework is shutting down; discovery is moot at this
+            // point, so skip this result instead of letting the exception surface as an unhandled ERROR
+            logger.debug("{}: Configuration Admin unavailable, skipping discovery result", serviceName);
+            return null;
         }
     }
 


### PR DESCRIPTION
# Description

Fix:
* Shelly device discovery via mDNS no longer logs an unhandled error and aborts when the ConfigurationAdmin service is temporarily unavailable (e.g. while openHAB is shutting down); the discovery result is simply skipped instead

# Testing

**How to verify on hardware**

- Trigger mDNS discovery while the framework is shutting down (or ConfigurationAdmin is otherwise unregistered) and confirm no `IllegalStateException` is logged for `ShellyMDNSDiscoveryParticipant`.
- Normal discovery of Shelly devices continues to work as before.

## Acceptance criteria

- [x] Implementation done
- [x] Documentation is up-to-date
- [x] Verified by Community

## Backport assessment

Small, low-risk robustness fix; backport-eligible if desired.
