### PR TITLE
[shelly] Never create deprecated meter/energy channels for new Things

### DIFF
--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/provider/ShellyChannelDefinitions.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/provider/ShellyChannelDefinitions.java
@@ -943,12 +943,9 @@ public class ShellyChannelDefinitions {
     private static void addChannel(Thing thing, Map<String, Channel> newChannels, boolean supported, String group,
             String channelName) throws IllegalArgumentException {
         if (supported) {
-            // These methods only run once, on first-ever channel creation for a Thing. A deprecated
-            // channelName here is only ever reached via a call site that still names the old id; for a
-            // brand-new Thing there's no pre-existing item link to preserve, so create the current
-            // replacement directly and skip the deprecated one entirely (same reasoning as the
-            // CHANNEL_METER_LASTMIN1 fix below). Things that already carry the deprecated channel from
-            // before the replacement existed get it added alongside via ShellyChannelMigration instead.
+            // First-ever channel creation for a Thing: skip a deprecated name and create its replacement
+            // directly. Things that already have the deprecated channel get the replacement added
+            // alongside via ShellyChannelMigration instead.
             String replacement = getReplacementChannelName(channelName);
             String effectiveName = replacement != null ? replacement : channelName;
             String channelId = group + ChannelUID.CHANNEL_GROUP_SEPARATOR + effectiveName;

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/provider/ShellyChannelDefinitions.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/provider/ShellyChannelDefinitions.java
@@ -943,14 +943,18 @@ public class ShellyChannelDefinitions {
     private static void addChannel(Thing thing, Map<String, Channel> newChannels, boolean supported, String group,
             String channelName) throws IllegalArgumentException {
         if (supported) {
-            String channelId = group + ChannelUID.CHANNEL_GROUP_SEPARATOR + channelName;
-            Channel channel = createChannel(thing, channelId, group, channelName);
+            // These methods only run once, on first-ever channel creation for a Thing. A deprecated
+            // channelName here is only ever reached via a call site that still names the old id; for a
+            // brand-new Thing there's no pre-existing item link to preserve, so create the current
+            // replacement directly and skip the deprecated one entirely (same reasoning as the
+            // CHANNEL_METER_LASTMIN1 fix below). Things that already carry the deprecated channel from
+            // before the replacement existed get it added alongside via ShellyChannelMigration instead.
+            String replacement = getReplacementChannelName(channelName);
+            String effectiveName = replacement != null ? replacement : channelName;
+            String channelId = group + ChannelUID.CHANNEL_GROUP_SEPARATOR + effectiveName;
+            Channel channel = createChannel(thing, channelId, group, effectiveName);
             if (channel != null) {
                 newChannels.put(channelId, channel);
-                String replacement = getReplacementChannelName(channelName);
-                if (replacement != null) {
-                    addChannel(thing, newChannels, true, group, replacement);
-                }
             }
         }
     }

--- a/bundles/org.openhab.binding.shelly/src/test/java/org/openhab/binding/shelly/internal/provider/ShellyChannelMigrationTest.java
+++ b/bundles/org.openhab.binding.shelly/src/test/java/org/openhab/binding/shelly/internal/provider/ShellyChannelMigrationTest.java
@@ -147,6 +147,48 @@ public class ShellyChannelMigrationTest {
     }
 
     @Test
+    void createMeterChannelsCreatesOnlyReplacementForNewDevices() {
+        Thing thing = mock(Thing.class);
+        when(thing.getUID()).thenReturn(new ThingUID("shelly", "shelly1pm", "test"));
+        ShellyDeviceProfile profile = new ShellyDeviceProfile(THING_TYPE_SHELLY1PM);
+        ShellySettingsMeter meter = new ShellySettingsMeter();
+        meter.power = 42.0;
+        meter.total = 123.0;
+
+        Map<String, Channel> created = ShellyChannelDefinitions.createMeterChannels(thing, profile, meter,
+                CHANNEL_GROUP_METER);
+
+        assertFalse(created.containsKey(mkChannelId(CHANNEL_GROUP_METER, CHANNEL_METER_CURRENTWATTS)));
+        assertFalse(created.containsKey(mkChannelId(CHANNEL_GROUP_METER, CHANNEL_METER_TOTALKWH)));
+        assertTrue(created.containsKey(mkChannelId(CHANNEL_GROUP_METER, CHANNEL_METER_CURRENTPOWER)));
+        assertTrue(created.containsKey(mkChannelId(CHANNEL_GROUP_METER, CHANNEL_METER_TOTALENERGY)));
+    }
+
+    @Test
+    void createEMeterChannelsCreatesOnlyReplacementForNewDevices() {
+        Thing thing = mock(Thing.class);
+        when(thing.getUID()).thenReturn(new ThingUID("shelly", "shellyplus1pm", "test"));
+        ShellyDeviceProfile profile = new ShellyDeviceProfile(THING_TYPE_SHELLYPLUS1PM);
+        ShellySettingsEMeter emeter = new ShellySettingsEMeter();
+        emeter.power = 42.0;
+        emeter.total = 123.0;
+        emeter.totalReturned = 5.0;
+        emeter.reactive = 1.0;
+
+        Map<String, Channel> created = ShellyChannelDefinitions.createEMeterChannels(thing, profile, emeter,
+                CHANNEL_GROUP_METER);
+
+        assertFalse(created.containsKey(mkChannelId(CHANNEL_GROUP_METER, CHANNEL_METER_CURRENTWATTS)));
+        assertFalse(created.containsKey(mkChannelId(CHANNEL_GROUP_METER, CHANNEL_METER_TOTALKWH)));
+        assertFalse(created.containsKey(mkChannelId(CHANNEL_GROUP_METER, CHANNEL_EMETER_TOTALRET)));
+        assertFalse(created.containsKey(mkChannelId(CHANNEL_GROUP_METER, CHANNEL_EMETER_REACTWATTS)));
+        assertTrue(created.containsKey(mkChannelId(CHANNEL_GROUP_METER, CHANNEL_METER_CURRENTPOWER)));
+        assertTrue(created.containsKey(mkChannelId(CHANNEL_GROUP_METER, CHANNEL_METER_TOTALENERGY)));
+        assertTrue(created.containsKey(mkChannelId(CHANNEL_GROUP_METER, CHANNEL_EMETER_RETURNEDENERGY)));
+        assertTrue(created.containsKey(mkChannelId(CHANNEL_GROUP_METER, CHANNEL_EMETER_REACTPOWER)));
+    }
+
+    @Test
     void energyHistMinLabelHasNoTrailingDigitSuffix() {
         // Regression: createChannel() used to append a digit to any label whose channel NAME ended in a
         // digit, even when that digit is part of the channel's fixed identity, not a group index.


### PR DESCRIPTION
# Description

- Fix: a newly discovered Thing no longer gets both the deprecated and the current meter/energy channel created together (e.g. `currentWatts` + `currentPower`, `totalKWH` + `totalEnergy`, `reactiveWatts` + `reactivePower`, and the equivalent device-level accumulated/threshold pairs). Only the current channel is created for a new Thing.
- Things that were discovered before the current channel names existed are unaffected — they still get the current channel added alongside the deprecated one they already carry, so existing item links keep working.

# Testing

How to verify on hardware:
1. Delete an existing Shelly Thing with a meter/energy component (e.g. a Plug, PM relay, or EM device) and let it be re-discovered, or add a new device to the binding for the first time.
2. Check the Thing's channel list: only `currentPower`/`totalEnergy` (and the other current names) should be present — `currentWatts`/`totalKWH` and the other deprecated names must NOT appear.
3. For an existing, already-commissioned Thing, confirm nothing changes: both the deprecated and current channels it already had remain present and update as before.

- [x] New Things only get the current channel names, never the deprecated ones
- [ ] Existing Things keep both their deprecated and current channels working as before

## Backport assessment

Bug fix, no breaking change — safe to backport.
