### PR TITLE
[shelly] Fix brightness slider flicker on dimmer/light status updates

### DIFF
--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api1/Shelly1CoIoTProtocol.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api1/Shelly1CoIoTProtocol.java
@@ -219,16 +219,16 @@ public class Shelly1CoIoTProtocol {
 
     /**
      *
-     * Handles the combined updated of the brightness channel:
-     * brightness$Switch is the OnOffType (power state)
-     * brightness&amp;Value is the brightness value
+     * Handles the combined update of the brightness channel: the power state and brightness sensor values are
+     * combined into a single Percent update (0% when off) rather than publishing the power state separately, so a
+     * Dimmer-linked item never sees an intermediate OnOffType state.
      *
      * @param profile Device profile, required to select the channel group and name
-     * @param updates List of updates. updatePower will add brightness$Switch and brightness&amp;Value if changed
+     * @param updates List of updates. updatePower will add brightness$Value if changed
      * @param id Sensor id from the update
      * @param sen Sensor description from the update
      * @param s New sensor value
-     * @param allUpdates List of updates. This is required, because we need to update both values at the same time
+     * @param allUpdates List of updates. This is required, because we need power and brightness from the same batch
      */
     protected void updatePower(ShellyDeviceProfile profile, Map<String, State> updates, int id, CoIotDescrSen sen,
             CoIotSensor s, List<CoIotSensor> allUpdates) {
@@ -264,9 +264,6 @@ public class Shelly1CoIoTProtocol {
                 } else if ("output".equalsIgnoreCase(d.desc) || "state".equalsIgnoreCase(d.desc)) {
                     power = update.value;
                 }
-            }
-            if (power != -1) {
-                updateChannel(updates, group, channel + "$Switch", OnOffType.from(power == 1));
             }
             if (brightness != -1) {
                 updateChannel(updates, group, channel + "$Value",

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/handler/ShellyComponents.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/handler/ShellyComponents.java
@@ -922,7 +922,6 @@ public class ShellyComponents {
                 ShellySettingsLight light = lights.get(i);
                 String groupName = profile.getControlGroup(i);
                 OnOffType power = getOnOff(light.ison);
-                updated |= thingHandler.updateChannel(groupName, CHANNEL_BRIGHTNESS + "$Switch", power);
                 updated |= thingHandler.updateChannel(groupName, CHANNEL_BRIGHTNESS + "$Value",
                         toQuantityType(power == OnOffType.ON ? (double) getInteger(light.brightness) : 0.0, DIGITS_NONE,
                                 Units.PERCENT));
@@ -972,11 +971,9 @@ public class ShellyComponents {
                 // When the device's brightness is > 0 we send the new value to the channel and an ON command
                 if (dimmer.ison != null) {
                     if (dimmer.ison) {
-                        updated |= thingHandler.updateChannel(groupName, CHANNEL_BRIGHTNESS + "$Switch", OnOffType.ON);
                         updated |= thingHandler.updateChannel(groupName, CHANNEL_BRIGHTNESS + "$Value",
                                 toQuantityType((double) getInteger(dimmer.brightness), DIGITS_NONE, Units.PERCENT));
                     } else {
-                        updated |= thingHandler.updateChannel(groupName, CHANNEL_BRIGHTNESS + "$Switch", OnOffType.OFF);
                         updated |= thingHandler.updateChannel(groupName, CHANNEL_BRIGHTNESS + "$Value",
                                 toQuantityType(0.0, DIGITS_NONE, Units.PERCENT));
                     }

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/handler/ShellyLightHandler.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/handler/ShellyLightHandler.java
@@ -147,7 +147,6 @@ public class ShellyLightHandler extends ShellyBaseHandler {
                         col.power = getOnOff(light.ison);
                         col.setBrightness(light.brightness);
                         String brightnessGroup = buildWhiteGroupName(profile, lightId);
-                        updateChannel(brightnessGroup, CHANNEL_BRIGHTNESS + "$Switch", col.power);
                         updateChannel(brightnessGroup, CHANNEL_BRIGHTNESS + "$Value", toQuantityType(
                                 (double) (col.power == OnOffType.ON ? col.brightness : 0), DIGITS_NONE, Units.PERCENT));
                         update = false;
@@ -423,7 +422,6 @@ public class ShellyLightHandler extends ShellyBaseHandler {
             if (updatesWhiteChannels(profile, lightId)) {
                 String whiteGroup = buildWhiteGroupName(profile, lightId);
                 col.setBrightness(getInteger(light.brightness));
-                updated |= updateChannel(whiteGroup, CHANNEL_BRIGHTNESS + "$Switch", col.power);
                 updated |= updateChannel(whiteGroup, CHANNEL_BRIGHTNESS + "$Value",
                         toQuantityType(col.power == OnOffType.ON ? col.percentBrightness.doubleValue() : 0, DIGITS_NONE,
                                 Units.PERCENT));

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/handler/ShellyRelayHandler.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/handler/ShellyRelayHandler.java
@@ -186,16 +186,19 @@ public class ShellyRelayHandler extends ShellyBaseHandler {
 
     private void updateBrightnessChannel(int lightId, OnOffType power, int brightness) throws ShellyApiException {
         String group = profile.getControlGroup(lightId);
-        updateChannel(group, CHANNEL_BRIGHTNESS + "$Switch", power);
+        int actualBrightness = brightness;
         if (brightness > 0) {
             api.setBrightness(lightId, brightness, config.getBrightnessAutoOn());
         } else {
-            api.setLightTurn(lightId, power == OnOffType.ON ? SHELLY_API_ON : SHELLY_API_OFF);
-            if (brightness >= 0) { // ignore -1
-                updateChannel(group, CHANNEL_BRIGHTNESS + "$Value",
-                        toQuantityType((double) (power == OnOffType.ON ? brightness : 0), DIGITS_NONE, Units.PERCENT));
+            ShellyShortLightStatus light = api.setLightTurn(lightId,
+                    power == OnOffType.ON ? SHELLY_API_ON : SHELLY_API_OFF);
+            if (brightness < 0) { // blind Switch command, brightness unknown -> use the device-reported value
+                actualBrightness = getInteger(light.brightness);
             }
         }
+        // single Percent update only; a linked Switch item still gets a correct ON/OFF state via core's conversion
+        updateChannel(group, CHANNEL_BRIGHTNESS + "$Value",
+                toQuantityType((double) (power == OnOffType.ON ? actualBrightness : 0), DIGITS_NONE, Units.PERCENT));
     }
 
     @Override

--- a/bundles/org.openhab.binding.shelly/src/test/java/org/openhab/binding/shelly/internal/api2/Shelly2ApiClientLightStatusTest.java
+++ b/bundles/org.openhab.binding.shelly/src/test/java/org/openhab/binding/shelly/internal/api2/Shelly2ApiClientLightStatusTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.openhab.binding.shelly.internal.ShellyBindingConstants.*;
 import static org.openhab.binding.shelly.internal.api2.Shelly2ApiJsonDTO.*;
+import static org.openhab.binding.shelly.internal.util.ShellyUtils.toQuantityType;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -46,6 +47,7 @@ import org.openhab.binding.shelly.internal.config.ShellyBindingConfiguration;
 import org.openhab.binding.shelly.internal.config.ShellyBindingRuntimeConfig;
 import org.openhab.binding.shelly.internal.handler.ShellyThingInterface;
 import org.openhab.core.library.types.OnOffType;
+import org.openhab.core.library.unit.Units;
 import org.openhab.core.net.NetworkAddressChangeListener;
 import org.openhab.core.net.NetworkAddressService;
 import org.openhab.core.thing.ThingTypeUID;
@@ -226,7 +228,8 @@ public class Shelly2ApiClientLightStatusTest {
         boolean updated = client.fillDeviceStatus(profile.status, result, true);
 
         assertThat(updated, is(true));
-        verify(thing).updateChannel(CHANNEL_GROUP_LIGHT_INDEX + "1", CHANNEL_BRIGHTNESS + "$Switch", OnOffType.ON);
+        verify(thing).updateChannel(CHANNEL_GROUP_LIGHT_INDEX + "1", CHANNEL_BRIGHTNESS + "$Value",
+                toQuantityType(55.0, DIGITS_NONE, Units.PERCENT));
         verify(thing, never()).updateChannel(CHANNEL_GROUP_LIGHT_INDEX + "1", CHANNEL_LIGHT_POWER, OnOffType.ON);
     }
 
@@ -243,7 +246,8 @@ public class Shelly2ApiClientLightStatusTest {
         boolean updated = client.fillDeviceStatus(profile.status, result, true);
 
         assertThat(updated, is(true));
-        verify(thing).updateChannel(CHANNEL_GROUP_LIGHT_CONTROL, CHANNEL_BRIGHTNESS + "$Switch", OnOffType.ON);
+        verify(thing).updateChannel(CHANNEL_GROUP_LIGHT_CONTROL, CHANNEL_BRIGHTNESS + "$Value",
+                toQuantityType(55.0, DIGITS_NONE, Units.PERCENT));
     }
 
     @Test

--- a/bundles/org.openhab.binding.shelly/src/test/java/org/openhab/binding/shelly/internal/handler/ShellyComponentsTest.java
+++ b/bundles/org.openhab.binding.shelly/src/test/java/org/openhab/binding/shelly/internal/handler/ShellyComponentsTest.java
@@ -936,8 +936,8 @@ public class ShellyComponentsTest {
 
         assertThat(updated, is(true));
         verify(handler, never()).updateChannel(eq(CHANNEL_GROUP_LIGHT_CONTROL), anyString(), any());
-        verify(handler).updateChannel(eq(CHANNEL_GROUP_LIGHT_INDEX + "1"), eq(CHANNEL_BRIGHTNESS + "$Switch"),
-                eq(OnOffType.ON));
+        verify(handler).updateChannel(eq(CHANNEL_GROUP_LIGHT_INDEX + "1"), eq(CHANNEL_BRIGHTNESS + "$Value"),
+                argThat(s -> s instanceof QuantityType<?> qt && qt.doubleValue() == 42.0));
         verify(handler).updateChannel(eq(CHANNEL_GROUP_LIGHT_INDEX + "1"), eq(CHANNEL_COLOR_TEMP), any());
     }
 


### PR DESCRIPTION
Fixes:
* Fixed the brightness slider flickering to 0% or 100% before settling on the correct value when changing brightness on a light or dimmer. Affects Duo, Bulb, RGBW2, Dimmer relays and Gen1 CoIoT status updates.

# Testing

* Link a Dimmer item to a Duo/Bulb/RGBW2/Dimmer brightness channel and change brightness from the UI slider (or `Percent` command) — the slider must move smoothly to the target value without jumping to 0% or 100% first.
* Link a Switch item to the same brightness channel — turning the light on/off must still correctly show ON/OFF, and sending an ON/OFF command to the channel must still switch the light.

## Acceptance criteria

- [x] Implementation done
- [x] Verified by community
- [x] Ready for review
