### PR TITLE
[amazonechocontrol] Read the security panel arm state as a string

### DIFF
--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/smarthome/HandlerSecurityPanelController.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/smarthome/HandlerSecurityPanelController.java
@@ -28,10 +28,11 @@ import org.openhab.core.library.types.StringType;
 import org.openhab.core.types.Command;
 import org.openhab.core.types.UnDefType;
 
+import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 
 /**
- * The {@link HandlerSecurityPanelController} is responsible for the Alexa.PowerControllerInterface
+ * The {@link HandlerSecurityPanelController} is responsible for the Alexa.SecurityPanelController interface
  *
  * @author Lukas Knoeller - Initial contribution
  * @author Michael Geramb - Initial contribution
@@ -84,11 +85,14 @@ public class HandlerSecurityPanelController extends AbstractInterfaceHandler {
         Boolean fireAlarmValue = null;
         Boolean waterAlarmValue = null;
         for (JsonObject state : stateList) {
-            String propertyValue = state.get("value").getAsJsonObject().get("value").getAsString();
+            String propertyValue = readValue(state);
+            if (propertyValue == null) {
+                continue;
+            }
             String propertyName = state.get("name").getAsString();
             if (ARM_STATE.propertyName.equals(propertyName)) {
                 if (armStateValue == null) {
-                    armStateValue = state.get("value").getAsString();
+                    armStateValue = propertyValue;
                 }
             } else if (BURGLARY_ALARM.propertyName.equals(propertyName)) {
                 if (burglaryAlarmValue == null) {
@@ -119,6 +123,18 @@ public class HandlerSecurityPanelController extends AbstractInterfaceHandler {
                 : (fireAlarmValue ? OpenClosedType.CLOSED : OpenClosedType.OPEN));
         smartHomeDeviceHandler.updateState(WATER_ALARM.channelId, waterAlarmValue == null ? UnDefType.UNDEF
                 : (waterAlarmValue ? OpenClosedType.CLOSED : OpenClosedType.OPEN));
+    }
+
+    private static @Nullable String readValue(JsonObject state) {
+        JsonElement value = state.get("value");
+        if (value == null || value.isJsonNull()) {
+            return null;
+        }
+        if (value.isJsonObject()) {
+            JsonElement inner = value.getAsJsonObject().get("value");
+            return inner == null || inner.isJsonNull() ? null : inner.getAsString();
+        }
+        return value.getAsString();
     }
 
     @Override

--- a/bundles/org.openhab.binding.amazonechocontrol/src/test/java/org/openhab/binding/amazonechocontrol/internal/smarthome/HandlerSecurityPanelControllerTest.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/test/java/org/openhab/binding/amazonechocontrol/internal/smarthome/HandlerSecurityPanelControllerTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.amazonechocontrol.internal.smarthome;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.jupiter.api.Test;
+import org.openhab.binding.amazonechocontrol.internal.handler.SmartHomeDeviceHandler;
+import org.openhab.binding.amazonechocontrol.internal.smarthome.InterfaceHandler.UpdateChannelResult;
+import org.openhab.core.library.types.OpenClosedType;
+import org.openhab.core.library.types.StringType;
+import org.openhab.core.types.UnDefType;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+/**
+ * Tests the {@link HandlerSecurityPanelController} against the two value shapes Amazon sends.
+ *
+ * @author Martin Littkovsky - Initial contribution
+ */
+@NonNullByDefault
+public class HandlerSecurityPanelControllerTest {
+    // shaped like the trace in openhab/openhab-addons#20091, armState a string and alarms objects, values varied
+    private static final String ARM_STATE_AS_STRING = "{\"namespace\":\"Alexa.SecurityPanelController\","
+            + "\"name\":\"armState\",\"value\":\"DISARMED\",\"timeOfSample\":\"2026-01-17T16:52:06Z\"}";
+    private static final String ARM_STATE_AS_OBJECT = "{\"namespace\":\"Alexa.SecurityPanelController\","
+            + "\"name\":\"armState\",\"value\":{\"value\":\"ARMED_AWAY\"},\"timeOfSample\":\"2026-01-17T16:52:06Z\"}";
+    private static final String FIRE_ALARM_OK = "{\"namespace\":\"Alexa.SecurityPanelController\","
+            + "\"name\":\"fireAlarm\",\"value\":{\"value\":\"OK\"},\"timeOfSample\":\"2026-01-17T16:52:06Z\"}";
+    private static final String BURGLARY_ALARM_TRIGGERED = "{\"namespace\":\"Alexa.SecurityPanelController\","
+            + "\"name\":\"burglaryAlarm\",\"value\":{\"value\":\"ALARM\"},\"timeOfSample\":\"2026-01-17T16:52:06Z\"}";
+    private static final String CARBON_MONOXIDE_ALARM_OK = "{\"namespace\":\"Alexa.SecurityPanelController\","
+            + "\"name\":\"carbonMonoxideAlarm\",\"value\":{\"value\":\"OK\"},"
+            + "\"timeOfSample\":\"2026-01-17T16:52:06Z\"}";
+
+    private final SmartHomeDeviceHandler deviceHandler = mock(SmartHomeDeviceHandler.class);
+    private final HandlerSecurityPanelController handler = new HandlerSecurityPanelController(deviceHandler);
+
+    @Test
+    public void armStateSentAsStringUpdatesEveryChannel() {
+        handler.updateChannels(HandlerSecurityPanelController.INTERFACE,
+                states(ARM_STATE_AS_STRING, FIRE_ALARM_OK, BURGLARY_ALARM_TRIGGERED, CARBON_MONOXIDE_ALARM_OK),
+                new UpdateChannelResult());
+
+        verify(deviceHandler).updateState("armState", new StringType("DISARMED"));
+        verify(deviceHandler).updateState("fireAlarm", OpenClosedType.OPEN);
+        verify(deviceHandler).updateState("burglaryAlarm", OpenClosedType.CLOSED);
+        verify(deviceHandler).updateState("carbonMonoxideAlarm", OpenClosedType.OPEN);
+        verify(deviceHandler).updateState("waterAlarm", UnDefType.UNDEF);
+    }
+
+    @Test
+    public void armStateSentAsObjectStillUpdatesEveryChannel() {
+        handler.updateChannels(HandlerSecurityPanelController.INTERFACE, states(ARM_STATE_AS_OBJECT, FIRE_ALARM_OK),
+                new UpdateChannelResult());
+
+        verify(deviceHandler).updateState("armState", new StringType("ARMED_AWAY"));
+        verify(deviceHandler).updateState("fireAlarm", OpenClosedType.OPEN);
+        verify(deviceHandler).updateState("burglaryAlarm", UnDefType.UNDEF);
+    }
+
+    @Test
+    public void firstArmStateWins() {
+        handler.updateChannels(HandlerSecurityPanelController.INTERFACE,
+                states(ARM_STATE_AS_STRING, ARM_STATE_AS_OBJECT), new UpdateChannelResult());
+
+        verify(deviceHandler).updateState("armState", new StringType("DISARMED"));
+    }
+
+    @Test
+    public void statesWithoutValueAreSkipped() {
+        handler.updateChannels(HandlerSecurityPanelController.INTERFACE, states("{\"name\":\"armState\"}",
+                "{\"name\":\"armState\",\"value\":null}", "{\"name\":\"burglaryAlarm\",\"value\":{}}", FIRE_ALARM_OK),
+                new UpdateChannelResult());
+
+        verify(deviceHandler).updateState("armState", UnDefType.UNDEF);
+        verify(deviceHandler).updateState("burglaryAlarm", UnDefType.UNDEF);
+        verify(deviceHandler).updateState("fireAlarm", OpenClosedType.OPEN);
+    }
+
+    private static List<JsonObject> states(String... json) {
+        return Arrays.stream(json).map(s -> JsonParser.parseString(s).getAsJsonObject()).toList();
+    }
+}


### PR DESCRIPTION
`HandlerSecurityPanelController.updateChannels` unwrapped every state value as an object before looking at the property name. Amazon sends `armState` as a plain string (`"value":"DISARMED"`) while the alarm properties stay objects (`"value":{"value":"OK"}`), so the first state ended the loop with `IllegalStateException: Not a JSON Object` and no channel of the interface was ever updated.

- read the value once per state, as a string or as the object's inner `value`, and skip a state that has neither
- `HandlerSecurityPanelControllerTest` runs states shaped like the trace in #20091 through the handler, arm state as a string and as an object, and checks every channel

Same idea as #20564, which was closed without the DCO sign-off.

I have no security panel. The reporter offered to test a build. A test build for openHAB 5.2.x with this fix: https://github.com/ML19821/openhab-addons/releases/tag/amazonechocontrol-all-fixes-test-10

Fixes #20091

**Transparency:** this patch and the comments on this PR were written with AI assistance (Claude); every commit carries an `AI-assisted-by` trailer. Reviewed against wborn/github-review-policy@ca8d3f4d07b33d3df9abe5989d0d8ae1b3fc2529 (2026-08-19) before submission.
