### PR TITLE
[amazonechocontrol] Fix the comms host and name aborted requests

### DIFF
--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/connection/Connection.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/connection/Connection.java
@@ -37,6 +37,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -289,18 +290,20 @@ public class Connection {
         }
     }
 
-    private String normalizeRetailDomain(@Nullable String domain) {
-        if (domain != null && !domain.isBlank()) {
-            try {
-                URI uri = new URI(domain.trim());
-                String host = uri.getHost();
-                if (host != null && !host.isBlank()) {
-                    return host.toLowerCase();
-                }
-            } catch (URISyntaxException ignored) {
-            }
+    static String normalizeRetailDomain(@Nullable String domainOrUrl) {
+        if (domainOrUrl == null || domainOrUrl.isBlank()) {
+            return AmazonEchoControlBindingConstants.DEFAULT_RETAIL_DOMAIN;
         }
-        return AmazonEchoControlBindingConstants.DEFAULT_RETAIL_DOMAIN;
+        String host = domainOrUrl.trim();
+        try {
+            String uriHost = new URI(host).getHost();
+            if (uriHost != null && !uriHost.isBlank()) {
+                host = uriHost;
+            }
+        } catch (URISyntaxException ignored) {
+        }
+        host = host.toLowerCase(Locale.ROOT);
+        return host.startsWith("www.") ? host.substring(4) : host;
     }
 
     public boolean registerConnectionAsApp(String accessToken) {

--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/util/HttpRequestBuilder.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/util/HttpRequestBuilder.java
@@ -320,6 +320,11 @@ public class HttpRequestBuilder {
                 || (amznErrorType != null && amznErrorType.startsWith(THROTTLING_EXCEPTION));
     }
 
+    static String abortedMessage(URI requestUri, @Nullable Throwable failure) {
+        String message = "Request to " + requestUri + " aborted";
+        return failure == null ? message : message + ": " + failure;
+    }
+
     static String buildFailureReason(@Nullable String reason, @Nullable String amznErrorType) {
         String statusReason = reason == null || reason.isBlank() ? NO_REASON_GIVEN : reason;
         return amznErrorType == null || amznErrorType.isBlank() ? statusReason
@@ -413,7 +418,9 @@ public class HttpRequestBuilder {
                 // a throttled request is not retried: every retry is itself a counted request
                 if (failMode == EXCEPTION || retryCounter == 0 || (throttled && failMode != NORMAL)) {
                     if (responseStatus == 0) {
-                        httpResponse.completeExceptionally(new ConnectionException("Request aborted."));
+                        Throwable failure = result.getFailure();
+                        httpResponse.completeExceptionally(
+                                new ConnectionException(abortedMessage(requestUri, failure), failure));
                         return;
                     }
                     httpResponse.completeExceptionally(new ConnectionException(requestUri + " failed with code "

--- a/bundles/org.openhab.binding.amazonechocontrol/src/test/java/org/openhab/binding/amazonechocontrol/internal/connection/ConnectionRetailDomainTest.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/test/java/org/openhab/binding/amazonechocontrol/internal/connection/ConnectionRetailDomainTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.amazonechocontrol.internal.connection;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.openhab.binding.amazonechocontrol.internal.connection.Connection.normalizeRetailDomain;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests that the retail domain comes out as the bare domain Amazon's hosts are built from, whatever shape the
+ * endpoints and users/me answers deliver it in.
+ *
+ * @author Martin Littkovsky - Initial contribution
+ */
+@NonNullByDefault
+public class ConnectionRetailDomainTest {
+
+    @Test
+    public void aBareDomainFromTheEndpointsAnswerIsKept() {
+        assertThat(normalizeRetailDomain("amazon.de"), is("amazon.de"));
+    }
+
+    @Test
+    public void theHostOfTheMarketplaceUrlLosesItsWwwPrefix() {
+        assertThat(normalizeRetailDomain("https://www.amazon.de"), is("amazon.de"));
+        assertThat(normalizeRetailDomain("https://www.amazon.com"), is("amazon.com"));
+        assertThat(normalizeRetailDomain("https://www.amazon.co.jp/"), is("amazon.co.jp"));
+    }
+
+    @Test
+    public void caseAndWhitespaceDoNotMatter() {
+        assertThat(normalizeRetailDomain(" WWW.Amazon.DE "), is("amazon.de"));
+    }
+
+    @Test
+    public void nothingUsableFallsBackToTheDefault() {
+        assertThat(normalizeRetailDomain(null), is("amazon.com"));
+        assertThat(normalizeRetailDomain("  "), is("amazon.com"));
+    }
+}

--- a/bundles/org.openhab.binding.amazonechocontrol/src/test/java/org/openhab/binding/amazonechocontrol/internal/util/HttpRequestBuilderTest.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/test/java/org/openhab/binding/amazonechocontrol/internal/util/HttpRequestBuilderTest.java
@@ -25,11 +25,13 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.openhab.binding.amazonechocontrol.internal.util.HttpRequestBuilder.abortedMessage;
 import static org.openhab.binding.amazonechocontrol.internal.util.HttpRequestBuilder.buildFailureReason;
 import static org.openhab.binding.amazonechocontrol.internal.util.HttpRequestBuilder.isThrottled;
 
 import java.net.CookieManager;
 import java.net.URI;
+import java.net.UnknownHostException;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -100,6 +102,20 @@ public class HttpRequestBuilderTest {
         assertThat(buildFailureReason("", null), is("no reason given"));
         assertThat(buildFailureReason(null, THROTTLING_ERROR_TYPE),
                 is("no reason given (x-amzn-ErrorType: " + THROTTLING_ERROR_TYPE + ")"));
+    }
+
+    @Test
+    public void testAnAbortedRequestNamesTheUriAndTheTransportFailure() {
+        URI commsUri = URI.create("https://alexa-comms-mobile-service.www.amazon.de/accounts");
+        String message = abortedMessage(commsUri, new UnknownHostException(commsUri.getHost()));
+
+        assertThat(message, is("Request to " + commsUri + " aborted: java.net.UnknownHostException: "
+                + "alexa-comms-mobile-service.www.amazon.de"));
+    }
+
+    @Test
+    public void testAnAbortedRequestWithoutAFailureStillNamesTheUri() {
+        assertThat(abortedMessage(REQUEST_URI, null), is("Request to " + REQUEST_URI + " aborted"));
     }
 
     @Test


### PR DESCRIPTION
The `sendMessage` channel of the account thing fails with `Request aborted`, status 0, since November 2025, when the auth rework (#19690) added a normaliser for the stored retail domain. The comms host is built from that value, and the normaliser does not fit the two shapes Amazon delivers: the endpoints answer carries `retailDomain: "amazon.de"`, a bare host that `URI.getHost()` does not recognise, so the value fell back to `amazon.com`. The next `users/me` check carries `marketPlaceDomainName: "https://www.amazon.de"` and the value became `www.amazon.de`. `alexa-comms-mobile-service.www.amazon.de` does not resolve. The normaliser came with #19690, the login changes of this month did not touch it.

- `normalizeRetailDomain` keeps a bare domain, takes the host of a URL and drops a leading `www.`, with a test for the shapes Amazon sends, plus case and whitespace
- an aborted request now names its URI and Jetty's failure instead of a bare `Request aborted.`, and carries the failure as its cause, so a DNS failure reads as one

Two consequences: a stored session that holds `www.amazon.de` repairs itself on the next login check, no re-login needed, because `users/me` runs through the normaliser again. And an amazon.com account that had `www.amazon.com` stored talked to the EU push dispatcher, it now gets the NA one, which is the one `PushConnection` intends for it. For an amazon.de account the push dispatcher does not change.

Verified on my own account: with the binding's session the accounts call fails on `www.amazon.de` and answers 200 on `amazon.de`. Live test on openHAB 5.2.1 with the fix sideloaded: before it, a `sendMessage` command ended six seconds later in `Request aborted.`. After the swap the stored session went from `www.amazon.de` to `amazon.de` on the first login check, the same command posted to `alexa-comms-mobile-service.amazon.de` with 200, and the message showed up in the Alexa app on my phone, under Communicate, as a conversation with myself. I have no Echo, only Sonos speakers, so that is where it was verified, not as an announcement on a device. A test build for openHAB 5.2.x with this fix: https://github.com/ML19821/openhab-addons/releases/tag/amazonechocontrol-all-fixes-test-11

Fixes #19783

**Transparency:** this patch and the comments on this PR were written with AI assistance (Claude); every commit carries an `AI-assisted-by` trailer. All changes were built, tested and verified on a production system by the author. Reviewed against wborn/github-review-policy@ca8d3f4d07b33d3df9abe5989d0d8ae1b3fc2529 (2026-08-19) before submission.
