### PR TITLE
[nobohub] Fix ignored keepaliveInterval setting

### DIFF
--- a/bundles/org.openhab.binding.nobohub/README.md
+++ b/bundles/org.openhab.binding.nobohub/README.md
@@ -44,6 +44,9 @@ serialNumber=103000xxxxxx
 
 # Host name or IP address of the Nobø hub
 hostName=10.0.0.10
+
+# Interval between keepalives sent to the hub, in seconds, minimum 5. Optional, defaults to 14.
+keepaliveInterval=14
 ```
 
 ## Channels

--- a/bundles/org.openhab.binding.nobohub/src/main/java/org/openhab/binding/nobohub/internal/NoboHubBridgeConfiguration.java
+++ b/bundles/org.openhab.binding.nobohub/src/main/java/org/openhab/binding/nobohub/internal/NoboHubBridgeConfiguration.java
@@ -36,7 +36,7 @@ public class NoboHubBridgeConfiguration {
     public String hostName;
 
     /**
-     * Polling interval (seconds)
+     * Keepalive/polling interval (seconds)
      */
-    public int pollingInterval;
+    public int keepaliveInterval;
 }

--- a/bundles/org.openhab.binding.nobohub/src/main/java/org/openhab/binding/nobohub/internal/NoboHubBridgeHandler.java
+++ b/bundles/org.openhab.binding.nobohub/src/main/java/org/openhab/binding/nobohub/internal/NoboHubBridgeHandler.java
@@ -158,8 +158,8 @@ public class NoboHubBridgeHandler extends BaseBridgeHandler {
                 logger.debug("Done connecting to {} ({})", hostName, serialNumber);
 
                 Duration timeout = RECOMMENDED_KEEPALIVE_INTERVAL;
-                if (config.pollingInterval > 0) {
-                    timeout = Duration.ofSeconds(config.pollingInterval);
+                if (config.keepaliveInterval > 0) {
+                    timeout = Duration.ofSeconds(config.keepaliveInterval);
                 }
 
                 logger.debug("Starting communication thread to {}", hostName);

--- a/bundles/org.openhab.binding.nobohub/src/test/java/org/openhab/binding/nobohub/internal/NoboHubBridgeConfigurationTest.java
+++ b/bundles/org.openhab.binding.nobohub/src/test/java/org/openhab/binding/nobohub/internal/NoboHubBridgeConfigurationTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.nobohub.internal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.jupiter.api.Test;
+import org.openhab.core.config.core.Configuration;
+
+/**
+ * Unit tests for the Nobø Hub bridge configuration.
+ *
+ * A thing configuration is bound to a configuration class by field name, so a parameter declared in the thing type
+ * whose name has no matching field is silently dropped and the field keeps its default value.
+ *
+ * @author Max Freedom Pollard - Initial contribution
+ */
+@NonNullByDefault
+public class NoboHubBridgeConfigurationTest {
+
+    private static final Path BRIDGE_XML = Path.of("src", "main", "resources", "OH-INF", "thing", "bridge.xml");
+    private static final Pattern PARAMETER_NAME_PATTERN = Pattern.compile("<parameter\\s+name=\"([^\"]+)\"");
+
+    private static final String KEEPALIVE_INTERVAL = "keepaliveInterval";
+
+    @Test
+    public void everyDeclaredParameterHasAMatchingConfigurationField() throws IOException {
+        List<String> declaredParameters = readDeclaredParameterNames();
+        assertFalse(declaredParameters.isEmpty(), "No configuration parameters found in " + BRIDGE_XML);
+
+        Set<String> fieldNames = new HashSet<>();
+        for (Field field : NoboHubBridgeConfiguration.class.getFields()) {
+            fieldNames.add(field.getName());
+        }
+
+        for (String parameter : declaredParameters) {
+            assertTrue(fieldNames.contains(parameter), "Parameter '" + parameter + "' declared in " + BRIDGE_XML
+                    + " has no matching field in NoboHubBridgeConfiguration");
+        }
+    }
+
+    @Test
+    public void keepaliveIntervalReachesTheConfiguration() throws ReflectiveOperationException {
+        Configuration configuration = new Configuration(Map.of(KEEPALIVE_INTERVAL, 30));
+
+        NoboHubBridgeConfiguration config = configuration.as(NoboHubBridgeConfiguration.class);
+
+        // Read by name because it is the parameter name matching the field name that is under test here.
+        assertEquals(30, NoboHubBridgeConfiguration.class.getField(KEEPALIVE_INTERVAL).getInt(config));
+    }
+
+    private List<String> readDeclaredParameterNames() throws IOException {
+        List<String> names = new ArrayList<>();
+        for (String line : Files.readAllLines(BRIDGE_XML)) {
+            Matcher matcher = PARAMETER_NAME_PATTERN.matcher(line);
+            if (matcher.find()) {
+                names.add(matcher.group(1));
+            }
+        }
+        return names;
+    }
+}


### PR DESCRIPTION
Bugfix. The Nobo Hub bridge has a "Polling interval" setting that has never done anything.

`bundles/org.openhab.binding.nobohub/src/main/resources/OH-INF/thing/bridge.xml` declares the parameter as `keepaliveInterval` (minimum 5, default 14), and both `nobohub.properties` and `nobohub_fr.properties` translate it under that name. `NoboHubBridgeConfiguration` called the matching field `pollingInterval`.

openHAB binds a thing configuration to a configuration class by field name. `ConfigParser#constructClass` in openhab-core does `properties.get(fieldName)` and skips the field when the configuration has no entry under that exact name. So the value a user sets never reached the field, it stayed at 0, the `config.pollingInterval > 0` guard at `NoboHubBridgeHandler.java:161` was never true, and the timeout passed to `HubCommunicationThread` was always `RECOMMENDED_KEEPALIVE_INTERVAL`, 14 seconds, no matter what was configured. The two names have differed since the initial contribution in bc9cf8e0 (#12937).

The fix renames the field to `keepaliveInterval`. I renamed the field rather than the parameter so that thing configurations people already have keep working and both i18n files stay correct.

`NoboHubBridgeConfigurationTest` is new. It reads the parameter names out of `bridge.xml` and asserts each one has a matching field on the configuration class, and it round-trips a `keepaliveInterval` of 30 through `org.openhab.core.config.core.Configuration#as`. Against unmodified main both tests fail, with `Parameter 'keepaliveInterval' declared in src/main/resources/OH-INF/thing/bridge.xml has no matching field in NoboHubBridgeConfiguration` and `NoSuchFieldException: keepaliveInterval`. With the change they pass.

The README gained three lines for the parameter, since it now has an effect.

Testing: `mvn clean verify -am -amd -pl :org.openhab.binding.nobohub` plus the three BOM index modules, the way `.github/scripts/maven-build` invokes it for a single changed add-on, on Temurin 21.0.12.1. BUILD SUCCESS, `Tests run: 61, Failures: 0, Errors: 0, Skipped: 0`. That run includes `spotless:check` and the static analysis for the module; the six SAT findings it reports for nobohub are all priority 3 and all in files this PR does not touch. `mvn spotless:apply -pl :org.openhab.binding.nobohub` produced no changes, and `npx markdownlint-cli2 --config .github/markdownlint.yaml bundles/org.openhab.binding.nobohub/README.md` reports 0 issues.
