### PR TITLE
[shelly] Fix spurious meter channels on non-PM relay devices

### DIFF
--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/ShellyDevices.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/ShellyDevices.java
@@ -743,10 +743,16 @@ public class ShellyDevices {
 
     // Number of meters, if they can't be auto-detected
     public static final Map<ThingTypeUID, Integer> THING_TYPE_CAP_NUM_METERS = Map.ofEntries( //
+            // no power metering, verified against shelly-api-docs.shelly.cloud
+            Map.entry(THING_TYPE_SHELLY1, 0), //
+            Map.entry(THING_TYPE_SHELLY1L, 0), //
+            Map.entry(THING_TYPE_SHELLYPLUS1, 0), //
+            Map.entry(THING_TYPE_SHELLYPRO1, 0), //
+            Map.entry(THING_TYPE_SHELLYMINI_1, 0), //
             Map.entry(THING_TYPE_SHELLYPRO2, 0), //
             Map.entry(THING_TYPE_SHELLYPRO3, 0), //
-            Map.entry(THING_TYPE_SHELLYPLUS1L, 0), // no power metering
-            Map.entry(THING_TYPE_SHELLYPLUS2L, 0), // no power metering
+            Map.entry(THING_TYPE_SHELLYPLUS1L, 0), //
+            Map.entry(THING_TYPE_SHELLYPLUS2L, 0), //
             Map.entry(THING_TYPE_SHELLYPROEM50, 2), //
             Map.entry(THING_TYPE_SHELLY3EM, 3), //
             Map.entry(THING_TYPE_SHELLYPLUS3EM63, 3), //

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/handler/ShellyComponents.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/handler/ShellyComponents.java
@@ -224,6 +224,7 @@ public class ShellyComponents {
      */
     public static boolean updateMeters(ShellyThingInterface thingHandler, ShellySettingsStatus status) {
         ShellyDeviceProfile profile = thingHandler.getProfile();
+        reconcileMeterChannels(thingHandler, profile);
         if (status.meters == null && status.emeters == null) {
             return false;
         }
@@ -1031,6 +1032,13 @@ public class ShellyComponents {
         if (!profile.settings.loraDetected) {
             profile.addOnFw = "";
             thingHandler.removeProperty(PROPERTY_ADDON_FIRMWARE);
+        }
+    }
+
+    private static void reconcileMeterChannels(ShellyThingInterface thingHandler, ShellyDeviceProfile profile) {
+        Set<String> obsolete = ShellyChannelDefinitions.getObsoleteMeterChannelIds(profile);
+        if (!obsolete.isEmpty()) {
+            thingHandler.removeChannels(obsolete);
         }
     }
 

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/provider/ShellyChannelDefinitions.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/provider/ShellyChannelDefinitions.java
@@ -757,6 +757,25 @@ public class ShellyChannelDefinitions {
         return newChannels;
     }
 
+    private static final Set<String> SIMPLE_METER_CHANNELS = Set.of(CHGR_METER + "#" + CHANNEL_METER_CURRENTWATTS,
+            CHGR_METER + "#" + CHANNEL_METER_TOTALKWH, CHGR_METER + "#" + CHANNEL_METER_ENERGYHISTMIN1,
+            CHGR_METER + "#" + CHANNEL_METER_ENERGYHISTMIN2, CHGR_METER + "#" + CHANNEL_METER_ENERGYHISTMIN3,
+            CHGR_METER + "#" + CHANNEL_METER_ENERGYAVGLAST3MIN, CHGR_METER + "#" + CHANNEL_LAST_UPDATE);
+
+    /**
+     * @return simple-meter channel ids ("group#channel") stale once resolveNumMeters() reports no metering
+     *         hardware for this device (numMeters == 0), left over on Things created before
+     *         THING_TYPE_CAP_NUM_METERS covered it, and to be removed. Never returned for EMeter/3EM or the
+     *         roller/RGBW2 aggregated-meter devices, which share several of the same channel ids under their
+     *         own code paths.
+     */
+    public static Set<String> getObsoleteMeterChannelIds(final ShellyDeviceProfile profile) {
+        if (profile.numMeters > 0 || profile.isEMeter || profile.isRoller || profile.isRGBW2) {
+            return Set.of();
+        }
+        return SIMPLE_METER_CHANNELS;
+    }
+
     public static Map<String, Channel> createEMNCurrentChannels(final Thing thing,
             @Nullable ShellyEMNCurrentSettings settings, ShellyEMNCurrentStatus status) {
         String group = CHANNEL_GROUP_NMETER;

--- a/bundles/org.openhab.binding.shelly/src/test/java/org/openhab/binding/shelly/internal/api/ShellyDeviceProfileTest.java
+++ b/bundles/org.openhab.binding.shelly/src/test/java/org/openhab/binding/shelly/internal/api/ShellyDeviceProfileTest.java
@@ -486,6 +486,12 @@ public class ShellyDeviceProfileTest {
                 Arguments.of(THING_TYPE_SHELLYPROEM50, -1, -1, false, false, 0, false, 0, 0, false, 2), //
                 // ProEM50 capMap wins even when relay is present (relay gets its own slot via hasEM1Clamps override)
                 Arguments.of(THING_TYPE_SHELLYPROEM50, -1, -1, false, false, 0, true, 1, 0, false, 2), //
+                // no-PM relay-only devices: capMap wins over the relay-count fallback
+                Arguments.of(THING_TYPE_SHELLY1, 0, -1, false, false, 0, true, 1, 0, false, 0), //
+                Arguments.of(THING_TYPE_SHELLY1L, 0, -1, false, false, 0, true, 1, 0, false, 0), //
+                Arguments.of(THING_TYPE_SHELLYPLUS1, -1, -1, false, false, 0, true, 1, 0, false, 0), //
+                Arguments.of(THING_TYPE_SHELLYPRO1, -1, -1, false, false, 0, true, 1, 0, false, 0), //
+                Arguments.of(THING_TYPE_SHELLYMINI_1, -1, -1, false, false, 0, true, 1, 0, false, 0), //
 
                 // P3: device-config detection — thingType not in capMap
                 Arguments.of(THING_TYPE_SHELLYMINI_PM, -1, 1, false, false, 0, false, 0, 0, false, 1), // pm10 → 1
@@ -505,7 +511,6 @@ public class ShellyDeviceProfileTest {
                 Arguments.of(THING_TYPE_SHELLYBULB, -1, -1, true, true, 1, false, 0, 0, false, 1), //
 
                 // P5: relay fallback (not in capMap, not a light, no config data)
-                Arguments.of(THING_TYPE_SHELLYPLUS1, -1, -1, false, false, 0, true, 1, 0, false, 1), //
                 Arguments.of(THING_TYPE_SHELLYPRO1PM, -1, -1, false, false, 0, true, 1, 0, false, 1), //
                 Arguments.of(THING_TYPE_SHELLYPRO4PM, -1, -1, false, false, 0, true, 4, 0, false, 4), //
                 Arguments.of(THING_TYPE_SHELLY25_ROLLER, -1, -1, false, false, 0, true, 0, 1, true, 1), //

--- a/bundles/org.openhab.binding.shelly/src/test/java/org/openhab/binding/shelly/internal/handler/ShellyComponentsTest.java
+++ b/bundles/org.openhab.binding.shelly/src/test/java/org/openhab/binding/shelly/internal/handler/ShellyComponentsTest.java
@@ -561,6 +561,63 @@ public class ShellyComponentsTest {
     }
 
     @Test
+    void updateMetersNumMetersZeroRemovesObsoleteMeterChannels() {
+        ShellyDeviceProfile profile = simpleRelayProfile(0);
+        ShellySettingsMeter m0 = new ShellySettingsMeter();
+        m0.isValid = true;
+
+        ShellySettingsStatus status = statusWithMeters(m0);
+        ShellyThingInterface handler = mockHandler(profile);
+
+        ShellyComponents.updateMeters(handler, status);
+
+        verify(handler)
+                .removeChannels(argThat(ids -> ids.contains(CHANNEL_GROUP_METER + "#" + CHANNEL_METER_CURRENTWATTS)
+                        && ids.contains(CHANNEL_GROUP_METER + "#" + CHANNEL_METER_TOTALKWH)
+                        && ids.contains(CHANNEL_GROUP_METER + "#" + CHANNEL_LAST_UPDATE)));
+        verify(handler, never()).updateChannel(eq(CHANNEL_GROUP_METER), anyString(), any(State.class));
+    }
+
+    @Test
+    void updateMetersNumMetersPositiveKeepsMeterChannels() {
+        ShellyDeviceProfile profile = simpleRelayProfile(1);
+        ShellySettingsMeter m0 = new ShellySettingsMeter();
+        m0.isValid = true;
+        m0.power = 55.0;
+
+        ShellySettingsStatus status = statusWithMeters(m0);
+        ShellyThingInterface handler = mockHandler(profile);
+
+        ShellyComponents.updateMeters(handler, status);
+
+        verify(handler, never()).removeChannels(any());
+    }
+
+    @Test
+    void updateMetersEMeterNumMetersZeroKeepsMeterChannels() {
+        ShellyDeviceProfile profile = emeterProfile(false, 0);
+
+        ShellySettingsStatus status = statusWithEMeters(emeter(100.0));
+        ShellyThingInterface handler = mockHandler(profile);
+
+        ShellyComponents.updateMeters(handler, status);
+
+        verify(handler, never()).removeChannels(any());
+    }
+
+    @Test
+    void updateMetersRollerNumMetersZeroKeepsMeterChannels() {
+        ShellyDeviceProfile profile = rollerGen2Profile(0);
+
+        ShellySettingsStatus status = statusWithEMeters(emeter(100.0));
+        ShellyThingInterface handler = mockHandler(profile);
+
+        ShellyComponents.updateMeters(handler, status);
+
+        verify(handler, never()).removeChannels(any());
+    }
+
+    @Test
     void gen1RollerAggregatedMeterSumsBothMotorChannels() {
         ShellyDeviceProfile profile = gen1RollerProfile();
         ShellySettingsMeter m0 = new ShellySettingsMeter();


### PR DESCRIPTION
## Fix

- No more spurious `meter`/`device#accumulated*` channels on devices without power metering hardware 

Affected devices:
  - Shelly 1 (Gen1)
  - Shelly 1L (Gen1)
  - Shelly Plus 1
  - Shelly Pro 1
  - Shelly 1 Mini
