### PR TITLE
[amazonechocontrol] Drop hardcoded conversation id

### DIFF
--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/dto/request/SendConversationDTO.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/dto/request/SendConversationDTO.java
@@ -23,7 +23,6 @@ import org.eclipse.jdt.annotation.NonNull;
  * @author Jan N. Klug - Initial contribution
  */
 public class SendConversationDTO {
-    public String conversationId;
     public String clientMessageId;
     public int messageId;
     public String time;
@@ -34,8 +33,8 @@ public class SendConversationDTO {
 
     @Override
     public @NonNull String toString() {
-        return "SendConversationDTO{conversationId='" + conversationId + "', clientMessageId='" + clientMessageId
-                + "', messageId=" + messageId + ", nextAlarmTime='" + time + "', sender='" + sender + "', type='" + type
-                + "', payload=" + payload + ", status=" + status + "}";
+        return "SendConversationDTO{clientMessageId='" + clientMessageId + "', messageId=" + messageId + ", time='"
+                + time + "', sender='" + sender + "', type='" + type + "', payload=" + payload + ", status=" + status
+                + "}";
     }
 }

--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/handler/AccountHandler.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/handler/AccountHandler.java
@@ -244,7 +244,6 @@ public class AccountHandler extends BaseBridgeHandler implements PushConnection.
                 }
 
                 SendConversationDTO conversation = new SendConversationDTO();
-                conversation.conversationId = "amzn1.comms.messaging.id.conversationV2~31e6fe8f-8b0c-4e84-a1e4-80030a09009b";
                 conversation.clientMessageId = java.util.UUID.randomUUID().toString();
                 conversation.messageId = lastMessageId++;
                 conversation.sender = currentAccount.commsId;


### PR DESCRIPTION
An improvement, not a bug fix: nothing was broken for the user, the message is delivered either way.

`sendMessage` sends a conversation id that is hardcoded in the source and derived from no account. It arrived with the 2.x migration and is the same string for every user of the binding.

The request already addresses the conversation in the path, with the account's own comms id (`/users/<commsId>/conversations/<commsId>/messages`), so the field in the body named a conversation that belongs to nobody here. With the field gone, Amazon answers 200 and the message arrives.

While that `toString` is rewrapped, the label of the neighbouring field is corrected: it printed `time` as `nextAlarmTime`.

Verified on openHAB 5.3.0.M1 against amazon.de: same account, same item, one run with the constant and one without, fifteen minutes apart. Both answered 200, both messages showed up in the Alexa app under Communicate.

Reviewed against wborn/github-review-policy at `ca8d3f4d07b3` (2026-08-19) before submission.

**Transparency:** this patch and the comments on this PR were written with AI assistance (Claude); every commit carries an `AI-assisted-by` trailer.
