### PR TITLE
[icalendar] Stop reusing stale connections

### DIFF
--- a/bundles/org.openhab.binding.icalendar/src/main/java/org/openhab/binding/icalendar/internal/handler/PullJob.java
+++ b/bundles/org.openhab.binding.icalendar/src/main/java/org/openhab/binding/icalendar/internal/handler/PullJob.java
@@ -91,8 +91,10 @@ class PullJob implements Runnable {
 
     @Override
     public void run() {
+        // A calendar server can close a pooled connection without the client seeing it go, and the
+        // next pull minutes later then fails with an EOFException. Do not keep the connection.
         final Request request = httpClient.newRequest(sourceURI).followRedirects(true).method(HttpMethod.GET)
-                .timeout(HTTP_TIMEOUT_SECS, TimeUnit.SECONDS);
+                .timeout(HTTP_TIMEOUT_SECS, TimeUnit.SECONDS).header(HttpHeader.CONNECTION, "close");
         if (userAgent != null && !userAgent.isBlank()) {
             request.agent(userAgent);
         }


### PR DESCRIPTION
Every second pull of a calendar on `outlook.live.com` failed with an `EOFException`, in a clean 30 minute rhythm on a 15 minute refresh. 329 failures in September, every one of them against that host.

The clients core hands out set no idle timeout, so a connection stays in the pool for the life of the process. Jetty drops a pooled connection when it sees the far end close it, and that is the whole difference between the calendars here. An idle probe from the same machine has `calendar.google.com` sending a FIN after 237 seconds, which Jetty acts on, while `outlook.live.com` sends nothing after 1021 seconds, and a production endpoint dump reported such a connection as `OPEN` after 900 seconds idle. The four Google calendars, two of them on the same 15 minute refresh, never failed once.

So the request now says it will not reuse the connection. hdpowerview does the same on the same shared client ([HDPowerViewWebTargets](https://github.com/openhab/openhab-addons/blob/e1607fe833fd39ca6192b4ab97c0a96ed4a4838f/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/HDPowerViewWebTargets.java#L586), [GatewayWebTargets](https://github.com/openhab/openhab-addons/blob/e1607fe833fd39ca6192b4ab97c0a96ed4a4838f/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/GatewayWebTargets.java#L252)), linkplay does it on a client of its own for the same `EOFException`.

Measured on openHAB 5.3.0.M1 with five calendars, four on Google and one on Outlook: 47, 47, 47, 47 and 46 failures on the five days before the change, and one on the day of the change. The pulls after it have all succeeded on both providers, and no connection to the failing host stayed open between them.

Reviewed against wborn/github-review-policy at `ca8d3f4d07b3` (2026-08-19) before submission.

**Transparency:** this patch and the comments on this PR were written with AI assistance (Claude), every commit carries an `AI-assisted-by` trailer.
