### PR TITLE
[freeathome] Do not replace the executor in use

### DIFF
--- a/bundles/org.openhab.binding.freeathome/src/main/java/org/openhab/binding/freeathome/internal/handler/FreeAtHomeBridgeHandler.java
+++ b/bundles/org.openhab.binding.freeathome/src/main/java/org/openhab/binding/freeathome/internal/handler/FreeAtHomeBridgeHandler.java
@@ -46,7 +46,6 @@ import org.eclipse.jetty.client.util.BasicAuthentication;
 import org.eclipse.jetty.client.util.StringContentProvider;
 import org.eclipse.jetty.http.HttpMethod;
 import org.eclipse.jetty.http.HttpStatus;
-import org.eclipse.jetty.util.thread.QueuedThreadPool;
 import org.eclipse.jetty.websocket.api.Session;
 import org.eclipse.jetty.websocket.api.StatusCode;
 import org.eclipse.jetty.websocket.api.WebSocketListener;
@@ -93,7 +92,6 @@ public class FreeAtHomeBridgeHandler extends BaseBridgeHandler implements WebSoc
     private final HttpClient httpClient;
     private @Nullable WebSocketClient websocketClient = null;
     private final FreeAtHomeWebsocketMonitorThread socketMonitor = new FreeAtHomeWebsocketMonitorThread();
-    private @Nullable QueuedThreadPool jettyThreadPool = null;
     private volatile @Nullable Session websocketSession = null;
 
     private final String sysApUID = "00000000-0000-0000-0000-000000000000";
@@ -688,17 +686,6 @@ public class FreeAtHomeBridgeHandler extends BaseBridgeHandler implements WebSoc
     public void closeWebSocketConnection() {
         socketMonitor.interrupt();
 
-        QueuedThreadPool localThreadPool = jettyThreadPool;
-
-        if (localThreadPool != null) {
-            try {
-                localThreadPool.stop();
-            } catch (Exception e1) {
-                logger.debug("Error by closing Websocket connection [{}]", e1.getMessage());
-            }
-            jettyThreadPool = null;
-        }
-
         WebSocketClient localWebSocketClient = websocketClient;
 
         if (localWebSocketClient != null) {
@@ -713,7 +700,7 @@ public class FreeAtHomeBridgeHandler extends BaseBridgeHandler implements WebSoc
 
     /**
      * Opens a WebSocket connection to the free@home system.
-     * This method initializes the thread pool and WebSocket client if they don't exist.
+     * This method creates the WebSocket client if it does not exist yet.
      *
      * @return true if the WebSocket connection is successfully opened or already exists, false otherwise.
      */
@@ -723,53 +710,21 @@ public class FreeAtHomeBridgeHandler extends BaseBridgeHandler implements WebSoc
         try {
             logger.debug("Current Jetty version: {}", org.eclipse.jetty.util.Jetty.VERSION);
 
-            QueuedThreadPool localThreadPool = jettyThreadPool;
-
-            if (localThreadPool == null) {
-                // Create a new thread pool if it doesn't exist
-                jettyThreadPool = new QueuedThreadPool();
-                localThreadPool = jettyThreadPool;
-
-                if (localThreadPool != null) {
-                    localThreadPool.setName(FreeAtHomeBridgeHandler.class.getSimpleName());
-                    localThreadPool.setDaemon(true);
-                    localThreadPool.setStopTimeout(0);
-                } else {
-                    throw new IllegalStateException("Failed to create QueuedThreadPool");
-                }
-            }
-
             WebSocketClient localWebSocketClient = websocketClient;
 
             if (localWebSocketClient == null) {
-                // Create a new WebSocket client if it doesn't exist
+                // A client built on an HttpClient runs on that client's executor. Handing it one of its
+                // own would replace the executor of a client that has already been started.
                 logger.debug("Creating new WebSocketClient with Jetty version {}",
                         org.eclipse.jetty.util.Jetty.VERSION);
-                localWebSocketClient = new WebSocketClient(httpClient);
-                websocketClient = localWebSocketClient;
-
-                if (localWebSocketClient != null) {
-                    // Set the executor immediately after creation, before any start
-                    localWebSocketClient.setExecutor(localThreadPool);
-                    // Do not start the client here; let connectWebsocketSession() handle it, see
-                    // localWebsocketClient.start() there
-                    socketMonitor.start();
-                    ret = true;
-                } else {
-                    throw new IllegalStateException("WebSocketClient initialization failed");
-                }
-            } else {
-                if (localWebSocketClient.isStarted()) {
-                    logger.debug("WebSocketClient is already started, skipping setExecutor()");
-                    ret = true; // Client exists and is running, no need to reconfigure
-                } else {
-                    // Set executor only if the client is not yet started
-                    logger.debug("WebSocketClient exists but not started, setting executor");
-                    localWebSocketClient.setExecutor(localThreadPool);
-                    socketMonitor.start();
-                    ret = true;
-                }
+                websocketClient = new WebSocketClient(httpClient);
+                // Do not start the client here; let connectWebsocketSession() handle it, see
+                // localWebsocketClient.start() there
+                socketMonitor.start();
+            } else if (!localWebSocketClient.isStarted()) {
+                socketMonitor.start();
             }
+            ret = true;
         } catch (Exception e) {
             logger.warn("Error in openWebSocketConnection: {}", e.getMessage());
             ret = false;
@@ -844,7 +799,6 @@ public class FreeAtHomeBridgeHandler extends BaseBridgeHandler implements WebSoc
     /**
      * Method to dispose
      */
-    @SuppressWarnings("null")
     @Override
     public void dispose() {
         // let run out the thread
@@ -853,17 +807,6 @@ public class FreeAtHomeBridgeHandler extends BaseBridgeHandler implements WebSoc
 
         logger.debug("Closing WebSocket connection");
         closeWebSocketConnection();
-
-        if (jettyThreadPool != null) {
-            try {
-                logger.debug("Stopping Jetty thread pool");
-                jettyThreadPool.stop();
-            } catch (Exception e) {
-                logger.warn("Error stopping Jetty thread pool: {}", e.getMessage());
-            } finally {
-                jettyThreadPool = null;
-            }
-        }
     }
 
     /**


### PR DESCRIPTION
I am working towards a startup without a single warning line.

The bridge hands a thread pool of its own to a WebSocket client built on the binding's `HttpClient`. `setExecutor` forwards to that `HttpClient`, which the handler factory has already started, so Jetty logs "Calling setExecutor() while started is deprecated" at every binding start, assigns the executor anyway, and `closeWebSocketConnection()` stops the pool again. The guard beside it asks the WebSocket client whether it is started, which at that point it never is.

The pool goes, and with it both `setExecutor` calls and the places that stopped it. Ten of the eleven bindings that build a WebSocket client on an existing `HttpClient` set no executor either. The websocket then shares the pool core gives that client, where `onWebSocketConnect()` already runs its blocking `fetchSysapVersion()`.

Tested on openHAB 5.3.0.M1 against a SysAP: the warning is gone and the bridge keeps its two connections to the gateway. With #21559 applied as well, which my device things need to initialize at all, everything stays online with websocket data and ping and pong over three minutes.

**Transparency:** this patch and the comments on this PR were written with AI assistance (Claude), every commit carries an `AI-assisted-by` trailer.
