### PR TITLE
[yamlcomposer] Fix missing empty maps in the package output

### DIFF
--- a/bundles/org.openhab.io.yamlcomposer/doc/packages.md
+++ b/bundles/org.openhab.io.yamlcomposer/doc/packages.md
@@ -205,23 +205,6 @@ Package consumers can use `!default`, `!replace` (or `!freeze`), and `!remove` t
 The [deep‑merge](deep-merge.md) documentation contains the authoritative, consolidated definitions and examples for these tags.
 Use the deep‑merge reference when you need the precise semantics for the merge behavior during package merging.
 
-## Automatic Removal of Empty Values
-
-During merging, empty structures are automatically stripped from the final configuration.
-Empty maps (`{}`) and lists (`[]`) as well as map keys whose value is `null` or an empty string are removed.
-This keeps the resulting configuration clean and allows packages to define catch‑all defaults.
-
-**Example:**
-
-```yaml
-variables:
-  icon: null   # default to avoid unknown‑variable warnings
-
-icon: ${icon}
-```
-
-Because `icon` evaluates to `null`, the entire `icon:` key is removed from the merged output unless the including file overrides it.
-
 ## How Package Merging Differs from YAML Merge Keys
 
 Mappings from packages are merged recursively with the corresponding mappings in the final top‑level section.

--- a/bundles/org.openhab.io.yamlcomposer/src/main/java/org/openhab/io/yamlcomposer/internal/core/PackageProcessor.java
+++ b/bundles/org.openhab.io.yamlcomposer/src/main/java/org/openhab/io/yamlcomposer/internal/core/PackageProcessor.java
@@ -13,8 +13,6 @@
 package org.openhab.io.yamlcomposer.internal.core;
 
 import java.nio.file.Path;
-import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -101,7 +99,6 @@ public class PackageProcessor {
             EvaluationContext pkgContext = new EvaluationContext(packageScope, ProcessingPhase.STANDARD);
             Object resolvedPkg = recursiveTransformer.transform(pkg, pkgContext);
 
-            resolvedPkg = stripEmptyMapsAndLists(resolvedPkg);
             if (!(resolvedPkg instanceof Map<?, ?> packageMap)) {
                 var position = sourceLocator.findPosition(PACKAGES_KEY, packageId);
                 logger.warn("{}:{} package '{}' resolved to {} instead of a Map", relativePath, position, packageId,
@@ -112,32 +109,5 @@ public class PackageProcessor {
             logger.debug("Merging package '{}' {} into main data: {}", packageId, packageMap, mainData);
             recursiveTransformer.getStructuralMerger().deepMerge(packageMap, mainData);
         });
-    }
-
-    private static @Nullable Object stripEmptyMapsAndLists(@Nullable Object data) {
-        if (data == null || data instanceof String s && s.isBlank()) {
-            return null;
-        }
-        if (data instanceof Map<?, ?> map) {
-            var result = new LinkedHashMap<Object, Object>();
-            for (Map.Entry<?, ?> e : map.entrySet()) {
-                Object key = e.getKey();
-                Object value = stripEmptyMapsAndLists(e.getValue());
-                if (value != null) {
-                    result.put(key, value);
-                }
-            }
-            return result.isEmpty() ? null : result;
-        } else if (data instanceof List<?> list) {
-            var result = new java.util.ArrayList<Object>(list.size());
-            for (Object item : list) {
-                Object value = stripEmptyMapsAndLists(item);
-                if (value != null) {
-                    result.add(value);
-                }
-            }
-            return result.isEmpty() ? null : result;
-        }
-        return data;
     }
 }

--- a/bundles/org.openhab.io.yamlcomposer/src/test/java/org/openhab/io/yamlcomposer/internal/YamlComposerPackagingTest.java
+++ b/bundles/org.openhab.io.yamlcomposer/src/test/java/org/openhab/io/yamlcomposer/internal/YamlComposerPackagingTest.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import org.eclipse.jdt.annotation.Nullable;
 import org.junit.jupiter.api.DisplayName;
@@ -319,6 +320,40 @@ class YamlComposerPackagingTest extends AbstractYamlComposerTest {
 
             assertThat(getNestedValue(data, "things", "thing", "config"),
                     equalTo(Map.of("from_main", true, "retained", true, "from_package", true)));
+        }
+
+        @Test
+        @DisplayName("Preserves empty maps and lists in main document and package output")
+        void preservesEmptyMapsAndLists() throws IOException {
+            writeFixture("pkg.yaml", """
+                    things:
+                      pkg_empty_map: {}
+                      pkg_empty_list: []
+                    """);
+
+            Path main = writeFixture("main.yaml", """
+                    packages:
+                      p1: !include pkg.yaml
+                    things:
+                      main_empty_map: {}
+                      main_empty_list: []
+                    """);
+
+            Map<Object, @Nullable Object> data = loadFixture(main);
+
+            @SuppressWarnings("unchecked")
+            Map<Object, @Nullable Object> things = (Map<Object, @Nullable Object>) Objects
+                    .requireNonNull(getNestedValue(data, "things"));
+            assertThat(things, hasKey("pkg_empty_map"));
+            assertThat(things, hasKey("pkg_empty_list"));
+            assertThat(things, hasKey("main_empty_map"));
+            assertThat(things, hasKey("main_empty_list"));
+
+            assertThat(things.get("pkg_empty_map"), equalTo(Map.of()));
+            assertThat(things.get("pkg_empty_list"), equalTo(List.of()));
+
+            assertThat(things.get("main_empty_map"), equalTo(Map.of()));
+            assertThat(things.get("main_empty_list"), equalTo(List.of()));
         }
 
         @Nested


### PR DESCRIPTION
Issue reported in the forum
https://community.openhab.org/t/yamlcomposer-pass-empty-map-to-channels-definition-bug/170356