### PR TITLE
[yamlcomposer] Fix missing empty maps in the package output

### DIFF
--- a/bundles/org.openhab.io.yamlcomposer/doc/packages.md
+++ b/bundles/org.openhab.io.yamlcomposer/doc/packages.md
@@ -219,23 +219,6 @@ The way keys interact depends on their data type.
 | Map       | Merge     | Maps are merged key by key, recursively.                                                                 |
 | List      | Merge     | Lists are concatenated (package values first) and de-duplicated.                                         |
 
-### Automatic Removal of Empty Values
-
-During merging, empty structures are automatically stripped from the final configuration.
-Empty maps (`{}`) and lists (`[]`) as well as map keys whose value is `null` or an empty string are removed.
-This keeps the resulting configuration clean and allows packages to define catch‑all defaults.
-
-**Example:**
-
-```yaml
-variables:
-  icon: null   # default to avoid unknown‑variable warnings
-
-icon: ${icon}
-```
-
-Because `icon` evaluates to `null`, the entire `icon:` key is removed from the merged output unless the including file overrides it.
-
 ### How Package Merging Differs from YAML Merge Keys
 
 Mappings from packages are merged recursively with the corresponding mappings in the final top‑level section.

--- a/bundles/org.openhab.io.yamlcomposer/src/main/java/org/openhab/io/yamlcomposer/internal/core/PackageProcessor.java
+++ b/bundles/org.openhab.io.yamlcomposer/src/main/java/org/openhab/io/yamlcomposer/internal/core/PackageProcessor.java
@@ -13,8 +13,6 @@
 package org.openhab.io.yamlcomposer.internal.core;
 
 import java.nio.file.Path;
-import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 
@@ -92,7 +90,6 @@ public class PackageProcessor {
             RecursiveTransformer packageTransformer = recursiveTransformer.withOverrideVariables(packageIdMap);
             Object resolvedPkg = packageTransformer.transform(pkg, ProcessingPhase.STANDARD);
 
-            resolvedPkg = stripEmptyMapsAndLists(resolvedPkg);
             if (!(resolvedPkg instanceof Map<?, ?> packageMap)) {
                 var position = sourceLocator.findPosition(PACKAGES_KEY, packageId);
                 logger.warn("{}:{} package '{}' resolved to {} instead of a Map", relativePath, position, packageId,
@@ -153,32 +150,5 @@ public class PackageProcessor {
                 rawMainData.put(packageKey, packageValue);
             }
         });
-    }
-
-    private static @Nullable Object stripEmptyMapsAndLists(@Nullable Object data) {
-        if (data == null || data instanceof String s && s.isBlank()) {
-            return null;
-        }
-        if (data instanceof Map<?, ?> map) {
-            var result = new LinkedHashMap<Object, Object>();
-            for (Map.Entry<?, ?> e : map.entrySet()) {
-                Object key = e.getKey();
-                Object value = stripEmptyMapsAndLists(e.getValue());
-                if (value != null) {
-                    result.put(key, value);
-                }
-            }
-            return result.isEmpty() ? null : result;
-        } else if (data instanceof List<?> list) {
-            var result = new java.util.ArrayList<Object>(list.size());
-            for (Object item : list) {
-                Object value = stripEmptyMapsAndLists(item);
-                if (value != null) {
-                    result.add(value);
-                }
-            }
-            return result.isEmpty() ? null : result;
-        }
-        return data;
     }
 }


### PR DESCRIPTION
This is the backport for #21635 onto 5.2.x

This backport doesn't include the accompanying test, because the single test file in 5.2.x has been split up into separate files in the `main` branch.