### PR TITLE
[tuya] Map cloud schema type Bitmap to bitmap

### DIFF
--- a/bundles/org.openhab.binding.tuya/src/main/java/org/openhab/binding/tuya/internal/util/SchemaDp.java
+++ b/bundles/org.openhab.binding.tuya/src/main/java/org/openhab/binding/tuya/internal/util/SchemaDp.java
@@ -34,6 +34,7 @@ import com.google.gson.Gson;
 @NonNullByDefault
 public class SchemaDp {
     private static final Map<String, String> REMOTE_LOCAL_TYPE_MAP = Map.of( //
+            "Bitmap", "bitmap", //
             "Boolean", "bool", //
             "Enum", "enum", //
             "Integer", "value", //

--- a/bundles/org.openhab.binding.tuya/src/test/java/org/openhab/binding/tuya/internal/util/SchemaDpTest.java
+++ b/bundles/org.openhab.binding.tuya/src/test/java/org/openhab/binding/tuya/internal/util/SchemaDpTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.tuya.internal.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.openhab.binding.tuya.internal.cloud.dto.DeviceSchema;
+
+import com.google.gson.Gson;
+
+/**
+ * The {@link SchemaDpTest} verifies the conversion of cloud schema descriptions to {@link SchemaDp}.
+ *
+ * @author Carlo Dischler - Initial contribution
+ */
+@NonNullByDefault
+public class SchemaDpTest {
+    private final Gson gson = new Gson();
+
+    @ParameterizedTest
+    @CsvSource({ "Bitmap,bitmap", "Boolean,bool", "Enum,enum", "Integer,value", "String,string", "Json,string" })
+    public void remoteTypeIsMappedToLocalType(String remoteType, String localType) {
+        DeviceSchema.Description description = new DeviceSchema.Description();
+        description.code = "fault";
+        description.dp_id = 22;
+        description.type = remoteType;
+        description.values = "{\"label\":[\"E1\",\"E2\"],\"maxlen\":4}";
+
+        SchemaDp schemaDp = SchemaDp.fromRemoteSchema(gson, description, Boolean.TRUE);
+
+        assertEquals(localType, schemaDp.type);
+        assertEquals(22, schemaDp.id);
+        assertEquals("fault", schemaDp.code);
+        assertEquals(Boolean.TRUE, schemaDp.readOnly);
+    }
+
+    @Test
+    public void unknownRemoteTypeFallsBackToRaw() {
+        DeviceSchema.Description description = new DeviceSchema.Description();
+        description.code = "unknown";
+        description.dp_id = 1;
+        description.type = "Raw";
+
+        SchemaDp schemaDp = SchemaDp.fromRemoteSchema(gson, description, Boolean.FALSE);
+
+        assertEquals("raw", schemaDp.type);
+    }
+}


### PR DESCRIPTION
**Classification:** Bugfix

## Description

Tuya reports fault/alarm datapoints in device specifications retrieved from the cloud with the type `Bitmap`.
`SchemaDp.REMOTE_LOCAL_TYPE_MAP` only knows `Boolean`, `Enum`, `Integer`, `String` and `Json`, so such datapoints fall back to the type `raw` when a schema is stored during discovery.
`TuyaChannelTypeProvider` then does not know how to build a channel type for `raw` and creates a `String` channel ("Don't know how to build a channel type for schema entry fault type raw - using string").
Because the device reports a number for the datapoint, `TuyaDeviceHandler` discards every update ("Datatype incompatible") and the linked item stays `UNDEF`.

The `bitmap` channel type itself (a read-only `Number` channel with pattern `%x`, config description `channel-type:tuya:bitmap`) was added in #20428, but it is only reachable for schemas built into the binding because the cloud type name was never mapped.
This PR adds the missing mapping so cloud-retrieved schemas produce the same channel.

**Changes for end users:** Devices whose cloud schema contains `Bitmap` datapoints get a `Number` channel for them instead of a non-working `String` channel.
Schemas that were already stored with type `raw` are not rewritten by this change; they need to be retrieved from the cloud again (a way to do that from the console and the UI is proposed in a separate PR).

No documentation change is needed, the `bitmap` channel type is not user-configurable.

## Testing

- `mvn spotless:apply` and `mvn clean install -pl :org.openhab.binding.tuya` run locally.
- New unit test `SchemaDpTest` covers the type mapping and the `raw` fallback.
- Tested on openHAB 5.2.1 with a dehumidifier (product `c3tqjuz74lobbpew`) whose `fault` datapoint is reported as `Bitmap` with `maxlen` 4: with the mapping the channel is created as `Number` and receives the fault value.