### PR TITLE
[roborock] Fix formatting in README.md examples

### DIFF
--- a/bundles/org.openhab.binding.roborock/README.md
+++ b/bundles/org.openhab.binding.roborock/README.md
@@ -132,7 +132,7 @@ In case your vacuum does not support one of these commands, it will show "unsupp
 
 ```java
 Bridge roborock:account:account [ email="xxxx", twofa="xxxx" ] {
-    roborock:vacuum:QrevoS [ refresh=5, cloudRefreshInterval=300 ]
+    Thing vacuum QrevoS [ refresh=5, cloudRefreshInterval=300 ]
 }
 ```
 


### PR DESCRIPTION
Syntax Error on things configuration, provided by VSCode with openhab plugin: Line 2: Provide a thing type ID and a thing ID in this format: <thingTypeId> <thingId>

