### PR TITLE
[goecharger] Keep refresh job alive on unexpected errors

### DIFF
--- a/bundles/org.openhab.binding.goecharger/src/main/java/org/openhab/binding/goecharger/internal/handler/GoEChargerBaseHandler.java
+++ b/bundles/org.openhab.binding.goecharger/src/main/java/org/openhab/binding/goecharger/internal/handler/GoEChargerBaseHandler.java
@@ -138,19 +138,24 @@ public abstract class GoEChargerBaseHandler extends BaseThingHandler {
         } catch (IllegalArgumentException e) {
             logger.debug("Invalid configuration getting data: {}", e.toString());
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.OFFLINE.CONFIGURATION_ERROR, e.getMessage());
+        } catch (RuntimeException e) {
+            // scheduleWithFixedDelay silently stops the periodic execution once an exception escapes the task.
+            // An unexpected value in a single response must not kill the refresh job for good.
+            logger.warn("Unexpected error while refreshing go-e Charger data", e);
+            updateChannelsAndStatus(null, e.toString());
         }
     }
 
     private void startAutomaticRefresh() {
         ScheduledFuture<?> refreshJob = this.refreshJob;
-        if (refreshJob != null && !refreshJob.isCancelled()) {
+        if (refreshJob != null && !refreshJob.isDone()) {
             logger.debug("Refresh job is already running, not starting a new one.");
             return;
         }
 
         int delay = config.refreshInterval.intValue();
         logger.debug("Running refresh job with delay {} s", delay);
-        refreshJob = scheduler.scheduleWithFixedDelay(this::refresh, 0, delay, TimeUnit.SECONDS);
+        this.refreshJob = scheduler.scheduleWithFixedDelay(this::refresh, 0, delay, TimeUnit.SECONDS);
     }
 
     @Override

--- a/bundles/org.openhab.binding.goecharger/src/main/java/org/openhab/binding/goecharger/internal/handler/GoEChargerV2Handler.java
+++ b/bundles/org.openhab.binding.goecharger/src/main/java/org/openhab/binding/goecharger/internal/handler/GoEChargerV2Handler.java
@@ -24,6 +24,9 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+import javax.measure.Quantity;
+import javax.measure.Unit;
+
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.jetty.client.HttpClient;
@@ -154,12 +157,12 @@ public class GoEChargerV2Handler extends GoEChargerBaseHandler {
                 if (goeResponse.temperatures == null || goeResponse.temperatures.length < 2) {
                     return UnDefType.UNDEF;
                 }
-                return new QuantityType<>(goeResponse.temperatures[0], SIUnits.CELSIUS);
+                return toQuantity(goeResponse.temperatures[0], SIUnits.CELSIUS);
             case TEMPERATURE_CIRCUIT_BOARD:
                 if (goeResponse.temperatures == null || goeResponse.temperatures.length < 2) {
                     return UnDefType.UNDEF;
                 }
-                return new QuantityType<>(goeResponse.temperatures[1], SIUnits.CELSIUS);
+                return toQuantity(goeResponse.temperatures[1], SIUnits.CELSIUS);
             case SESSION_CHARGE_CONSUMPTION:
                 if (goeResponse.sessionChargeConsumption == null) {
                     return UnDefType.UNDEF;
@@ -176,55 +179,25 @@ public class GoEChargerV2Handler extends GoEChargerBaseHandler {
                 }
                 return new QuantityType<>(goeResponse.totalChargeConsumption / 1000d, Units.KILOWATT_HOUR);
             case VOLTAGE_L1:
-                if (goeResponse.energy == null || goeResponse.energy.length < 1) {
-                    return UnDefType.UNDEF;
-                }
-                return new QuantityType<>(goeResponse.energy[0], Units.VOLT);
+                return toQuantity(element(goeResponse.energy, 0), Units.VOLT);
             case VOLTAGE_L2:
-                if (goeResponse.energy == null || goeResponse.energy.length < 2) {
-                    return UnDefType.UNDEF;
-                }
-                return new QuantityType<>(goeResponse.energy[1], Units.VOLT);
+                return toQuantity(element(goeResponse.energy, 1), Units.VOLT);
             case VOLTAGE_L3:
-                if (goeResponse.energy == null || goeResponse.energy.length < 3) {
-                    return UnDefType.UNDEF;
-                }
-                return new QuantityType<>(goeResponse.energy[2], Units.VOLT);
+                return toQuantity(element(goeResponse.energy, 2), Units.VOLT);
             case CURRENT_L1:
-                if (goeResponse.energy == null || goeResponse.energy.length < 5) {
-                    return UnDefType.UNDEF;
-                }
-                return new QuantityType<>(goeResponse.energy[4], Units.AMPERE);
+                return toQuantity(element(goeResponse.energy, 4), Units.AMPERE);
             case CURRENT_L2:
-                if (goeResponse.energy == null || goeResponse.energy.length < 6) {
-                    return UnDefType.UNDEF;
-                }
-                return new QuantityType<>(goeResponse.energy[5], Units.AMPERE);
+                return toQuantity(element(goeResponse.energy, 5), Units.AMPERE);
             case CURRENT_L3:
-                if (goeResponse.energy == null || goeResponse.energy.length < 7) {
-                    return UnDefType.UNDEF;
-                }
-                return new QuantityType<>(goeResponse.energy[6], Units.AMPERE);
+                return toQuantity(element(goeResponse.energy, 6), Units.AMPERE);
             case POWER_L1:
-                if (goeResponse.energy == null || goeResponse.energy.length < 8) {
-                    return UnDefType.UNDEF;
-                }
-                return new QuantityType<>(goeResponse.energy[7], Units.WATT);
+                return toQuantity(element(goeResponse.energy, 7), Units.WATT);
             case POWER_L2:
-                if (goeResponse.energy == null || goeResponse.energy.length < 9) {
-                    return UnDefType.UNDEF;
-                }
-                return new QuantityType<>(goeResponse.energy[8], Units.WATT);
+                return toQuantity(element(goeResponse.energy, 8), Units.WATT);
             case POWER_L3:
-                if (goeResponse.energy == null || goeResponse.energy.length < 10) {
-                    return UnDefType.UNDEF;
-                }
-                return new QuantityType<>(goeResponse.energy[9], Units.WATT);
+                return toQuantity(element(goeResponse.energy, 9), Units.WATT);
             case POWER_ALL:
-                if (goeResponse.energy == null || goeResponse.energy.length < 12) {
-                    return UnDefType.UNDEF;
-                }
-                return new QuantityType<>(goeResponse.energy[11], Units.WATT);
+                return toQuantity(element(goeResponse.energy, 11), Units.WATT);
             case FORCE_STATE:
                 if (goeResponse.forceState == null) {
                     return UnDefType.UNDEF;
@@ -232,6 +205,18 @@ public class GoEChargerV2Handler extends GoEChargerBaseHandler {
                 return new DecimalType(goeResponse.forceState.toString());
         }
         return UnDefType.UNDEF;
+    }
+
+    private static <T extends Quantity<T>> State toQuantity(@Nullable Number value, Unit<T> unit) {
+        return value == null ? UnDefType.UNDEF : new QuantityType<>(value, unit);
+    }
+
+    /**
+     * The charger reports JSON arrays whose elements may be {@code null} (e.g. {@code "tma": [null, null]} on the go-e
+     * Charger PRO), so the boxed elements have to be checked before use.
+     */
+    private static @Nullable Double element(Double @Nullable [] array, int index) {
+        return array == null || array.length <= index ? null : array[index];
     }
 
     @Override

--- a/bundles/org.openhab.binding.goecharger/src/test/java/org/openhab/binding/goecharger/internal/handler/GoEChargerV2HandlerTest.java
+++ b/bundles/org.openhab.binding.goecharger/src/test/java/org/openhab/binding/goecharger/internal/handler/GoEChargerV2HandlerTest.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.goecharger.internal.handler;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.openhab.binding.goecharger.internal.GoEChargerBindingConstants.*;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.jetty.client.HttpClient;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openhab.binding.goecharger.internal.api.GoEStatusResponseBaseDTO;
+import org.openhab.binding.goecharger.internal.api.GoEStatusResponseV2DTO;
+import org.openhab.core.config.core.Configuration;
+import org.openhab.core.library.types.QuantityType;
+import org.openhab.core.library.unit.SIUnits;
+import org.openhab.core.library.unit.Units;
+import org.openhab.core.thing.Channel;
+import org.openhab.core.thing.ChannelUID;
+import org.openhab.core.thing.Thing;
+import org.openhab.core.thing.ThingStatus;
+import org.openhab.core.thing.ThingStatusDetail;
+import org.openhab.core.thing.ThingUID;
+import org.openhab.core.thing.binding.ThingHandlerCallback;
+import org.openhab.core.thing.binding.builder.ChannelBuilder;
+import org.openhab.core.types.UnDefType;
+
+/**
+ * Tests for {@link GoEChargerV2Handler}.
+ *
+ * @author Carlo Dischler - Initial contribution
+ */
+@NonNullByDefault
+public class GoEChargerV2HandlerTest {
+
+    private static final ThingUID THING_UID = new ThingUID(THING_TYPE_GOE, "test");
+
+    private final Thing thing = mock(Thing.class);
+    private final ThingHandlerCallback callback = mock(ThingHandlerCallback.class);
+
+    private @Nullable GoEChargerBaseHandler handler;
+
+    @BeforeEach
+    public void setUp() {
+        when(thing.getUID()).thenReturn(THING_UID);
+        when(thing.getConfiguration())
+                .thenReturn(new Configuration(Map.of("ip", "127.0.0.1", "refreshInterval", 1, "apiVersion", 2)));
+        Channel channel = ChannelBuilder.create(new ChannelUID(THING_UID, TEMPERATURE_TYPE2_PORT), "Number:Temperature")
+                .build();
+        when(thing.getChannels()).thenReturn(List.of(channel));
+    }
+
+    @AfterEach
+    public void tearDown() {
+        GoEChargerBaseHandler handler = this.handler;
+        if (handler != null) {
+            handler.dispose();
+        }
+    }
+
+    private GoEChargerV2Handler createHandler() {
+        GoEChargerV2Handler handler = new GoEChargerV2Handler(thing, mock(HttpClient.class));
+        handler.setCallback(callback);
+        this.handler = handler;
+        return handler;
+    }
+
+    @Test
+    public void nullArrayElementsResultInUndef() {
+        GoEChargerV2Handler handler = createHandler();
+        GoEStatusResponseV2DTO response = new GoEStatusResponseV2DTO();
+        response.temperatures = new Double[] { null, null };
+        response.energy = new Double[] { 230d, null, 231d };
+
+        assertThat(handler.getValue(TEMPERATURE_TYPE2_PORT, response), is(UnDefType.UNDEF));
+        assertThat(handler.getValue(TEMPERATURE_CIRCUIT_BOARD, response), is(UnDefType.UNDEF));
+        assertThat(handler.getValue(VOLTAGE_L2, response), is(UnDefType.UNDEF));
+        assertThat(handler.getValue(VOLTAGE_L1, response), is(new QuantityType<>(230d, Units.VOLT)));
+        assertThat(handler.getValue(VOLTAGE_L3, response), is(new QuantityType<>(231d, Units.VOLT)));
+    }
+
+    @Test
+    public void tooShortArraysResultInUndef() {
+        GoEChargerV2Handler handler = createHandler();
+        GoEStatusResponseV2DTO response = new GoEStatusResponseV2DTO();
+        response.temperatures = new Double[] { 25.5 };
+        response.energy = new Double[] { 230d };
+
+        assertThat(handler.getValue(TEMPERATURE_TYPE2_PORT, response), is(UnDefType.UNDEF));
+        assertThat(handler.getValue(TEMPERATURE_CIRCUIT_BOARD, response), is(UnDefType.UNDEF));
+        assertThat(handler.getValue(VOLTAGE_L2, response), is(UnDefType.UNDEF));
+        assertThat(handler.getValue(POWER_ALL, response), is(UnDefType.UNDEF));
+    }
+
+    @Test
+    public void nullFieldsResultInUndef() {
+        GoEChargerV2Handler handler = createHandler();
+        GoEStatusResponseV2DTO response = new GoEStatusResponseV2DTO();
+
+        assertThat(handler.getValue(SESSION_CHARGE_CONSUMPTION_LIMIT, response), is(UnDefType.UNDEF));
+        assertThat(handler.getValue(TEMPERATURE_TYPE2_PORT, response), is(UnDefType.UNDEF));
+        assertThat(handler.getValue(VOLTAGE_L1, response), is(UnDefType.UNDEF));
+    }
+
+    @Test
+    public void validValuesAreConverted() {
+        GoEChargerV2Handler handler = createHandler();
+        GoEStatusResponseV2DTO response = new GoEStatusResponseV2DTO();
+        response.temperatures = new Double[] { 25.5, 30d };
+
+        assertThat(handler.getValue(TEMPERATURE_TYPE2_PORT, response), is(new QuantityType<>(25.5, SIUnits.CELSIUS)));
+        assertThat(handler.getValue(TEMPERATURE_CIRCUIT_BOARD, response), is(new QuantityType<>(30d, SIUnits.CELSIUS)));
+    }
+
+    @Test
+    public void refreshJobSurvivesRuntimeException() throws InterruptedException {
+        CountDownLatch refreshed = new CountDownLatch(2);
+        GoEChargerV2Handler handler = new GoEChargerV2Handler(thing, mock(HttpClient.class)) {
+            @Override
+            protected @Nullable GoEStatusResponseBaseDTO getGoEData() {
+                refreshed.countDown();
+                throw new IllegalStateException("simulated unexpected response");
+            }
+        };
+        handler.setCallback(callback);
+        this.handler = handler;
+
+        handler.initialize();
+
+        assertTrue(refreshed.await(10, TimeUnit.SECONDS), "refresh job stopped after an unexpected exception");
+        verify(callback, timeout(10_000).atLeastOnce()).statusUpdated(any(),
+                argThat(status -> status.getStatus() == ThingStatus.OFFLINE
+                        && status.getStatusDetail() == ThingStatusDetail.COMMUNICATION_ERROR));
+        verify(callback, timeout(10_000).atLeastOnce()).stateUpdated(new ChannelUID(THING_UID, TEMPERATURE_TYPE2_PORT),
+                UnDefType.UNDEF);
+    }
+}


### PR DESCRIPTION

### Description

BUGIFX: After the Thing starts, all channels are filled exactly once and then never update again.
The Thing stays `ONLINE`, there is no status message, and disabling/enabling the Thing restores the values for exactly one more cycle.
`openhab.log` contains a single `NullPointerException` from `GoEChargerV2Handler.getValue(...)`:

```text
java.lang.NullPointerException: Cannot invoke "Object.toString()" because "value" is null
```

Observed on openHAB 5.2.1 with two go-e Charger PRO (API v2, firmware 60.5).
The chargers report `"tma": [null, null, 22.25, ...]` and `"dwo": null`, so the `temperatureType2Port`, `temperature` and `sessionChargeEnergyLimit` channels hit the null path.

### Root cause

`GoEChargerBaseHandler` schedules the refresh with `scheduleWithFixedDelay`.
That method stops the periodic execution permanently as soon as the task lets an exception escape, without any log or status change.
`refresh()` only caught the checked exceptions plus `IllegalArgumentException`, so any other `RuntimeException` while evaluating a single response killed the polling for good.

This is a recurring pattern in this binding: #13054, #12661 and #14632 each fixed one particular field that broke the poller.
This PR fixes the pattern itself so that the next unexpected field no longer silences the binding.

### Changes

- `refresh()` now catches `RuntimeException`, logs it at `warn` with the stack trace and sets the Thing to `OFFLINE`/`COMMUNICATION_ERROR` for that cycle. The next cycle runs normally.
- The scheduled future is now stored in the `refreshJob` field. A local variable shadowed the field, so `dispose()` never cancelled the job and disposed handlers kept polling until the next restart (visible as `tried updating channel ... although the handler was already disposed` warnings every refresh interval).
- Null elements in the `tma` and `nrg` arrays are mapped to `UNDEF`, consistent with the existing handling of too-short arrays from #14632. Valid values are converted exactly as before.
- Unit tests for null array elements, too-short arrays, null DTO fields, and for the refresh job surviving a `RuntimeException`.

No documentation changes: documented behavior is unchanged.
The `amx`/`maxCurrentTemp` write path on firmware 60.5 is a separate topic and intentionally not touched here.

## Testing

Tested on openHAB 5.2.1 with two go-e Charger PRO (firmware 60.5) that return `"tma": [null, null, ...]` and `"dwo": null`.
With the affected channels attached, polling has been running stably every 5 s with no log entries; the three channels show `UNDEF` as intended.
Before the fix the same setup stopped after the first cycle.


