### PR TITLE
[spotify] Fix http redirect_uri when running behind an https reverse proxy

### DIFF
--- a/bundles/org.openhab.binding.spotify/README.md
+++ b/bundles/org.openhab.binding.spotify/README.md
@@ -20,10 +20,25 @@ Follow the instructions under:
 When registering your new Spotify application for the openHAB Spotify bridge, you must specify the allowed "Redirect URIs" (allowlist).
 Here you have to specify the URL to the bridge authorization servlet on your server.
 
-For example, if you run your openHAB server on `http://openhab:8080`, you should add [http://openhab:8080/connectspotify](http://openhab:8080/connectspotify) as the redirect URI.
+Spotify only accepts `http://` redirect URIs when the host is a loopback IP literal (`127.0.0.1` or `[::1]`) — not the `localhost` hostname.
+For every other host, including your public domain or LAN hostname, the redirect URI **must** use `https://`.
+
+- Local/development access from the same machine: [http://127.0.0.1:8080/connectspotify](http://127.0.0.1:8080/connectspotify)
+- Any other access (LAN hostname, public domain, or through a reverse proxy): `https://<your openHAB address>/connectspotify`, for example [https://openhab.example.com/connectspotify](https://openhab.example.com/connectspotify)
+
+If openHAB itself does not terminate https (e.g. it sits behind a reverse proxy that does), see [Binding Configuration](#binding-configuration) below for the `forceHttps` setting, which may be required for the binding to generate a matching `https://` redirect URI.
 
 This is important since the authorization process with Spotify uses your web browser, and Spotify must know the correct URL to your openHAB server for authorization to complete.
 After authorizing with Spotify, this redirect URI is where authorization tokens for your openHAB Spotify bridge will be sent, and they have to be received by the servlet on `/connectspotify`.
+The `/connectspotify` page itself always shows you the exact redirect URI the binding will send to Spotify — make sure it matches what you registered, including the scheme.
+
+### Binding Configuration
+
+The binding has the following configuration options, available under the Spotify Binding add-on settings:
+
+| Parameter  | Type    | Description                                                                                                                                                                                                                                                    |
+|------------|---------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| forceHttps | Boolean | Always use `https` for the Spotify redirect URI, regardless of the scheme openHAB detects for the incoming request. Enable this when openHAB is reachable through a reverse proxy that terminates https but does not identify itself through a recognized forwarded-proto header (`X-Forwarded-Proto`, `X-Forwarded-Ssl`, `Front-End-Https`, or `Forwarded`), causing the redirect URI shown on `/connectspotify` to incorrectly use `http`. Defaults to `false`. |
 
 ### Configure the binding
 
@@ -32,7 +47,7 @@ After authorizing with Spotify, this redirect URI is where authorization tokens 
 1. Make sure you have your Spotify application _Client ID_ and _Client Secret_ available.
 1. Add a new **"Spotify Player Bridge"** Thing. Choose a new ID for the player (unless you prefer the generated one), and enter the _Client ID_ and _Client Secret_ from the Spotify application registration in the corresponding fields of the bridge configuration. You can leave _refreshPeriod_ as is. Save the bridge.
 1. The bridge Thing will stay in state _INITIALIZING_ and eventually go _OFFLINE_ — this is fine. You have to authorize this bridge with Spotify.
-1. Go to the authorization page of your server: `http://<your openHAB address>:8080/connectspotify`. Your newly added bridge should be listed there.
+1. Go to the authorization page of your server: `https://<your openHAB address>/connectspotify` (or `http://127.0.0.1:8080/connectspotify` for local/development access). Your newly added bridge should be listed there.
 1. Press the _"Authorize Player"_ button. This will take you either to the Spotify login page or directly to the authorization screen. Log in and/or authorize the application. If the redirect URIs are correct, you will be returned and the entry should show you are authorized with your Spotify username/ID. If not, go back to your Spotify application and ensure you have the correct redirect URIs.
 1. The binding will be updated with a refresh token and go _ONLINE_. The refresh token is used to re-authorize the bridge with the Spotify Web API whenever required.
 

--- a/bundles/org.openhab.binding.spotify/src/main/java/org/openhab/binding/spotify/internal/SpotifyAuthService.java
+++ b/bundles/org.openhab.binding.spotify/src/main/java/org/openhab/binding/spotify/internal/SpotifyAuthService.java
@@ -31,11 +31,13 @@ import javax.servlet.http.HttpServlet;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.spotify.internal.api.exception.SpotifyException;
+import org.openhab.core.config.core.ConfigParser;
 import org.osgi.framework.BundleContext;
 import org.osgi.service.component.ComponentContext;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Modified;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.http.HttpService;
 import org.osgi.service.http.NamespaceException;
@@ -56,6 +58,7 @@ public class SpotifyAuthService {
     private static final String TEMPLATE_PLAYER = TEMPLATE_PATH + "player.html";
     private static final String TEMPLATE_INDEX = TEMPLATE_PATH + "index.html";
     private static final String ERROR_UKNOWN_BRIDGE = "Returned 'state' by doesn't match any Bridges. Has the bridge been removed?";
+    private static final String CONFIG_FORCE_HTTPS = "forceHttps";
 
     private final Logger logger = LoggerFactory.getLogger(SpotifyAuthService.class);
 
@@ -63,11 +66,13 @@ public class SpotifyAuthService {
 
     private @NonNullByDefault({}) HttpService httpService;
     private @NonNullByDefault({}) BundleContext bundleContext;
+    private volatile boolean forceHttps;
 
     @Activate
     protected void activate(ComponentContext componentContext, Map<String, Object> properties) {
         try {
             bundleContext = componentContext.getBundleContext();
+            forceHttps = ConfigParser.valueAsOrElse(properties.get(CONFIG_FORCE_HTTPS), Boolean.class, false);
             httpService.registerServlet(SPOTIFY_ALIAS, createServlet(), new Hashtable<>(),
                     httpService.createDefaultHttpContext());
             httpService.registerResources(SPOTIFY_ALIAS + SPOTIFY_IMG_ALIAS, "web", null);
@@ -76,10 +81,24 @@ public class SpotifyAuthService {
         }
     }
 
+    @Modified
+    protected void modified(Map<String, Object> properties) {
+        forceHttps = ConfigParser.valueAsOrElse(properties.get(CONFIG_FORCE_HTTPS), Boolean.class, false);
+    }
+
     @Deactivate
     protected void deactivate(ComponentContext componentContext) {
         httpService.unregister(SPOTIFY_ALIAS);
         httpService.unregister(SPOTIFY_ALIAS + SPOTIFY_IMG_ALIAS);
+    }
+
+    /**
+     * @return true if the redirect_uri scheme should always be forced to https, regardless of what the received
+     *         request or its headers indicate. Useful when openHAB is reachable through a reverse proxy that does
+     *         not identify itself through any of the headers this binding recognizes.
+     */
+    public boolean isForceHttps() {
+        return forceHttps;
     }
 
     /**

--- a/bundles/org.openhab.binding.spotify/src/main/java/org/openhab/binding/spotify/internal/SpotifyAuthServlet.java
+++ b/bundles/org.openhab.binding.spotify/src/main/java/org/openhab/binding/spotify/internal/SpotifyAuthServlet.java
@@ -18,6 +18,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -58,6 +59,7 @@ public class SpotifyAuthServlet extends HttpServlet {
     private static final String HEADER_FORWARDED = "Forwarded";
     private static final Pattern FORWARDED_PROTO_PATTERN = Pattern.compile("proto=\"?([a-zA-Z]+)\"?",
             Pattern.CASE_INSENSITIVE);
+    private static final Set<String> VALID_SCHEMES = Set.of("http", "https");
 
     // Simple HTML templates for inserting messages.
     private static final String HTML_EMPTY_PLAYERS = "<p class='block'>Manually add a Spotify Player Bridge to authorize it here.<p>";
@@ -114,7 +116,7 @@ public class SpotifyAuthServlet extends HttpServlet {
      * @param req the received http request
      * @return the servlet base url with the correct scheme
      */
-    private String extractServletBaseURL(HttpServletRequest req) {
+    String extractServletBaseURL(HttpServletRequest req) {
         final StringBuffer requestURL = req.getRequestURL();
         final String scheme;
 
@@ -135,20 +137,20 @@ public class SpotifyAuthServlet extends HttpServlet {
      * @param req the received http request
      * @return the scheme to use for the redirect URI
      */
-    private String determineScheme(HttpServletRequest req) {
+    String determineScheme(HttpServletRequest req) {
         String scheme = schemeFromForwardedProto(req);
         if (scheme == null) {
-            scheme = schemeFromForwardedSsl(req);
+            scheme = schemeFromOnOffHeader(req, HEADER_X_FORWARDED_SSL);
         }
         if (scheme == null) {
-            scheme = schemeFromFrontEndHttps(req);
+            scheme = schemeFromOnOffHeader(req, HEADER_FRONT_END_HTTPS);
         }
         if (scheme == null) {
             scheme = schemeFromForwarded(req);
         }
         if (scheme == null) {
             scheme = req.getScheme();
-            logger.debug("None of the recognized forwarded-proto headers were present, falling back to the "
+            logger.debug("None of the recognized forwarded-proto headers had a valid value, falling back to the "
                     + "request scheme '{}'.", scheme);
         }
         return scheme;
@@ -156,19 +158,39 @@ public class SpotifyAuthServlet extends HttpServlet {
 
     private @Nullable String schemeFromForwardedProto(HttpServletRequest req) {
         final String value = logAndGetHeader(req, HEADER_X_FORWARDED_PROTO);
+        if (value == null || value.isBlank()) {
+            return null;
+        }
         // The header may contain a comma-separated list when multiple proxies are chained; the first entry is
         // the scheme seen by the outermost proxy, i.e. the one the client actually used.
-        return value == null || value.isBlank() ? null : value.split(",")[0].trim();
+        final String candidate = value.split(",")[0].trim();
+        return normalizeSchemeOrIgnore(HEADER_X_FORWARDED_PROTO, candidate);
     }
 
-    private @Nullable String schemeFromForwardedSsl(HttpServletRequest req) {
-        final String value = logAndGetHeader(req, HEADER_X_FORWARDED_SSL);
-        return value == null || value.isBlank() ? null : ("on".equalsIgnoreCase(value.trim()) ? "https" : "http");
-    }
-
-    private @Nullable String schemeFromFrontEndHttps(HttpServletRequest req) {
-        final String value = logAndGetHeader(req, HEADER_FRONT_END_HTTPS);
-        return value == null || value.isBlank() ? null : ("on".equalsIgnoreCase(value.trim()) ? "https" : "http");
+    /**
+     * Parses a de-facto "on"/"off" style header (e.g. {@code X-Forwarded-Ssl}, {@code Front-End-Https}) into a
+     * scheme. Any value other than the two documented ones is ignored rather than defaulting to http, so an
+     * unrecognized value does not incorrectly shadow a lower-priority but valid header.
+     *
+     * @param req the received http request
+     * @param headerName the name of the header to read
+     * @return "https" for "on", "http" for "off", or {@code null} if the header is absent or has any other value
+     */
+    private @Nullable String schemeFromOnOffHeader(HttpServletRequest req, String headerName) {
+        final String value = logAndGetHeader(req, headerName);
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        final String normalized = value.trim().toLowerCase(Locale.ROOT);
+        if ("on".equals(normalized)) {
+            return "https";
+        } else if ("off".equals(normalized)) {
+            return "http";
+        } else {
+            logger.debug("Header '{}' has unrecognized value '{}', expected 'on' or 'off'; ignoring it.", headerName,
+                    value);
+            return null;
+        }
     }
 
     private @Nullable String schemeFromForwarded(HttpServletRequest req) {
@@ -178,7 +200,29 @@ public class SpotifyAuthServlet extends HttpServlet {
         }
         // RFC 7239, e.g. "for=1.2.3.4;proto=https;by=203.0.113.43"; only the first hop is relevant here.
         final Matcher matcher = FORWARDED_PROTO_PATTERN.matcher(value.split(",")[0]);
-        return matcher.find() ? matcher.group(1).toLowerCase(Locale.ROOT) : null;
+        if (!matcher.find()) {
+            return null;
+        }
+        return normalizeSchemeOrIgnore(HEADER_FORWARDED, matcher.group(1));
+    }
+
+    /**
+     * Normalizes a candidate scheme extracted from a header and validates it is either "http" or "https", logging
+     * and returning {@code null} for anything else so the caller can fall through to the next, lower-priority
+     * source instead of using an invalid scheme in the redirect URI.
+     *
+     * @param headerName the header the candidate was extracted from, used for logging only
+     * @param candidate the candidate scheme value
+     * @return the normalized scheme ("http" or "https"), or {@code null} if the candidate is not a valid scheme
+     */
+    private @Nullable String normalizeSchemeOrIgnore(String headerName, String candidate) {
+        final String normalized = candidate.toLowerCase(Locale.ROOT);
+        if (VALID_SCHEMES.contains(normalized)) {
+            return normalized;
+        }
+        logger.debug("Header '{}' has unrecognized scheme value '{}', expected 'http' or 'https'; ignoring it.",
+                headerName, candidate);
+        return null;
     }
 
     /**

--- a/bundles/org.openhab.binding.spotify/src/main/java/org/openhab/binding/spotify/internal/SpotifyAuthServlet.java
+++ b/bundles/org.openhab.binding.spotify/src/main/java/org/openhab/binding/spotify/internal/SpotifyAuthServlet.java
@@ -16,6 +16,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -48,6 +49,15 @@ public class SpotifyAuthServlet extends HttpServlet {
     private static final long serialVersionUID = -4719613645562518231L;
 
     private static final String CONTENT_TYPE = "text/html;charset=UTF-8";
+
+    // Headers consulted, in order, to determine the scheme (http/https) used by the client when openHAB is
+    // reachable through a reverse proxy. The first header found to be present wins.
+    private static final String HEADER_X_FORWARDED_PROTO = "X-Forwarded-Proto";
+    private static final String HEADER_X_FORWARDED_SSL = "X-Forwarded-Ssl";
+    private static final String HEADER_FRONT_END_HTTPS = "Front-End-Https";
+    private static final String HEADER_FORWARDED = "Forwarded";
+    private static final Pattern FORWARDED_PROTO_PATTERN = Pattern.compile("proto=\"?([a-zA-Z]+)\"?",
+            Pattern.CASE_INSENSITIVE);
 
     // Simple HTML templates for inserting messages.
     private static final String HTML_EMPTY_PLAYERS = "<p class='block'>Manually add a Spotify Player Bridge to authorize it here.<p>";
@@ -85,7 +95,7 @@ public class SpotifyAuthServlet extends HttpServlet {
     protected void doGet(@Nullable HttpServletRequest req, @Nullable HttpServletResponse resp)
             throws ServletException, IOException {
         logger.debug("Spotify auth callback servlet received GET request {}.", req.getRequestURI());
-        final String servletBaseURL = req.getRequestURL().toString();
+        final String servletBaseURL = extractServletBaseURL(req);
         final Map<String, String> replaceMap = new HashMap<>();
 
         handleSpotifyRedirect(replaceMap, servletBaseURL, req.getQueryString());
@@ -94,6 +104,98 @@ public class SpotifyAuthServlet extends HttpServlet {
         replaceMap.put(KEY_PLAYERS, formatPlayers(playerTemplate, servletBaseURL));
         resp.getWriter().append(replaceKeysFromMap(indexTemplate, replaceMap));
         resp.getWriter().close();
+    }
+
+    /**
+     * Extracts the servlet base url from the received http request, taking into account that openHAB may be running
+     * behind a reverse proxy that terminates https, which means {@link HttpServletRequest#getRequestURL()} would
+     * incorrectly report a http scheme instead of the https scheme used by the client.
+     *
+     * @param req the received http request
+     * @return the servlet base url with the correct scheme
+     */
+    private String extractServletBaseURL(HttpServletRequest req) {
+        final StringBuffer requestURL = req.getRequestURL();
+        final String scheme;
+
+        if (spotifyAuthService.isForceHttps()) {
+            logger.debug("Force HTTPS is enabled, using 'https' as the redirect URI scheme.");
+            scheme = "https";
+        } else {
+            scheme = determineScheme(req);
+        }
+        return requestURL.replace(0, requestURL.indexOf(":"), scheme).toString();
+    }
+
+    /**
+     * Determines the scheme (http/https) used by the client, cascading through a series of headers commonly set by
+     * reverse proxies before falling back to the scheme reported by the servlet container itself, which is wrong
+     * when a reverse proxy terminates https and connects to openHAB over plain http.
+     *
+     * @param req the received http request
+     * @return the scheme to use for the redirect URI
+     */
+    private String determineScheme(HttpServletRequest req) {
+        String scheme = schemeFromForwardedProto(req);
+        if (scheme == null) {
+            scheme = schemeFromForwardedSsl(req);
+        }
+        if (scheme == null) {
+            scheme = schemeFromFrontEndHttps(req);
+        }
+        if (scheme == null) {
+            scheme = schemeFromForwarded(req);
+        }
+        if (scheme == null) {
+            scheme = req.getScheme();
+            logger.debug("None of the recognized forwarded-proto headers were present, falling back to the "
+                    + "request scheme '{}'.", scheme);
+        }
+        return scheme;
+    }
+
+    private @Nullable String schemeFromForwardedProto(HttpServletRequest req) {
+        final String value = logAndGetHeader(req, HEADER_X_FORWARDED_PROTO);
+        // The header may contain a comma-separated list when multiple proxies are chained; the first entry is
+        // the scheme seen by the outermost proxy, i.e. the one the client actually used.
+        return value == null || value.isBlank() ? null : value.split(",")[0].trim();
+    }
+
+    private @Nullable String schemeFromForwardedSsl(HttpServletRequest req) {
+        final String value = logAndGetHeader(req, HEADER_X_FORWARDED_SSL);
+        return value == null || value.isBlank() ? null : ("on".equalsIgnoreCase(value.trim()) ? "https" : "http");
+    }
+
+    private @Nullable String schemeFromFrontEndHttps(HttpServletRequest req) {
+        final String value = logAndGetHeader(req, HEADER_FRONT_END_HTTPS);
+        return value == null || value.isBlank() ? null : ("on".equalsIgnoreCase(value.trim()) ? "https" : "http");
+    }
+
+    private @Nullable String schemeFromForwarded(HttpServletRequest req) {
+        final String value = logAndGetHeader(req, HEADER_FORWARDED);
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        // RFC 7239, e.g. "for=1.2.3.4;proto=https;by=203.0.113.43"; only the first hop is relevant here.
+        final Matcher matcher = FORWARDED_PROTO_PATTERN.matcher(value.split(",")[0]);
+        return matcher.find() ? matcher.group(1).toLowerCase(Locale.ROOT) : null;
+    }
+
+    /**
+     * Reads the given header from the request and logs whether it was present and, if so, its value.
+     *
+     * @param req the received http request
+     * @param headerName the name of the header to read
+     * @return the header value, or {@code null} if not present
+     */
+    private @Nullable String logAndGetHeader(HttpServletRequest req, String headerName) {
+        final String value = req.getHeader(headerName);
+        if (value == null) {
+            logger.debug("Header '{}' is not present on the request.", headerName);
+        } else {
+            logger.debug("Header '{}' is present with value '{}'.", headerName, value);
+        }
+        return value;
     }
 
     /**

--- a/bundles/org.openhab.binding.spotify/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.binding.spotify/src/main/resources/OH-INF/addon/addon.xml
@@ -7,5 +7,7 @@
 	<name>Spotify Binding</name>
 	<description>This is the openHAB binding for Spotify used to manage Spotify Connect devices using the Spotify Web API.</description>
 	<connection>cloud</connection>
+	<service-id>binding.spotify.authService</service-id>
+	<config-description-ref uri="binding:spotify:authService"/>
 
 </addon:addon>

--- a/bundles/org.openhab.binding.spotify/src/main/resources/OH-INF/config/config.xml
+++ b/bundles/org.openhab.binding.spotify/src/main/resources/OH-INF/config/config.xml
@@ -22,4 +22,15 @@
 			<default>0</default>
 		</parameter>
 	</config-description>
+	<config-description uri="binding:spotify:authService">
+		<parameter name="forceHttps" type="boolean">
+			<label>Force HTTPS</label>
+			<description>Always use https for the Spotify redirect URI, regardless of the scheme openHAB detects for the
+				incoming
+				request. Enable this when running behind a reverse proxy that terminates https but does not identify
+				itself through a
+				recognized forwarded-proto header, causing the redirect URI to incorrectly use http.</description>
+			<default>false</default>
+		</parameter>
+	</config-description>
 </config-description:config-descriptions>

--- a/bundles/org.openhab.binding.spotify/src/main/resources/OH-INF/i18n/spotify.properties
+++ b/bundles/org.openhab.binding.spotify/src/main/resources/OH-INF/i18n/spotify.properties
@@ -3,12 +3,17 @@
 addon.spotify.name = Spotify Binding
 addon.spotify.description = This is the openHAB binding for Spotify used to manage Spotify Connect devices using the Spotify Web API.
 
+# add-on config
+
+addon.config.spotify.authService.forceHttps.label = Force HTTPS
+addon.config.spotify.authService.forceHttps.description = Always use https for the Spotify redirect URI, regardless of the scheme openHAB detects for the incoming request. Enable this when running behind a reverse proxy that terminates https but does not identify itself through a recognized forwarded-proto header, causing the redirect URI to incorrectly use http.
+
 # thing types
 
 thing-type.spotify.device.label = Spotify Connect Device
 thing-type.spotify.device.description = Thing representing a Spotify Connect device. The device exists in the context of the bridge and the Spotify account associated with the bridge. This means the same device can be present as a thing under each Spotify bridge you have configured.
 thing-type.spotify.player.label = Spotify Player Bridge
-thing-type.spotify.player.description = Bridge representing the Spotify Player in the context of a user account. The bridge is associated with one specific Spotify account. If you want to control your devices in the context of different accounts you have to register a bridge for each account. Go to http://<your openHAB address>:8080/connectspotify to authorize.
+thing-type.spotify.player.description = Bridge representing the Spotify Player in the context of a user account. The bridge is associated with one specific Spotify account. If you want to control your devices in the context of different accounts you have to register a bridge for each account. Go to https://<your openHAB address>/connectspotify (or http://127.0.0.1:8080/connectspotify for local access) to authorize.
 
 # thing types config
 

--- a/bundles/org.openhab.binding.spotify/src/test/java/org/openhab/binding/spotify/internal/SpotifyAuthServletTest.java
+++ b/bundles/org.openhab.binding.spotify/src/test/java/org/openhab/binding/spotify/internal/SpotifyAuthServletTest.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.spotify.internal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link SpotifyAuthServlet}, focused on how it determines the scheme (http/https) to use for the Spotify
+ * redirect_uri from a request that may have passed through one or more reverse proxies.
+ *
+ * @author Claude Sonnet 5 - Initial contribution
+ */
+@NonNullByDefault
+public class SpotifyAuthServletTest {
+
+    private @NonNullByDefault({}) SpotifyAuthService spotifyAuthService;
+    private @NonNullByDefault({}) SpotifyAuthServlet servlet;
+    private @NonNullByDefault({}) HttpServletRequest req;
+
+    @BeforeEach
+    public void setUp() {
+        spotifyAuthService = mock(SpotifyAuthService.class);
+        servlet = new SpotifyAuthServlet(spotifyAuthService, "", "");
+        req = mock(HttpServletRequest.class);
+        when(req.getScheme()).thenReturn("http");
+    }
+
+    @Test
+    public void noHeadersFallsBackToRequestScheme() {
+        assertEquals("http", servlet.determineScheme(req));
+    }
+
+    @Test
+    public void validForwardedProtoIsUsed() {
+        when(req.getHeader("X-Forwarded-Proto")).thenReturn("https");
+
+        assertEquals("https", servlet.determineScheme(req));
+    }
+
+    @Test
+    public void forwardedProtoIsCaseInsensitiveAndTrimmed() {
+        when(req.getHeader("X-Forwarded-Proto")).thenReturn("  HTTPS  ");
+
+        assertEquals("https", servlet.determineScheme(req));
+    }
+
+    @Test
+    public void chainedForwardedProtoUsesFirstEntry() {
+        when(req.getHeader("X-Forwarded-Proto")).thenReturn("https, http");
+
+        assertEquals("https", servlet.determineScheme(req));
+    }
+
+    @Test
+    public void invalidForwardedProtoFallsThroughToRequestScheme() {
+        when(req.getHeader("X-Forwarded-Proto")).thenReturn("ftp");
+
+        assertEquals("http", servlet.determineScheme(req));
+    }
+
+    @Test
+    public void invalidForwardedProtoFallsThroughToLowerPriorityValidHeader() {
+        // Regression test: an unrecognized value on the highest-priority header must not shadow a valid,
+        // lower-priority one.
+        when(req.getHeader("X-Forwarded-Proto")).thenReturn("ftp");
+        when(req.getHeader("Forwarded")).thenReturn("for=1.2.3.4;proto=https;by=203.0.113.43");
+
+        assertEquals("https", servlet.determineScheme(req));
+    }
+
+    @Test
+    public void forwardedSslOnMapsToHttps() {
+        when(req.getHeader("X-Forwarded-Ssl")).thenReturn("on");
+
+        assertEquals("https", servlet.determineScheme(req));
+    }
+
+    @Test
+    public void forwardedSslOffMapsToHttp() {
+        when(req.getScheme()).thenReturn("https");
+        when(req.getHeader("X-Forwarded-Ssl")).thenReturn("off");
+
+        assertEquals("http", servlet.determineScheme(req));
+    }
+
+    @Test
+    public void forwardedSslUnrecognizedValueFallsThrough() {
+        when(req.getHeader("X-Forwarded-Ssl")).thenReturn("maybe");
+
+        assertEquals("http", servlet.determineScheme(req));
+    }
+
+    @Test
+    public void frontEndHttpsOnMapsToHttps() {
+        when(req.getHeader("Front-End-Https")).thenReturn("On");
+
+        assertEquals("https", servlet.determineScheme(req));
+    }
+
+    @Test
+    public void frontEndHttpsUnrecognizedValueFallsThrough() {
+        when(req.getHeader("Front-End-Https")).thenReturn("yes");
+
+        assertEquals("http", servlet.determineScheme(req));
+    }
+
+    @Test
+    public void forwardedHeaderValidProtoIsUsed() {
+        when(req.getHeader("Forwarded")).thenReturn("for=1.2.3.4;proto=https;by=203.0.113.43");
+
+        assertEquals("https", servlet.determineScheme(req));
+    }
+
+    @Test
+    public void forwardedHeaderInvalidProtoFallsThroughToRequestScheme() {
+        when(req.getHeader("Forwarded")).thenReturn("for=1.2.3.4;proto=ftp;by=203.0.113.43");
+
+        assertEquals("http", servlet.determineScheme(req));
+    }
+
+    @Test
+    public void precedenceForwardedProtoWinsOverAllOthersWhenValid() {
+        when(req.getHeader("X-Forwarded-Proto")).thenReturn("https");
+        when(req.getHeader("X-Forwarded-Ssl")).thenReturn("off");
+        when(req.getHeader("Front-End-Https")).thenReturn("off");
+        when(req.getHeader("Forwarded")).thenReturn("proto=http");
+
+        assertEquals("https", servlet.determineScheme(req));
+    }
+
+    @Test
+    public void precedenceForwardedSslWinsOverFrontEndHttpsAndForwarded() {
+        when(req.getHeader("X-Forwarded-Ssl")).thenReturn("on");
+        when(req.getHeader("Front-End-Https")).thenReturn("off");
+        when(req.getHeader("Forwarded")).thenReturn("proto=http");
+
+        assertEquals("https", servlet.determineScheme(req));
+    }
+
+    @Test
+    public void precedenceFrontEndHttpsWinsOverForwarded() {
+        when(req.getHeader("Front-End-Https")).thenReturn("on");
+        when(req.getHeader("Forwarded")).thenReturn("proto=http");
+
+        assertEquals("https", servlet.determineScheme(req));
+    }
+
+    @Test
+    public void forceHttpsOverrideIgnoresAllHeadersAndRequestScheme() {
+        when(spotifyAuthService.isForceHttps()).thenReturn(true);
+        when(req.getHeader("X-Forwarded-Proto")).thenReturn("http");
+        when(req.getRequestURL()).thenReturn(new StringBuffer("http://example.com/connectspotify"));
+
+        assertEquals("https://example.com/connectspotify", servlet.extractServletBaseURL(req));
+    }
+
+    @Test
+    public void extractServletBaseURLAppliesDeterminedScheme() {
+        when(req.getHeader("X-Forwarded-Proto")).thenReturn("https");
+        when(req.getRequestURL()).thenReturn(new StringBuffer("http://example.com/connectspotify"));
+
+        assertEquals("https://example.com/connectspotify", servlet.extractServletBaseURL(req));
+    }
+}


### PR DESCRIPTION
## Summary
- The Spotify OAuth `redirect_uri` was built from the raw servlet request URL, which always reports `http` when openHAB sits behind a reverse proxy that terminates https and forwards over plain http to the backend. This broke Spotify's authorization callback for anyone running openHAB behind such a proxy.
- The scheme is now derived from a cascading set of forwarded-proto headers (`X-Forwarded-Proto`, `X-Forwarded-Ssl`, `Front-End-Https`, RFC 7239 `Forwarded`), each logged at debug level for troubleshooting, falling back to the raw request scheme if none are present.
- Added a "Force HTTPS" binding-level configuration option as a manual override for reverse proxies that don't identify themselves through any of the recognized headers.

## Test plan
- [x] `mvn compile` for `org.openhab.binding.spotify` succeeds
- [x] `mvn spotless:check` passes
- [x] `mvn package` produces a valid jar
- [ ] Verified on a live openHAB instance behind a reverse proxy: prior to the fix the Spotify authorization page generated an `http://` redirect_uri; after deploying the fix it correctly generates `https://`, and Spotify's "Authorize Player" flow completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)