### PR TITLE
[miele] Add UoM support for spinning speed

### DIFF
--- a/bundles/org.openhab.binding.miele/README.md
+++ b/bundles/org.openhab.binding.miele/README.md
@@ -366,7 +366,7 @@ See oven.
 | failure             | Switch               | Read       | Signals failure, check appliance for details                         |
 | switch              | Switch               | Write      | Switch the appliance on or off                                       |
 | target              | Number:Temperature   | Read       | Temperature of the selected program (10 °C = cold)                   |
-| spinningspeed       | String               | Read       | Spinning speed in the program running on the appliance               |
+| spinningspeed       | Number:Frequency     | Read       | Spinning speed of the currently running program on the appliance     |
 | energyConsumption   | Number:Energy        | Read       | Energy consumption by the currently running program on the appliance |
 | waterConsumption    | Number:Volume        | Read       | Water consumption by the currently running program on the appliance  |
 | laundryWeight       | Number:Mass          | Read       | Weight of the laundry inside the appliance                           |
@@ -471,7 +471,7 @@ Number WashingMachine_RawState                                {channel="miele:wa
 String WashingMachine_Program "Program [%s]"                  {channel="miele:washingmachine:home:washingmachine:program"}
 String WashingMachine_Phase "Phase [%s]"                      {channel="miele:washingmachine:home:washingmachine:phase"}
 Number:Temperature WashingMachine_Temperature <temperature>   {channel="miele:washingmachine:home:washingmachine:target"}
-String WashingMachine_SpinningSpeed                           {channel="miele:washingmachine:home:washingmachine:spinningspeed"}
+Number:Frequency WashingMachine_SpinningSpeed                 {channel="miele:washingmachine:home:washingmachine:spinningspeed", unit="rpm"}
 Number:Time WashingMachine_ElapsedTime "Elapsed time" <time>  {channel="miele:washingmachine:home:washingmachine:elapsed"}
 Number:Time WashingMachine_FinishTime "Remaining time" <time> {channel="miele:washingmachine:home:washingmachine:finish"}
 Number:Energy WashingMachine_EnergyConsumption                {channel="miele:washingmachine:home:washingmachine:energyConsumption"}

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/WashingMachineChannelSelector.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/WashingMachineChannelSelector.java
@@ -101,16 +101,10 @@ public enum WashingMachineChannelSelector implements ApplianceChannelSelector {
             return getTemperatureState(s);
         }
     },
-    SPINNING_SPEED("spinningSpeed", "spinningspeed", StringType.class, false, false) {
+    SPINNING_SPEED("spinningSpeed", "spinningspeed", QuantityType.class, false, false) {
         @Override
         public State getState(String s, @Nullable DeviceMetaData dmd, MieleTranslationProvider translationProvider) {
-            if ("0".equals(s)) {
-                return getState("Without spinning");
-            }
-            if ("256".equals(s)) {
-                return getState("Rinsing");
-            }
-            return getState(Integer.toString((Integer.valueOf(s))));
+            return getSpinningSpeedState(s);
         }
     },
     DOOR("signalDoor", "door", OpenClosedType.class, false, false) {
@@ -241,6 +235,16 @@ public enum WashingMachineChannelSelector implements ApplianceChannelSelector {
     public State getTemperatureState(String s) {
         try {
             return DeviceUtil.getTemperatureState(s);
+        } catch (NumberFormatException e) {
+            logger.warn("An exception occurred while converting '{}' into a State", s);
+            return UnDefType.UNDEF;
+        }
+    }
+
+    public State getSpinningSpeedState(String s) {
+        try {
+            int speed = Integer.parseInt(s);
+            return speed == 0 ? UnDefType.UNDEF : new QuantityType<>(speed, Units.RPM);
         } catch (NumberFormatException e) {
             logger.warn("An exception occurred while converting '{}' into a State", s);
             return UnDefType.UNDEF;

--- a/bundles/org.openhab.binding.miele/src/main/resources/OH-INF/thing/channeltypes.xml
+++ b/bundles/org.openhab.binding.miele/src/main/resources/OH-INF/thing/channeltypes.xml
@@ -268,10 +268,10 @@
 		<state readOnly="true"></state>
 	</channel-type>
 
-	<channel-type id="spinningspeed" advanced="true">
-		<item-type>String</item-type>
+	<channel-type id="spinning-speed" advanced="true">
+		<item-type unitHint="rpm">Number:Frequency</item-type>
 		<label>Spinning Speed</label>
-		<description>Spinning speed in the program running on the appliance</description>
+		<description>Spinning speed of the currently running program on the appliance</description>
 		<state readOnly="true"></state>
 	</channel-type>
 

--- a/bundles/org.openhab.binding.miele/src/main/resources/OH-INF/thing/washingmachine.xml
+++ b/bundles/org.openhab.binding.miele/src/main/resources/OH-INF/thing/washingmachine.xml
@@ -35,14 +35,14 @@
 				<label>Temperature</label>
 				<description>Temperature of the selected program (10 °C = cold)</description>
 			</channel>
-			<channel id="spinningspeed" typeId="spinningspeed"/>
+			<channel id="spinningspeed" typeId="spinning-speed"/>
 			<channel id="energyConsumption" typeId="energy-consumption"/>
 			<channel id="waterConsumption" typeId="water-consumption"/>
 			<channel id="laundryWeight" typeId="laundry-weight"/>
 		</channels>
 
 		<properties>
-			<property name="thingTypeVersion">3</property>
+			<property name="thingTypeVersion">4</property>
 		</properties>
 
 		<representation-property>uid</representation-property>

--- a/bundles/org.openhab.binding.miele/src/main/resources/OH-INF/update/instructions.xml
+++ b/bundles/org.openhab.binding.miele/src/main/resources/OH-INF/update/instructions.xml
@@ -101,6 +101,11 @@
 				<type>miele:laundry-weight</type>
 			</add-channel>
 		</instruction-set>
+		<instruction-set targetVersion="4">
+			<update-channel id="spinningspeed">
+				<type>miele:spinning-speed</type>
+			</update-channel>
+		</instruction-set>
 	</thing-type>
 
 </update:update-descriptions>


### PR DESCRIPTION
This changes the washing machine `spinningspeed` channel from `String` to `Number:Frequency` with default unit **rpm**.

This is backwards compatible, because a `String` item can receive `Number` state, and the raw format hasn't changed. Previously 0 was mapped to "Without spinning" (hardcoded English string), which is now changed to `UNDEF`. I don't think the "Rinsing" mapping ever worked. This is documented in the JSON-RPC payload:

```json
          "Metadata": {
            "Filter": "false",
            "description": "Spinning speed divided by 10!, 0x00 = without spinning, 0xFF = rinse hold.",
            "access": "RE"
          }
```

The spinning speed is not actually divided by 10, so this part of the description is wrong. I have not been able to observe the special value for rinse hold, but 0xFF is 255, not 256, so it seems unlikely that anything broke here. I tried all programs on my WMV 960 WPS, and also observed the value during the rinse hold phase 30 minutes after the program ended. The value was never anything other than 0 or the actual spinning speed. I don't think anything can be lost anyway, since the phase channels already expose rinse hold.