### PR TITLE
[miele] Remove redundant method

### DIFF
--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/DeviceUtil.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/DeviceUtil.java
@@ -34,7 +34,6 @@ import org.openhab.core.types.UnDefType;
  */
 @NonNullByDefault
 public class DeviceUtil {
-    private static final byte[] HEX_ARRAY = "0123456789ABCDEF".getBytes(StandardCharsets.US_ASCII);
     private static final String TEMPERATURE_UNDEFINED = "32768";
     private static final String TEMPERATURE_COLD = "-32760";
     private static final String TEXT_PREFIX = "miele.";
@@ -45,20 +44,6 @@ public class DeviceUtil {
             Map.entry("10", "idle"), Map.entry("11", "rinse-hold"), Map.entry("12", "service"),
             Map.entry("13", "super-freezing"), Map.entry("14", "super-cooling"), Map.entry("15", "super-heating"),
             Map.entry("144", "default"), Map.entry("145", "locked"), Map.entry("255", "not-connected"));
-
-    /**
-     * Convert byte array to hex representation.
-     */
-    public static String bytesToHex(byte[] bytes) {
-        byte[] hexChars = new byte[bytes.length * 2];
-        for (int j = 0; j < bytes.length; j++) {
-            int v = bytes[j] & 0xFF;
-            hexChars[j * 2] = HEX_ARRAY[v >>> 4];
-            hexChars[j * 2 + 1] = HEX_ARRAY[v & 0x0F];
-        }
-
-        return new String(hexChars, StandardCharsets.UTF_8);
-    }
 
     /**
      * Convert string consisting of 8 bit characters to byte array.

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/MieleApplianceHandler.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/MieleApplianceHandler.java
@@ -52,6 +52,7 @@ import org.openhab.core.types.Command;
 import org.openhab.core.types.RefreshType;
 import org.openhab.core.types.State;
 import org.openhab.core.types.UnDefType;
+import org.openhab.core.util.HexUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -263,8 +264,10 @@ public abstract class MieleApplianceHandler<E extends Enum<E> & ApplianceChannel
             if (EXTENDED_DEVICE_STATE_PROPERTY_NAME.equals(dp.Name)) {
                 if (!dp.Value.isEmpty()) {
                     byte[] extendedStateBytes = DeviceUtil.stringToBytes(dp.Value);
-                    logger.trace("Extended device state for {}: {}", getThing().getUID(),
-                            DeviceUtil.bytesToHex(extendedStateBytes));
+                    if (logger.isTraceEnabled()) {
+                        logger.trace("Extended device state for {}: {}", getThing().getUID(),
+                                HexUtils.bytesToHex(extendedStateBytes));
+                    }
                     if (this instanceof ExtendedDeviceStateListener listener) {
                         listener.onApplianceExtendedStateChanged(extendedStateBytes);
                     }

--- a/bundles/org.openhab.binding.miele/src/test/java/org/openhab/binding/miele/internal/DeviceUtilTest.java
+++ b/bundles/org.openhab.binding.miele/src/test/java/org/openhab/binding/miele/internal/DeviceUtilTest.java
@@ -39,12 +39,6 @@ public class DeviceUtilTest extends JavaTest {
 
     private @Mock @NonNullByDefault({}) MieleTranslationProvider translationProvider;
 
-    @Test
-    public void bytesToHexWhenTopBitIsUsedReturnsCorrectString() {
-        String actual = DeviceUtil.bytesToHex(new byte[] { (byte) 0xde, (byte) 0xad, (byte) 0xbe, (byte) 0xef });
-        assertEquals("DEADBEEF", actual);
-    }
-
     /**
      * This test guards that the UTF-16 returned by the RPC-JSON API will be
      * considered as a sequence of 8-bit characters and converted into bytes


### PR DESCRIPTION
Replace custom `bytesToHex` method with the similar method provided by core.

Also avoid calling it when trace logging is disabled.