### PR TITLE
[samsungtv] Log a standby TV at startup on DEBUG

### DIFF
--- a/bundles/org.openhab.binding.samsungtv/src/main/java/org/openhab/binding/samsungtv/internal/handler/SamsungTvHandler.java
+++ b/bundles/org.openhab.binding.samsungtv/src/main/java/org/openhab/binding/samsungtv/internal/handler/SamsungTvHandler.java
@@ -291,7 +291,7 @@ public class SamsungTvHandler extends BaseThingHandler implements RegistryListen
             case PROTOCOL_SECUREWEBSOCKET:
                 initializeConfig();
                 if (!initialized) {
-                    logger.warn("{}: TV binding is not yet Initialized", host);
+                    logger.debug("{}: TV binding is not yet Initialized", host);
                 }
                 break;
             case PROTOCOL_LEGACY:


### PR DESCRIPTION
At startup the Samsung TV binding logs `TV binding is not yet Initialized` as WARN for every TV in standby. A switched-off TV does not answer the properties request, the handler sets the thing OFFLINE right after and initializes it again once the TV announces itself via UPnP. #17119 moved the two log lines before this one to DEBUG for the same reason, this line stayed on WARN. There is no GitHub issue for it.

Tested on a production system with two Samsung TVs in standby: after a restart of the binding both things go OFFLINE as before and the WARN is gone.

**Transparency:** this patch and the comments on this PR were written with AI assistance (Claude); every commit carries an `AI-assisted-by` trailer.
