### PR TITLE
[lghorizon] Initial contribution

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -210,6 +210,7 @@
 /bundles/org.openhab.binding.lcn/ @fwolter
 /bundles/org.openhab.binding.leapmotion/ @kaikreuzer
 /bundles/org.openhab.binding.lghombot/ @FluBBaOfWard
+/bundles/org.openhab.binding.lghorizon/ @mherwege
 /bundles/org.openhab.binding.lgthinq/ @nemerdaud
 /bundles/org.openhab.binding.lgtvserial/ @fa2k
 /bundles/org.openhab.binding.lgwebos/ @sprehn

--- a/bom/openhab-addons/pom.xml
+++ b/bom/openhab-addons/pom.xml
@@ -1038,6 +1038,11 @@
     </dependency>
     <dependency>
       <groupId>org.openhab.addons.bundles</groupId>
+      <artifactId>org.openhab.binding.lghorizon</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.openhab.addons.bundles</groupId>
       <artifactId>org.openhab.binding.lgthinq</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/bundles/org.openhab.binding.lghorizon/NOTICE
+++ b/bundles/org.openhab.binding.lghorizon/NOTICE
@@ -1,0 +1,13 @@
+This content is produced and maintained by the openHAB project.
+
+* Project home: https://www.openhab.org
+
+== Declared Project Licenses
+
+This program and the accompanying materials are made available under the terms
+of the Eclipse Public License 2.0 which is available at
+https://www.eclipse.org/legal/epl-2.0/.
+
+== Source Code
+
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.lghorizon/README.md
+++ b/bundles/org.openhab.binding.lghorizon/README.md
@@ -1,0 +1,237 @@
+# Liberty Global Horizon Binding
+
+The Liberty Global Horizon binding integrates set-top boxes running the **Liberty Global Horizon** platform.
+
+| Provider               | Country     | Auth              |
+|------------------------|-------------|-------------------|
+| BASE TV                | Belgium     | refresh token     |
+| Telenet TV             | Belgium     | refresh token     |
+| UPC / Sunrise          | Switzerland | refresh token     |
+| Virgin Media           | Ireland     | username/password |
+| Virgin Media           | UK          | refresh token     |
+| Ziggo                  | Netherlands | username/password |
+| UPC                    | Poland      | username/password |
+
+Status and control both go over the same cloud MQTT channel the official apps use.
+There is no local API on the box itself.
+
+## Supported Things
+
+| Thing   | Type   | Description                                                                              |
+|---------|--------|------------------------------------------------------------------------------------------|
+| account | Bridge | One LG Horizon account/household. Owns the login session and the shared MQTT connection. |
+| box     | Thing  | One physical set-top box. Discovered automatically under an `account` bridge.            |
+
+## Discovery
+
+Once an `account` is configured and active, the binding will discover available set-top boxes.
+
+## Thing Configuration
+
+### `account` (Bridge)
+
+| Parameter       | Required | Description                                                                 |
+|-----------------|----------|-----------------------------------------------------------------------------|
+| provider        | no       | Provider: `telenet`, `basetv`, `ziggo`, `upc-sunrise`, `virginmedia-gb`, `virginmedia-ie`, `upc-poland`. Leave empty ("Custom") to configure an unlisted provider manually with the three advanced fields below. |
+| country         | no       | Advanced. Only used when `provider` is empty: two-letter locale used in the service-discovery URL path (e.g. `be`) - not necessarily the same region as the API URL. Known automatically when `provider` is set. |
+| apiUrl          | no       | Advanced. Only used when `provider` is empty: base URL of the provider's "spark" REST API. Known automatically when `provider` is set. |
+| useRefreshToken | no       | Advanced. Only used when `provider` is empty: whether the provider needs refresh-token auth instead of username/password. Default `false`. Known automatically when `provider` is set. |
+| username        | no       | Only for password-based providers                                           |
+| password        | no       | Only for password-based providers                                           |
+| refreshToken    | no       | Only for refresh-token-based providers                                      |
+| mqttClientId    | no       | Fixed MQTT client id; random if left blank                                  |
+
+### Refresh token based authentication (BASE TV, Telenet, UPC/Sunrise, Virgin Media GB)
+
+These providers don't expose a public login endpoint for third-party apps, so the refresh token has to be extracted once from the browser.
+Username and password are not required.
+
+1. Open your provider's web player in a Chromium-based browser (e.g. `https://www.telenet.tv`) and log in.
+1. Press `F12` to open Developer Tools → **Application** (Chrome) / **Storage** (Firefox) tab.
+1. Expand **Local Storage** → select the provider's domain.
+1. Find the key containing `refresh_token` / `refreshToken` and copy its full value (starts with `eyJ`, 200+ characters).
+1. Paste it into the `account` thing's **Refresh Token** configuration field.
+
+The binding will keep the refresh token current automatically from then on (the backend rotates it on every use), persisting the new value back into the
+bridge configuration.
+You should not need to repeat this process unless the token is revoked (e.g. after a very long period offline, or a password change).
+
+### Username/password based authentication (Virgin Media Ireland, Ziggo, UPC Poland)
+
+These providers use your regular account username and password instead.
+A refresh token is not needed.
+
+### Advanced configuration without provider preset
+
+`country`, `apiUrl` and `useRefreshToken` are advanced parameters.
+When `provider` is set, the binding resolves these three from known provider presets and the advanced parameters are ignored.
+When `provider` is left empty, the advanced parameters are required and used as-is.
+This allows supporting a provider that isn't in the providers list yet - a new white-label deployment, or a provider's preprod/test backend.
+
+### `box` (Thing)
+
+| Parameter              | Required | Description                                                                      |
+|------------------------|----------|----------------------------------------------------------------------------------|
+| deviceId               | yes      | LG Horizon device id (filled in by discovery)                                    |
+| profileId              | no       | Household profile to use for favorites/language; defaults to the box default one |
+
+## Channels
+
+| Channel                    | Type   | R/W | Description                                                                       |
+|----------------------------|--------|-----|-----------------------------------------------------------------------------------|
+| power                      | Switch | RW  | ON wakes the box from standby, OFF puts it into standby                           |
+| source-type                | String | R   | linear / replay / nDVR / localDVR / reviewBuffer / VOD / app                      |
+| channel-name               | String | RW  | Name of the channel currently playing                                             |
+| channel-number             | Number | RW  | Logical channel number, send a number to change the channel                       |
+| favorite-channel-number    | Number | RW  | Same, limited to favorite channels                                                |
+| program-title              | String | R   | The primary title for whatever's playing - a show name, movie name, or app name   |
+| series-title               | String | R   | TV series/show name, only set for genuinely episodic content (see table below)    |
+| episode-title              | String | R   | Episode title, falling back to "Episode N" if only a number is known              |
+| season                     | Number | R   | Season number, when known                                                         |
+| episode                    | Number | R   | Episode number, when known                                                        |
+| media-image                | Image  | R   | Poster/background image for the current channel, program, VOD title, or recording |
+| player                     | Player | RW  | PLAY / PAUSE / REWIND / FASTFORWARD                                               |
+| stop                       | Switch | W   | Stop playback and return to live TV                                               |
+| record                     | Switch | RW  | Record the current live TV program                                                |
+| channel-up                 | Switch | W   | Move to the next channel                                                          |
+| channel-down               | Switch | W   | Move to the previous channel                                                      |
+| arrow-up                   | Switch | W   | Navigate up in the on-screen menu                                                 |
+| arrow-down                 | Switch | W   | Navigate down in the on-screen menu                                               |
+| arrow-left                 | Switch | W   | Navigate left in the on-screen menu                                               |
+| arrow-right                | Switch | W   | Navigate right in the on-screen menu                                              |
+| top-menu                   | Switch | W   | Open the main menu / jump to the top of the screen                                |
+| info                       | Switch | W   | Show info about the current program                                               |
+| context-menu               | Switch | W   | Open the context menu (subtitles, favourites, watchlist, ...)                     |
+| tv                         | Switch | W   | Switch to live TV                                                                 |
+| enter                      | Switch | W   | Confirm selection / open the channel zap bar                                      |
+| escape                     | Switch | W   | Back / stop and return to live TV                                                 |
+| key-code                   | String | W   | Send any remote-control key by its W3C key name (see below)                       |
+
+### Favorite channels
+
+Favorite channels not available with the default profile.
+You need to create a specific profile and set the box `profileId` parameter for them to be available.
+
+### Media content
+
+`program-title`/`series-title`/`episode-title`/`season`/`episode`/`media-image` are resolved per source type.
+`program-title` is always the primary title for whatever's playing; `series-title` (and `episode-title`/`season`/`episode`)
+are only populated when the content is genuinely episodic - a movie or standalone broadcast leaves them undefined, so a
+rule can check whether `series-title` is set as a simple "is this a TV series episode" signal.
+
+| Source type             | Title/episode from                         | Image from                            |
+|-------------------------|--------------------------------------------|---------------------------------------|
+| live / time shift       | EPG lookup by event id                     | the channel's own logo/preview image  |
+| replay                  | EPG lookup by event id                     | a separate per-event image lookup     |
+| video on demand         | VOD detail-screen lookup                   | a separate per-title image lookup     |
+| recordings              | recording detail lookup                    | a separate per-recording image lookup |
+| app (e.g. Netflix)      | the app's own name (as program-title only) | the app's own logo                    |
+
+### `key-code` values
+
+Any of the values from the box's `CPE.KeyEvent` protocol, for example:
+`Power`, `Standby`, `WakeUp`, `MediaPlay`, `MediaPause`, `MediaPlayPause`,
+`MediaStop`, `MediaRecord`, `MediaFastForward`, `MediaRewind`, `ChannelUp`,
+`ChannelDown`, `Guide`, `Info`, `ContextMenu`, `ArrowUp`, `ArrowDown`,
+`ArrowLeft`, `ArrowRight`, `Enter`, `Escape`, `Backspace`, `Red`, `Green`,
+`Yellow`, `Blue`.
+
+## Full Example
+
+### Thing Configuration
+
+```java
+Bridge lghorizon:account:home "Telenet Account" [ country="be-nl", refreshToken="eyJ..." ] {
+    Thing box livingroom "Living Room Box" [ deviceId="AB12CD34EF56" ]
+}
+```
+
+### Item Configuration
+
+```java
+Switch  TV_Power           "TV Power"          { channel="lghorizon:box:home:livingroom:power" }
+String  TV_State           "TV State"          { channel="lghorizon:box:home:livingroom:state" }
+String  TV_Channel         "TV Channel"        { channel="lghorizon:box:home:livingroom:channel-name" }
+Number  TV_ChannelNumber   "TV Channel Number" { channel="lghorizon:box:home:livingroom:channel-number" }
+String  TV_Program         "TV Program"        { channel="lghorizon:box:home:livingroom:program-title" }
+Player  TV_Player          "TV Playback"       { channel="lghorizon:box:home:livingroom:player" }
+String  TV_SendKey         "TV Send Key"       { channel="lghorizon:box:home:livingroom:key-code" }
+```
+
+## Advanced Configuration for Unknown Provider
+
+The binding supports manually configuring a provider that is not in the preset list yet.
+
+```java
+Bridge lghorizon:account:preprod "Telenet Account (preprod)" [
+    country="be",
+    apiUrl="https://spark-preprod-be.gnp.cloud.telenet.tv",
+    useRefreshToken=true,
+    refreshToken="eyJ..."
+]
+```
+
+Leaving `provider` empty is what activates the advanced fields; `country` and `apiUrl` are required in that case.
+The same pattern works for any backend not in the preset list - just supply the three fields that a preset would normally fill in for you.
+
+## Actions
+
+```java
+displayMessage(message, duration)
+```
+
+Shows a short text message as an on-screen overlay on the TV.
+`duration` is optional and defaults to `10` seconds when omitted or `null`.
+
+```java
+val actions = getActions("lghorizon", "lghorizon:box:home:livingroom")
+actions.displayMessage("Doorbell")
+actions.displayMessage("Doorbell", "Front Door", 15)
+```
+
+## Console Commands
+
+A number of commands are supported from the console.
+Accounts and boxes are identified by their own `customerId`/`deviceId`, not the openHAB thing UID.
+
+```java
+lghorizon profiles [<customerId>]
+lghorizon boxes [<customerId>]
+lghorizon fingerprint [<customerId>]
+lghorizon capture <customerId> <deviceId> <durationSeconds>
+```
+
+`accounts`, `profiles` and `boxes` take no arguments to list across all accounts, or a `customerId` to limit the output to one account.
+`boxes` lists every device known from the account's REST data, annotated with its box thing's UID for whichever ones actually have one configured (`(no thing)` otherwise) - useful both to find the `deviceId` for `capture` and to spot a device you haven't added a thing for yet.
+
+`fingerprint` and `capture` are separate commands with different purposes:
+
+- `fingerprint` is a quick, mostly-instant REST-only snapshot (customer/entitlements/channels/service config), plus a passive wait for each box's next (or already-cached) `.../status` message - not an active request for a fresh one.
+  Useful for a first look at an unsupported provider/device, or to check what the REST side of things looks like.
+- `capture <customerId> <deviceId> <durationSeconds>` actively records live traffic for **one specific box** over a fixed window: every MQTT status/uiStatus message, every REST call the binding makes.
+  Requires that device to already have a box thing configured - interact with the box (change channels, rewind, launch an app, start a recording,
+  ...) for the duration of the capture to get a meaningful sequence of events.
+
+Both commands write their output as a zip file in the user's home `lghorizon` directory.
+All personal information is masked.
+
+## Known Limitations / Roadmap
+
+The binding focuses on live status + control.
+Not implemented:
+
+- EPG / program guide browsing
+- Replay/catch-up TV channel list
+- Ad-break detection/skipping
+- localDVR (locally-recorded content) title/image resolution
+
+## Credits
+
+The Liberty Global Horizon cloud protocol used by this binding (REST auth flow, service discovery, MQTT-over-WebSockets status/control channel) was reverse engineered and documented by:
+
+- [Sholofly/lghorizon-python](https://github.com/Sholofly/lghorizon-python) and the [lghorizon](https://github.com/Sholofly/lghorizon) Home Assistant integration
+- [mase1981/uc-intg-horizon](https://github.com/mase1981/uc-intg-horizon) (Unfolded Circle Remote integration)
+
+This binding is an independent Java reimplementation of the protocol those projects document.
+It shares no code with them.
+It is not affiliated with or supported by Telenet, Ziggo, Virgin Media, UPC, Sunrise, BASE, or Liberty Global.

--- a/bundles/org.openhab.binding.lghorizon/pom.xml
+++ b/bundles/org.openhab.binding.lghorizon/pom.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.openhab.addons.bundles</groupId>
+    <artifactId>org.openhab.addons.reactor.bundles</artifactId>
+    <version>5.3.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>org.openhab.binding.lghorizon</artifactId>
+  <name>openHAB Add-ons :: Bundles :: LGHorizon Binding</name>
+
+</project>

--- a/bundles/org.openhab.binding.lghorizon/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.lghorizon/src/main/feature/feature.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<features name="org.openhab.binding.lghorizon-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.6.0">
+	<repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
+
+	<feature name="openhab-binding-lghorizon" description="LG Horizon Binding" version="${project.version}">
+		<feature>openhab-runtime-base</feature>
+		<feature>openhab-transport-mqtt</feature>
+		<feature>openhab-transport-upnp</feature>
+		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.lghorizon/${project.version}</bundle>
+	</feature>
+</features>

--- a/bundles/org.openhab.binding.lghorizon/src/main/java/org/openhab/binding/lghorizon/internal/LGHorizonBindingConstants.java
+++ b/bundles/org.openhab.binding.lghorizon/src/main/java/org/openhab/binding/lghorizon/internal/LGHorizonBindingConstants.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.lghorizon.internal;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.core.thing.ThingTypeUID;
+
+/**
+ * The {@link LGHorizonBindingConstants} class defines common constants, which are used across the whole binding.
+ *
+ * @author Mark Herwege - Initial contribution
+ */
+@NonNullByDefault
+public class LGHorizonBindingConstants {
+
+    public static final String BINDING_ID = "lghorizon";
+
+    // Thing type UIDs
+    public static final ThingTypeUID THING_TYPE_ACCOUNT = new ThingTypeUID(BINDING_ID, "account");
+    public static final ThingTypeUID THING_TYPE_BOX = new ThingTypeUID(BINDING_ID, "box");
+
+    // Account (bridge) config
+    public static final String CONFIG_PROVIDER = "provider";
+    public static final String CONFIG_COUNTRY = "country";
+    public static final String CONFIG_API_URL = "apiUrl";
+    public static final String CONFIG_USE_REFRESH_TOKEN = "useRefreshToken";
+    public static final String CONFIG_USERNAME = "username";
+    public static final String CONFIG_PASSWORD = "password";
+    public static final String CONFIG_REFRESH_TOKEN = "refreshToken";
+
+    // Account properties
+    public static final String PROPERTY_HOUSEHOLD_ID = "householdId";
+    public static final String PROPERTY_CUSTOMER_ID = "customerId";
+    public static final String PROPERTY_COUNTRY_ID = "countryId";
+    public static final String PROPERTY_CITY_ID = "cityId";
+
+    // Box config
+    public static final String CONFIG_DEVICE_ID = "deviceId";
+    public static final String CONFIG_PROFILE_ID = "profileId";
+
+    // Box properties
+    public static final String PROPERTY_DEFAULT_PROFILE_ID = "defaultProfileId";
+    public static final String PROPERTY_DEVICE_TYPE = "deviceType";
+    public static final String PROPERTY_PLATFORM_TYPE = "platformType";
+    public static final String PROPERTY_SERIAL_NUMBER = "serialNumber";
+    public static final String PROPERTY_WIFI_MAC_ADDRESS = "wifiMacAddress";
+    public static final String PROPERTY_ETHERNET_MAC_ADDRESS = "ethernetMacAddress";
+    public static final int DEFAULT_DISPLAY_MESSAGE_DURATION_SECONDS = 10;
+
+    // Channel IDs
+    public static final String CHANNEL_POWER = "power";
+    public static final String CHANNEL_SOURCE_TYPE = "source-type";
+    public static final String CHANNEL_CHANNEL_NAME = "channel-name";
+    public static final String CHANNEL_CHANNEL_NUMBER = "channel-number";
+    public static final String CHANNEL_FAVORITE_CHANNEL_NUMBER = "favorite-channel-number";
+    public static final String CHANNEL_PROGRAM_TITLE = "program-title";
+    public static final String CHANNEL_SERIES_TITLE = "series-title";
+    public static final String CHANNEL_EPISODE_TITLE = "episode-title";
+    public static final String CHANNEL_SEASON = "season";
+    public static final String CHANNEL_EPISODE = "episode";
+    public static final String CHANNEL_MEDIA_IMAGE = "media-image";
+    public static final String CHANNEL_PLAYER = "player";
+    public static final String CHANNEL_STOP = "stop";
+    public static final String CHANNEL_RECORD = "record";
+    public static final String CHANNEL_CHANNEL_UP = "channel-up";
+    public static final String CHANNEL_CHANNEL_DOWN = "channel-down";
+    public static final String CHANNEL_ARROW_UP = "arrow-up";
+    public static final String CHANNEL_ARROW_DOWN = "arrow-down";
+    public static final String CHANNEL_ARROW_LEFT = "arrow-left";
+    public static final String CHANNEL_ARROW_RIGHT = "arrow-right";
+    public static final String CHANNEL_TOP_MENU = "top-menu";
+    public static final String CHANNEL_INFO = "info";
+    public static final String CHANNEL_CONTEXT_MENU = "context-menu";
+    public static final String CHANNEL_TV = "tv";
+    public static final String CHANNEL_ENTER = "enter";
+    public static final String CHANNEL_ESCAPE = "escape";
+    public static final String CHANNEL_KEY_CODE = "key-code";
+
+    private LGHorizonBindingConstants() {
+        // constants class
+    }
+}

--- a/bundles/org.openhab.binding.lghorizon/src/main/java/org/openhab/binding/lghorizon/internal/LGHorizonContentAnonymizer.java
+++ b/bundles/org.openhab.binding.lghorizon/src/main/java/org/openhab/binding/lghorizon/internal/LGHorizonContentAnonymizer.java
@@ -1,0 +1,233 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.lghorizon.internal;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
+/**
+ * Static methods to remove sensitive content from captured LG Horizon REST/MQTT payloads, for use in the
+ * {@code lghorizon fingerprint} console command.
+ * <p>
+ * Two anonymization styles are used, matching what's actually useful to a maintainer analyzing a dump:
+ * <ul>
+ * <li>Fields worth correlating across a dump (the same device/customer/profile appearing in several files)
+ * get a stable per-value placeholder via a counter map, so repeated occurrences of the same real value always
+ * anonymize to the same placeholder within a session.</li>
+ * <li>Fields with no cross-referencing value (MAC/IP addresses) get a single fixed placeholder.</li>
+ * </ul>
+ *
+ * @author Mark - Initial contribution
+ */
+@NonNullByDefault
+public final class LGHorizonContentAnonymizer {
+
+    private static final Map<String, String> CUSTOMER_ID_MAP = new HashMap<>();
+    private static final AtomicInteger CUSTOMER_ID_COUNTER = new AtomicInteger();
+
+    private static final Map<String, String> HASHED_ID_MAP = new HashMap<>();
+    private static final AtomicInteger HASHED_ID_COUNTER = new AtomicInteger();
+
+    private static final Map<String, String> DEVICE_ID_MAP = new HashMap<>();
+    private static final AtomicInteger DEVICE_ID_COUNTER = new AtomicInteger();
+
+    private static final Map<String, String> DEVICE_NAME_MAP = new HashMap<>();
+    private static final AtomicInteger DEVICE_NAME_COUNTER = new AtomicInteger();
+
+    private static final Map<String, String> SERIAL_MAP = new HashMap<>();
+    private static final AtomicInteger SERIAL_COUNTER = new AtomicInteger();
+
+    private static final Map<String, String> PROFILE_ID_MAP = new HashMap<>();
+    private static final AtomicInteger PROFILE_ID_COUNTER = new AtomicInteger();
+
+    private static final Map<String, String> AD_DEVICE_ID_MAP = new HashMap<>();
+    private static final AtomicInteger AD_DEVICE_ID_COUNTER = new AtomicInteger();
+
+    private static final Map<String, String> PIN_MAP = new HashMap<>();
+    private static final AtomicInteger PIN_COUNTER = new AtomicInteger();
+
+    private static final Map<String, String> TOKEN_MAP = new HashMap<>();
+    private static final AtomicInteger TOKEN_COUNTER = new AtomicInteger();
+
+    private static final Map<String, String> HOUSEHOLD_ID_MAP = new HashMap<>();
+    private static final AtomicInteger HOUSEHOLD_ID_COUNTER = new AtomicInteger();
+
+    private static final Map<String, String> CITY_ID_MAP = new HashMap<>();
+    private static final AtomicInteger CITY_ID_COUNTER = new AtomicInteger();
+
+    // Field-name-scoped patterns: "<fieldName>":"<value>" (value may be empty)
+    private static final Pattern CUSTOMER_ID_PATTERN = fieldPattern("customerId");
+    private static final Pattern HASHED_ID_PATTERN = fieldPattern("hashed\\w*Id");
+    private static final Pattern DEVICE_ID_PATTERN = fieldPattern("deviceId");
+    private static final Pattern DEVICE_NAME_PATTERN = fieldPattern("deviceFriendlyName");
+    private static final Pattern SERIAL_PATTERN = fieldPattern("serialNumber");
+    private static final Pattern PROFILE_ID_PATTERN = fieldPattern("profileId");
+    private static final Pattern DEFAULT_PROFILE_ID_PATTERN = fieldPattern("defaultProfileId");
+    private static final Pattern AD_DEVICE_ID_PATTERN = fieldPattern("advertisementDeviceId");
+    private static final Pattern PIN_PATTERN = fieldPattern("pin");
+    private static final Pattern TOKEN_PATTERN = fieldPattern("(claimsToken|token)");
+
+    // Content-shape patterns, not scoped to a specific field name.
+    private static final Pattern MAC_ADDRESS_PATTERN = fieldPattern("\\w*[Mm]ac\\w*",
+            "([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}");
+    private static final Pattern IP_ADDRESS_PATTERN = fieldPattern("\\w*[Ii][Pp]\\w*",
+            "(\\d{1,3}\\.){3}\\d{1,3}(/(\\d{1,3}\\.){3}\\d{1,3})?");
+    // cityId is a Liberty Global city/region identifier that keys the local channel line-up - close enough
+    // to a postcode to be too specific to leave in. Unlike every field above, it's an unquoted JSON number
+    // ("cityId":12345, no quotes around the value), so it needs its own pattern rather than fieldPattern()
+    // (which always expects a quoted value) - and it separately appears as a URL query parameter
+    // (?cityId=12345&...) in the channel-fetch URL, a third shape again. Both are handled here, sharing the
+    // same map/counter so the same real value maps to the same placeholder in either context.
+    private static final Pattern CITY_ID_JSON_PATTERN = Pattern
+            .compile("(?<leading>\"cityId\"\\s*:\\s*)(?<value>\\d+)");
+    private static final Pattern CITY_ID_URL_PATTERN = Pattern.compile("(?<leading>[?&]cityId=)(?<value>\\d+)");
+    // The household id shape (e.g. "DTV123456_be") also appears bare inside MQTT topic strings, not just as
+    // a JSON field value, so this one is not field-name-scoped at all - it matches the token shape anywhere.
+    private static final Pattern HOUSEHOLD_ID_PATTERN = Pattern.compile("\\b[A-Z]{2,6}\\d{4,10}_[a-z]{2}\\b");
+
+    private LGHorizonContentAnonymizer() {
+        // static utility class
+    }
+
+    private static Pattern fieldPattern(String fieldNameRegex) {
+        return fieldPattern(fieldNameRegex, "[^\"]*");
+    }
+
+    private static Pattern fieldPattern(String fieldNameRegex, String valueRegex) {
+        return Pattern.compile("(?<leading>\"" + fieldNameRegex + "\")\\s*:\\s*\"(?<value>" + valueRegex + ")\"");
+    }
+
+    /**
+     * Anonymizes an MQTT topic string (may contain an embedded household id, e.g.
+     * {@code DTV123456_be/E0B7B1-APPSTB-301179302106/status}).
+     */
+    public static @Nullable String anonymizeTopic(@Nullable String topic) {
+        if (topic == null) {
+            return null;
+        }
+        String withCityId = replaceNumericField(topic, CITY_ID_URL_PATTERN, CITY_ID_MAP, CITY_ID_COUNTER);
+        return replaceConsistently(withCityId, HOUSEHOLD_ID_PATTERN, "HOUSEHOLD_", HOUSEHOLD_ID_MAP,
+                HOUSEHOLD_ID_COUNTER);
+    }
+
+    /**
+     * Anonymizes a JSON (or plain text) payload: REST response bodies, MQTT message bodies, or anything else
+     * that might contain the sensitive fields listed on this class.
+     */
+    public static @Nullable String anonymizeMessage(@Nullable String message) {
+        if (message == null) {
+            return null;
+        }
+
+        String anonymized = message;
+        anonymized = replaceField(anonymized, CUSTOMER_ID_PATTERN, "CUSTOMER_", CUSTOMER_ID_MAP, CUSTOMER_ID_COUNTER);
+        anonymized = replaceField(anonymized, HASHED_ID_PATTERN, "HASHED_", HASHED_ID_MAP, HASHED_ID_COUNTER);
+        anonymized = replaceField(anonymized, DEVICE_ID_PATTERN, "DEVICE_", DEVICE_ID_MAP, DEVICE_ID_COUNTER);
+        anonymized = replaceField(anonymized, DEVICE_NAME_PATTERN, "DEVICE_NAME_", DEVICE_NAME_MAP,
+                DEVICE_NAME_COUNTER);
+        anonymized = replaceField(anonymized, SERIAL_PATTERN, "SERIAL_", SERIAL_MAP, SERIAL_COUNTER);
+        anonymized = replaceField(anonymized, PROFILE_ID_PATTERN, "PROFILE_", PROFILE_ID_MAP, PROFILE_ID_COUNTER);
+        anonymized = replaceField(anonymized, DEFAULT_PROFILE_ID_PATTERN, "PROFILE_", PROFILE_ID_MAP,
+                PROFILE_ID_COUNTER);
+        anonymized = replaceField(anonymized, AD_DEVICE_ID_PATTERN, "AD_DEVICE_", AD_DEVICE_ID_MAP,
+                AD_DEVICE_ID_COUNTER);
+        anonymized = replaceField(anonymized, PIN_PATTERN, "PIN_", PIN_MAP, PIN_COUNTER);
+        anonymized = replaceField(anonymized, TOKEN_PATTERN, "TOKEN_", TOKEN_MAP, TOKEN_COUNTER);
+        anonymized = replaceNumericField(anonymized, CITY_ID_JSON_PATTERN, CITY_ID_MAP, CITY_ID_COUNTER);
+        anonymized = replaceNumericField(anonymized, CITY_ID_URL_PATTERN, CITY_ID_MAP, CITY_ID_COUNTER);
+        anonymized = replaceFixed(anonymized, MAC_ADDRESS_PATTERN, "xx:xx:xx:xx:xx:xx");
+        anonymized = replaceFixed(anonymized, IP_ADDRESS_PATTERN, "xxx.xxx.xxx.xxx");
+        anonymized = replaceConsistently(anonymized, HOUSEHOLD_ID_PATTERN, "HOUSEHOLD_", HOUSEHOLD_ID_MAP,
+                HOUSEHOLD_ID_COUNTER);
+        return anonymized;
+    }
+
+    /**
+     * Replaces every match of an unquoted {@code field:123} or {@code field=123} numeric pattern, mapping
+     * each distinct value consistently. The replacement is itself numeric (not wrapped in quotes) so JSON
+     * stays syntactically valid and the field's original type (a number, not a string) is preserved.
+     */
+    private static String replaceNumericField(String content, Pattern pattern, Map<String, String> map,
+            AtomicInteger counter) {
+        Matcher matcher = pattern.matcher(content);
+        StringBuilder result = new StringBuilder();
+        int last = 0;
+        while (matcher.find()) {
+            result.append(content, last, matcher.start());
+            String value = matcher.group("value");
+            String anonymous = map.computeIfAbsent(value, v -> String.valueOf(10000 + counter.incrementAndGet()));
+            result.append(matcher.group("leading")).append(anonymous);
+            last = matcher.end();
+        }
+        result.append(content, last, content.length());
+        return result.toString();
+    }
+
+    /** Replaces every match of a {@code "field":"value"} pattern, mapping each distinct value consistently. */
+    private static String replaceField(String content, Pattern pattern, String placeholderPrefix,
+            Map<String, String> map, AtomicInteger counter) {
+        Matcher matcher = pattern.matcher(content);
+        StringBuilder result = new StringBuilder();
+        int last = 0;
+        while (matcher.find()) {
+            result.append(content, last, matcher.start());
+            String value = matcher.group("value");
+            if (value.isEmpty()) {
+                result.append(matcher.group());
+            } else {
+                String anonymous = map.computeIfAbsent(value, v -> placeholderPrefix + counter.incrementAndGet());
+                result.append(matcher.group("leading")).append(":\"").append(anonymous).append('"');
+            }
+            last = matcher.end();
+        }
+        result.append(content, last, content.length());
+        return result.toString();
+    }
+
+    /** Replaces every match of a {@code "field":"value"} pattern with the same fixed placeholder value. */
+    private static String replaceFixed(String content, Pattern pattern, String placeholder) {
+        Matcher matcher = pattern.matcher(content);
+        StringBuilder result = new StringBuilder();
+        int last = 0;
+        while (matcher.find()) {
+            result.append(content, last, matcher.start());
+            result.append(matcher.group("leading")).append(":\"").append(placeholder).append('"');
+            last = matcher.end();
+        }
+        result.append(content, last, content.length());
+        return result.toString();
+    }
+
+    /** Replaces every bare match of a pattern (not field-name-scoped), mapping each distinct value consistently. */
+    private static String replaceConsistently(String content, Pattern pattern, String placeholderPrefix,
+            Map<String, String> map, AtomicInteger counter) {
+        Matcher matcher = pattern.matcher(content);
+        StringBuilder result = new StringBuilder();
+        int last = 0;
+        while (matcher.find()) {
+            result.append(content, last, matcher.start());
+            String value = matcher.group();
+            String anonymous = map.computeIfAbsent(value, v -> placeholderPrefix + counter.incrementAndGet());
+            result.append(anonymous);
+            last = matcher.end();
+        }
+        result.append(content, last, content.length());
+        return result.toString();
+    }
+}

--- a/bundles/org.openhab.binding.lghorizon/src/main/java/org/openhab/binding/lghorizon/internal/LGHorizonHandlerFactory.java
+++ b/bundles/org.openhab.binding.lghorizon/src/main/java/org/openhab/binding/lghorizon/internal/LGHorizonHandlerFactory.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.lghorizon.internal;
+
+import java.util.Set;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.lghorizon.internal.handler.LGHorizonAccountHandler;
+import org.openhab.binding.lghorizon.internal.handler.LGHorizonBoxHandler;
+import org.openhab.binding.lghorizon.internal.handler.LGHorizonDynamicStateDescriptionProvider;
+import org.openhab.core.io.net.http.HttpClientFactory;
+import org.openhab.core.thing.Bridge;
+import org.openhab.core.thing.Thing;
+import org.openhab.core.thing.ThingTypeUID;
+import org.openhab.core.thing.binding.BaseThingHandlerFactory;
+import org.openhab.core.thing.binding.ThingHandler;
+import org.openhab.core.thing.binding.ThingHandlerFactory;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * The {@link LGHorizonHandlerFactory} creates the account bridge handler and box thing handlers.
+ *
+ * @author Mark Herwege - Initial contribution
+ */
+@NonNullByDefault
+@Component(configurationPid = "binding.lghorizon", service = ThingHandlerFactory.class)
+public class LGHorizonHandlerFactory extends BaseThingHandlerFactory {
+
+    private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Set
+            .of(LGHorizonBindingConstants.THING_TYPE_ACCOUNT, LGHorizonBindingConstants.THING_TYPE_BOX);
+
+    private final HttpClientFactory httpClientFactory;
+    private final LGHorizonDynamicStateDescriptionProvider dynamicStateDescriptionProvider;
+
+    @Activate
+    public LGHorizonHandlerFactory(@Reference HttpClientFactory httpClientFactory,
+            @Reference LGHorizonDynamicStateDescriptionProvider dynamicStateDescriptionProvider) {
+        this.httpClientFactory = httpClientFactory;
+        this.dynamicStateDescriptionProvider = dynamicStateDescriptionProvider;
+    }
+
+    @Override
+    public boolean supportsThingType(ThingTypeUID thingTypeUID) {
+        return SUPPORTED_THING_TYPES_UIDS.contains(thingTypeUID);
+    }
+
+    @Override
+    protected @Nullable ThingHandler createHandler(Thing thing) {
+        ThingTypeUID thingTypeUID = thing.getThingTypeUID();
+
+        if (LGHorizonBindingConstants.THING_TYPE_ACCOUNT.equals(thingTypeUID) && thing instanceof Bridge bridge) {
+            return new LGHorizonAccountHandler(bridge, httpClientFactory);
+        }
+        if (LGHorizonBindingConstants.THING_TYPE_BOX.equals(thingTypeUID)) {
+            return new LGHorizonBoxHandler(thing, dynamicStateDescriptionProvider);
+        }
+        return null;
+    }
+}

--- a/bundles/org.openhab.binding.lghorizon/src/main/java/org/openhab/binding/lghorizon/internal/action/LGHorizonActions.java
+++ b/bundles/org.openhab.binding.lghorizon/src/main/java/org/openhab/binding/lghorizon/internal/action/LGHorizonActions.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.lghorizon.internal.action;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.lghorizon.internal.handler.LGHorizonBoxHandler;
+import org.openhab.core.automation.annotation.ActionInput;
+import org.openhab.core.automation.annotation.RuleAction;
+import org.openhab.core.thing.binding.ThingActions;
+import org.openhab.core.thing.binding.ThingActionsScope;
+import org.openhab.core.thing.binding.ThingHandler;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ServiceScope;
+
+/**
+ * Thing Actions for a {@code box}: displays a short on-screen message. {@code title} and {@code duration} are
+ * optional; when omitted, {@link LGHorizonBoxHandler#displayMessage} falls back to
+ * {@link org.openhab.binding.lghorizon.internal.LGHorizonBindingConstants#DEFAULT_DISPLAY_MESSAGE_TITLE} /
+ * {@link org.openhab.binding.lghorizon.internal.LGHorizonBindingConstants#DEFAULT_DISPLAY_MESSAGE_DURATION_SECONDS}.
+ *
+ * @author Mark - Initial contribution
+ */
+@ThingActionsScope(name = "lghorizon")
+@NonNullByDefault
+@Component(scope = ServiceScope.PROTOTYPE, service = LGHorizonActions.class)
+public class LGHorizonActions implements ThingActions {
+
+    private @Nullable LGHorizonBoxHandler handler;
+
+    @Override
+    public void setThingHandler(ThingHandler handler) {
+        this.handler = handler instanceof LGHorizonBoxHandler boxHandler ? boxHandler : null;
+    }
+
+    @Override
+    public @Nullable ThingHandler getThingHandler() {
+        return handler;
+    }
+
+    @RuleAction(label = "Display Message", description = "Shows a short text message as an on-screen overlay on the TV.")
+    public void displayMessage(
+            @ActionInput(name = "message", type = "java.lang.String", label = "Message", description = "The text to display.", required = true) String message,
+            @ActionInput(name = "duration", type = "java.lang.Integer", label = "Duration (s)", description = "Optional duration in seconds the message stays visible. Defaults to 10s if not given.") @Nullable Integer duration) {
+        LGHorizonBoxHandler boxHandler = handler;
+        if (boxHandler == null) {
+            return;
+        }
+        boxHandler.displayMessage(message, duration);
+    }
+
+    /**
+     * Display message on screen. Static delegate for use from the Rules DSL / scripted automation.
+     *
+     * @param actions
+     * @param message
+     */
+    public static void displayMessage(ThingActions actions, String message) {
+        displayMessage(actions, message, null);
+    }
+
+    /**
+     * Display message on screen. Static delegate for use from the Rules DSL / scripted automation.
+     *
+     * @param actions
+     * @param message
+     * @param duration
+     */
+    public static void displayMessage(ThingActions actions, String message, @Nullable Integer duration) {
+        ((LGHorizonActions) actions).displayMessage(message, duration);
+    }
+}

--- a/bundles/org.openhab.binding.lghorizon/src/main/java/org/openhab/binding/lghorizon/internal/api/LGHorizonApiException.java
+++ b/bundles/org.openhab.binding.lghorizon/src/main/java/org/openhab/binding/lghorizon/internal/api/LGHorizonApiException.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.lghorizon.internal.api;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
+/**
+ * Thrown for any failure talking to the LG Horizon cloud backend: network errors, unexpected payloads, or the backend
+ * rejecting our credentials.
+ *
+ * @author Mark - Initial contribution
+ */
+@NonNullByDefault
+public class LGHorizonApiException extends Exception {
+
+    private static final long serialVersionUID = 1L;
+
+    private final boolean authenticationFailure;
+
+    public LGHorizonApiException(String message) {
+        this(message, false, null);
+    }
+
+    public LGHorizonApiException(String message, boolean authenticationFailure) {
+        this(message, authenticationFailure, null);
+    }
+
+    public LGHorizonApiException(String message, @Nullable Throwable cause) {
+        this(message, false, cause);
+    }
+
+    public LGHorizonApiException(String message, boolean authenticationFailure, @Nullable Throwable cause) {
+        super(message, cause);
+        this.authenticationFailure = authenticationFailure;
+    }
+
+    /**
+     * @return true if this failure means the stored credentials/refresh token are no longer valid and the thing should
+     *         go to an offline/configuration-error state instead of being retried automatically.
+     */
+    public boolean isAuthenticationFailure() {
+        return authenticationFailure;
+    }
+}

--- a/bundles/org.openhab.binding.lghorizon/src/main/java/org/openhab/binding/lghorizon/internal/api/LGHorizonAuthClient.java
+++ b/bundles/org.openhab.binding.lghorizon/src/main/java/org/openhab/binding/lghorizon/internal/api/LGHorizonAuthClient.java
@@ -1,0 +1,321 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.lghorizon.internal.api;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.api.ContentResponse;
+import org.eclipse.jetty.client.api.Request;
+import org.eclipse.jetty.client.util.StringContentProvider;
+import org.eclipse.jetty.http.HttpMethod;
+import org.openhab.binding.lghorizon.internal.LGHorizonContentAnonymizer;
+import org.openhab.binding.lghorizon.internal.api.dto.AuthResponseDto;
+import org.openhab.binding.lghorizon.internal.api.dto.ServiceConfigDto;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.google.gson.JsonSyntaxException;
+
+/**
+ * Handles authentication against the LG Horizon "spark" cloud backend and acts as the low-level HTTP client for every
+ * other REST call the binding makes.
+ * <p>
+ * Two auth flows are supported:
+ * <ul>
+ * <li>Username + password (used by e.g. Ziggo NL)</li>
+ * <li>Refresh token (used by e.g. Telenet BE, UPC/Sunrise CH, Virgin Media GB) - the refresh token itself has to be
+ * extracted once from the provider's web player (browser dev tools, local storage) since there is no public login flow
+ * for it.</li>
+ * </ul>
+ * The access token obtained here is also used, unmodified, as the MQTT password (see {@link #getMqttToken()}) for the
+ * real-time status channel.
+ *
+ * @author Mark - Initial contribution
+ */
+@NonNullByDefault
+public class LGHorizonAuthClient {
+
+    private static final long TOKEN_REFRESH_MARGIN_SECONDS = TimeUnit.DAYS.toSeconds(1);
+
+    private final Logger logger = LoggerFactory.getLogger(LGHorizonAuthClient.class);
+
+    private final HttpClient httpClient;
+    private final Gson gson = new Gson();
+    private final String apiBaseUrl;
+    private final String localeCode;
+    private final boolean useRefreshTokenFlow;
+
+    private @Nullable String username;
+    private @Nullable String password;
+    private @Nullable String refreshToken;
+
+    private volatile @Nullable String accessToken;
+    private volatile @Nullable String householdId;
+    private volatile long refreshTokenExpiryEpochSeconds;
+    private volatile @Nullable ServiceConfigDto serviceConfig;
+
+    private @Nullable Consumer<String> refreshTokenListener;
+
+    /**
+     * Set by the {@code lghorizon capture} console command for the duration of a live-capture window:
+     * notified with (anonymized url, anonymized response body) for every successful REST call this client
+     * makes, regardless of which higher-level method triggered it - typed DTO fetches and raw
+     * JsonElement/JsonObject fetches all funnel through {@link #getRaw}, so this one hook point covers all
+     * of them uniformly. {@code null} when no capture is active (the normal case).
+     */
+    private @Nullable BiConsumer<String, String> callCaptureListener;
+
+    public void setCallCaptureListener(@Nullable BiConsumer<String, String> listener) {
+        this.callCaptureListener = listener;
+    }
+
+    /**
+     * @param apiBaseUrl base URL of the provider's "spark" REST API, e.g.
+     *            {@code https://spark-prod-be.gnp.cloud.telenet.tv}
+     * @param localeCode two-letter locale used in the service discovery path (e.g. {@code be}, {@code nl}, {@code ch})
+     * @param useRefreshTokenFlow whether this provider requires refresh-token auth instead of username/password
+     */
+    public LGHorizonAuthClient(HttpClient httpClient, String apiBaseUrl, String localeCode, boolean useRefreshTokenFlow,
+            @Nullable String username, @Nullable String password, @Nullable String refreshToken) {
+        this.httpClient = httpClient;
+        this.apiBaseUrl = apiBaseUrl;
+        this.localeCode = localeCode;
+        this.useRefreshTokenFlow = useRefreshTokenFlow;
+        this.username = username;
+        this.password = password;
+        this.refreshToken = refreshToken;
+    }
+
+    /**
+     * Registers a callback that is invoked every time a new refresh token is issued by the backend, so the caller (the
+     * bridge handler) can persist it back into the thing configuration. Refresh tokens are single-use/rotating on some
+     * providers, so this is important for long-term reliability.
+     */
+    public void setRefreshTokenListener(Consumer<String> listener) {
+        this.refreshTokenListener = listener;
+    }
+
+    public @Nullable String getHouseholdId() {
+        return householdId;
+    }
+
+    /**
+     * Performs the initial login (or resumes from a stored refresh token) and fetches the service discovery document.
+     * Must be called once before any other method.
+     */
+    public void initialize() throws LGHorizonApiException {
+        fetchAccessToken();
+        getServiceConfig();
+    }
+
+    private boolean usesRefreshTokenFlow() {
+        String refreshToken = this.refreshToken;
+        return useRefreshTokenFlow || !(refreshToken == null || refreshToken.isBlank());
+    }
+
+    /**
+     * Exchanges either username/password or a refresh token for a fresh access token + refresh token pair.
+     */
+    public synchronized void fetchAccessToken() throws LGHorizonApiException {
+        logger.debug("Fetching LG Horizon access token (locale={})", localeCode);
+        JsonObject payload = new JsonObject();
+        String path;
+        if (!usesRefreshTokenFlow() && accessToken == null) {
+            payload.addProperty("username", username);
+            payload.addProperty("password", password);
+            path = "/auth-service/v1/authorization";
+        } else {
+            payload.addProperty("refreshToken", refreshToken);
+            path = "/auth-service/v1/authorization/refresh";
+        }
+
+        Request request = httpClient.newRequest(apiBaseUrl + path).method(HttpMethod.POST)
+                .header("content-type", "application/json").header("charset", "utf-8")
+                .content(new StringContentProvider("application/json", gson.toJson(payload), StandardCharsets.UTF_8));
+        if (!usesRefreshTokenFlow() && accessToken == null) {
+            request = request.header("x-device-code", "web");
+        }
+
+        ContentResponse response = send(request);
+        AuthResponseDto auth = parse(response, AuthResponseDto.class);
+
+        if (response.getStatus() >= 300 || auth.accessToken == null) {
+            AuthResponseDto.ErrorDto error = auth.error;
+            if (error != null && error.statusCode == 97401) {
+                throw new LGHorizonApiException("Invalid credentials", true);
+            } else if (error != null && error.statusCode == 97402) {
+                throw new LGHorizonApiException("Invalid or expired refresh token", true);
+            } else if (error != null) {
+                throw new LGHorizonApiException("LG Horizon auth error: " + error.message, true);
+            }
+            throw new LGHorizonApiException(
+                    "Unknown LG Horizon authentication error (HTTP " + response.getStatus() + ")", true);
+        }
+
+        this.householdId = auth.householdId;
+        this.accessToken = auth.accessToken;
+        String newRefreshToken = auth.refreshToken;
+        if (newRefreshToken != null) {
+            this.refreshToken = newRefreshToken;
+            Consumer<String> listener = refreshTokenListener;
+            if (listener != null) {
+                listener.accept(newRefreshToken);
+            }
+        }
+        this.refreshTokenExpiryEpochSeconds = auth.refreshTokenExpiry;
+        logger.debug("LG Horizon access token acquired; refresh token expires {}",
+                Instant.ofEpochSecond(refreshTokenExpiryEpochSeconds));
+    }
+
+    private boolean isTokenExpiring() {
+        String token = accessToken;
+        if (token == null || refreshTokenExpiryEpochSeconds == 0) {
+            return true;
+        }
+        return Instant.now().getEpochSecond() >= (refreshTokenExpiryEpochSeconds - TOKEN_REFRESH_MARGIN_SECONDS);
+    }
+
+    private void ensureFreshToken() throws LGHorizonApiException {
+        if (isTokenExpiring()) {
+            fetchAccessToken();
+        }
+    }
+
+    /**
+     * Performs an authenticated GET request against one of the "spark" REST services and parses the response as the
+     * given DTO type.
+     */
+    public <T> T get(String serviceBaseUrl, String path, Class<T> type) throws LGHorizonApiException {
+        return parse(getRaw(serviceBaseUrl, path), type);
+    }
+
+    private ContentResponse getRaw(String serviceBaseUrl, String path) throws LGHorizonApiException {
+        ensureFreshToken();
+        String url = serviceBaseUrl + path;
+        String anonymizedUrl = String.valueOf(LGHorizonContentAnonymizer.anonymizeTopic(url));
+        ContentResponse response = send(
+                httpClient.newRequest(url).method(HttpMethod.GET).header("Authorization", "Bearer " + accessToken));
+
+        if (response.getStatus() == 401) {
+            logger.debug("Got HTTP 401 from {}, refreshing token and retrying once", anonymizedUrl);
+            fetchAccessToken();
+            response = send(
+                    httpClient.newRequest(url).method(HttpMethod.GET).header("Authorization", "Bearer " + accessToken));
+        }
+        if (response.getStatus() >= 300) {
+            throw new LGHorizonApiException(
+                    "Unable to call " + anonymizedUrl + ", HTTP status " + response.getStatus());
+        }
+        String anonymizedBody = LGHorizonContentAnonymizer.anonymizeMessage(response.getContentAsString());
+        logger.trace("Raw response from {}: {}", anonymizedUrl, anonymizedBody);
+        BiConsumer<String, String> capture = callCaptureListener;
+        if (capture != null) {
+            capture.accept(anonymizedUrl, String.valueOf(anonymizedBody));
+        }
+        return response;
+    }
+
+    public JsonObject getAsJsonObject(String serviceBaseUrl, String path) throws LGHorizonApiException {
+        return getAsJsonElement(serviceBaseUrl, path).getAsJsonObject();
+    }
+
+    /**
+     * Like {@link #getAsJsonObject(String, String)}, but for responses that may be a top-level JSON array
+     * (e.g. the channel list) as well as an object - used by the {@code lghorizon fingerprint} console
+     * command, which wants the raw, untyped response regardless of shape.
+     */
+    public JsonElement getAsJsonElement(String serviceBaseUrl, String path) throws LGHorizonApiException {
+        ContentResponse response = getRaw(serviceBaseUrl, path);
+        return JsonParser.parseString(response.getContentAsString());
+    }
+
+    private ContentResponse send(Request request) throws LGHorizonApiException {
+        try {
+            return request.timeout(15, TimeUnit.SECONDS).send();
+        } catch (Exception e) {
+            throw new LGHorizonApiException(
+                    "Unable to call " + LGHorizonContentAnonymizer.anonymizeTopic(request.getURI().toString()), e);
+        }
+    }
+
+    private <T> T parse(ContentResponse response, Class<T> type) throws LGHorizonApiException {
+        try {
+            @Nullable
+            T result = gson.fromJson(response.getContentAsString(), type);
+            if (result == null) {
+                throw new LGHorizonApiException("Empty response body from "
+                        + LGHorizonContentAnonymizer.anonymizeTopic(response.getRequest().getURI().toString()));
+            }
+            return result;
+        } catch (JsonSyntaxException e) {
+            throw new LGHorizonApiException("Unable to parse response from "
+                    + LGHorizonContentAnonymizer.anonymizeTopic(response.getRequest().getURI().toString()), e);
+        }
+    }
+
+    /**
+     * Fetches and caches the service discovery document ({@code /config-service/conf/web/backoffice.json}) that maps
+     * logical service names (personalizationService, linearService, mqttBroker, ...) to their concrete URLs for this
+     * provider.
+     */
+    public ServiceConfigDto getServiceConfig() throws LGHorizonApiException {
+        ServiceConfigDto cached = serviceConfig;
+        if (cached != null) {
+            return cached;
+        }
+        JsonObject raw = getServiceConfigAsJsonElement().getAsJsonObject();
+        Map<String, JsonObject> services = new HashMap<>();
+        for (String key : raw.keySet()) {
+            if (raw.get(key).isJsonObject()) {
+                services.put(key, raw.get(key).getAsJsonObject());
+            }
+        }
+        ServiceConfigDto config = new ServiceConfigDto(services);
+        this.serviceConfig = config;
+        return config;
+    }
+
+    /**
+     * Raw (untyped) JSON of the service discovery document, for the {@code lghorizon fingerprint} console
+     * command - mirrors the path built internally by {@link #getServiceConfig()}, but returns the unparsed
+     * document instead of the cached {@link ServiceConfigDto} wrapper.
+     */
+    public JsonElement getServiceConfigAsJsonElement() throws LGHorizonApiException {
+        return getAsJsonElement(apiBaseUrl, "/" + localeCode + "/en/config-service/conf/web/backoffice.json");
+    }
+
+    /**
+     * Fetches a short-lived token used as the MQTT password (username is the household id).
+     */
+    public String getMqttToken() throws LGHorizonApiException {
+        String url = getServiceConfig().getServiceUrl("authorizationService");
+        JsonObject result = getAsJsonObject(url, "/v1/mqtt/token");
+        if (!result.has("token")) {
+            throw new LGHorizonApiException("MQTT token response did not contain a 'token' field");
+        }
+        return result.get("token").getAsString();
+    }
+}

--- a/bundles/org.openhab.binding.lghorizon/src/main/java/org/openhab/binding/lghorizon/internal/api/LGHorizonKeys.java
+++ b/bundles/org.openhab.binding.lghorizon/src/main/java/org/openhab/binding/lghorizon/internal/api/LGHorizonKeys.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.lghorizon.internal.api;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * W3C key names accepted by the set-top box's {@code CPE.KeyEvent} MQTT message.
+ *
+ * @author Mark - Initial contribution
+ */
+@NonNullByDefault
+public final class LGHorizonKeys {
+
+    // Power
+    public static final String POWER = "Power";
+    public static final String STANDBY = "Standby";
+    public static final String WAKE_UP = "WakeUp";
+
+    // Playback
+    public static final String PLAY = "MediaPlay";
+    public static final String PAUSE = "MediaPause";
+    public static final String PLAY_PAUSE = "MediaPlayPause";
+    public static final String STOP = "MediaStop";
+    public static final String RECORD = "MediaRecord";
+    public static final String FAST_FORWARD = "MediaFastForward";
+    public static final String REWIND = "MediaRewind";
+    public static final String TRACK_NEXT = "MediaTrackNext";
+    public static final String TRACK_PREVIOUS = "MediaTrackPrevious";
+
+    // Jump to linear TV
+    public static final String TV = "TV";
+
+    // Channel / navigation
+    public static final String CHANNEL_UP = "ChannelUp";
+    public static final String CHANNEL_DOWN = "ChannelDown";
+    public static final String TOP_MENU = "MediaTopMenu";
+    public static final String GUIDE = "Guide";
+    public static final String INFO = "Info";
+    public static final String CONTEXT_MENU = "ContextMenu";
+
+    // D-Pad
+    public static final String ARROW_UP = "ArrowUp";
+    public static final String ARROW_DOWN = "ArrowDown";
+    public static final String ARROW_LEFT = "ArrowLeft";
+    public static final String ARROW_RIGHT = "ArrowRight";
+    public static final String ENTER = "Enter";
+    public static final String ESCAPE = "Escape";
+    public static final String BACKSPACE = "Backspace";
+
+    // Color buttons
+    public static final String RED = "Red";
+    public static final String GREEN = "Green";
+    public static final String YELLOW = "Yellow";
+    public static final String BLUE = "Blue";
+
+    private LGHorizonKeys() {
+        // constants
+    }
+}

--- a/bundles/org.openhab.binding.lghorizon/src/main/java/org/openhab/binding/lghorizon/internal/api/ProviderPresets.java
+++ b/bundles/org.openhab.binding.lghorizon/src/main/java/org/openhab/binding/lghorizon/internal/api/ProviderPresets.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.lghorizon.internal.api;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * Known LG Horizon providers and the connection details behind each one. LG Horizon is white-labelled by several cable
+ * operators; each one runs its own "spark" cloud backend under the same platform.
+ * <p>
+ * This is the single source of truth for known providers: both {@link #get(String)} (used to resolve a selected
+ * provider to its connection details) and {@code LGHorizonConfigOptionProvider} (used to populate the "provider"
+ * dropdown in the UI) read from the same table.
+ * <p>
+ * A provider that isn't listed here at all (an unreleased backend, a provider's preprod/test environment, ...) doesn't
+ * need an entry: the account thing's advanced {@code country}/{@code apiUrl}/ {@code useRefreshToken} parameters can be
+ * filled in manually instead.
+ *
+ * @author Mark - Initial contribution
+ */
+@NonNullByDefault
+public class ProviderPresets {
+
+    /**
+     * Connection details for a single known provider.
+     *
+     * @param apiUrl base URL of the provider's "spark" REST API
+     * @param countryCode two-letter locale code used in the service-discovery
+     *            URL path (e.g. {@code be}, {@code nl}, {@code ch}) - not
+     *            necessarily identical to the country implied by the provider
+     *            name (matches {@code country_code[0:2]} in
+     *            lghorizon-python)
+     * @param useRefreshToken whether this provider requires refresh-token auth
+     *            instead of plain username/password
+     * @param displayName human readable provider name
+     */
+    public record Preset(String apiUrl, String countryCode, boolean useRefreshToken, String displayName) {
+    }
+
+    private static final Map<String, Preset> PRESETS = new HashMap<>();
+
+    static {
+        PRESETS.put("telenet",
+                new Preset("https://spark-prod-be.gnp.cloud.telenet.tv", "be", true, "Telenet (Belgium)"));
+        PRESETS.put("basetv", new Preset("https://spark-prod-be.gnp.cloud.base.tv", "be", true, "BASE TV (Belgium)"));
+        PRESETS.put("ziggo",
+                new Preset("https://spark-prod-nl.gnp.cloud.ziggogo.tv", "nl", false, "Ziggo (Netherlands)"));
+        PRESETS.put("upc-sunrise",
+                new Preset("https://spark-prod-ch.gnp.cloud.sunrisetv.ch", "ch", true, "UPC / Sunrise (Switzerland)"));
+        PRESETS.put("virginmedia-gb", new Preset("https://spark-prod-gb.gnp.cloud.virgintvgo.virginmedia.com", "gb",
+                true, "Virgin Media (United Kingdom)"));
+        PRESETS.put("virginmedia-ie",
+                new Preset("https://spark-prod-ie.gnp.cloud.virginmediatv.ie", "ie", false, "Virgin Media (Ireland)"));
+        PRESETS.put("upc-poland", new Preset("https://spark-prod-pl.gnp.cloud.upctv.pl", "pl", false, "UPC (Poland)"));
+    }
+
+    private ProviderPresets() {
+        // static lookup table
+    }
+
+    public static Preset get(String providerId) {
+        Preset preset = PRESETS.get(providerId);
+        if (preset == null) {
+            throw new IllegalArgumentException("Unknown/unsupported LG Horizon provider: " + providerId);
+        }
+        return preset;
+    }
+
+    public static Map<String, Preset> all() {
+        return PRESETS;
+    }
+}

--- a/bundles/org.openhab.binding.lghorizon/src/main/java/org/openhab/binding/lghorizon/internal/api/dto/AuthResponseDto.java
+++ b/bundles/org.openhab.binding.lghorizon/src/main/java/org/openhab/binding/lghorizon/internal/api/dto/AuthResponseDto.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.lghorizon.internal.api.dto;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * Response body of {@code POST /auth-service/v1/authorization} and {@code POST /auth-service/v1/authorization/refresh}.
+ *
+ * @author Mark - Initial contribution
+ */
+public class AuthResponseDto {
+
+    @SerializedName("householdId")
+    public String householdId;
+
+    @SerializedName("accessToken")
+    public String accessToken;
+
+    @SerializedName("refreshToken")
+    public String refreshToken;
+
+    @SerializedName("refreshTokenExpiry")
+    public long refreshTokenExpiry;
+
+    @SerializedName("username")
+    public String username;
+
+    @SerializedName("error")
+    public ErrorDto error;
+
+    public static class ErrorDto {
+        @SerializedName("statusCode")
+        public int statusCode;
+
+        @SerializedName("message")
+        public String message;
+    }
+
+    @Override
+    public String toString() {
+        return "AuthResponseDto [householdId=" + householdId + ", accessToken=" + accessToken + ", refreshToken="
+                + refreshToken + ", refreshTokenExpiry=" + refreshTokenExpiry + ", username=" + username + ", error="
+                + error + "]";
+    }
+}

--- a/bundles/org.openhab.binding.lghorizon/src/main/java/org/openhab/binding/lghorizon/internal/api/dto/ChannelDto.java
+++ b/bundles/org.openhab.binding.lghorizon/src/main/java/org/openhab/binding/lghorizon/internal/api/dto/ChannelDto.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.lghorizon.internal.api.dto;
+
+import java.util.List;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * A single entry of {@code GET /linearService/v2/channels}.
+ *
+ * @author Mark - Initial contribution
+ */
+public class ChannelDto {
+
+    @SerializedName("id")
+    public String id;
+
+    @SerializedName("name")
+    public String name;
+
+    @SerializedName("logicalChannelNumber")
+    public String logicalChannelNumber;
+
+    @SerializedName("isRadio")
+    public boolean isRadio;
+
+    @SerializedName("linearProducts")
+    public List<String> linearProducts;
+
+    @SerializedName("imageStream")
+    public ImageStreamDto imageStream;
+
+    public List<String> getLinearProducts() {
+        List<String> products = linearProducts;
+        return products == null ? List.of() : products;
+    }
+
+    /** The channel's own logo/preview image, preferring the full-size variant if both are present. */
+    public String getStreamImage() {
+        ImageStreamDto stream = imageStream;
+        if (stream == null) {
+            return null;
+        }
+        return stream.full != null ? stream.full : stream.small;
+    }
+
+    public static class ImageStreamDto {
+        @SerializedName("full")
+        public String full;
+
+        @SerializedName("small")
+        public String small;
+    }
+
+    @Override
+    public String toString() {
+        return "ChannelDto [id=" + id + ", name=" + name + ", logicalChannelNumber=" + logicalChannelNumber
+                + ", isRadio=" + isRadio + ", linearProducts=" + linearProducts + "]";
+    }
+}

--- a/bundles/org.openhab.binding.lghorizon/src/main/java/org/openhab/binding/lghorizon/internal/api/dto/CustomerDto.java
+++ b/bundles/org.openhab.binding.lghorizon/src/main/java/org/openhab/binding/lghorizon/internal/api/dto/CustomerDto.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.lghorizon.internal.api.dto;
+
+import java.util.List;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * Response body of {@code GET /personalizationService/v1/customer/{householdId}?with=profiles,devices}.
+ *
+ * @author Mark - Initial contribution
+ */
+public class CustomerDto {
+
+    @SerializedName("customerId")
+    public String customerId;
+
+    @SerializedName("countryId")
+    public String countryId;
+
+    @SerializedName("cityId")
+    public int cityId;
+
+    @SerializedName("profiles")
+    public List<ProfileDto> profiles;
+
+    @SerializedName("assignedDevices")
+    public List<DeviceDto> assignedDevices;
+
+    @Override
+    public String toString() {
+        return "CustomerDto [customerId=" + customerId + ", countryId=" + countryId + ", cityId=" + cityId
+                + ", profiles=" + profiles + ", assignedDevices=" + assignedDevices + "]";
+    }
+
+    public static class ProfileDto {
+        @SerializedName("profileId")
+        public String profileId;
+
+        @SerializedName("name")
+        public String name;
+
+        @SerializedName("favoriteChannels")
+        public List<String> favoriteChannels;
+
+        @SerializedName("options")
+        public OptionsDto options;
+
+        @Override
+        public String toString() {
+            return "ProfileDto [profileId=" + profileId + ", name=" + name + ", favoriteChannels=" + favoriteChannels
+                    + ", options=" + options + "]";
+        }
+
+        public static class OptionsDto {
+            @SerializedName("lang")
+            public String lang;
+
+            @Override
+            public String toString() {
+                return "OptionsDto [lang=" + lang + "]";
+            }
+        }
+    }
+
+    public static class DeviceDto {
+        @SerializedName("deviceId")
+        public String deviceId;
+
+        @SerializedName("hashedCPEId")
+        public String hashedCpeId;
+
+        @SerializedName("defaultProfileId")
+        public String defaultProfileId;
+
+        @SerializedName("deviceType")
+        public String deviceType;
+
+        @SerializedName("platformType")
+        public String platformType;
+
+        @SerializedName("serialNumber")
+        public String serialNumber;
+
+        @SerializedName("wifiMacAddress")
+        public String wifiMacAddress;
+
+        @SerializedName("ethernetMacAddress")
+        public String ethernetMacAddress;
+
+        @Override
+        public String toString() {
+            return "DeviceDto [deviceId=" + deviceId + ", hashedCpeId=" + hashedCpeId + ", deviceType=" + deviceType
+                    + ", defaultProfileId=" + defaultProfileId + ", platformType=" + platformType + ", settings="
+                    + settings + "]";
+        }
+
+        @SerializedName("settings")
+        public SettingsDto settings;
+
+        public static class SettingsDto {
+            @SerializedName("deviceFriendlyName")
+            public String deviceFriendlyName;
+
+            @Override
+            public String toString() {
+                return "SettingsDto [deviceFriendlyName=" + deviceFriendlyName + "]";
+            }
+        }
+    }
+}

--- a/bundles/org.openhab.binding.lghorizon/src/main/java/org/openhab/binding/lghorizon/internal/api/dto/EntitlementsDto.java
+++ b/bundles/org.openhab.binding.lghorizon/src/main/java/org/openhab/binding/lghorizon/internal/api/dto/EntitlementsDto.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.lghorizon.internal.api.dto;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * Response body of {@code GET /purchaseService/v2/customers/{householdId}/entitlements}.
+ *
+ * @author Mark - Initial contribution
+ */
+public class EntitlementsDto {
+
+    @SerializedName("entitlements")
+    public List<EntitlementDto> entitlements;
+
+    @SerializedName("features")
+    public List<String> features;
+
+    public List<String> getEntitlementIds() {
+        List<EntitlementDto> list = entitlements;
+        if (list == null) {
+            return List.of();
+        }
+        List<String> ids = new ArrayList<>();
+        for (EntitlementDto e : list) {
+            String id = e.id;
+            if (id != null) {
+                ids.add(id);
+            }
+        }
+        return ids;
+    }
+
+    public boolean hasPvr() {
+        List<String> f = features;
+        return f != null && f.contains("PVR");
+    }
+
+    public boolean hasLocalDvr() {
+        List<String> f = features;
+        return f != null && f.contains("LOCALDVR");
+    }
+
+    @Override
+    public String toString() {
+        return "EntitlementsDto [entitlements=" + entitlements + ", features=" + features + "]";
+    }
+
+    public static class EntitlementDto {
+        @SerializedName("id")
+        public String id;
+
+        @Override
+        public String toString() {
+            return "EntitlementDto [id=" + id + "]";
+        }
+    }
+}

--- a/bundles/org.openhab.binding.lghorizon/src/main/java/org/openhab/binding/lghorizon/internal/api/dto/EventDetailDto.java
+++ b/bundles/org.openhab.binding.lghorizon/src/main/java/org/openhab/binding/lghorizon/internal/api/dto/EventDetailDto.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.lghorizon.internal.api.dto;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * Response body of {@code GET
+ * /linearService/v2/replayEvent/{eventId}?returnLinearContent=true&forceLinearResponse=true}.
+ * Used to resolve title/episode metadata for linear TV, live-TV rewind (reviewBuffer) and catch-up replay -
+ * all three share this identical endpoint and identifier shape.
+ *
+ * @author Mark - Initial contribution
+ */
+public class EventDetailDto {
+
+    @SerializedName("eventId")
+    public String eventId;
+
+    @SerializedName("channelId")
+    public String channelId;
+
+    @SerializedName("title")
+    public String title;
+
+    @SerializedName("episodeName")
+    public String episodeName;
+
+    @SerializedName("seasonNumber")
+    public Integer seasonNumber;
+
+    @SerializedName("episodeNumber")
+    public Integer episodeNumber;
+
+    @Override
+    public String toString() {
+        return "EventDetailDto [eventId=" + eventId + ", channelId=" + channelId + ", title=" + title + ", episodeName="
+                + episodeName + ", seasonNumber=" + seasonNumber + ", episodeNumber=" + episodeNumber + "]";
+    }
+}

--- a/bundles/org.openhab.binding.lghorizon/src/main/java/org/openhab/binding/lghorizon/internal/api/dto/RecordingDetailDto.java
+++ b/bundles/org.openhab.binding.lghorizon/src/main/java/org/openhab/binding/lghorizon/internal/api/dto/RecordingDetailDto.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.lghorizon.internal.api.dto;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * Response body of {@code GET /recordingService/customers/{customerId}/details/single/{recordingId}} - a
+ * single nDVR (network recording) detail.
+ * <p>
+ * {@code title}'s meaning depends on {@code source}: for a {@code "show"}-sourced recording (a standalone
+ * item recorded individually, not part of an ongoing series recording rule), {@code title} itself holds the
+ * show/program name; for any other source (an episode recorded as part of a series/season rule), the show
+ * name is instead in the separate {@code showTitle} field, and {@code title} is a general/fallback label.
+ * See {@link #getShowTitle()}, which applies this distinction. *
+ *
+ * @author Mark - Initial contribution
+ */
+public class RecordingDetailDto {
+
+    @SerializedName("id")
+    public String id;
+
+    @SerializedName("title")
+    public String title;
+
+    @SerializedName("source")
+    public String source;
+
+    @SerializedName("channelId")
+    public String channelId;
+
+    @SerializedName("episodeTitle")
+    public String episodeTitle;
+
+    @SerializedName("showTitle")
+    public String showTitle;
+
+    @SerializedName("seasonNumber")
+    public Integer seasonNumber;
+
+    @SerializedName("episodeNumber")
+    public Integer episodeNumber;
+
+    /**
+     * The show/program name: {@code title} itself for a {@code "show"}-sourced (standalone) recording, otherwise the
+     * separate {@code showTitle} field.
+     */
+    public String getShowTitle() {
+        return "show".equalsIgnoreCase(source) ? title : showTitle;
+    }
+
+    @Override
+    public String toString() {
+        return "RecordingDetailDto [id=" + id + ", title=" + title + ", source=" + source + ", channelId=" + channelId
+                + ", episodeTitle=" + episodeTitle + ", showTitle=" + showTitle + ", seasonNumber=" + seasonNumber
+                + ", episodeNumber=" + episodeNumber + "]";
+    }
+}

--- a/bundles/org.openhab.binding.lghorizon/src/main/java/org/openhab/binding/lghorizon/internal/api/dto/ServiceConfigDto.java
+++ b/bundles/org.openhab.binding.lghorizon/src/main/java/org/openhab/binding/lghorizon/internal/api/dto/ServiceConfigDto.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.lghorizon.internal.api.dto;
+
+import java.util.Map;
+
+import com.google.gson.JsonObject;
+
+/**
+ * The {@code /config-service/conf/web/backoffice.json} document. It is a flat map of service-name to an object
+ * containing (at least) a {@code URL} field, e.g. {@code personalizationService.URL}, {@code mqttBroker.URL}, etc.
+ * <p>
+ * Modelled as a raw {@link JsonObject} because the set of services differs slightly per provider and new ones are added
+ * over time.
+ *
+ * @author Mark - Initial contribution
+ */
+public class ServiceConfigDto {
+
+    private final Map<String, JsonObject> services;
+
+    public ServiceConfigDto(Map<String, JsonObject> services) {
+        this.services = services;
+    }
+
+    public String getServiceUrl(String serviceName) throws IllegalArgumentException {
+        JsonObject service = services.get(serviceName);
+        if (service == null || !service.has("URL")) {
+            throw new IllegalArgumentException("Service URL for '" + serviceName + "' not found in configuration");
+        }
+        String url = service.get("URL").getAsString();
+        // Workaround for a historically broken Ziggo NL EPG host.
+        if (url.contains("static.spark.ziggogo.tv")) {
+            url = url.replace("static.spark.ziggogo.tv", "staticqbr-prod-nl.gnp.cloud.ziggogo.tv");
+        }
+        return url;
+    }
+
+    @Override
+    public String toString() {
+        return "ServiceConfigDto [services=" + services + "]";
+    }
+}

--- a/bundles/org.openhab.binding.lghorizon/src/main/java/org/openhab/binding/lghorizon/internal/api/dto/VodDetailDto.java
+++ b/bundles/org.openhab.binding.lghorizon/src/main/java/org/openhab/binding/lghorizon/internal/api/dto/VodDetailDto.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.lghorizon.internal.api.dto;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * Response body of {@code GET /vodService/v2/detailscreen/{titleId}}. For an episode, {@code title} is the
+ * episode's own title and {@code seriesTitle} is the show name; for a movie, {@code title} is the movie
+ * title and {@code seriesTitle} is absent.
+ *
+ * @author Mark - Initial contribution
+ */
+public class VodDetailDto {
+
+    @SerializedName("id")
+    public String id;
+
+    @SerializedName("type")
+    public String type;
+
+    @SerializedName("title")
+    public String title;
+
+    @SerializedName("seriesTitle")
+    public String seriesTitle;
+
+    @SerializedName("season")
+    public Integer season;
+
+    @SerializedName("episode")
+    public Integer episode;
+
+    public boolean isEpisode() {
+        return "EPISODE".equalsIgnoreCase(type);
+    }
+
+    @Override
+    public String toString() {
+        return "VodDetailDto [id=" + id + ", type=" + type + ", title=" + title + ", seriesTitle=" + seriesTitle
+                + ", season=" + season + ", episode=" + episode + "]";
+    }
+}

--- a/bundles/org.openhab.binding.lghorizon/src/main/java/org/openhab/binding/lghorizon/internal/console/LGHorizonCommandExtension.java
+++ b/bundles/org.openhab.binding.lghorizon/src/main/java/org/openhab/binding/lghorizon/internal/console/LGHorizonCommandExtension.java
@@ -1,0 +1,603 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.lghorizon.internal.console;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.StandardOpenOption;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.lghorizon.internal.LGHorizonBindingConstants;
+import org.openhab.binding.lghorizon.internal.LGHorizonContentAnonymizer;
+import org.openhab.binding.lghorizon.internal.api.dto.CustomerDto.DeviceDto;
+import org.openhab.binding.lghorizon.internal.api.dto.CustomerDto.DeviceDto.SettingsDto;
+import org.openhab.binding.lghorizon.internal.api.dto.CustomerDto.ProfileDto;
+import org.openhab.binding.lghorizon.internal.handler.LGHorizonAccountHandler;
+import org.openhab.core.io.console.Console;
+import org.openhab.core.io.console.ConsoleCommandCompleter;
+import org.openhab.core.io.console.StringsCompleter;
+import org.openhab.core.io.console.extensions.AbstractConsoleCommandExtension;
+import org.openhab.core.io.console.extensions.ConsoleCommandExtension;
+import org.openhab.core.thing.Thing;
+import org.openhab.core.thing.ThingRegistry;
+import org.openhab.core.thing.ThingStatus;
+import org.openhab.core.thing.ThingUID;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.google.gson.JsonSyntaxException;
+
+/**
+ * Console commands to inspect configured LG Horizon accounts/boxes and to capture anonymized REST/MQTT
+ * content for later analysis without needing physical access to the box or provider in question.
+ * <p>
+ * Accounts and boxes are selected by their own identifiers ({@code customerId}, {@code deviceId}) rather
+ * than the openHAB thing UID, since a fingerprint or capture is meaningful independent of whether a thing
+ * has even been created for a given device yet - {@code boxes} shows both, correlating REST-known devices
+ * with any actual box thing that exists for them.
+ * <p>
+ * Two distinct, deliberately decoupled capture commands:
+ * <ul>
+ * <li>{@code fingerprint} - a quick, mostly-instant REST-only dump (customer/entitlements/channels/service
+ * config), plus a passive wait for each box's next (or already-cached) {@code .../status} message, since
+ * that's the only way to learn a box's state at all - the backend never resends it on request, so skipping
+ * this entirely would leave every fingerprint blank on that point.</li>
+ * <li>{@code capture} - an active, duration-based live-traffic recording for one specific box: every MQTT
+ * status/uiStatus message, every REST call the binding makes in response (event/VOD/recording detail
+ * lookups, the intent image URL lookup), and metadata (never the actual bytes) for every image fetch.
+ * Requires the device to have an actual box thing already configured, since live capture attaches to that
+ * thing's own message handling.</li>
+ * </ul>
+ *
+ * @author Mark - Initial contribution
+ */
+@NonNullByDefault
+@Component(service = ConsoleCommandExtension.class)
+public class LGHorizonCommandExtension extends AbstractConsoleCommandExtension implements ConsoleCommandCompleter {
+
+    private static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
+
+    private static final String FINGERPRINT_ROOT_PATH = System.getProperty("user.home") + File.separator
+            + LGHorizonBindingConstants.BINDING_ID;
+
+    private static final int CAPTURE_TIMEOUT_SECONDS = 10;
+    // Safety cap so a mistyped duration doesn't lock the console shell for an unreasonable time.
+    private static final int MAX_LIVE_CAPTURE_DURATION_SECONDS = 300;
+
+    private static final String ACCOUNTS = "accounts";
+    private static final String PROFILES = "profiles";
+    private static final String BOXES = "boxes";
+    private static final String FINGERPRINT = "fingerprint";
+    private static final String CAPTURE = "capture";
+    private static final StringsCompleter CMD_COMPLETER = new StringsCompleter(
+            List.of(ACCOUNTS, PROFILES, BOXES, FINGERPRINT, CAPTURE), false);
+
+    private static final DateTimeFormatter CAPTURE_ENTRY_TIME_FORMAT = DateTimeFormatter.ofPattern("HH:mm:ss.SSS");
+
+    private final ThingRegistry thingRegistry;
+
+    @Activate
+    public LGHorizonCommandExtension(final @Reference ThingRegistry thingRegistry) {
+        super("lghorizon", "Interact with the Liberty Global Horizon binding");
+        this.thingRegistry = thingRegistry;
+    }
+
+    @Override
+    public void execute(String[] args, Console console) {
+        if (args.length < 1) {
+            console.println("Invalid number of arguments");
+            printUsage(console);
+            return;
+        }
+
+        List<LGHorizonAccountHandler> accountHandlers = allAccountHandlers();
+        if (accountHandlers.isEmpty()) {
+            console.println("No Liberty Global Horizon accounts configured");
+            return;
+        }
+
+        String subCommand = args[0];
+
+        if (CAPTURE.equalsIgnoreCase(subCommand)) {
+            executeCapture(args, console, accountHandlers);
+            return;
+        }
+
+        if (!(ACCOUNTS.equalsIgnoreCase(subCommand) || PROFILES.equalsIgnoreCase(subCommand)
+                || BOXES.equalsIgnoreCase(subCommand) || FINGERPRINT.equalsIgnoreCase(subCommand))) {
+            console.println("Unsupported command '" + subCommand + "'");
+            printUsage(console);
+            return;
+        }
+        if (args.length > 2) {
+            console.println("Invalid number of arguments");
+            printUsage(console);
+            return;
+        }
+
+        if (ACCOUNTS.equalsIgnoreCase(subCommand)) {
+            accounts(console, accountHandlers);
+            return;
+        }
+
+        List<LGHorizonAccountHandler> handlers;
+        if (args.length > 1) {
+            String customerId = args[1];
+            handlers = accountHandlers.stream().filter(h -> customerId.equalsIgnoreCase(h.getCustomerId()))
+                    .collect(Collectors.toList());
+            if (handlers.isEmpty()) {
+                console.println("No Liberty Global Horizon account with customer id '" + args[1] + "'");
+                printUsage(console);
+                return;
+            }
+        } else {
+            handlers = accountHandlers;
+        }
+
+        if (PROFILES.equalsIgnoreCase(subCommand)) {
+            profiles(console, handlers);
+        } else if (BOXES.equalsIgnoreCase(subCommand)) {
+            boxes(console, handlers);
+        } else {
+            fingerprint(console, handlers);
+        }
+    }
+
+    private void executeCapture(String[] args, Console console, List<LGHorizonAccountHandler> accountHandlers) {
+        if (args.length != 4) {
+            console.println("Usage: " + CAPTURE + " <customerId> <deviceId> <durationSeconds>");
+            return;
+        }
+        String customerId = args[1];
+        String deviceId = args[2];
+        LGHorizonAccountHandler handler = accountHandlers.stream()
+                .filter(h -> customerId.equalsIgnoreCase(h.getCustomerId())).findFirst().orElse(null);
+        if (handler == null) {
+            console.println("No Liberty Global Horizon account with customer id '" + customerId + "'");
+            return;
+        }
+        Integer duration = tryParseInt(args[3]);
+        if (duration == null || duration < 1 || duration > MAX_LIVE_CAPTURE_DURATION_SECONDS) {
+            console.println("Capture duration must be a whole number of seconds between 1 and "
+                    + MAX_LIVE_CAPTURE_DURATION_SECONDS);
+            return;
+        }
+        if (!handler.hasRegisteredBox(deviceId)) {
+            console.println("Device '" + deviceId
+                    + "' has no configured box thing on this account - live capture requires an actual box thing to attach to, since it works by listening in on that thing's own message handling. Add the box thing first (see the 'boxes' command), then retry.");
+            return;
+        }
+        capture(console, handler, deviceId, duration);
+    }
+
+    private static @Nullable Integer tryParseInt(String s) {
+        try {
+            return Integer.parseInt(s);
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    private List<LGHorizonAccountHandler> allAccountHandlers() {
+        return thingRegistry.stream()
+                .filter(t -> LGHorizonBindingConstants.THING_TYPE_ACCOUNT.equals(t.getThingTypeUID()))
+                .map(Thing::getHandler).filter(LGHorizonAccountHandler.class::isInstance)
+                .map(LGHorizonAccountHandler.class::cast).collect(Collectors.toList());
+    }
+
+    /** Label used in section headers: the customer id when known, falling back to the thing UID otherwise. */
+    private String accountLabel(LGHorizonAccountHandler handler) {
+        String customerId = handler.getCustomerId();
+        return customerId != null ? customerId : handler.getThing().getUID().toString();
+    }
+
+    private void accounts(Console console, List<LGHorizonAccountHandler> handlers) {
+        for (LGHorizonAccountHandler handler : handlers) {
+            Thing thing = handler.getThing();
+            String customerId = handler.getCustomerId();
+            Object provider = thing.getConfiguration().get(LGHorizonBindingConstants.CONFIG_PROVIDER);
+            console.println(String.format("%-20s: %-12s provider=%-20s thingUID=%s",
+                    customerId != null ? customerId : "(not yet known)", thing.getStatus(), provider, thing.getUID()));
+        }
+    }
+
+    private List<Thing> boxThingsFor(LGHorizonAccountHandler handler) {
+        ThingUID bridgeUid = handler.getThing().getUID();
+        return thingRegistry.stream().filter(t -> LGHorizonBindingConstants.THING_TYPE_BOX.equals(t.getThingTypeUID())
+                && bridgeUid.equals(t.getBridgeUID())).collect(Collectors.toList());
+    }
+
+    private void profiles(Console console, List<LGHorizonAccountHandler> handlers) {
+        boolean multipleAccount = handlers.size() > 1;
+        for (LGHorizonAccountHandler handler : handlers) {
+            if (multipleAccount) {
+                console.println("### Account " + accountLabel(handler));
+            }
+
+            List<ProfileDto> profiles = handler.getProfiles();
+            if (profiles.isEmpty()) {
+                console.println("No profiles found");
+            }
+            for (ProfileDto profile : profiles) {
+                String profileId = profile.profileId;
+                String name = profile.name;
+                name = name != null ? name : "";
+                console.println(String.format("%-30s: %s", profileId, name));
+            }
+        }
+    }
+
+    /**
+     * Lists every device known from the account's REST data, annotated with the box thing's UID for
+     * whichever ones actually have one configured - the ones without are still valid targets for
+     * {@code fingerprint} (which is account-scoped, not per-box) but not for {@code capture} (which needs
+     * an actual thing to attach to).
+     */
+    private void boxes(Console console, List<LGHorizonAccountHandler> handlers) {
+        boolean multipleAccount = handlers.size() > 1;
+        for (LGHorizonAccountHandler handler : handlers) {
+            if (multipleAccount) {
+                console.println("### Account " + accountLabel(handler));
+            }
+            Map<String, ThingUID> thingUidByDeviceId = new HashMap<>();
+            for (Thing box : boxThingsFor(handler)) {
+                Object deviceIdObj = box.getConfiguration().get(LGHorizonBindingConstants.CONFIG_DEVICE_ID);
+                if (deviceIdObj != null) {
+                    thingUidByDeviceId.put(deviceIdObj.toString(), box.getUID());
+                }
+            }
+
+            List<DeviceDto> boxes = handler.getAssignedDevices();
+            if (boxes.isEmpty()) {
+                console.println("No boxes found");
+            }
+            for (DeviceDto box : boxes) {
+                String deviceId = box.deviceId;
+                SettingsDto settings = box.settings;
+                String friendlyName = settings != null ? settings.deviceFriendlyName : null;
+                friendlyName = friendlyName != null ? friendlyName : "";
+                ThingUID thingUid = deviceId != null ? thingUidByDeviceId.get(deviceId) : null;
+                String thingInfo = thingUid != null ? thingUid.toString() : "(no thing)";
+                console.println(String.format("%-30s: %-30s %s", deviceId, friendlyName, thingInfo));
+            }
+            if (multipleAccount) {
+                console.println("### End account");
+            }
+        }
+    }
+
+    /**
+     * A quick, mostly-instant REST-only snapshot (customer/entitlements/channels/service config), plus a
+     * passive wait for each box's next (or already-cached) {@code .../status} message - not an active
+     * request for a fresh one, and no {@code CPE.uiStatus} request/wait at all. For a full picture of live
+     * traffic while actively interacting with a box, use {@code capture} instead.
+     */
+    private void fingerprint(Console console, List<LGHorizonAccountHandler> handlers) {
+        String basePath = FINGERPRINT_ROOT_PATH + File.separator
+                + LocalDateTime.now().format(DateTimeFormatter.BASIC_ISO_DATE);
+        String path = nextPath(basePath, null);
+
+        console.println("Generating fingerprint, please be patient...");
+        console.println("# Start fingerprint");
+        int accountNdx = 0;
+        boolean multipleAccount = handlers.size() > 1;
+        for (LGHorizonAccountHandler handler : handlers) {
+            accountNdx++;
+            Thing accountThing = handler.getThing();
+            if (multipleAccount) {
+                console.println("### Account " + accountLabel(handler));
+            }
+            if (!ThingStatus.ONLINE.equals(accountThing.getStatus())) {
+                console.println("LG Horizon account not online, cannot create fingerprint");
+                if (multipleAccount) {
+                    console.println("### End account");
+                }
+                continue;
+            }
+            String accountPath = path + File.separator + "Account-" + accountNdx;
+
+            console.println("###### REST snapshot");
+            Map<String, String> restSnapshot = handler.fetchDiagnosticRestSnapshot();
+            if (restSnapshot.isEmpty()) {
+                console.println("Could not retrieve any REST responses");
+            }
+            restSnapshot.forEach((name, json) -> printAndSave(console, accountPath, name, json));
+
+            List<Thing> boxThings = boxThingsFor(handler);
+            if (boxThings.isEmpty()) {
+                console.println("No box things found");
+            }
+            for (Thing box : boxThings) {
+                Object deviceIdObj = box.getConfiguration().get(LGHorizonBindingConstants.CONFIG_DEVICE_ID);
+                String deviceId = deviceIdObj == null ? "" : deviceIdObj.toString();
+                console.println("###### Box " + box.getUID() + " - " + box.getLabel());
+                captureAndSave(console, accountPath, "box-status_" + deviceId, handler.captureNextStatus(deviceId));
+            }
+            if (multipleAccount) {
+                console.println("### End account " + accountLabel(handler));
+            }
+        }
+
+        try {
+            String zipfile = nextPath(basePath, "zip");
+            zipDirectory(Paths.get(path), Paths.get(zipfile));
+            deleteDirectory(path);
+            console.println("### Fingerprint has been written to zipfile: " + zipfile);
+        } catch (IOException e) {
+            console.println("Exception zipping fingerprint: " + e.getMessage());
+            console.println("### Fingerprint has been written to files in directory: " + path);
+        }
+
+        console.println("# End fingerprint");
+    }
+
+    /**
+     * Actively records live traffic for one specific box over a fixed window into a single, sequentially
+     * appended log file - MQTT status/uiStatus messages, every REST call the binding makes in response
+     * (event/VOD/recording detail lookups, the intent image URL lookup), and metadata (never bytes) for
+     * every image fetch, all sharing one sequence number so the actual order events happened in is
+     * preserved and scannable, rather than split across separate per-type files that each restart their
+     * own counter - that made it impossible to see what triggered what.
+     * <p>
+     * Meant to be run while a user actively interacts with the box (changing channels, rewinding, launching
+     * an app, starting a recording, ...). Blocks the console's own command thread for the duration, which is the point:
+     * the command doesn't return control until the window has elapsed.
+     */
+    private void capture(Console console, LGHorizonAccountHandler handler, String deviceId, int durationSeconds) {
+        String path = nextPath(FINGERPRINT_ROOT_PATH + File.separator + "capture-" + deviceId + "-"
+                + LocalDateTime.now().format(DateTimeFormatter.BASIC_ISO_DATE), "log");
+
+        console.println("Capturing live traffic for " + durationSeconds
+                + "s - interact with the box now (change channels, rewind, launch an app, start a recording, ...)");
+        console.println("Writing to: " + path);
+
+        AtomicInteger sequence = new AtomicInteger();
+        // Guards the actual file append: the three capture callbacks below can each fire concurrently, on
+        // different threads (the MQTT client's own thread for live messages, whichever thread happened to
+        // trigger a given REST/image call), so appends need to be serialized to avoid interleaved writes.
+        Object fileLock = new Object();
+
+        handler.startLiveCapture(deviceId, (topic, payload) -> {
+            String anonymizedTopic = String.valueOf(LGHorizonContentAnonymizer.anonymizeTopic(topic));
+            JsonObject wrapper = new JsonObject();
+            wrapper.addProperty("topic", topic);
+            wrapper.add("payload", payload);
+            String body = prettyJson(anonymizeOrEmpty(wrapper.toString()));
+            appendCaptureEntry(console, path, fileLock, sequence, "MQTT", anonymizedTopic, body);
+        });
+        handler.startRestCapture((url, responseBody) -> {
+            JsonObject wrapper = new JsonObject();
+            wrapper.addProperty("url", url);
+            try {
+                wrapper.add("response", JsonParser.parseString(responseBody));
+            } catch (JsonSyntaxException e) {
+                wrapper.addProperty("response", responseBody);
+            }
+            String body = prettyJson(anonymizeOrEmpty(wrapper.toString()));
+            appendCaptureEntry(console, path, fileLock, sequence, "REST", url, body);
+        });
+        handler.startImageCapture(description -> appendCaptureEntry(console, path, fileLock, sequence, "IMAGE",
+                anonymizeOrEmpty(description), null));
+
+        try {
+            Thread.sleep(durationSeconds * 1000L);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        } finally {
+            handler.stopLiveCapture(deviceId);
+            handler.stopRestCapture();
+            handler.stopImageCapture();
+        }
+
+        console.println("Live capture complete (" + sequence.get() + " events captured)");
+        console.println("Capture written to: " + path);
+    }
+
+    /**
+     * Appends one entry to the shared capture log: a scannable one-line header (sequence number, timestamp,
+     * type, short label - topic/URL/description) followed by the full pretty-printed body, if any. Callers
+     * are responsible for anonymizing both {@code label} and {@code body} beforehand.
+     */
+    private void appendCaptureEntry(Console console, String path, Object fileLock, AtomicInteger sequence, String type,
+            String label, @Nullable String body) {
+        int index = sequence.incrementAndGet();
+        String timestamp = LocalDateTime.now().format(CAPTURE_ENTRY_TIME_FORMAT);
+        StringBuilder entry = new StringBuilder();
+        entry.append(String.format("--- #%03d %s %-5s %s ---%n", index, timestamp, type, label));
+        if (body != null) {
+            entry.append(body).append(System.lineSeparator());
+        }
+        entry.append(System.lineSeparator());
+        String text = entry.toString();
+
+        console.println(text);
+        synchronized (fileLock) {
+            try {
+                File file = new File(path);
+                Objects.requireNonNull(file.getParentFile()).mkdirs();
+                Files.writeString(Paths.get(path), text, StandardCharsets.UTF_8, StandardOpenOption.CREATE,
+                        StandardOpenOption.APPEND);
+            } catch (IOException e) {
+                console.println("Exception writing to capture file: " + e.getMessage());
+            }
+        }
+    }
+
+    private String anonymizeOrEmpty(String content) {
+        String anonymized = LGHorizonContentAnonymizer.anonymizeMessage(content);
+        return anonymized != null ? anonymized : "";
+    }
+
+    private void captureAndSave(Console console, String accountPath, String filename,
+            CompletableFuture<JsonObject> future) {
+        try {
+            JsonObject captured = future.get(CAPTURE_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            printAndSave(console, accountPath, filename, captured.toString());
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        } catch (ExecutionException | TimeoutException e) {
+            console.println("Could not capture a message for " + filename + " within " + CAPTURE_TIMEOUT_SECONDS
+                    + "s (box may be offline, or does not send this message type)");
+        }
+    }
+
+    private void printAndSave(Console console, String path, String filename, String content) {
+        String anonymized = LGHorizonContentAnonymizer.anonymizeMessage(content);
+        anonymized = anonymized != null ? anonymized : "";
+        String json = prettyJson(anonymized);
+        console.println(json);
+        try {
+            writeJsonToFile(path, filename, json);
+        } catch (IOException e) {
+            console.println("Exception writing to file: " + e.getMessage());
+        }
+    }
+
+    private String nextPath(String pathString, @Nullable String extension) {
+        String path = pathString + ((extension != null) ? ("." + extension) : "");
+        int pathNdx = 1;
+        while (Files.exists(Paths.get(path))) {
+            path = pathString + "_" + pathNdx + ((extension != null) ? ("." + extension) : "");
+            pathNdx++;
+        }
+        return path;
+    }
+
+    private String prettyJson(String json) {
+        try {
+            return GSON.toJson(JsonParser.parseString(json));
+        } catch (JsonSyntaxException e) {
+            // Keep the unformatted content if there is a syntax exception
+            return json;
+        }
+    }
+
+    private void writeJsonToFile(String pathString, String filename, String json) throws IOException {
+        try {
+            JsonElement element = JsonParser.parseString(json);
+            if (element.isJsonNull() || (element.isJsonArray() && ((JsonArray) element).isEmpty())) {
+                // Don't write a file if empty
+                return;
+            }
+        } catch (JsonSyntaxException e) {
+            // Just continue and write the file with non-valid json anyway
+        }
+
+        String path = nextPath(pathString + File.separator + filename, "json");
+
+        // ensure full path exists
+        File file = new File(path);
+        Objects.requireNonNull(file.getParentFile()).mkdirs();
+
+        final byte[] contents = json.getBytes(StandardCharsets.UTF_8);
+        Files.write(file.toPath(), contents);
+    }
+
+    // Stackoverflow:
+    // https://stackoverflow.com/questions/57997257/how-can-i-zip-a-complete-directory-with-all-subfolders-in-java
+    private void zipDirectory(Path sourceDirectoryPath, Path zipPath) throws IOException {
+        try (FileOutputStream fos = new FileOutputStream(zipPath.toFile());
+                ZipOutputStream zos = new ZipOutputStream(fos)) {
+            Files.walkFileTree(sourceDirectoryPath, new SimpleFileVisitor<@Nullable Path>() {
+                @Override
+                public FileVisitResult visitFile(@Nullable Path file, @Nullable BasicFileAttributes attrs)
+                        throws IOException {
+                    zos.putNextEntry(new ZipEntry(sourceDirectoryPath.relativize(file).toString()));
+                    Files.copy(file, zos);
+                    zos.closeEntry();
+                    return FileVisitResult.CONTINUE;
+                }
+            });
+        }
+    }
+
+    private void deleteDirectory(String path) throws IOException {
+        Files.walk(Paths.get(path)).sorted(Comparator.reverseOrder()).map(Path::toFile).forEach(File::delete);
+    }
+
+    @Override
+    public List<String> getUsages() {
+        return Arrays.asList(buildCommandUsage(ACCOUNTS, "list all configured Liberty Global Horizon accounts"),
+                buildCommandUsage(PROFILES, "list all profiles on all accounts"),
+                buildCommandUsage(PROFILES + " <customerId>", "list all profiles on one account"),
+                buildCommandUsage(BOXES, "list all boxes on all accounts, with their box thing UID if configured"),
+                buildCommandUsage(BOXES + " <customerId>", "list all boxes on one account"),
+                buildCommandUsage(FINGERPRINT,
+                        "quick REST-only snapshot (+ each box's last known status) for all accounts"),
+                buildCommandUsage(FINGERPRINT + " <customerId>", "quick REST-only snapshot for one account"),
+                buildCommandUsage(CAPTURE + " <customerId> <deviceId> <durationSeconds>",
+                        "actively record live MQTT/REST traffic for one box over a fixed duration - requires an existing box thing for that device"));
+    }
+
+    @Override
+    public @Nullable ConsoleCommandCompleter getCompleter() {
+        return this;
+    }
+
+    @Override
+    public boolean complete(String[] args, int cursorArgumentIndex, int cursorPosition, List<String> candidates) {
+        if (cursorArgumentIndex <= 0) {
+            return CMD_COMPLETER.complete(args, cursorArgumentIndex, cursorPosition, candidates);
+        }
+        List<LGHorizonAccountHandler> allHandlers = allAccountHandlers();
+        if (cursorArgumentIndex == 1) {
+            List<String> customerIds = allHandlers.stream().map(LGHorizonAccountHandler::getCustomerId)
+                    .filter(Objects::nonNull).map(Objects::requireNonNull).toList();
+            return new StringsCompleter(customerIds, false).complete(args, cursorArgumentIndex, cursorPosition,
+                    candidates);
+        }
+        if (CAPTURE.equalsIgnoreCase(args[0]) && cursorArgumentIndex == 2 && args.length > 1) {
+            LGHorizonAccountHandler handler = allHandlers.stream()
+                    .filter(h -> args[1].equalsIgnoreCase(h.getCustomerId())).findFirst().orElse(null);
+            if (handler != null) {
+                List<String> deviceIds = handler.getAssignedDevices().stream().map(d -> d.deviceId)
+                        .filter(Objects::nonNull).map(Objects::requireNonNull).toList();
+                return new StringsCompleter(deviceIds, false).complete(args, cursorArgumentIndex, cursorPosition,
+                        candidates);
+            }
+        }
+        return false;
+    }
+}

--- a/bundles/org.openhab.binding.lghorizon/src/main/java/org/openhab/binding/lghorizon/internal/discovery/LGHorizonDiscoveryService.java
+++ b/bundles/org.openhab.binding.lghorizon/src/main/java/org/openhab/binding/lghorizon/internal/discovery/LGHorizonDiscoveryService.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.lghorizon.internal.discovery;
+
+import java.util.Set;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.binding.lghorizon.internal.LGHorizonBindingConstants;
+import org.openhab.binding.lghorizon.internal.api.dto.CustomerDto;
+import org.openhab.binding.lghorizon.internal.api.dto.CustomerDto.DeviceDto.SettingsDto;
+import org.openhab.binding.lghorizon.internal.handler.LGHorizonAccountHandler;
+import org.openhab.core.config.discovery.AbstractThingHandlerDiscoveryService;
+import org.openhab.core.config.discovery.DiscoveryResult;
+import org.openhab.core.config.discovery.DiscoveryResultBuilder;
+import org.openhab.core.thing.ThingUID;
+import org.openhab.core.thing.binding.ThingHandler;
+import org.openhab.core.thing.binding.ThingHandlerService;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ServiceScope;
+
+/**
+ * Discovers the set-top boxes registered on an LG Horizon account as child things of the {@code account} bridge, once
+ * the bridge has successfully
+ * logged in.
+ *
+ * @author Mark - Initial contribution
+ */
+@NonNullByDefault
+@Component(scope = ServiceScope.PROTOTYPE, service = ThingHandlerService.class)
+public class LGHorizonDiscoveryService extends AbstractThingHandlerDiscoveryService<LGHorizonAccountHandler> {
+
+    private static final int TIMEOUT_SECONDS = 10;
+
+    public LGHorizonDiscoveryService() {
+        super(LGHorizonAccountHandler.class, Set.of(LGHorizonBindingConstants.THING_TYPE_BOX), TIMEOUT_SECONDS, false);
+    }
+
+    @Override
+    protected void startScan() {
+        discoverDevices();
+    }
+
+    @Override
+    public void setThingHandler(ThingHandler handler) {
+        super.setThingHandler(handler);
+        if (handler instanceof LGHorizonAccountHandler accountHandler) {
+            accountHandler.setDiscoveryService(this);
+        }
+    }
+
+    public void discoverDevices() {
+        LGHorizonAccountHandler account = thingHandler;
+        ThingUID bridgeUid = account.getThing().getUID();
+
+        for (CustomerDto.DeviceDto device : account.getAssignedDevices()) {
+            String deviceId = device.deviceId;
+            if (deviceId == null) {
+                continue;
+            }
+            ThingUID thingUid = new ThingUID(LGHorizonBindingConstants.THING_TYPE_BOX, bridgeUid, deviceId);
+            SettingsDto settings = device.settings;
+            String label = settings != null && settings.deviceFriendlyName != null ? settings.deviceFriendlyName
+                    : "LG Horizon box " + deviceId;
+
+            DiscoveryResultBuilder builder = DiscoveryResultBuilder.create(thingUid).withBridge(bridgeUid)
+                    .withProperty(LGHorizonBindingConstants.CONFIG_DEVICE_ID, deviceId)
+                    .withRepresentationProperty(LGHorizonBindingConstants.CONFIG_DEVICE_ID).withLabel(label);
+            String platformType = device.platformType;
+            if (platformType != null) {
+                builder = builder.withProperty(LGHorizonBindingConstants.PROPERTY_PLATFORM_TYPE, platformType);
+            }
+            DiscoveryResult result = builder.build();
+            thingDiscovered(result);
+        }
+    }
+}

--- a/bundles/org.openhab.binding.lghorizon/src/main/java/org/openhab/binding/lghorizon/internal/discovery/LGHorizonUpnpDiscoveryParticipant.java
+++ b/bundles/org.openhab.binding.lghorizon/src/main/java/org/openhab/binding/lghorizon/internal/discovery/LGHorizonUpnpDiscoveryParticipant.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.lghorizon.internal.discovery;
+
+import java.util.Set;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.jupnp.model.meta.DeviceDetails;
+import org.jupnp.model.meta.ManufacturerDetails;
+import org.jupnp.model.meta.ModelDetails;
+import org.jupnp.model.meta.RemoteDevice;
+import org.openhab.binding.lghorizon.internal.LGHorizonBindingConstants;
+import org.openhab.core.config.discovery.DiscoveryResult;
+import org.openhab.core.config.discovery.DiscoveryResultBuilder;
+import org.openhab.core.config.discovery.upnp.UpnpDiscoveryParticipant;
+import org.openhab.core.thing.ThingRegistry;
+import org.openhab.core.thing.ThingTypeUID;
+import org.openhab.core.thing.ThingUID;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * LG Horizon set-top boxes advertise via UPnP/SSDP.
+ * The Telenet IP TV Box is identified with manufacturer "TELENETTVBOX" in the UPnP device manufacturer field.
+ * Other providers and boxes may use another identifier.
+ * <p>
+ * Unlike most {@link UpnpDiscoveryParticipant}s, this one does not represent the physical box as a discovered
+ * Thing: the box itself is only meaningfully addressable once an {@code account} bridge has authenticated against
+ * the cloud backend and enumerated it (see {@link LGHorizonDiscoveryService}), and none of the credentials that
+ * requires can be learned from the local network. Instead, seeing this fingerprint on the network is used purely
+ * as a hint to suggest adding and configuring an {@code account} bridge in the first place.
+ * <p>
+ * All matches collapse onto a single, stable {@code lghorizon:account:detected} suggestion (regardless of how many
+ * physical boxes respond), and the suggestion is withheld entirely once at least one {@code account} thing already
+ * exists, since one configured account already covers however many boxes are in the household.
+ *
+ * @author Mark - Initial contribution
+ */
+@Component(service = UpnpDiscoveryParticipant.class)
+@NonNullByDefault
+public class LGHorizonUpnpDiscoveryParticipant implements UpnpDiscoveryParticipant {
+
+    private static final Set<String> EXPECTED_MANUFACTURERS = Set.of("TELENETTVBOX");
+    private static final ThingUID SUGGESTED_ACCOUNT_UID = new ThingUID(LGHorizonBindingConstants.THING_TYPE_ACCOUNT,
+            "detected");
+
+    private final Logger logger = LoggerFactory.getLogger(LGHorizonUpnpDiscoveryParticipant.class);
+    private final ThingRegistry thingRegistry;
+
+    @Activate
+    public LGHorizonUpnpDiscoveryParticipant(@Reference ThingRegistry thingRegistry) {
+        this.thingRegistry = thingRegistry;
+    }
+
+    @Override
+    public Set<ThingTypeUID> getSupportedThingTypeUIDs() {
+        return Set.of(LGHorizonBindingConstants.THING_TYPE_ACCOUNT);
+    }
+
+    @Override
+    public @Nullable ThingUID getThingUID(RemoteDevice device) {
+        if (!isLGHorizonBox(device) || hasExistingAccount()) {
+            return null;
+        }
+        return SUGGESTED_ACCOUNT_UID;
+    }
+
+    @Override
+    public @Nullable DiscoveryResult createResult(RemoteDevice device) {
+        ThingUID thingUID = getThingUID(device);
+        if (thingUID == null) {
+            return null;
+        }
+
+        DeviceDetails details = device.getDetails();
+        String friendlyName = details == null ? null : details.getFriendlyName();
+        ModelDetails modelDetails = details == null ? null : details.getModelDetails();
+        String modelName = modelDetails == null ? null : modelDetails.getModelName();
+
+        logger.debug("Detected an LG Horizon set-top box on the network (name={}, model={})", friendlyName, modelName);
+
+        DiscoveryResultBuilder builder = DiscoveryResultBuilder.create(thingUID)
+                .withLabel("LG Horizon set-top box detected - add an account to control it");
+        if (friendlyName != null) {
+            builder = builder.withProperty("detectedDeviceName", friendlyName);
+        }
+        if (modelName != null) {
+            builder = builder.withProperty("detectedDeviceModel", modelName);
+        }
+        return builder.build();
+    }
+
+    private boolean isLGHorizonBox(RemoteDevice device) {
+        DeviceDetails details = device.getDetails();
+        if (details == null) {
+            return false;
+        }
+        ManufacturerDetails manufacturerDetails = details.getManufacturerDetails();
+        String manufacturer = manufacturerDetails == null ? null : manufacturerDetails.getManufacturer();
+        return manufacturer != null
+                && EXPECTED_MANUFACTURERS.stream().anyMatch(m -> m.equalsIgnoreCase(manufacturer.trim()));
+    }
+
+    private boolean hasExistingAccount() {
+        return thingRegistry.getAll().stream()
+                .anyMatch(thing -> LGHorizonBindingConstants.THING_TYPE_ACCOUNT.equals(thing.getThingTypeUID()));
+    }
+}

--- a/bundles/org.openhab.binding.lghorizon/src/main/java/org/openhab/binding/lghorizon/internal/handler/LGHorizonAccountConfiguration.java
+++ b/bundles/org.openhab.binding.lghorizon/src/main/java/org/openhab/binding/lghorizon/internal/handler/LGHorizonAccountConfiguration.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.lghorizon.internal.handler;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
+/**
+ * Configuration for the {@code account} bridge thing.
+ *
+ * @author Mark - Initial contribution
+ */
+@NonNullByDefault
+public class LGHorizonAccountConfiguration {
+
+    // Selects a known provider from {@link org.openhab.binding.lghorizon.internal.api.ProviderPresets},
+    // e.g. {@code telenet}. When set, it determines {@link #country}, {@link #apiUrl} and
+    // {@link #useRefreshToken} automatically. Leave empty to configure an unlisted provider (a new
+    // white-label deployment, or a provider's preprod/test backend) manually via those three
+    // advanced fields instead.
+    public @Nullable String provider;
+
+    // Two-letter locale code used in the service-discovery URL path (e.g. {@code be}, {@code nl},
+    // {@code ch}) - not necessarily the same region as the API URL itself. Known automatically
+    // when {@link #provider} is set; required if it is left empty.
+    public String country = "";
+
+    // Base URL of the provider's "spark" REST API, e.g. {@code https://spark-prod-be.gnp.cloud.telenet.tv}. Known
+    // automatically when {@link #provider} is set; required if it is left empty.
+    public String apiUrl = "";
+
+    // * Whether the provider requires refresh-token auth instead of username/password. Known
+    // automatically when {@link #provider} is set; only consulted if it is left empty.
+    public boolean useRefreshToken = false;
+
+    // Only used for password-based providers (e.g. Ziggo NL).
+    public @Nullable String username;
+
+    // Only used for password-based providers (e.g. Ziggo NL).
+    public @Nullable String password;
+
+    // Only used for token-based providers (e.g. Telenet BE, UPC/Sunrise CH, Virgin Media GB).
+    // Refresh token extracted from the provider's web player. The binding will keep this up to date automatically once
+    // it starts rotating tokens, but the very first value has to be supplied manually.
+    public String refreshToken = "";
+
+    // Poll interval (seconds) for the lightweight REST-based reachability check.
+    public int refreshInterval = 300;
+}

--- a/bundles/org.openhab.binding.lghorizon/src/main/java/org/openhab/binding/lghorizon/internal/handler/LGHorizonAccountHandler.java
+++ b/bundles/org.openhab.binding.lghorizon/src/main/java/org/openhab/binding/lghorizon/internal/handler/LGHorizonAccountHandler.java
@@ -1,0 +1,960 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.lghorizon.internal.handler;
+
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.api.Response;
+import org.eclipse.jetty.client.util.InputStreamResponseListener;
+import org.eclipse.jetty.http.HttpHeader;
+import org.openhab.binding.lghorizon.internal.LGHorizonBindingConstants;
+import org.openhab.binding.lghorizon.internal.LGHorizonContentAnonymizer;
+import org.openhab.binding.lghorizon.internal.api.LGHorizonApiException;
+import org.openhab.binding.lghorizon.internal.api.LGHorizonAuthClient;
+import org.openhab.binding.lghorizon.internal.api.ProviderPresets;
+import org.openhab.binding.lghorizon.internal.api.dto.ChannelDto;
+import org.openhab.binding.lghorizon.internal.api.dto.CustomerDto;
+import org.openhab.binding.lghorizon.internal.api.dto.EntitlementsDto;
+import org.openhab.binding.lghorizon.internal.api.dto.EventDetailDto;
+import org.openhab.binding.lghorizon.internal.api.dto.RecordingDetailDto;
+import org.openhab.binding.lghorizon.internal.api.dto.VodDetailDto;
+import org.openhab.binding.lghorizon.internal.discovery.LGHorizonDiscoveryService;
+import org.openhab.binding.lghorizon.internal.mqtt.LGHorizonMqttClient;
+import org.openhab.binding.lghorizon.internal.mqtt.LGHorizonMqttListener;
+import org.openhab.core.config.core.Configuration;
+import org.openhab.core.io.net.http.HttpClientFactory;
+import org.openhab.core.library.types.RawType;
+import org.openhab.core.thing.Bridge;
+import org.openhab.core.thing.ChannelUID;
+import org.openhab.core.thing.ThingStatus;
+import org.openhab.core.thing.ThingStatusDetail;
+import org.openhab.core.thing.binding.BaseBridgeHandler;
+import org.openhab.core.thing.binding.ThingHandlerService;
+import org.openhab.core.types.Command;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+/**
+ * Bridge handler for one LG Horizon (Telenet/Ziggo/Virgin Media/UPC/Sunrise/ BASE TV) account. Owns:
+ * <ul>
+ * <li>the REST auth session (access/refresh token lifecycle)</li>
+ * <li>the household's channel line-up (needed to translate a channel name/number into the internal channel id used by
+ * the API)</li>
+ * <li>the single MQTT connection shared by all set-top boxes on the account</li>
+ * </ul>
+ * Individual set-top boxes are represented by child {@link LGHorizonBoxHandler} things, which register themselves here
+ * to receive status updates and to send commands.
+ *
+ * @author Mark - Initial contribution
+ */
+@NonNullByDefault
+public class LGHorizonAccountHandler extends BaseBridgeHandler implements LGHorizonMqttListener {
+
+    private final Logger logger = LoggerFactory.getLogger(LGHorizonAccountHandler.class);
+    private static final Gson GSON = new Gson();
+
+    private final HttpClientFactory httpClientFactory;
+
+    private @Nullable LGHorizonAuthClient authClient;
+    private @Nullable LGHorizonMqttClient mqttClient;
+    private @Nullable CustomerDto customer;
+    private @Nullable LGHorizonDiscoveryService discoveryService;
+
+    private @Nullable EntitlementsDto entitlements;
+    private Map<String, String> languageByProfileId = Map.of();
+    private Map<String, Map<String, ChannelDto>> channelsByLanguage = Map.of();
+
+    private final Map<String, LGHorizonBoxHandler> registeredBoxes = new ConcurrentHashMap<>();
+
+    // A single logical "refresh this box" event (e.g. all channels being refreshed at once after linking, or
+    // a UI refresh) triggers one independent RefreshType command per linked channel - without debouncing, a
+    // box with N channels would fire N separate CPE.getUiStatus requests within milliseconds of each other.
+    private final Map<String, Long> lastStateRequestMillis = new ConcurrentHashMap<>();
+    private static final long STATE_REQUEST_DEBOUNCE_MILLIS = 2000;
+
+    // How long the box's own per-publish display time lasts, in seconds. Not user-configurable: it describes fixed box
+    // behaviour, not a preference.
+    private static final int DISPLAY_MESSAGE_REPEAT_INTERVAL_SECONDS = 3;
+    // Message ids of our own displayMessage() publishes, so a CPE.pushToTV.rsp failure for one of them can
+    // be told apart from a genuine tune-command rejection. displayMessage deliberately sends a fake, non-existent
+    // channelId ("1234") purely to trigger the box's "something wants to push content to your screen" notification
+    // banner without performing a real tune - the box rejecting that fake tune is expected, and unrelated
+    // to whether the notification itself renders.
+    private final java.util.Set<String> pendingDisplayMessageIds = ConcurrentHashMap.newKeySet();
+    private static final int MAX_TRACKED_DISPLAY_MESSAGE_IDS = 50;
+
+    // Limit size of fetched images
+    private static final int MAX_IMAGE_BYTES = 8 * 1024 * 1024; // 8 MiB
+
+    // The account does not resend the status, even when polled, so we keep the last one around.
+    private final Map<String, String> lastKnownStatusByDeviceId = new ConcurrentHashMap<>();
+
+    private final Map<String, CompletableFuture<JsonObject>> pendingStatusCaptures = new ConcurrentHashMap<>();
+    // For the lghorizon fingerprint console command's duration-based live capture: unlike the single-shot
+    // captures above, this stays registered and keeps firing for every matching message until explicitly
+    // stopped, rather than completing once and being removed.
+    private final Map<String, BiConsumer<String, JsonObject>> liveCaptureListeners = new ConcurrentHashMap<>();
+    // Metadata-only image-fetch capture for the lghorizon capture command - see fetchImage(); deliberately
+    // never carries the actual image bytes, only a one-line description of the call.
+    private volatile @Nullable Consumer<String> imageCaptureListener;
+
+    private @Nullable ScheduledFuture<?> initializeFuture;
+    private @Nullable ScheduledFuture<?> tokenRefreshFuture;
+
+    public LGHorizonAccountHandler(Bridge bridge, HttpClientFactory httpClientFactory) {
+        super(bridge);
+        this.httpClientFactory = httpClientFactory;
+    }
+
+    @Override
+    public void initialize() {
+        updateStatus(ThingStatus.UNKNOWN);
+        initializeFuture = scheduler.schedule(this::doInitialize, 0, TimeUnit.SECONDS);
+    }
+
+    private void doInitialize() {
+        LGHorizonAccountConfiguration config = getConfigAs(LGHorizonAccountConfiguration.class);
+
+        ResolvedProvider provider;
+        try {
+            provider = resolveProvider(config);
+        } catch (IllegalArgumentException e) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, e.getMessage());
+            return;
+        }
+
+        persistResolvedProviderFields(config, provider);
+
+        HttpClient httpClient = httpClientFactory.getCommonHttpClient();
+        LGHorizonAuthClient auth = new LGHorizonAuthClient(httpClient, provider.apiUrl(), provider.countryCode(),
+                provider.useRefreshToken(), config.username, config.password, config.refreshToken);
+        auth.setRefreshTokenListener(this::persistRefreshToken);
+        this.authClient = auth;
+
+        try {
+            auth.initialize();
+            String householdId = auth.getHouseholdId();
+            if (householdId == null) {
+                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
+                        "Authenticated but no household id was returned");
+                return;
+            }
+            updateProperty(LGHorizonBindingConstants.PROPERTY_HOUSEHOLD_ID, householdId);
+
+            refreshCustomerAndChannels(auth);
+
+            LGHorizonMqttClient mqtt = new LGHorizonMqttClient(auth, this, scheduler);
+            this.mqttClient = mqtt;
+            mqtt.connect();
+
+            updateStatus(ThingStatus.ONLINE);
+
+            LGHorizonDiscoveryService discoveryService = this.discoveryService;
+            if (discoveryService != null) {
+                discoveryService.discoverDevices();
+            }
+
+            tokenRefreshFuture = scheduler.scheduleWithFixedDelay(this::checkTokenRefresh, 1, 1, TimeUnit.HOURS);
+        } catch (LGHorizonApiException e) {
+            if (e.isAuthenticationFailure()) {
+                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, e.getMessage());
+            } else {
+                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, e.getMessage());
+            }
+        }
+    }
+
+    public void setDiscoveryService(LGHorizonDiscoveryService discoveryService) {
+        this.discoveryService = discoveryService;
+        if (ThingStatus.ONLINE.equals(thing.getStatus())) {
+            discoveryService.discoverDevices();
+        }
+    }
+
+    /**
+     * The three pieces of provider configuration {@link LGHorizonAuthClient} actually needs,
+     * resolved from either a {@link ProviderPresets} preset or the account thing's advanced
+     * {@code country}/{@code apiUrl}/{@code useRefreshToken} fields.
+     */
+    private record ResolvedProvider(String apiUrl, String countryCode, boolean useRefreshToken) {
+    }
+
+    private ResolvedProvider resolveProvider(LGHorizonAccountConfiguration config) {
+        String provider = config.provider;
+        if (provider != null && !provider.isBlank()) {
+            ProviderPresets.Preset preset = ProviderPresets.get(provider); // throws if unknown
+            return new ResolvedProvider(preset.apiUrl(), preset.countryCode(), preset.useRefreshToken());
+        }
+        if (config.apiUrl.isBlank() || config.country.isBlank()) {
+            throw new IllegalArgumentException("Either 'Provider' or both 'Country' and 'API URL' must be set");
+        }
+        return new ResolvedProvider(config.apiUrl, config.country, config.useRefreshToken);
+    }
+
+    /**
+     * Writes a preset's resolved values back into the visible {@code country}/{@code apiUrl}/
+     * {@code useRefreshToken} fields when a provider is selected.
+     */
+    private void persistResolvedProviderFields(LGHorizonAccountConfiguration config, ResolvedProvider provider) {
+        String currentProvider = config.provider;
+        if (currentProvider == null || currentProvider.isBlank()) {
+            return;
+        }
+        if (provider.countryCode().equals(config.country) && provider.apiUrl().equals(config.apiUrl)
+                && provider.useRefreshToken() == config.useRefreshToken) {
+            return;
+        }
+        Configuration configuration = editConfiguration();
+        configuration.put(LGHorizonBindingConstants.CONFIG_COUNTRY, provider.countryCode());
+        configuration.put(LGHorizonBindingConstants.CONFIG_API_URL, provider.apiUrl());
+        configuration.put(LGHorizonBindingConstants.CONFIG_USE_REFRESH_TOKEN, provider.useRefreshToken());
+        updateConfiguration(configuration);
+    }
+
+    /**
+     * Keeps {@code provider} and the advanced {@code country}/{@code apiUrl}/{@code useRefreshToken} fields in
+     * sync as the account configuration is edited, so the advanced fields always reflect either a chosen preset
+     * or an explicit manual override - never a stale mix of both:
+     * <ul>
+     * <li>selecting a provider (including switching from one preset to another) overwrites the three advanced
+     * fields with that provider's preset values, discarding whatever was in them before;</li>
+     * <li>hand-editing any of the three advanced fields while a preset is active clears {@code provider} back to
+     * "Custom", since the configuration no longer matches that preset and should not silently keep re-applying
+     * it on the next save.</li>
+     */
+    @Override
+    public void handleConfigurationUpdate(Map<String, Object> configurationParameters) {
+        Map<String, Object> updated = new HashMap<>(configurationParameters);
+
+        String oldProvider = stringConfig(LGHorizonBindingConstants.CONFIG_PROVIDER);
+        Object submittedProvider = updated.get(LGHorizonBindingConstants.CONFIG_PROVIDER);
+        String newProvider = submittedProvider == null ? oldProvider : submittedProvider.toString();
+
+        if (!newProvider.equals(oldProvider) && !newProvider.isBlank()) {
+            // A provider was (newly) selected, or switched to a different one: its preset always wins over
+            // whatever was previously in the advanced fields.
+            try {
+                ProviderPresets.Preset preset = ProviderPresets.get(newProvider);
+                updated.put(LGHorizonBindingConstants.CONFIG_COUNTRY, preset.countryCode());
+                updated.put(LGHorizonBindingConstants.CONFIG_API_URL, preset.apiUrl());
+                updated.put(LGHorizonBindingConstants.CONFIG_USE_REFRESH_TOKEN, preset.useRefreshToken());
+            } catch (IllegalArgumentException e) {
+                // Unknown provider id - leave the advanced fields as submitted; doInitialize() will surface a
+                // clear configuration error for it.
+            }
+        } else if (newProvider.equals(oldProvider) && !oldProvider.isBlank()
+                && (configFieldChanged(updated, LGHorizonBindingConstants.CONFIG_COUNTRY)
+                        || configFieldChanged(updated, LGHorizonBindingConstants.CONFIG_API_URL)
+                        || configFieldChanged(updated, LGHorizonBindingConstants.CONFIG_USE_REFRESH_TOKEN))) {
+            // A preset was active, but one of its fields was hand-edited: fall through to manual/"Custom" mode.
+            updated.put(LGHorizonBindingConstants.CONFIG_PROVIDER, "");
+        }
+
+        super.handleConfigurationUpdate(updated);
+    }
+
+    private String stringConfig(String key) {
+        Object value = getConfig().get(key);
+        return value == null ? "" : value.toString();
+    }
+
+    private boolean configFieldChanged(Map<String, Object> submitted, String key) {
+        return submitted.containsKey(key) && !Objects.equals(getConfig().get(key), submitted.get(key));
+    }
+
+    /**
+     * Fetches the raw (untyped) JSON for the REST calls this handler makes during normal operation, for the
+     * {@code lghorizon fingerprint} console command - e.g. to see fields our DTOs don't yet model, or
+     * differences across provider/box combinations the maintainer doesn't have physical access to. Each
+     * entry may be missing if that particular call failed; a failure never aborts the rest of the snapshot.
+     *
+     * @return map of a short logical name (used as a filename) to the raw JSON response
+     */
+    public Map<String, String> fetchDiagnosticRestSnapshot() {
+        Map<String, String> snapshot = new LinkedHashMap<>();
+        LGHorizonAuthClient auth = authClient;
+        String householdId = getHouseholdId();
+        if (auth == null || householdId == null) {
+            return snapshot;
+        }
+
+        tryFetch(snapshot, "service-config", () -> auth.getServiceConfigAsJsonElement().toString());
+        try {
+            String personalizationServiceUrl = auth.getServiceConfig().getServiceUrl("personalizationService");
+            tryFetch(snapshot, "customer", () -> auth.getAsJsonElement(personalizationServiceUrl,
+                    "/v1/customer/" + householdId + "?with=profiles%2Cdevices").toString());
+
+            String purchaseServiceUrl = auth.getServiceConfig().getServiceUrl("purchaseService");
+            tryFetch(snapshot, "entitlements", () -> auth.getAsJsonElement(purchaseServiceUrl,
+                    "/v2/customers/" + householdId + "/entitlements?enableDaypass=true").toString());
+
+            String linearServiceUrl = auth.getServiceConfig().getServiceUrl("linearService");
+            CustomerDto c = customer;
+            int cityId = c != null ? c.cityId : 0;
+            for (String lang : languageByProfileId.values().stream().distinct().toList()) {
+                tryFetch(snapshot, "channels-" + lang,
+                        () -> auth.getAsJsonElement(linearServiceUrl,
+                                "/v2/channels?cityId=" + cityId + "&language=" + lang + "&productClass=Orion-DASH")
+                                .toString());
+            }
+        } catch (LGHorizonApiException e) {
+            logger.debug("Could not resolve service URLs for diagnostic snapshot: {}", e.getMessage());
+        }
+        return snapshot;
+    }
+
+    private interface JsonFetcher {
+        String get() throws LGHorizonApiException;
+    }
+
+    private void tryFetch(Map<String, String> snapshot, String name, JsonFetcher fetcher) {
+        try {
+            snapshot.put(name, fetcher.get());
+        } catch (LGHorizonApiException e) {
+            logger.debug("Diagnostic fetch '{}' failed: {}", name, e.getMessage());
+        }
+    }
+
+    /**
+     * Registers a callback invoked for every {@code .../status} or {@code CPE.uiStatus} message concerning
+     * the given device, for as long as the capture is active - used by the {@code lghorizon fingerprint}
+     * console command's duration-based live capture. Runs alongside (not instead of) the box handler's own
+     * normal message handling and any pending single-shot capture; the callback itself runs on whatever
+     * thread the message arrived on (the MQTT client's own thread), not the caller's, so it should be quick
+     * and non-blocking.
+     */
+    public void startLiveCapture(String deviceId, BiConsumer<String, JsonObject> onMessage) {
+        liveCaptureListeners.put(deviceId, onMessage);
+    }
+
+    /** Stops a live capture previously started with {@link #startLiveCapture}. */
+    public void stopLiveCapture(String deviceId) {
+        liveCaptureListeners.remove(deviceId);
+    }
+
+    private void notifyLiveCapture(String deviceId, String topic, JsonObject payload) {
+        BiConsumer<String, JsonObject> listener = liveCaptureListeners.get(deviceId);
+        if (listener != null) {
+            listener.accept(topic, payload);
+        }
+    }
+
+    /**
+     * Starts capturing every REST call this account's auth client makes (regardless of which method
+     * triggers it - event/VOD/recording detail lookups, the intent image URL lookup, ...), for the
+     * {@code lghorizon capture} console command's live-capture window. Image byte fetches are NOT REST
+     * calls in this sense (they bypass the auth client entirely, being unauthenticated CDN requests) - see
+     * {@link #startImageCapture} for those.
+     */
+    public void startRestCapture(BiConsumer<String, String> onCall) {
+        LGHorizonAuthClient auth = authClient;
+        if (auth != null) {
+            auth.setCallCaptureListener(onCall);
+        }
+    }
+
+    public void stopRestCapture() {
+        LGHorizonAuthClient auth = authClient;
+        if (auth != null) {
+            auth.setCallCaptureListener(null);
+        }
+    }
+
+    /** Starts capturing metadata (not bytes) about every image fetch - see {@link #fetchImage}. */
+    public void startImageCapture(Consumer<String> onImageFetch) {
+        this.imageCaptureListener = onImageFetch;
+    }
+
+    public void stopImageCapture() {
+        this.imageCaptureListener = null;
+    }
+
+    /**
+     * Captures the next {@code .../status} message for the given device, for the {@code lghorizon
+     * fingerprint} console command.
+     */
+    public CompletableFuture<JsonObject> captureNextStatus(String deviceId) {
+        CompletableFuture<JsonObject> future = new CompletableFuture<>();
+        pendingStatusCaptures.put(deviceId, future);
+        return future;
+    }
+
+    private void refreshCustomerAndChannels(LGHorizonAuthClient auth) throws LGHorizonApiException {
+        String householdId = auth.getHouseholdId();
+        CustomerDto customerDto = auth.get(auth.getServiceConfig().getServiceUrl("personalizationService"),
+                "/v1/customer/" + householdId + "?with=profiles%2Cdevices", CustomerDto.class);
+        logger.trace("Received: {} customer info: {}", LGHorizonContentAnonymizer.anonymizeTopic(householdId),
+                LGHorizonContentAnonymizer.anonymizeMessage(GSON.toJson(customerDto)));
+        this.customer = customerDto;
+
+        List<CustomerDto.ProfileDto> profiles = customerDto.profiles;
+        if (profiles == null || profiles.isEmpty()) {
+            throw new LGHorizonApiException("LG Horizon account has no profiles");
+        }
+
+        String defaultLanguage = "en";
+        this.languageByProfileId = profiles.stream().filter(p -> p.profileId != null)
+                .collect(Collectors.<CustomerDto.ProfileDto, String, String> toMap(p -> p.profileId,
+                        p -> p.options != null && p.options.lang != null ? p.options.lang : defaultLanguage));
+
+        EntitlementsDto entitlementsDto = auth.get(auth.getServiceConfig().getServiceUrl("purchaseService"),
+                "/v2/customers/" + householdId + "/entitlements?enableDaypass=true", EntitlementsDto.class);
+        logger.trace("Received: {} entitlements: {}", LGHorizonContentAnonymizer.anonymizeTopic(householdId),
+                LGHorizonContentAnonymizer.anonymizeMessage(GSON.toJson(entitlementsDto)));
+        this.entitlements = entitlementsDto;
+
+        List<String> entitlementIds = entitlementsDto.getEntitlementIds();
+        Map<String, Map<String, ChannelDto>> channelsByLanguage = new HashMap<>();
+        for (String lang : languageByProfileId.values()) {
+            ChannelDto[] channelArray = auth.get(auth.getServiceConfig().getServiceUrl("linearService"),
+                    "/v2/channels?cityId=" + customerDto.cityId + "&language=" + lang + "&productClass=Orion-DASH",
+                    ChannelDto[].class);
+            logger.trace("Received: {}, {} channels: {}", LGHorizonContentAnonymizer.anonymizeTopic(householdId), lang,
+                    Arrays.toString(channelArray));
+
+            Map<String, ChannelDto> filtered = List.of(channelArray).stream().filter(c -> c.id != null)
+                    .filter(c -> c.getLinearProducts().stream().anyMatch(entitlementIds::contains))
+                    .collect(Collectors.toMap(c -> c.id, c -> c));
+            logger.debug("LG Horizon account {}, {}: {} entitled channels loaded", getThing().getUID(), lang,
+                    filtered.size());
+            channelsByLanguage.put(lang, filtered);
+        }
+        this.channelsByLanguage = Map.copyOf(channelsByLanguage);
+        registeredBoxes.values().forEach(LGHorizonBoxHandler::updateChannelNumberOptions);
+
+        String customerId = customerDto.customerId;
+        if (customerId != null) {
+            updateProperty(LGHorizonBindingConstants.PROPERTY_CUSTOMER_ID, customerId);
+        }
+        String countryId = customerDto.countryId;
+        if (countryId != null) {
+            updateProperty(LGHorizonBindingConstants.PROPERTY_COUNTRY_ID, countryId);
+        }
+        updateProperty(LGHorizonBindingConstants.PROPERTY_CITY_ID, String.valueOf(customerDto.cityId));
+    }
+
+    private void persistRefreshToken(String newRefreshToken) {
+        Configuration configuration = editConfiguration();
+        configuration.put(LGHorizonBindingConstants.CONFIG_REFRESH_TOKEN, newRefreshToken);
+        updateConfiguration(configuration);
+    }
+
+    private void checkTokenRefresh() {
+        LGHorizonAuthClient auth = authClient;
+        if (auth == null) {
+            return;
+        }
+        try {
+            auth.fetchAccessToken();
+        } catch (LGHorizonApiException e) {
+            logger.debug("Background LG Horizon token refresh failed: {}", e.getMessage());
+        }
+    }
+
+    /** Called by {@link LGHorizonDiscoveryService}. */
+    public List<CustomerDto.DeviceDto> getAssignedDevices() {
+        CustomerDto c = customer;
+        List<CustomerDto.DeviceDto> devices = c == null ? null : c.assignedDevices;
+        return devices == null ? List.of() : new ArrayList<>(devices);
+    }
+
+    public CustomerDto.@Nullable DeviceDto getAssignedDevice(String deviceId) {
+        CustomerDto c = customer;
+        if (c == null || c.assignedDevices == null) {
+            return null;
+        }
+        return c.assignedDevices.stream().filter(d -> deviceId.equals(d.deviceId)).findFirst().orElse(null);
+    }
+
+    public List<CustomerDto.ProfileDto> getProfiles() {
+        CustomerDto c = customer;
+        List<CustomerDto.ProfileDto> profiles = c == null ? null : c.profiles;
+        return profiles == null ? List.of() : new ArrayList<>(profiles);
+    }
+
+    public String getLanguageForProfile(@Nullable String profileId) {
+        String lang = profileId != null ? languageByProfileId.get(profileId) : null;
+        return lang != null ? lang : "en";
+    }
+
+    public Map<String, ChannelDto> getChannels(String language) {
+        return channelsByLanguage.getOrDefault(language, Map.of());
+    }
+
+    /**
+     * The given profile's favorite channel ids (channel ids, not numbers/names), for populating the
+     * favorite-channel-number selection list. Empty if the profile isn't found or has no favorites set.
+     */
+    public List<String> getFavoriteChannelIds(String profileId) {
+        CustomerDto.ProfileDto profile = getProfiles().stream().filter(p -> profileId.equals(p.profileId)).findFirst()
+                .orElse(null);
+        List<String> favorites = profile == null ? null : profile.favoriteChannels;
+        return favorites == null ? List.of() : favorites;
+    }
+
+    /** The account's own customer id, or {@code null} until the account has loaded its customer info. */
+    public @Nullable String getCustomerId() {
+        CustomerDto c = customer;
+        return c == null ? null : c.customerId;
+    }
+
+    /**
+     * Resolves title/episode metadata for a linear/reviewBuffer/replay program from its {@code eventId}
+     * (CRID).
+     * <p>
+     * Performs a real network call - callers must invoke this off the MQTT/event-bus thread.
+     *
+     * @return the event detail, or {@code null} if it could not be resolved
+     */
+    public @Nullable EventDetailDto getEventDetail(String eventId, String language) {
+        LGHorizonAuthClient auth = authClient;
+        if (auth == null) {
+            return null;
+        }
+        try {
+            String linearServiceUrl = auth.getServiceConfig().getServiceUrl("linearService");
+            return auth.get(
+                    linearServiceUrl, "/v2/replayEvent/" + eventId
+                            + "?returnLinearContent=true&forceLinearResponse=true&language=" + language,
+                    EventDetailDto.class);
+        } catch (LGHorizonApiException e) {
+            logger.debug("Could not resolve event detail for {}: {}", eventId, e.getMessage());
+            return null;
+        }
+    }
+
+    /**
+     * Resolves title/episode metadata for a VOD (video on demand) asset from its {@code titleId}.
+     * <p>
+     * Performs a real network call - callers must invoke this off the MQTT/event-bus thread.
+     *
+     * @return the VOD detail, or {@code null} if it could not be resolved
+     */
+    public @Nullable VodDetailDto getVodDetail(String titleId, String profileId, String language) {
+        LGHorizonAuthClient auth = authClient;
+        CustomerDto c = customer;
+        if (auth == null || c == null) {
+            return null;
+        }
+        try {
+            String vodServiceUrl = auth.getServiceConfig().getServiceUrl("vodService");
+            return auth.get(vodServiceUrl, "/v2/detailscreen/" + titleId + "?language=" + language + "&profileId="
+                    + profileId + "&cityId=" + c.cityId, VodDetailDto.class);
+        } catch (LGHorizonApiException e) {
+            logger.debug("Could not resolve VOD detail for {}: {}", titleId, e.getMessage());
+            return null;
+        }
+    }
+
+    /**
+     * Resolves title/episode metadata for an nDVR (network recording) from its {@code recordingId}.
+     * <p>
+     * Performs a real network call - callers must invoke this off the MQTT/event-bus thread.
+     *
+     * @return the recording detail, or {@code null} if it could not be resolved
+     */
+    public @Nullable RecordingDetailDto getRecordingDetail(String recordingId, String profileId, String language) {
+        LGHorizonAuthClient auth = authClient;
+        String householdId = getHouseholdId();
+        if (auth == null || householdId == null) {
+            return null;
+        }
+        try {
+            String recordingServiceUrl = auth.getServiceConfig().getServiceUrl("recordingService");
+            return auth.get(recordingServiceUrl, "/customers/" + householdId + "/details/single/" + recordingId
+                    + "?profileId=" + profileId + "&language=" + language, RecordingDetailDto.class);
+        } catch (LGHorizonApiException e) {
+            logger.debug("Could not resolve recording detail for {}: {}", recordingId, e.getMessage());
+            return null;
+        }
+    }
+
+    /**
+     * Resolves an image URL for a replay/VOD/nDVR asset via the shared "intent" image lookup - all three
+     * use this same mechanism, keyed by the asset's own id (the eventId for replay, or the asset's own {@code id} field
+     * from its detail response for VOD/nDVR).
+     *
+     * @return the image URL, or {@code null} if it could not be resolved
+     */
+    public @Nullable String getIntentImageUrl(String intentId) {
+        LGHorizonAuthClient auth = authClient;
+        if (auth == null) {
+            return null;
+        }
+        try {
+            String imageServiceUrl = auth.getServiceConfig().getServiceUrl("imageService");
+            JsonArray intents = new JsonArray();
+            intents.add("detailedBackground");
+            intents.add("posterTile");
+            JsonObject item = new JsonObject();
+            item.addProperty("id", intentId);
+            item.add("intents", intents);
+            JsonArray body = new JsonArray();
+            body.add(item);
+            String encodedBody = URLEncoder.encode(body.toString(), StandardCharsets.UTF_8);
+            JsonElement result = auth.getAsJsonElement(imageServiceUrl, "/intent?jsonBody=" + encodedBody);
+            if (!result.isJsonArray() || result.getAsJsonArray().isEmpty()) {
+                return null;
+            }
+            JsonObject first = result.getAsJsonArray().get(0).getAsJsonObject();
+            if (!first.has("intents") || !first.get("intents").isJsonArray()
+                    || first.getAsJsonArray("intents").isEmpty()) {
+                return null;
+            }
+            JsonObject firstIntent = first.getAsJsonArray("intents").get(0).getAsJsonObject();
+            return firstIntent.has("url") ? firstIntent.get("url").getAsString() : null;
+        } catch (LGHorizonApiException | RuntimeException e) {
+            logger.debug("Could not resolve intent image for {}: {}", intentId, e.getMessage());
+            return null;
+        }
+    }
+
+    /**
+     * Fetches raw image bytes from a (public, unauthenticated) CDN image URL and wraps them as a
+     * {@link RawType} suitable for an {@code Image} channel. Performs a real network call - callers must
+     * invoke this off the MQTT/event-bus thread.
+     *
+     * @return the image, or {@code null} if it could not be fetched
+     */
+    public @Nullable RawType fetchImage(String url) {
+        String anonymizedUrl = LGHorizonContentAnonymizer.anonymizeTopic(url);
+        try {
+            InputStreamResponseListener listener = new InputStreamResponseListener();
+            httpClientFactory.getCommonHttpClient().newRequest(url).timeout(10, TimeUnit.SECONDS).send(listener);
+            Response response = listener.get(10, TimeUnit.SECONDS);
+            if (response.getStatus() >= 300) {
+                notifyImageCapture("GET " + anonymizedUrl + " -> status=" + response.getStatus() + " (fetch failed)");
+                return null;
+            }
+            byte[] bytes;
+            try (InputStream input = listener.getInputStream()) {
+                ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+                byte[] chunk = new byte[8192];
+                int total = 0;
+                int read;
+                while ((read = input.read(chunk)) != -1) {
+                    total += read;
+                    if (total > MAX_IMAGE_BYTES) {
+                        logger.debug("Image from {} exceeded {} bytes, aborting", url, MAX_IMAGE_BYTES);
+                        notifyImageCapture("GET " + anonymizedUrl + " -> exceeded " + MAX_IMAGE_BYTES
+                                + " bytes, aborted (fetch failed)");
+                        return null;
+                    }
+                    buffer.write(chunk, 0, read);
+                }
+                bytes = buffer.toByteArray();
+            }
+            String contentType = response.getHeaders().get(HttpHeader.CONTENT_TYPE);
+            notifyImageCapture("GET " + anonymizedUrl + " -> status=" + response.getStatus() + ", contentType="
+                    + contentType + ", bytes=" + bytes.length + " (content omitted)");
+            return new RawType(bytes, contentType != null ? contentType : "image/jpeg");
+        } catch (Exception e) {
+            logger.debug("Could not fetch image from {}: {}", url, e.getMessage());
+            notifyImageCapture("GET " + anonymizedUrl + " -> exception: " + e.getMessage());
+            return null;
+        }
+    }
+
+    private void notifyImageCapture(String description) {
+        Consumer<String> listener = imageCaptureListener;
+        if (listener != null) {
+            listener.accept(description);
+        }
+    }
+
+    public @Nullable String getHouseholdId() {
+        LGHorizonAuthClient auth = authClient;
+        return auth == null ? null : auth.getHouseholdId();
+    }
+
+    /**
+     * Registers a box handler so it receives status/UI-status updates for its
+     * device id, and (re)subscribes the MQTT topics needed to actually receive
+     * them for this specific box.
+     */
+    public void registerBox(String deviceId, LGHorizonBoxHandler handler) {
+        registeredBoxes.put(deviceId, handler);
+        String cachedState = lastKnownStatusByDeviceId.get(deviceId);
+        if (cachedState != null) {
+            handler.handleStatusMessage(cachedState);
+        }
+        handler.updateChannelNumberOptions();
+        LGHorizonMqttClient mqtt = mqttClient;
+        String householdId = getHouseholdId();
+        if (mqtt != null && householdId != null) {
+            // Ask the box to push its current UI status right away so the thing doesn't
+            // sit without state until the next spontaneous update.
+            requestBoxState(deviceId);
+        }
+    }
+
+    public void unregisterBox(String deviceId) {
+        registeredBoxes.remove(deviceId);
+    }
+
+    /** Whether the given device id has an actual, registered box thing - live capture requires one. */
+    public boolean hasRegisteredBox(String deviceId) {
+        return registeredBoxes.containsKey(deviceId);
+    }
+
+    // ------------------------------------------------------------------
+    // Outgoing commands, called by LGHorizonBoxHandler
+    // ------------------------------------------------------------------
+
+    public void sendKey(String deviceId, String w3cKey) {
+        JsonObject payload = new JsonObject();
+        payload.addProperty("type", "CPE.KeyEvent");
+        payload.addProperty("runtimeType", "key");
+        payload.addProperty("id", "openhab");
+        payload.addProperty("source", deviceId.toLowerCase());
+        JsonObject status = new JsonObject();
+        status.addProperty("w3cKey", w3cKey);
+        status.addProperty("eventType", "keyDownUp");
+        payload.add("status", status);
+        publishToBox(deviceId, payload);
+    }
+
+    public void tuneToChannel(String deviceId, String channelId) {
+        JsonObject payload = new JsonObject();
+        payload.addProperty("id", randomId(8));
+        payload.addProperty("type", "CPE.pushToTV");
+        JsonObject source = new JsonObject();
+        source.addProperty("clientId", mqttClientIdOrEmpty());
+        source.addProperty("friendlyDeviceName", "openHAB");
+        payload.add("source", source);
+        JsonObject status = new JsonObject();
+        status.addProperty("sourceType", "linear");
+        JsonObject statusSource = new JsonObject();
+        statusSource.addProperty("channelId", channelId);
+        status.add("source", statusSource);
+        status.addProperty("relativePosition", 0);
+        status.addProperty("speed", 1);
+        payload.add("status", status);
+        publishToBox(deviceId, payload);
+    }
+
+    /**
+     * Displays an on-screen message for approximately {@code durationSeconds}, by publishing it repeatedly
+     * every {@link #DISPLAY_MESSAGE_REPEAT_INTERVAL_SECONDS} seconds.
+     */
+    public void displayMessage(String deviceId, String message, int durationSeconds) {
+        JsonObject payload = new JsonObject();
+        payload.addProperty("type", "CPE.pushToTV");
+        JsonObject source = new JsonObject();
+        source.addProperty("clientId", mqttClientIdOrEmpty());
+        source.addProperty("friendlyDeviceName", "\n\n" + message);
+        payload.add("source", source);
+        JsonObject status = new JsonObject();
+        status.addProperty("sourceType", "linear");
+        JsonObject statusSource = new JsonObject();
+        statusSource.addProperty("channelId", "1234");
+        status.add("source", statusSource);
+        status.addProperty("relativePosition", 0);
+        status.addProperty("speed", 1);
+        payload.add("status", status);
+
+        int repeats = Math.max(1, Math.round(durationSeconds / (float) DISPLAY_MESSAGE_REPEAT_INTERVAL_SECONDS));
+        for (int i = 0; i < repeats; i++) {
+            long delaySeconds = i * DISPLAY_MESSAGE_REPEAT_INTERVAL_SECONDS;
+            scheduler.schedule(() -> publishDisplayMessage(deviceId, payload), delaySeconds, TimeUnit.SECONDS);
+        }
+    }
+
+    private void publishDisplayMessage(String deviceId, JsonObject payload) {
+        String id = randomId(8);
+        payload.addProperty("id", id);
+        if (pendingDisplayMessageIds.size() >= MAX_TRACKED_DISPLAY_MESSAGE_IDS) {
+            pendingDisplayMessageIds.clear();
+        }
+        pendingDisplayMessageIds.add(id);
+        publishToBox(deviceId, payload);
+    }
+
+    public void requestBoxState(String deviceId) {
+        long now = System.currentTimeMillis();
+        Long last = lastStateRequestMillis.put(deviceId, now);
+        if (last != null && now - last < STATE_REQUEST_DEBOUNCE_MILLIS) {
+            return; // a request for this device was already sent very recently - the box is already answering it
+        }
+        JsonObject payload = new JsonObject();
+        payload.addProperty("id", randomId(8));
+        payload.addProperty("type", "CPE.getUiStatus");
+        payload.addProperty("source", mqttClientIdOrEmpty());
+        publishToBox(deviceId, payload);
+    }
+
+    private void publishToBox(String deviceId, JsonObject payload) {
+        LGHorizonMqttClient mqtt = mqttClient;
+        String householdId = getHouseholdId();
+        if (mqtt == null || householdId == null) {
+            logger.debug("Cannot send command to box {}: account not connected",
+                    LGHorizonContentAnonymizer.anonymizeTopic(deviceId));
+            return;
+        }
+        mqtt.publish(householdId + "/" + deviceId, payload);
+    }
+
+    private String mqttClientIdOrEmpty() {
+        LGHorizonMqttClient mqtt = mqttClient;
+        return mqtt == null ? "" : mqtt.getClientId();
+    }
+
+    private static String randomId(int length) {
+        String letters = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+        java.security.SecureRandom random = new java.security.SecureRandom();
+        StringBuilder sb = new StringBuilder(length);
+        for (int i = 0; i < length; i++) {
+            sb.append(letters.charAt(random.nextInt(letters.length())));
+        }
+        return sb.toString();
+    }
+
+    // ------------------------------------------------------------------
+    // LGHorizonMqttListener
+    // ------------------------------------------------------------------
+
+    @Override
+    public void onConnected() {
+        LGHorizonMqttClient mqtt = mqttClient;
+        String householdId = getHouseholdId();
+        if (mqtt == null || householdId == null) {
+            return;
+        }
+        mqtt.subscribeAccountTopics(householdId);
+        updateStatus(ThingStatus.ONLINE);
+        for (String deviceId : registeredBoxes.keySet()) {
+            requestBoxState(deviceId);
+        }
+    }
+
+    @Override
+    public void onConnectionLost(Throwable cause) {
+        updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
+                "Lost connection to LG Horizon MQTT broker: " + cause.getMessage());
+    }
+
+    @Override
+    public void onMessage(String topic, JsonObject payload) {
+        logger.debug("MQTT Received on {}: {}", LGHorizonContentAnonymizer.anonymizeTopic(topic),
+                LGHorizonContentAnonymizer.anonymizeMessage(payload.toString()));
+
+        if (payload.has("source") && !payload.get("source").isJsonNull()) {
+            notifyLiveCapture(payload.get("source").getAsString(), topic, payload);
+        }
+
+        if (topic.contains("status") && payload.has("source") && payload.has("state")) {
+            String source = payload.get("source").getAsString();
+            lastKnownStatusByDeviceId.put(source, payload.get("state").getAsString());
+            LGHorizonBoxHandler handler = registeredBoxes.get(source);
+            if (handler != null) {
+                handler.handleStatusMessage(payload.get("state").getAsString());
+            }
+            CompletableFuture<JsonObject> pendingStatus = pendingStatusCaptures.remove(source);
+            if (pendingStatus != null) {
+                pendingStatus.complete(payload);
+            }
+            return;
+        }
+
+        if (payload.has("type") && "CPE.uiStatus".equals(payload.get("type").getAsString()) && payload.has("source")) {
+            String source = payload.get("source").getAsString();
+            LGHorizonBoxHandler handler = registeredBoxes.get(source);
+            if (handler != null) {
+                handler.handleUiStatusMessage(payload);
+            }
+            notifyLiveCapture(source, topic, payload);
+            return;
+        }
+
+        if (payload.has("type") && "CPE.pushToTV.rsp".equals(payload.get("type").getAsString())) {
+            JsonObject status = payload.has("status") && payload.get("status").isJsonObject()
+                    ? payload.getAsJsonObject("status")
+                    : null;
+            String response = status != null && status.has("response") && !status.get("response").isJsonNull()
+                    ? status.get("response").getAsString()
+                    : null;
+            if ("failed".equalsIgnoreCase(response)) {
+                String id = payload.has("id") && !payload.get("id").isJsonNull() ? payload.get("id").getAsString()
+                        : null;
+                if (id != null && pendingDisplayMessageIds.remove(id)) {
+                    // Expected: displayMessage()'s deliberate fake-channel tune always gets rejected this
+                    // way, unrelated to whether the on-screen notification itself renders.
+                    logger.debug("LG Horizon box rejected displayMessage()'s internal fake-tune (expected): {}",
+                            LGHorizonContentAnonymizer.anonymizeMessage(payload.toString()));
+                } else {
+                    logger.warn("LG Horizon box rejected a command: {}",
+                            LGHorizonContentAnonymizer.anonymizeMessage(payload.toString()));
+                }
+            }
+        }
+    }
+
+    @Override
+    public void handleCommand(ChannelUID channelUID, Command command) {
+        // The account bridge itself has no channels.
+    }
+
+    @Override
+    public void dispose() {
+        ScheduledFuture<?> init = initializeFuture;
+        if (init != null) {
+            init.cancel(true);
+        }
+        ScheduledFuture<?> refresh = tokenRefreshFuture;
+        if (refresh != null) {
+            refresh.cancel(true);
+        }
+        LGHorizonMqttClient mqtt = mqttClient;
+        if (mqtt != null) {
+            mqtt.disconnect();
+        }
+        registeredBoxes.clear();
+        lastKnownStatusByDeviceId.clear();
+        pendingStatusCaptures.values().forEach(f -> f.cancel(true));
+        pendingStatusCaptures.clear();
+        liveCaptureListeners.clear();
+        super.dispose();
+    }
+
+    @Override
+    public Collection<Class<? extends ThingHandlerService>> getServices() {
+        return Collections.singleton(LGHorizonDiscoveryService.class);
+    }
+}

--- a/bundles/org.openhab.binding.lghorizon/src/main/java/org/openhab/binding/lghorizon/internal/handler/LGHorizonBoxConfiguration.java
+++ b/bundles/org.openhab.binding.lghorizon/src/main/java/org/openhab/binding/lghorizon/internal/handler/LGHorizonBoxConfiguration.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.lghorizon.internal.handler;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * Configuration for a {@code box} thing (one physical set-top box).
+ *
+ * @author Mark - Initial contribution
+ */
+@NonNullByDefault
+public class LGHorizonBoxConfiguration {
+
+    // The LG Horizon device id, e.g. as found via discovery.
+    public String deviceId = "";
+
+    // Optional: profile id to use for favourite channels/language; defaults to the first profile.
+    public String profileId = "";
+}

--- a/bundles/org.openhab.binding.lghorizon/src/main/java/org/openhab/binding/lghorizon/internal/handler/LGHorizonBoxHandler.java
+++ b/bundles/org.openhab.binding.lghorizon/src/main/java/org/openhab/binding/lghorizon/internal/handler/LGHorizonBoxHandler.java
@@ -1,0 +1,682 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.lghorizon.internal.handler;
+
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.lghorizon.internal.LGHorizonBindingConstants;
+import org.openhab.binding.lghorizon.internal.action.LGHorizonActions;
+import org.openhab.binding.lghorizon.internal.api.LGHorizonKeys;
+import org.openhab.binding.lghorizon.internal.api.dto.ChannelDto;
+import org.openhab.binding.lghorizon.internal.api.dto.CustomerDto.DeviceDto;
+import org.openhab.binding.lghorizon.internal.api.dto.EventDetailDto;
+import org.openhab.binding.lghorizon.internal.api.dto.RecordingDetailDto;
+import org.openhab.binding.lghorizon.internal.api.dto.VodDetailDto;
+import org.openhab.core.library.types.DecimalType;
+import org.openhab.core.library.types.OnOffType;
+import org.openhab.core.library.types.PlayPauseType;
+import org.openhab.core.library.types.RawType;
+import org.openhab.core.library.types.RewindFastforwardType;
+import org.openhab.core.library.types.StringType;
+import org.openhab.core.thing.Bridge;
+import org.openhab.core.thing.ChannelUID;
+import org.openhab.core.thing.Thing;
+import org.openhab.core.thing.ThingStatus;
+import org.openhab.core.thing.ThingStatusDetail;
+import org.openhab.core.thing.binding.BaseThingHandler;
+import org.openhab.core.thing.binding.ThingHandlerService;
+import org.openhab.core.types.Command;
+import org.openhab.core.types.RefreshType;
+import org.openhab.core.types.State;
+import org.openhab.core.types.StateOption;
+import org.openhab.core.types.UnDefType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.gson.JsonObject;
+
+/**
+ * Handles a single LG Horizon set-top box. All actual network I/O goes through the parent
+ * {@link LGHorizonAccountHandler}; this handler only translates channel commands to/from the box's MQTT protocol and
+ * keeps openHAB channel state up to date as MQTT status/UI-status messages arrive.
+ *
+ * @author Mark - Initial contribution
+ */
+@NonNullByDefault
+public class LGHorizonBoxHandler extends BaseThingHandler {
+
+    private final Logger logger = LoggerFactory.getLogger(LGHorizonBoxHandler.class);
+    private final LGHorizonDynamicStateDescriptionProvider dynamicStateDescriptionProvider;
+
+    private String deviceId = "";
+    private String profileId = "";
+
+    // Last known running state, used to guard the power toggle key (see below). Defaults to {@code true}
+    // (running) so an OFF command is never silently dropped before the first status message arrives; a
+    // false-positive ON attempt against an already-running box is harmless (the box just ignores it), while
+    // a dropped OFF command is a much worse failure mode to default into.
+    private volatile boolean running = true;
+
+    // Last known paused state, from the {@code speed} field of the most recent {@code CPE.uiStatus} message
+    // (0 = paused). Used to guard the play/pause toggle key the same way {@link #running} guards power - see
+    // the comment on the CHANNEL_PLAYER case below.
+    private volatile boolean paused = false;
+
+    // Last content id (eventId / VOD titleId / recordingId / app logoPath) we already resolved metadata
+    // for, to avoid re-fetching from the network on every uiStatus message while the same content is still
+    // playing.
+    private volatile @Nullable String lastResolvedContentId;
+
+    public LGHorizonBoxHandler(Thing thing, LGHorizonDynamicStateDescriptionProvider dynamicStateDescriptionProvider) {
+        super(thing);
+        this.dynamicStateDescriptionProvider = dynamicStateDescriptionProvider;
+    }
+
+    @Override
+    public void initialize() {
+        LGHorizonBoxConfiguration config = getConfigAs(LGHorizonBoxConfiguration.class);
+        if (config.deviceId.isBlank()) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, "deviceId must be set");
+            return;
+        }
+        this.deviceId = config.deviceId;
+        this.profileId = config.profileId;
+
+        LGHorizonAccountHandler account = getAccountHandler();
+        if (account == null) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_UNINITIALIZED);
+            return;
+        }
+        updateStatus(ThingStatus.UNKNOWN);
+        account.registerBox(deviceId, this);
+
+        DeviceDto device = account.getAssignedDevice(deviceId);
+        if (device != null) {
+            String defaultProfileId = device.defaultProfileId;
+            if (defaultProfileId != null) {
+                updateProperty(LGHorizonBindingConstants.PROPERTY_DEFAULT_PROFILE_ID, defaultProfileId);
+            }
+            String deviceType = device.deviceType;
+            if (defaultProfileId != null) {
+                updateProperty(LGHorizonBindingConstants.PROPERTY_DEVICE_TYPE, deviceType);
+            }
+            String platformType = device.platformType;
+            if (platformType != null) {
+                updateProperty(LGHorizonBindingConstants.PROPERTY_PLATFORM_TYPE, platformType);
+            }
+            String serialNumber = device.serialNumber;
+            if (serialNumber != null) {
+                updateProperty(LGHorizonBindingConstants.PROPERTY_SERIAL_NUMBER, serialNumber);
+            }
+            String wifiMacAddress = device.wifiMacAddress;
+            if (wifiMacAddress != null) {
+                updateProperty(LGHorizonBindingConstants.PROPERTY_WIFI_MAC_ADDRESS, wifiMacAddress);
+            }
+            String ethernetMacAddress = device.ethernetMacAddress;
+            if (ethernetMacAddress != null) {
+                updateProperty(LGHorizonBindingConstants.PROPERTY_ETHERNET_MAC_ADDRESS, ethernetMacAddress);
+            }
+        }
+    }
+
+    @Override
+    public void dispose() {
+        LGHorizonAccountHandler account = getAccountHandler();
+        if (account != null && !deviceId.isBlank()) {
+            account.unregisterBox(deviceId);
+        }
+        super.dispose();
+    }
+
+    @Override
+    public Collection<Class<? extends ThingHandlerService>> getServices() {
+        return Set.of(LGHorizonActions.class);
+    }
+
+    private @Nullable LGHorizonAccountHandler getAccountHandler() {
+        Bridge bridge = getBridge();
+        if (bridge == null) {
+            return null;
+        }
+        Object handler = bridge.getHandler();
+        return handler instanceof LGHorizonAccountHandler accountHandler ? accountHandler : null;
+    }
+
+    @Override
+    public void handleCommand(ChannelUID channelUID, Command command) {
+        LGHorizonAccountHandler account = getAccountHandler();
+        if (account == null) {
+            return;
+        }
+        if (command instanceof RefreshType) {
+            account.requestBoxState(deviceId);
+            return;
+        }
+
+        switch (channelUID.getId()) {
+            case LGHorizonBindingConstants.CHANNEL_POWER:
+                // The box has a single physical "Power" toggle button, not separate discrete on/off keys -
+                // Guard on the last known state so we never send the toggle in the wrong direction if our cached state
+                // happens to be stale - that would turn the box off when asked to turn it on, or vice versa.
+                if (command == OnOffType.ON) {
+                    if (!running) {
+                        account.sendKey(deviceId, LGHorizonKeys.POWER);
+                    }
+                } else if (command == OnOffType.OFF) {
+                    if (running) {
+                        account.sendKey(deviceId, LGHorizonKeys.POWER);
+                    }
+                }
+                break;
+            case LGHorizonBindingConstants.CHANNEL_PLAYER:
+                // Like Power, the box has a single physical "Play/Pause" toggle button, not separate discrete
+                // play/pause keys - gated on the box being ONLINE_RUNNING and on the current paused state, so the
+                // toggle never fires in the wrong direction.
+                if (command == PlayPauseType.PLAY) {
+                    if (running && paused) {
+                        account.sendKey(deviceId, LGHorizonKeys.PLAY_PAUSE);
+                    }
+                } else if (command == PlayPauseType.PAUSE) {
+                    if (running && !paused) {
+                        account.sendKey(deviceId, LGHorizonKeys.PLAY_PAUSE);
+                    }
+                } else if (command == RewindFastforwardType.FASTFORWARD) {
+                    account.sendKey(deviceId, LGHorizonKeys.FAST_FORWARD);
+                } else if (command == RewindFastforwardType.REWIND) {
+                    account.sendKey(deviceId, LGHorizonKeys.REWIND);
+                }
+                break;
+            case LGHorizonBindingConstants.CHANNEL_STOP:
+                sendKeyOnPress(account, command, LGHorizonKeys.STOP);
+                break;
+            case LGHorizonBindingConstants.CHANNEL_RECORD:
+                sendKeyOnPress(account, command, LGHorizonKeys.RECORD);
+                break;
+            case LGHorizonBindingConstants.CHANNEL_CHANNEL_UP:
+                sendKeyOnPress(account, command, LGHorizonKeys.CHANNEL_UP);
+                break;
+            case LGHorizonBindingConstants.CHANNEL_CHANNEL_DOWN:
+                sendKeyOnPress(account, command, LGHorizonKeys.CHANNEL_DOWN);
+                break;
+            case LGHorizonBindingConstants.CHANNEL_ARROW_UP:
+                sendKeyOnPress(account, command, LGHorizonKeys.ARROW_UP);
+                break;
+            case LGHorizonBindingConstants.CHANNEL_ARROW_DOWN:
+                sendKeyOnPress(account, command, LGHorizonKeys.ARROW_DOWN);
+                break;
+            case LGHorizonBindingConstants.CHANNEL_ARROW_LEFT:
+                sendKeyOnPress(account, command, LGHorizonKeys.ARROW_LEFT);
+                break;
+            case LGHorizonBindingConstants.CHANNEL_ARROW_RIGHT:
+                sendKeyOnPress(account, command, LGHorizonKeys.ARROW_RIGHT);
+                break;
+            case LGHorizonBindingConstants.CHANNEL_TOP_MENU:
+                sendKeyOnPress(account, command, LGHorizonKeys.TOP_MENU);
+                break;
+            case LGHorizonBindingConstants.CHANNEL_INFO:
+                sendKeyOnPress(account, command, LGHorizonKeys.INFO);
+                break;
+            case LGHorizonBindingConstants.CHANNEL_CONTEXT_MENU:
+                sendKeyOnPress(account, command, LGHorizonKeys.CONTEXT_MENU);
+                break;
+            case LGHorizonBindingConstants.CHANNEL_TV:
+                sendKeyOnPress(account, command, LGHorizonKeys.TV);
+                break;
+            case LGHorizonBindingConstants.CHANNEL_ENTER:
+                sendKeyOnPress(account, command, LGHorizonKeys.ENTER);
+                break;
+            case LGHorizonBindingConstants.CHANNEL_ESCAPE:
+                sendKeyOnPress(account, command, LGHorizonKeys.ESCAPE);
+                break;
+            case LGHorizonBindingConstants.CHANNEL_CHANNEL_NUMBER:
+            case LGHorizonBindingConstants.CHANNEL_FAVORITE_CHANNEL_NUMBER:
+                resolveChannelByNumber(account, command.toString()).ifPresentOrElse(
+                        channel -> account.tuneToChannel(deviceId, channel.id),
+                        () -> logger.warn("Unknown LG Horizon channel number '{}' for box {}", command, deviceId));
+                break;
+            case LGHorizonBindingConstants.CHANNEL_CHANNEL_NAME:
+                resolveChannelByName(account, command.toString()).ifPresentOrElse(
+                        channel -> account.tuneToChannel(deviceId, channel.id),
+                        () -> logger.warn("Unknown LG Horizon channel name '{}' for box {}", command, deviceId));
+                break;
+            case LGHorizonBindingConstants.CHANNEL_KEY_CODE:
+                account.sendKey(deviceId, command.toString());
+                break;
+            default:
+                break;
+        }
+    }
+
+    /**
+     * Handles a command-only, stateless key channel (Switch, {@code autoUpdatePolicy="veto"}): only a press
+     * (ON) does anything, matching how a physical remote button works - there's no meaningful "released"
+     * state to react to, and OFF is never sent by these channels' own semantics anyway.
+     */
+    private void sendKeyOnPress(LGHorizonAccountHandler account, Command command, String w3cKey) {
+        if (command == OnOffType.ON) {
+            account.sendKey(deviceId, w3cKey);
+        }
+    }
+
+    private Optional<ChannelDto> resolveChannelByNumber(LGHorizonAccountHandler account, String number) {
+        return account.getChannels(getLanguage(account)).values().stream()
+                .filter(c -> c.id != null && number.equals(c.logicalChannelNumber)).findFirst();
+    }
+
+    private Optional<ChannelDto> resolveChannelByName(LGHorizonAccountHandler account, String name) {
+        // Fuzzy fallback: channel with the lowest logical channel number whose name contains the given text,
+        // case-insensitive - e.g. "vtm" matches VTM HD/2/3/4/GOLD/series, and deterministically picks
+        // whichever of those has the lowest channel number (usually the "main" one). Only used when no exact match
+        // exists, so an exact name is never shadowed by a shorter, unrelated channel that happens to contain it as a
+        // substring. A channel with a missing or non-numeric channel number sorts last, never winning over
+        // one with a real number.
+        String needle = name.toLowerCase();
+        return account.getChannels(getLanguage(account)).values().stream()
+                .filter(c -> c.id != null && c.name != null && c.name.toLowerCase().contains(needle))
+                .min(Comparator.comparingInt(this::channelNumberOrMax));
+    }
+
+    private int channelNumberOrMax(ChannelDto channel) {
+        String number = channel.logicalChannelNumber;
+        if (number == null) {
+            return Integer.MAX_VALUE;
+        }
+        try {
+            return Integer.parseInt(number);
+        } catch (NumberFormatException e) {
+            return Integer.MAX_VALUE;
+        }
+    }
+
+    /**
+     * Populates the five channel-number selection channels' dynamic state options (channel number as the
+     * value, channel name as the label): the unfiltered {@code channel-number}, plus four filtered subsets
+     * crossing "TV vs radio" with "favorite vs not" - {@code tv-channel-number}, {@code radio-channel-number},
+     * {@code favorite-tv-channel-number}, {@code favorite-radio-channel-number}. All five accept the same
+     * channel numbers as commands (a channel is addressed identically regardless of which list it appeared
+     * in); they only differ in which numbers show up as options, and which one reflects the currently
+     * playing channel - see {@link #updateChannelFromId}.
+     */
+    public void updateChannelNumberOptions() {
+        LGHorizonAccountHandler account = getAccountHandler();
+        if (account == null) {
+            return;
+        }
+        Map<String, ChannelDto> channels = account.getChannels(getLanguage(account));
+        List<String> favoriteIds = account.getFavoriteChannelIds(resolveProfileId(account));
+
+        setChannelNumberOptions(LGHorizonBindingConstants.CHANNEL_CHANNEL_NUMBER, channels.values().stream());
+        setChannelNumberOptions(LGHorizonBindingConstants.CHANNEL_FAVORITE_CHANNEL_NUMBER,
+                channels.values().stream().filter(c -> favoriteIds.contains(c.id)));
+    }
+
+    private void setChannelNumberOptions(String channelId, Stream<ChannelDto> channels) {
+        List<StateOption> options = channels.filter(c -> c.logicalChannelNumber != null && c.name != null)
+                .sorted(Comparator.comparingInt(this::channelNumberOrMax))
+                .map(c -> new StateOption(c.logicalChannelNumber, c.name)).toList();
+        dynamicStateDescriptionProvider.setStateOptions(new ChannelUID(getThing().getUID(), channelId), options);
+    }
+
+    /**
+     * Displays an on-screen message. Called by {@link LGHorizonActions}. {@code title}/{@code duration} fall
+     * back to {@link LGHorizonBindingConstants#DEFAULT_DISPLAY_MESSAGE_TITLE}/
+     * {@link LGHorizonBindingConstants#DEFAULT_DISPLAY_MESSAGE_DURATION_SECONDS} when not supplied.
+     */
+    public void displayMessage(String message, @Nullable Integer duration) {
+        LGHorizonAccountHandler account = getAccountHandler();
+        if (account == null) {
+            return;
+        }
+        int resolvedDuration = duration != null ? duration
+                : LGHorizonBindingConstants.DEFAULT_DISPLAY_MESSAGE_DURATION_SECONDS;
+        account.displayMessage(deviceId, message, resolvedDuration);
+    }
+
+    private String getLanguage(LGHorizonAccountHandler account) {
+        DeviceDto device = account.getAssignedDevice(deviceId);
+        if (device == null) {
+            return "en";
+        }
+        String profileId = this.profileId.isBlank() ? device.defaultProfileId : this.profileId;
+        return account.getLanguageForProfile(profileId);
+    }
+
+    // ------------------------------------------------------------------
+    // Inbound updates, called by LGHorizonAccountHandler
+    // ------------------------------------------------------------------
+
+    /** Handles a {@code .../status} message: coarse running state (online/standby/offline). */
+    public void handleStatusMessage(String rawState) {
+        running = "ONLINE_RUNNING".equalsIgnoreCase(rawState);
+        boolean reachable = running || "ONLINE_STANDBY".equalsIgnoreCase(rawState);
+
+        updateState(LGHorizonBindingConstants.CHANNEL_POWER, OnOffType.from(running));
+
+        if (reachable) {
+            updateStatus(ThingStatus.ONLINE);
+        } else {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
+                    "@text/offline.box-reports-state [\"" + rawState + "\"]");
+        }
+    }
+
+    /** Handles a {@code CPE.uiStatus} message: what is actually playing right now. */
+    public void handleUiStatusMessage(JsonObject payload) {
+        updateStatus(ThingStatus.ONLINE);
+        if (!payload.has("status") || !payload.get("status").isJsonObject()) {
+            return;
+        }
+        JsonObject status = payload.getAsJsonObject("status");
+        String uiStatus = getString(status, "uiStatus").orElse("");
+
+        if ("apps".equalsIgnoreCase(uiStatus)) {
+            handleAppsState(status);
+            return;
+        }
+
+        JsonObject playerState = status.has("playerState") && status.get("playerState").isJsonObject()
+                ? status.getAsJsonObject("playerState")
+                : null;
+        if (playerState == null) {
+            return;
+        }
+
+        String sourceType = getString(playerState, "sourceType").orElse(null);
+        if (sourceType != null) {
+            updateState(LGHorizonBindingConstants.CHANNEL_SOURCE_TYPE, new StringType(sourceType));
+        }
+
+        if (playerState.has("speed")) {
+            int speed = playerState.get("speed").getAsInt();
+            paused = speed == 0;
+            State channelPlayerState = speed == 0 ? PlayPauseType.PAUSE
+                    : speed < 0 ? RewindFastforwardType.REWIND
+                            : speed > 1 ? RewindFastforwardType.FASTFORWARD : PlayPauseType.PLAY;
+            updateState(LGHorizonBindingConstants.CHANNEL_PLAYER, channelPlayerState);
+        }
+
+        JsonObject source = playerState.has("source") && playerState.get("source").isJsonObject()
+                ? playerState.getAsJsonObject("source")
+                : null;
+        if (source == null || sourceType == null || sourceType.isBlank()) {
+            lastResolvedContentId = null;
+            clearTitleMetadata();
+            clearChannelSelections();
+            updateState(LGHorizonBindingConstants.CHANNEL_MEDIA_IMAGE, UnDefType.UNDEF);
+            return;
+        }
+
+        switch (sourceType.toLowerCase(java.util.Locale.ROOT)) {
+            case "linear", "reviewbuffer" -> {
+                String channelId = getString(source, "channelId").orElse(null);
+                if (channelId != null) {
+                    updateChannelFromId(channelId);
+                } else {
+                    clearChannelSelections();
+                }
+                getString(source, "eventId").ifPresent(eventId -> resolveEventMetadata(eventId, true));
+            }
+            case "replay" -> {
+                clearChannelSelections();
+                getString(source, "eventId").ifPresent(eventId -> resolveEventMetadata(eventId, false));
+            }
+            case "vod" -> {
+                clearChannelSelections();
+                getString(source, "titleId").ifPresent(this::resolveVodMetadata);
+            }
+            case "ndvr" -> getString(source, "recordingId").ifPresent(this::resolveRecordingMetadata);
+            default -> {
+                // localDVR and anything else: not implemented - reset all title/image channels
+                lastResolvedContentId = null;
+                clearTitleMetadata();
+                clearChannelSelections();
+                updateState(LGHorizonBindingConstants.CHANNEL_MEDIA_IMAGE, UnDefType.UNDEF);
+            }
+        }
+    }
+
+    /**
+     * Updates {@code channel-name} plus all five number-selection channels for the currently playing linear
+     * channel: {@code channel-number} always gets the number, while {@code tv-channel-number}/
+     * {@code radio-channel-number}/{@code favorite-tv-channel-number}/{@code favorite-radio-channel-number}
+     * only get it when the channel actually qualifies for that particular list - {@link UnDefType#UNDEF}
+     * otherwise, so switching to a channel that isn't a favorite (or isn't radio) doesn't leave a stale
+     * number from whatever qualified before. If the channel id can't be resolved at all, every one of these
+     * six channels is cleared via {@link #clearChannelSelections}.
+     */
+    private void updateChannelFromId(String channelId) {
+        LGHorizonAccountHandler account = getAccountHandler();
+        ChannelDto channel = account == null ? null : account.getChannels(getLanguage(account)).get(channelId);
+        if (channel == null || account == null) {
+            clearChannelSelections();
+            return;
+        }
+        updateState(LGHorizonBindingConstants.CHANNEL_CHANNEL_NAME,
+                channel.name != null ? new StringType(channel.name) : UnDefType.UNDEF);
+
+        State numberState = toChannelNumberState(channel.logicalChannelNumber);
+        updateState(LGHorizonBindingConstants.CHANNEL_CHANNEL_NUMBER, numberState);
+
+        boolean isFavorite = account.getFavoriteChannelIds(resolveProfileId(account)).contains(channel.id);
+
+        updateState(LGHorizonBindingConstants.CHANNEL_FAVORITE_CHANNEL_NUMBER,
+                isFavorite ? numberState : UnDefType.UNDEF);
+    }
+
+    private State toChannelNumberState(@Nullable String logicalChannelNumber) {
+        if (logicalChannelNumber == null) {
+            return UnDefType.UNDEF;
+        }
+        try {
+            return new DecimalType(logicalChannelNumber);
+        } catch (NumberFormatException e) {
+            return UnDefType.UNDEF;
+        }
+    }
+
+    /**
+     * Clears {@code channel-name} and all five number-selection channels - used whenever the box is not
+     * showing a specific, currently-known linear channel (VOD, a recording, replay, an app, localDVR, or an
+     * unresolvable channel id), so none of them keep showing a stale value from whatever was on before.
+     */
+    private void clearChannelSelections() {
+        updateState(LGHorizonBindingConstants.CHANNEL_CHANNEL_NAME, UnDefType.UNDEF);
+        updateState(LGHorizonBindingConstants.CHANNEL_CHANNEL_NUMBER, UnDefType.UNDEF);
+        updateState(LGHorizonBindingConstants.CHANNEL_FAVORITE_CHANNEL_NUMBER, UnDefType.UNDEF);
+    }
+
+    private void resolveEventMetadata(String eventId, boolean useChannelImage) {
+        if (eventId.equals(lastResolvedContentId)) {
+            return;
+        }
+        lastResolvedContentId = eventId;
+        LGHorizonAccountHandler account = getAccountHandler();
+        if (account == null) {
+            return;
+        }
+        String language = getLanguage(account);
+        scheduler.execute(() -> {
+            EventDetailDto detail = account.getEventDetail(eventId, language);
+            if (detail == null) {
+                clearTitleMetadata();
+                updateState(LGHorizonBindingConstants.CHANNEL_MEDIA_IMAGE, UnDefType.UNDEF);
+                return;
+            }
+            // For linear/reviewBuffer/replay, "title" is the show/program title and "episodeName" is the episode's own
+            // title - both already unambiguous.
+            applyTitleMetadata(detail.title, detail.episodeName, detail.seasonNumber, detail.episodeNumber);
+
+            String imageUrl;
+            if (useChannelImage && detail.channelId != null) {
+                ChannelDto channel = account.getChannels(language).get(detail.channelId);
+                imageUrl = channel == null ? null : channel.getStreamImage();
+            } else {
+                imageUrl = account.getIntentImageUrl(eventId);
+            }
+            updateImageFromUrlOrClear(imageUrl);
+        });
+    }
+
+    private void resolveVodMetadata(String titleId) {
+        if (titleId.equals(lastResolvedContentId)) {
+            return;
+        }
+        lastResolvedContentId = titleId;
+        LGHorizonAccountHandler account = getAccountHandler();
+        if (account == null) {
+            return;
+        }
+        String language = getLanguage(account);
+        String effectiveProfileId = resolveProfileId(account);
+        scheduler.execute(() -> {
+            VodDetailDto detail = account.getVodDetail(titleId, effectiveProfileId, language);
+            if (detail == null) {
+                clearTitleMetadata();
+                updateState(LGHorizonBindingConstants.CHANNEL_MEDIA_IMAGE, UnDefType.UNDEF);
+                return;
+            }
+            // For an episode, the field "title" holds the EPISODE's own name - the show name is in the separate
+            // "seriesTitle" field instead. For a movie, "title" is the movie's own title and there is no
+            // series/episode concept.
+            if (detail.isEpisode()) {
+                applyTitleMetadata(detail.seriesTitle, detail.title, detail.season, detail.episode);
+            } else {
+                applyTitleMetadata(detail.title, null, null, null);
+            }
+            String imageUrl = account.getIntentImageUrl(detail.id != null ? detail.id : titleId);
+            updateImageFromUrlOrClear(imageUrl);
+        });
+    }
+
+    private void resolveRecordingMetadata(String recordingId) {
+        if (recordingId.equals(lastResolvedContentId)) {
+            return;
+        }
+        lastResolvedContentId = recordingId;
+        LGHorizonAccountHandler account = getAccountHandler();
+        if (account == null) {
+            return;
+        }
+        String language = getLanguage(account);
+        String effectiveProfileId = resolveProfileId(account);
+        scheduler.execute(() -> {
+            RecordingDetailDto detail = account.getRecordingDetail(recordingId, effectiveProfileId, language);
+            if (detail == null) {
+                clearTitleMetadata();
+                updateState(LGHorizonBindingConstants.CHANNEL_MEDIA_IMAGE, UnDefType.UNDEF);
+                return;
+            }
+            // nDVR is conditional on "source": for a "show"-sourced (standalone) recording, "title"
+            // is the show name; for anything recorded as part of a series/season rule, the show name is in
+            // the "showTitle" field instead - RecordingDetailDto.getShowTitle() already applies this distinction.
+            applyTitleMetadata(detail.getShowTitle(), detail.episodeTitle, detail.seasonNumber, detail.episodeNumber);
+            String imageUrl = account.getIntentImageUrl(detail.id != null ? detail.id : recordingId);
+            updateImageFromUrlOrClear(imageUrl);
+        });
+    }
+
+    /**
+     * Populates the five separate title/episode channels from whichever content type just resolved -
+     * {@code programTitle} always mirrors the reference implementation's own "show_title" concept (computed
+     * differently per content type, but always meant as *the* title), while {@code seriesTitle} is only
+     * populated alongside it when the content is genuinely episodic (an episode title, season, or episode
+     * number is present) - so a rule can check "is seriesTitle set" as a simple signal for "is this a TV
+     * series episode" versus a movie or standalone broadcast. A missing episode title text falls back to a
+     * plain "Episode N" using the episode number, if that's available.
+     */
+    private void applyTitleMetadata(@Nullable String programTitle, @Nullable String episodeTitleText,
+            @Nullable Integer season, @Nullable Integer episode) {
+        updateState(LGHorizonBindingConstants.CHANNEL_PROGRAM_TITLE,
+                programTitle != null ? new StringType(programTitle) : UnDefType.UNDEF);
+
+        boolean isEpisodic = (episodeTitleText != null && !episodeTitleText.isBlank()) || season != null
+                || episode != null;
+        updateState(LGHorizonBindingConstants.CHANNEL_SERIES_TITLE,
+                isEpisodic && programTitle != null ? new StringType(programTitle) : UnDefType.UNDEF);
+
+        String resolvedEpisodeTitle = episodeTitleText != null && !episodeTitleText.isBlank() ? episodeTitleText
+                : episode != null ? "Episode " + episode : null;
+        updateState(LGHorizonBindingConstants.CHANNEL_EPISODE_TITLE,
+                resolvedEpisodeTitle != null ? new StringType(resolvedEpisodeTitle) : UnDefType.UNDEF);
+
+        updateState(LGHorizonBindingConstants.CHANNEL_SEASON,
+                season != null ? new DecimalType(season) : UnDefType.UNDEF);
+        updateState(LGHorizonBindingConstants.CHANNEL_EPISODE,
+                episode != null ? new DecimalType(episode) : UnDefType.UNDEF);
+    }
+
+    private void clearTitleMetadata() {
+        applyTitleMetadata(null, null, null, null);
+    }
+
+    private String resolveProfileId(LGHorizonAccountHandler account) {
+        DeviceDto device = account.getAssignedDevice(deviceId);
+        if (device == null) {
+            return "";
+        }
+        String resolved = this.profileId.isBlank() ? device.defaultProfileId : this.profileId;
+        return resolved != null ? resolved : "";
+    }
+
+    /** Fetches the image bytes (a real network call) and updates the media-image channel. */
+    private void updateImageFromUrl(String url) {
+        LGHorizonAccountHandler account = getAccountHandler();
+        if (account == null) {
+            return;
+        }
+        RawType image = account.fetchImage(url);
+        updateState(LGHorizonBindingConstants.CHANNEL_MEDIA_IMAGE, image != null ? image : UnDefType.UNDEF);
+    }
+
+    /** Clears media-image immediately if no image URL could be resolved at all, otherwise fetches it. */
+    private void updateImageFromUrlOrClear(@Nullable String url) {
+        if (url == null) {
+            updateState(LGHorizonBindingConstants.CHANNEL_MEDIA_IMAGE, UnDefType.UNDEF);
+            return;
+        }
+        updateImageFromUrl(url);
+    }
+
+    /** Handles the {@code status.appsState} shape used when {@code status.uiStatus} is {@code "apps"}. */
+    private void handleAppsState(JsonObject status) {
+        JsonObject appsState = status.has("appsState") && status.get("appsState").isJsonObject()
+                ? status.getAsJsonObject("appsState")
+                : null;
+        if (appsState == null) {
+            return;
+        }
+        updateState(LGHorizonBindingConstants.CHANNEL_SOURCE_TYPE, new StringType("app"));
+        clearTitleMetadata();
+        clearChannelSelections();
+        getString(appsState, "appName").ifPresent(
+                appName -> updateState(LGHorizonBindingConstants.CHANNEL_PROGRAM_TITLE, new StringType(appName)));
+
+        String logoPath = getString(appsState, "logoPath").orElse(null);
+        if (logoPath != null && !logoPath.equals(lastResolvedContentId)) {
+            lastResolvedContentId = logoPath;
+            scheduler.execute(() -> updateImageFromUrl(logoPath));
+        }
+    }
+
+    private static Optional<String> getString(JsonObject obj, String key) {
+        return obj.has(key) && !obj.get(key).isJsonNull() ? Optional.of(obj.get(key).getAsString()) : Optional.empty();
+    }
+}

--- a/bundles/org.openhab.binding.lghorizon/src/main/java/org/openhab/binding/lghorizon/internal/handler/LGHorizonConfigOptionProvider.java
+++ b/bundles/org.openhab.binding.lghorizon/src/main/java/org/openhab/binding/lghorizon/internal/handler/LGHorizonConfigOptionProvider.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.lghorizon.internal.handler;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.lghorizon.internal.LGHorizonBindingConstants;
+import org.openhab.binding.lghorizon.internal.api.ProviderPresets;
+import org.openhab.core.config.core.ConfigOptionProvider;
+import org.openhab.core.config.core.ParameterOption;
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * Supplies the selection list for the {@code account} thing type's {@code provider} parameter directly from
+ * {@link ProviderPresets}, so the dropdown shown in the UI can never drift out of sync with the providers the binding
+ * actually implements. Always includes an empty "Custom" entry so users can fall through to the advanced
+ * {@code country}/{@code apiUrl}/{@code useRefreshToken} parameters for anything not in the list.
+ *
+ * @author Mark - Initial contribution
+ */
+@NonNullByDefault
+@Component(service = ConfigOptionProvider.class)
+public class LGHorizonConfigOptionProvider implements ConfigOptionProvider {
+
+    private static final URI ACCOUNT_CONFIG_URI = URI
+            .create("thing-type:" + LGHorizonBindingConstants.THING_TYPE_ACCOUNT.getAsString());
+
+    @Override
+    public @Nullable Collection<ParameterOption> getParameterOptions(URI uri, String param, @Nullable String context,
+            @Nullable Locale locale) {
+        if (!ACCOUNT_CONFIG_URI.equals(uri) || !LGHorizonBindingConstants.CONFIG_PROVIDER.equals(param)) {
+            return null;
+        }
+
+        List<ParameterOption> presets = new ArrayList<>();
+        for (Map.Entry<String, ProviderPresets.Preset> entry : ProviderPresets.all().entrySet()) {
+            presets.add(new ParameterOption(entry.getKey(), entry.getValue().displayName()));
+        }
+        presets.sort((a, b) -> a.getLabel().compareToIgnoreCase(b.getLabel()));
+
+        List<ParameterOption> options = new ArrayList<>();
+        options.add(new ParameterOption("",
+                "Custom / manual configuration (see Country / API URL / Use Refresh Token below)"));
+        options.addAll(presets);
+        return options;
+    }
+}

--- a/bundles/org.openhab.binding.lghorizon/src/main/java/org/openhab/binding/lghorizon/internal/handler/LGHorizonDynamicStateDescriptionProvider.java
+++ b/bundles/org.openhab.binding.lghorizon/src/main/java/org/openhab/binding/lghorizon/internal/handler/LGHorizonDynamicStateDescriptionProvider.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.lghorizon.internal.handler;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.core.events.EventPublisher;
+import org.openhab.core.thing.binding.BaseDynamicStateDescriptionProvider;
+import org.openhab.core.thing.i18n.ChannelTypeI18nLocalizationService;
+import org.openhab.core.thing.link.ItemChannelLinkRegistry;
+import org.openhab.core.thing.type.DynamicStateDescriptionProvider;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * Supplies the {@code channel-number} channel with dynamic {@link org.openhab.core.types.StateOption}s (channel
+ * number as the value, channel name as the label) so it renders as a selection list in the UI instead of a plain
+ * numeric input, sourced from the account's actual entitled channel line-up for the box's own profile/language.
+ * Populated by {@link LGHorizonBoxHandler} via {@link #setStateOptions}.
+ *
+ * @author Mark - Initial contribution
+ */
+@NonNullByDefault
+@Component(service = { DynamicStateDescriptionProvider.class, LGHorizonDynamicStateDescriptionProvider.class })
+public class LGHorizonDynamicStateDescriptionProvider extends BaseDynamicStateDescriptionProvider {
+
+    @Activate
+    public LGHorizonDynamicStateDescriptionProvider(final @Reference EventPublisher eventPublisher,
+            final @Reference ItemChannelLinkRegistry itemChannelLinkRegistry,
+            final @Reference ChannelTypeI18nLocalizationService channelTypeI18nLocalizationService) {
+        this.eventPublisher = eventPublisher;
+        this.itemChannelLinkRegistry = itemChannelLinkRegistry;
+        this.channelTypeI18nLocalizationService = channelTypeI18nLocalizationService;
+    }
+}

--- a/bundles/org.openhab.binding.lghorizon/src/main/java/org/openhab/binding/lghorizon/internal/mqtt/LGHorizonMqttClient.java
+++ b/bundles/org.openhab.binding.lghorizon/src/main/java/org/openhab/binding/lghorizon/internal/mqtt/LGHorizonMqttClient.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.lghorizon.internal.mqtt;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
+import java.security.SecureRandom;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.lghorizon.internal.LGHorizonContentAnonymizer;
+import org.openhab.binding.lghorizon.internal.api.LGHorizonApiException;
+import org.openhab.binding.lghorizon.internal.api.LGHorizonAuthClient;
+import org.openhab.core.io.transport.mqtt.MqttBrokerConnection;
+import org.openhab.core.io.transport.mqtt.MqttConnectionObserver;
+import org.openhab.core.io.transport.mqtt.MqttConnectionState;
+import org.openhab.core.io.transport.mqtt.MqttMessageSubscriber;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+/**
+ * Wraps an openHAB {@link MqttBrokerConnection} to talk to the LG Horizon "obomsg" push broker over
+ * MQTT-over-WebSockets (wss://.../mqtt on port 443):
+ * <ul>
+ * <li>host/path come from the {@code mqttBroker} entry of the service discovery document.</li>
+ * <li>username = household id, password = short-lived MQTT token from {@link LGHorizonAuthClient#getMqttToken()}</li>
+ * <li>reconnects (including refreshing the token first) are handled by {@link LGHorizonReconnectStrategy}</li>
+ * </ul>
+ *
+ * @author Mark - Initial contribution
+ */
+@NonNullByDefault
+public class LGHorizonMqttClient implements MqttMessageSubscriber, MqttConnectionObserver {
+
+    private static final String WEBSOCKET_PATH = "/mqtt";
+    private static final int CONNECT_TIMEOUT_SECONDS = 15;
+
+    private final Logger logger = LoggerFactory.getLogger(LGHorizonMqttClient.class);
+
+    private final LGHorizonAuthClient authClient;
+    private final LGHorizonMqttListener listener;
+    private final String clientId;
+    private final MqttBrokerConnection connection;
+
+    public LGHorizonMqttClient(LGHorizonAuthClient authClient, LGHorizonMqttListener listener,
+            ScheduledExecutorService scheduler) throws LGHorizonApiException {
+        this.authClient = authClient;
+        this.listener = listener;
+        this.clientId = randomId(10);
+
+        String mqttBrokerUrl = authClient.getServiceConfig().getServiceUrl("mqttBroker");
+        String host = extractHost(mqttBrokerUrl);
+
+        MqttBrokerConnection conn = new MqttBrokerConnection(MqttBrokerConnection.Protocol.WEBSOCKETS,
+                MqttBrokerConnection.MqttVersion.V3, host, 443, true, clientId);
+        conn.setWebSocketPath(WEBSOCKET_PATH);
+        conn.setCleanSessionStart(true);
+        conn.setKeepAliveInterval(30);
+        conn.setTimeoutExecutor(scheduler, CONNECT_TIMEOUT_SECONDS * 1000);
+        conn.setReconnectStrategy(new LGHorizonReconnectStrategy(authClient));
+        conn.addConnectionObserver(this);
+        this.connection = conn;
+    }
+
+    public String getClientId() {
+        return clientId;
+    }
+
+    /**
+     * Fetches a fresh MQTT token and (re)connects. Blocks the calling thread until the connection is established or
+     * {@link #CONNECT_TIMEOUT_SECONDS} elapses; callers should invoke this from a background thread (e.g. the handler's
+     * own scheduler), never from the openHAB event bus thread.
+     */
+    public void connect() throws LGHorizonApiException {
+        String householdId = authClient.getHouseholdId();
+        if (householdId == null) {
+            throw new LGHorizonApiException("Not authenticated yet: no household id available");
+        }
+        String mqttToken = authClient.getMqttToken();
+        connection.setCredentials(householdId, mqttToken);
+        try {
+            Boolean connected = connection.start().get(CONNECT_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            if (!Boolean.TRUE.equals(connected)) {
+                throw new LGHorizonApiException("Timed out connecting to the LG Horizon MQTT broker");
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new LGHorizonApiException("Interrupted while connecting to the LG Horizon MQTT broker", e);
+        } catch (ExecutionException | TimeoutException e) {
+            throw new LGHorizonApiException("Unable to connect to the LG Horizon MQTT broker", e);
+        }
+    }
+
+    /**
+     * Subscribes to a topic filter (may contain {@code +}/{@code #} wildcards).
+     */
+    public void subscribe(String topicFilter) {
+        connection.subscribe(topicFilter, this).exceptionally(e -> {
+            logger.debug("Failed to subscribe to LG Horizon MQTT topic '{}': {}",
+                    LGHorizonContentAnonymizer.anonymizeTopic(topicFilter), e.getMessage());
+            return false;
+        });
+    }
+
+    /**
+     * Subscribes to all the topics the set-top boxes and account-level services publish on.
+     */
+    public void subscribeAccountTopics(String householdId) {
+        subscribe(householdId);
+        subscribe(householdId + "/" + clientId);
+        subscribe(householdId + "/+/status");
+        subscribe(householdId + "/watchlistService");
+        subscribe(householdId + "/personalizationService");
+        subscribe(householdId + "/recordingStatus");
+    }
+
+    /**
+     * Publishes a JSON payload with QoS 1. Fire-and-forget: failures are logged but not retried (the box will simply
+     * not react, same as if it were offline).
+     */
+    public void publish(String topic, JsonObject payload) {
+        if (connection.connectionState() != MqttConnectionState.CONNECTED) {
+            logger.debug("Not connected to the LG Horizon MQTT broker, dropping publish to {}",
+                    LGHorizonContentAnonymizer.anonymizeTopic(topic));
+            return;
+        }
+        byte[] bytes = payload.toString().getBytes(StandardCharsets.UTF_8);
+        connection.publish(topic, bytes, 1, false).exceptionally(e -> {
+            logger.warn("Failed to publish to LG Horizon MQTT topic '{}': {}",
+                    LGHorizonContentAnonymizer.anonymizeTopic(topic), e.getMessage());
+            return false;
+        });
+    }
+
+    public boolean isConnected() {
+        return connection.connectionState() == MqttConnectionState.CONNECTED;
+    }
+
+    public void disconnect() {
+        connection.stop();
+    }
+
+    // ------------------------------------------------------------------
+    // MqttMessageSubscriber
+    // ------------------------------------------------------------------
+
+    @Override
+    public void processMessage(String topic, byte[] payload) {
+        try {
+            String json = new String(payload, StandardCharsets.UTF_8);
+            JsonObject parsed = JsonParser.parseString(json).getAsJsonObject();
+            listener.onMessage(topic, parsed);
+        } catch (Exception e) {
+            logger.debug("Ignoring non-JSON or malformed MQTT message on topic {}: {}", topic, e.getMessage());
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // MqttConnectionObserver
+    // ------------------------------------------------------------------
+
+    @Override
+    public void connectionStateChanged(MqttConnectionState state, @Nullable Throwable error) {
+        switch (state) {
+            case CONNECTED -> listener.onConnected();
+            case DISCONNECTED -> {
+                String message = error != null ? error.getMessage() : "unknown reason";
+                logger.debug("Lost connection to LG Horizon MQTT broker: {}",
+                        LGHorizonContentAnonymizer.anonymizeMessage(message), error);
+                listener.onConnectionLost(error != null ? error : new Exception("unknown reason"));
+            }
+            case CONNECTING -> {
+                // no-op: nothing for the account handler to react to yet
+            }
+        }
+    }
+
+    private static String extractHost(String mqttBrokerUrl) {
+        try {
+            URI uri = new URI(mqttBrokerUrl.contains("://") ? mqttBrokerUrl : "wss://" + mqttBrokerUrl);
+            String host = uri.getHost();
+            if (host != null) {
+                return host;
+            }
+        } catch (URISyntaxException ignored) {
+            // fall through to the manual strip below
+        }
+        return mqttBrokerUrl.replaceFirst("^\\w+://", "").replaceFirst("[:/].*$", "");
+    }
+
+    private static String randomId(int length) {
+        String letters = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+        SecureRandom random = new SecureRandom();
+        StringBuilder sb = new StringBuilder(length);
+        for (int i = 0; i < length; i++) {
+            sb.append(letters.charAt(random.nextInt(letters.length())));
+        }
+        return sb.toString();
+    }
+}

--- a/bundles/org.openhab.binding.lghorizon/src/main/java/org/openhab/binding/lghorizon/internal/mqtt/LGHorizonMqttListener.java
+++ b/bundles/org.openhab.binding.lghorizon/src/main/java/org/openhab/binding/lghorizon/internal/mqtt/LGHorizonMqttListener.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.lghorizon.internal.mqtt;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+import com.google.gson.JsonObject;
+
+/**
+ * Callback for events coming from {@link LGHorizonMqttClient}.
+ *
+ * @author Mark - Initial contribution
+ */
+@NonNullByDefault
+public interface LGHorizonMqttListener {
+
+    /**
+     * Called for every JSON message received on any subscribed topic.
+     *
+     * @param topic the MQTT topic the message arrived on
+     * @param payload the parsed JSON payload
+     */
+    void onMessage(String topic, JsonObject payload);
+
+    /**
+     * Called once the client has (re)connected and subscriptions have been (re)established.
+     */
+    void onConnected();
+
+    /**
+     * Called when the connection is lost. The client will attempt to reconnect on its own (fetching a fresh MQTT token
+     * first); this is informational so the bridge handler can update its thing status.
+     */
+    void onConnectionLost(Throwable cause);
+}

--- a/bundles/org.openhab.binding.lghorizon/src/main/java/org/openhab/binding/lghorizon/internal/mqtt/LGHorizonReconnectStrategy.java
+++ b/bundles/org.openhab.binding.lghorizon/src/main/java/org/openhab/binding/lghorizon/internal/mqtt/LGHorizonReconnectStrategy.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.lghorizon.internal.mqtt;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.lghorizon.internal.api.LGHorizonApiException;
+import org.openhab.binding.lghorizon.internal.api.LGHorizonAuthClient;
+import org.openhab.core.io.transport.mqtt.MqttBrokerConnection;
+import org.openhab.core.io.transport.mqtt.reconnect.AbstractReconnectStrategy;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The LG Horizon broker authenticates with a short-lived token (see {@link LGHorizonAuthClient#getMqttToken()}) rather
+ * than a static password. The stock {@code PeriodicReconnectStrategy} would just keep retrying with the stale password
+ * after a disconnect, which will never succeed once the token has expired.
+ * <p>
+ * This strategy instead fetches a fresh token and calls {@link MqttBrokerConnection#setCredentials(String, String)}
+ * immediately before every reconnect attempt, with exponential backoff (5s, 10s, 20s, ... capped at 60s).
+ *
+ * @author Mark - Initial contribution
+ */
+@NonNullByDefault
+public class LGHorizonReconnectStrategy extends AbstractReconnectStrategy {
+
+    private static final int FIRST_RECONNECT_DELAY_SECONDS = 5;
+    private static final int MAX_RECONNECT_DELAY_SECONDS = 60;
+
+    private final Logger logger = LoggerFactory.getLogger(LGHorizonReconnectStrategy.class);
+
+    private final LGHorizonAuthClient authClient;
+    private final AtomicInteger attempt = new AtomicInteger();
+
+    private @Nullable ScheduledExecutorService scheduler = null;
+    private @Nullable ScheduledFuture<?> scheduledTask;
+
+    public LGHorizonReconnectStrategy(LGHorizonAuthClient authClient) {
+        this.authClient = authClient;
+    }
+
+    @Override
+    public synchronized boolean isReconnecting() {
+        ScheduledFuture<?> task = scheduledTask;
+        return task != null && !task.isDone();
+    }
+
+    @Override
+    public synchronized void lostConnection() {
+        ScheduledExecutorService scheduler = this.scheduler;
+        if (scheduler == null) {
+            return;
+        }
+        if (getBrokerConnection() == null) {
+            stop();
+            return;
+        }
+        ScheduledFuture<?> existing = scheduledTask;
+        if (existing != null && !existing.isDone()) {
+            return;
+        }
+        int delay = (int) Math.min(FIRST_RECONNECT_DELAY_SECONDS * Math.pow(2, attempt.getAndIncrement()),
+                MAX_RECONNECT_DELAY_SECONDS);
+        logger.debug("LG Horizon MQTT connection lost, retrying in {}s", delay);
+        scheduledTask = scheduler.schedule(this::attemptReconnect, delay, TimeUnit.SECONDS);
+    }
+
+    private void attemptReconnect() {
+        MqttBrokerConnection connection = getBrokerConnection();
+        if (connection == null || scheduler == null) {
+            return;
+        }
+        try {
+            String householdId = authClient.getHouseholdId();
+            String freshToken = authClient.getMqttToken();
+            if (householdId != null) {
+                connection.setCredentials(householdId, freshToken);
+            }
+        } catch (LGHorizonApiException e) {
+            logger.debug("Could not refresh LG Horizon MQTT token before reconnecting: {}", e.getMessage());
+        }
+        connection.start().exceptionally(e -> {
+            logger.debug("LG Horizon MQTT reconnect attempt failed: {}", e.getMessage());
+            return false;
+        });
+    }
+
+    @Override
+    public synchronized void connectionEstablished() {
+        attempt.set(0);
+        ScheduledFuture<?> task = scheduledTask;
+        if (task != null) {
+            task.cancel(false);
+            scheduledTask = null;
+        }
+    }
+
+    @Override
+    public void start() {
+        if (scheduler == null) {
+            scheduler = Executors.newScheduledThreadPool(1);
+        }
+    }
+
+    @Override
+    public synchronized void stop() {
+        ScheduledExecutorService scheduler = this.scheduler;
+        if (scheduler != null) {
+            scheduler.shutdownNow();
+            this.scheduler = null;
+        }
+
+        ScheduledFuture<?> task = scheduledTask;
+        if (task != null) {
+            task.cancel(true);
+            scheduledTask = null;
+        }
+    }
+}

--- a/bundles/org.openhab.binding.lghorizon/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.binding.lghorizon/src/main/resources/OH-INF/addon/addon.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<addon:addon id="lghorizon" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:addon="https://openhab.org/schemas/addon/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/addon/v1.0.0 https://openhab.org/schemas/addon-1.0.0.xsd">
+
+	<type>binding</type>
+	<name>LGHorizon Binding</name>
+	<description>Integrates TV set-top boxes using the LG Horizon platform.</description>
+	<keywords>Telenet, Base, Ziggo, Virgin Media, UPC, Sunrise</keywords>
+	<connection>cloud</connection>
+	<countries>be,nl,uk,ie,ch,pl</countries>
+
+	<discovery-methods>
+		<discovery-method>
+			<service-type>upnp</service-type>
+			<match-properties>
+				<match-property>
+					<name>manufacturer</name>
+					<regex>TELENETTVBOX</regex>
+				</match-property>
+			</match-properties>
+		</discovery-method>
+	</discovery-methods>
+
+</addon:addon>

--- a/bundles/org.openhab.binding.lghorizon/src/main/resources/OH-INF/i18n/lghorizon.properties
+++ b/bundles/org.openhab.binding.lghorizon/src/main/resources/OH-INF/i18n/lghorizon.properties
@@ -1,0 +1,134 @@
+# add-on
+
+addon.lghorizon.name = LGHorizon Binding
+addon.lghorizon.description = Integrates TV set-top boxes using the LG Horizon platform.
+
+# thing types
+
+thing-type.lghorizon.account.label = LG Horizon Account
+thing-type.lghorizon.account.description = An LG Horizon powered TV platform account (Telenet, Ziggo, Virgin Media, UPC, Sunrise, BASE TV). Discovers the set-top boxes registered on the account and provides the connection used to control them.
+thing-type.lghorizon.box.label = LG Horizon Set-Top Box
+thing-type.lghorizon.box.description = A single LG Horizon set-top box (e.g. a Telenet or Ziggo TV box).
+
+# thing types config
+
+thing-type.config.lghorizon.account.apiUrl.label = API URL
+thing-type.config.lghorizon.account.apiUrl.description = Base URL of the provider's "spark" REST API, e.g. https://spark-prod-be.gnp.cloud.telenet.tv. Known automatically when Provider is set; required if Provider is left empty.
+thing-type.config.lghorizon.account.country.label = Country
+thing-type.config.lghorizon.account.country.description = Two-letter locale code used in the service-discovery URL path (e.g. "be", "nl", "ch") - not necessarily the same region implied by the provider's name. Known automatically when Provider is set; required if Provider is left empty.
+thing-type.config.lghorizon.account.password.label = Password
+thing-type.config.lghorizon.account.password.description = Account password. Only required for password-based providers.
+thing-type.config.lghorizon.account.provider.label = Provider
+thing-type.config.lghorizon.account.provider.description = Your TV provider. Leave empty / choose "Custom" to configure an unlisted or test backend manually via the advanced Country, API URL and Use Refresh Token fields.
+thing-type.config.lghorizon.account.refreshToken.label = Refresh Token
+thing-type.config.lghorizon.account.refreshToken.description = Only required for token-based providers. Sign in to your provider's web player (e.g. telenet.tv) in a browser, open developer tools, and copy the "refresh_token" value out of Local Storage.
+thing-type.config.lghorizon.account.useRefreshToken.label = Use Refresh Token
+thing-type.config.lghorizon.account.useRefreshToken.description = Whether the provider requires refresh-token authentication instead of username/password. Known automatically when Provider is set; only consulted if Provider is left empty.
+thing-type.config.lghorizon.account.username.label = Username
+thing-type.config.lghorizon.account.username.description = Account username/email. Only required for password-based providers
+thing-type.config.lghorizon.box.deviceId.label = Device ID
+thing-type.config.lghorizon.box.deviceId.description = The LG Horizon device identifier for this box.
+thing-type.config.lghorizon.box.profileId.label = Profile ID
+thing-type.config.lghorizon.box.profileId.description = Which household profile's favourite channels and language to use. Defaults to the default box profile or the first profile by account.
+
+# channel types
+
+channel-type.lghorizon.arrow-down.label = Arrow Down
+channel-type.lghorizon.arrow-down.description = Navigates down in the on-screen menu.
+channel-type.lghorizon.arrow-left.label = Arrow Left
+channel-type.lghorizon.arrow-left.description = Navigates left in the on-screen menu.
+channel-type.lghorizon.arrow-right.label = Arrow Right
+channel-type.lghorizon.arrow-right.description = Navigates right in the on-screen menu.
+channel-type.lghorizon.arrow-up.label = Arrow Up
+channel-type.lghorizon.arrow-up.description = Navigates up in the on-screen menu.
+channel-type.lghorizon.channel-down.label = Channel Down
+channel-type.lghorizon.channel-down.description = Moves to the previous channel.
+channel-type.lghorizon.channel-name.label = Channel Name
+channel-type.lghorizon.channel-name.description = Name of the channel currently being watched.
+channel-type.lghorizon.channel-number.label = Channel Number
+channel-type.lghorizon.channel-number.description = The logical channel number. Send a number to this channel to change the channel.
+channel-type.lghorizon.channel-up.label = Channel Up
+channel-type.lghorizon.channel-up.description = Moves to the next channel.
+channel-type.lghorizon.context-menu.label = Context Menu
+channel-type.lghorizon.context-menu.description = Opens the context menu for extra actions (e.g. quickly enabling subtitles, adding the current channel/program to favorites or the watchlist).
+channel-type.lghorizon.enter.label = Enter / OK
+channel-type.lghorizon.enter.description = Confirms the current selection, or opens the channel zap bar during live TV.
+channel-type.lghorizon.episode-title.label = Episode Title
+channel-type.lghorizon.episode-title.description = Title of the current episode. Falls back to "Episode N" using the episode number if no episode title text is available.
+channel-type.lghorizon.episode.label = Episode
+channel-type.lghorizon.episode.description = Episode number of the current episode, when known.
+channel-type.lghorizon.escape.label = Back / Escape
+channel-type.lghorizon.escape.description = Goes back to the previous menu, or stops playback and returns to live TV.
+channel-type.lghorizon.favorite-channel-number.label = Favorite Channel Number
+channel-type.lghorizon.favorite-channel-number.description = The logical favorite channel number. Send a number to this channel to change the channel.
+channel-type.lghorizon.info.label = Info
+channel-type.lghorizon.info.description = Shows information about the current program.
+channel-type.lghorizon.key-code.label = Send Key
+channel-type.lghorizon.key-code.description = Send any remote-control key (W3C key name, e.g. "ArrowUp", "Guide", "Red", "MediaRecord") to the box.
+channel-type.lghorizon.media-image.label = Media Image
+channel-type.lghorizon.media-image.description = Poster/background image for the current channel, program, VOD title, or recording.
+channel-type.lghorizon.record.label = Record
+channel-type.lghorizon.record.description = Record selected TV program.
+channel-type.lghorizon.season.label = Season
+channel-type.lghorizon.season.description = Season number of the current episode, when known.
+channel-type.lghorizon.series-title.label = Series Title
+channel-type.lghorizon.series-title.description = Name of the TV series/show currently playing, only set for genuinely episodic content (a movie or standalone broadcast leaves this undefined). See Program Title for the always-populated title.
+channel-type.lghorizon.source-type.label = Source Type
+channel-type.lghorizon.source-type.description = What kind of content is currently active: linear, replay, nDVR, localDVR, reviewBuffer, VOD or app.
+channel-type.lghorizon.stop.label = Stop
+channel-type.lghorizon.stop.description = Stops the current playback and returns to live TV.
+channel-type.lghorizon.top-menu.label = Home
+channel-type.lghorizon.top-menu.description = Opens the main menu, or jumps back to the top of the screen from anywhere.
+channel-type.lghorizon.tv.label = TV
+channel-type.lghorizon.tv.description = Switch to live TV.
+
+# channel types
+
+channel-type.lghorizon.favorite-radio-channel-number.label = Channel Number
+channel-type.lghorizon.favorite-radio-channel-number.description = The logical favorite radio channel number. Send a number to this channel to change the channel.
+channel-type.lghorizon.favorite-tv-channel-number.label = Channel Number
+channel-type.lghorizon.favorite-tv-channel-number.description = The logical favorite tv channel number. Send a number to this channel to change the channel.
+channel-type.lghorizon.radio-channel-number.label = Channel Number
+channel-type.lghorizon.radio-channel-number.description = The logical radio channel number. Send a number to this channel to change the channel.
+channel-type.lghorizon.tv-channel-number.label = Channel Number
+channel-type.lghorizon.tv-channel-number.description = The logical TV channel number. Send a number to this channel to change the channel.
+
+# thing types config
+
+thing-type.config.lghorizon.box.displayMessageDuration.label = Display Message Duration
+thing-type.config.lghorizon.box.displayMessageDuration.description = How long a message sent to the Display Message channel should stay visible on screen, in seconds.
+thing-type.config.lghorizon.box.displayMessageTitle.label = Display Message Title
+thing-type.config.lghorizon.box.displayMessageTitle.description = The title to show in the on-screen overlay when sending a message to the Display Message channel. Defaults to "openHAB".
+
+# channel types
+
+channel-type.lghorizon.display-message.label = Display Message
+channel-type.lghorizon.display-message.description = Shows a short text message as an on-screen overlay on the TV.
+
+# channel types
+
+channel-type.lghorizon.player.label = Player Control
+channel-type.lghorizon.player.description = Play/pause/rewind/fast-forward the current playback.
+channel-type.lghorizon.power.label = Power
+channel-type.lghorizon.power.description = Turns the box on (wake from standby) or off (standby). The box stays reachable on the network while in standby.
+channel-type.lghorizon.program-title.label = Program Title
+channel-type.lghorizon.program-title.description = Title of the current show/movie/app.
+
+# thing types config
+
+thing-type.config.lghorizon.account.profileId.label = Profile ID
+thing-type.config.lghorizon.account.profileId.description = Which household profile's favourite channels and language to use. Defaults to the first profile on the account.
+
+# thing types config
+
+thing-type.config.lghorizon.account.country.option.be-basetv = BASE TV (Belgium)
+thing-type.config.lghorizon.account.country.option.be-nl = Telenet (Belgium)
+thing-type.config.lghorizon.account.country.option.ch = UPC / Sunrise (Switzerland)
+thing-type.config.lghorizon.account.country.option.ie = Virgin Media (Ireland)
+thing-type.config.lghorizon.account.country.option.gb = Virgin Media (United Kingdom)
+thing-type.config.lghorizon.account.country.option.nl = Ziggo (Netherlands)
+thing-type.config.lghorizon.account.country.option.pl = UPC (Poland)
+
+# thing status descriptions
+
+offline.box-reports-state = Set-top box reports {0}

--- a/bundles/org.openhab.binding.lghorizon/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.lghorizon/src/main/resources/OH-INF/thing/thing-types.xml
@@ -1,0 +1,331 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="lghorizon"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
+
+	<bridge-type id="account">
+		<label>LG Horizon Account</label>
+		<description>
+			An LG Horizon powered TV platform account (Telenet, Ziggo, Virgin Media, UPC, Sunrise, BASE TV).
+			Discovers the set-top boxes registered on the account and provides the connection used to control them.
+		</description>
+
+		<config-description>
+			<parameter name="provider" type="text">
+				<label>Provider</label>
+				<description>
+					Your TV provider. Leave empty / choose "Custom" to configure an unlisted or test backend manually via
+					the advanced Country, API URL and Use Refresh Token fields.</description>
+			</parameter>
+			<parameter name="country" type="text">
+				<label>Country</label>
+				<description>
+					Two-letter locale code used in the service-discovery URL path (e.g. "be", "nl", "ch") - not necessarily
+					the same region implied by the provider's name. Known automatically when Provider is set; required if Provider is
+					left empty.
+				</description>
+				<advanced>true</advanced>
+			</parameter>
+			<parameter name="apiUrl" type="text">
+				<label>API URL</label>
+				<description>
+					Base URL of the provider's "spark" REST API, e.g. https://spark-prod-be.gnp.cloud.telenet.tv. Known
+					automatically when Provider is set; required if Provider is left empty.
+				</description>
+				<advanced>true</advanced>
+			</parameter>
+			<parameter name="useRefreshToken" type="boolean">
+				<label>Use Refresh Token</label>
+				<description>
+					Whether the provider requires refresh-token authentication instead of username/password. Known
+					automatically when Provider is set; only consulted if Provider is left empty.
+				</description>
+				<default>false</default>
+				<advanced>true</advanced>
+			</parameter>
+			<parameter name="username" type="text">
+				<label>Username</label>
+				<description>Account username/email. Only required for password-based providers</description>
+			</parameter>
+			<parameter name="password" type="text">
+				<label>Password</label>
+				<description>Account password. Only required for password-based providers.</description>
+				<context>password</context>
+			</parameter>
+			<parameter name="refreshToken" type="text">
+				<label>Refresh Token</label>
+				<description>
+					Only required for token-based providers. Sign in to your provider's web player (e.g. telenet.tv) in a
+					browser, open developer tools, and copy the "refresh_token" value out of Local Storage.
+				</description>
+				<context>password</context>
+			</parameter>
+		</config-description>
+	</bridge-type>
+
+	<thing-type id="box">
+		<supported-bridge-type-refs>
+			<bridge-type-ref id="account"/>
+		</supported-bridge-type-refs>
+
+		<label>LG Horizon Set-Top Box</label>
+		<description>A single LG Horizon set-top box (e.g. a Telenet or Ziggo TV box).</description>
+
+		<channels>
+			<channel id="power" typeId="system.power"/>
+			<channel id="source-type" typeId="source-type"/>
+			<channel id="channel-name" typeId="channel-name"/>
+			<channel id="channel-number" typeId="channel-number"/>
+			<channel id="favorite-channel-number" typeId="favorite-channel-number"/>
+			<channel id="program-title" typeId="system.media-title"/>
+			<channel id="series-title" typeId="series-title"/>
+			<channel id="episode-title" typeId="episode-title"/>
+			<channel id="season" typeId="season"/>
+			<channel id="episode" typeId="episode"/>
+			<channel id="media-image" typeId="media-image"/>
+			<channel id="player" typeId="system.media-control"/>
+			<channel id="stop" typeId="stop"/>
+			<channel id="record" typeId="record"/>
+			<channel id="channel-up" typeId="channel-up"/>
+			<channel id="channel-down" typeId="channel-down"/>
+			<channel id="arrow-up" typeId="arrow-up"/>
+			<channel id="arrow-down" typeId="arrow-down"/>
+			<channel id="arrow-left" typeId="arrow-left"/>
+			<channel id="arrow-right" typeId="arrow-right"/>
+			<channel id="top-menu" typeId="top-menu"/>
+			<channel id="info" typeId="info"/>
+			<channel id="context-menu" typeId="context-menu"/>
+			<channel id="tv" typeId="tv"/>
+			<channel id="enter" typeId="enter"/>
+			<channel id="escape" typeId="escape"/>
+			<channel id="key-code" typeId="key-code"/>
+		</channels>
+
+		<representation-property>deviceId</representation-property>
+
+		<config-description>
+			<parameter name="deviceId" type="text" required="true">
+				<label>Device ID</label>
+				<description>The LG Horizon device identifier for this box.</description>
+			</parameter>
+			<parameter name="profileId" type="text">
+				<label>Profile ID</label>
+				<description>
+					Which household profile's favourite channels and language to use. Defaults to the default box profile
+					or the first profile by account.
+				</description>
+				<advanced>true</advanced>
+			</parameter>
+		</config-description>
+	</thing-type>
+
+	<channel-type id="source-type">
+		<item-type>String</item-type>
+		<label>Source Type</label>
+		<description>What kind of content is currently active: linear, replay, nDVR, localDVR, reviewBuffer, VOD or app.</description>
+		<tags>
+			<tag>Status</tag>
+		</tags>
+		<state readOnly="true"/>
+	</channel-type>
+
+	<channel-type id="channel-name">
+		<item-type>String</item-type>
+		<label>Channel Name</label>
+		<description>Name of the channel currently being watched.</description>
+		<tags>
+			<tag>Control</tag>
+			<tag>Channel</tag>
+		</tags>
+	</channel-type>
+
+	<channel-type id="channel-number">
+		<item-type>Number</item-type>
+		<label>Channel Number</label>
+		<description>The logical channel number. Send a number to this channel to change the channel.</description>
+		<tags>
+			<tag>Control</tag>
+			<tag>Channel</tag>
+		</tags>
+	</channel-type>
+
+	<channel-type id="favorite-channel-number">
+		<item-type>Number</item-type>
+		<label>Favorite Channel Number</label>
+		<description>The logical favorite channel number. Send a number to this channel to change the channel.</description>
+		<tags>
+			<tag>Control</tag>
+			<tag>Channel</tag>
+		</tags>
+	</channel-type>
+
+	<channel-type id="series-title">
+		<item-type>String</item-type>
+		<label>Series Title</label>
+		<description>
+			Name of the TV series/show currently playing, only set for genuinely episodic content (a movie or
+			standalone broadcast leaves this undefined). See Program Title for the always-populated title.
+		</description>
+		<state readOnly="true"/>
+	</channel-type>
+
+	<channel-type id="episode-title">
+		<item-type>String</item-type>
+		<label>Episode Title</label>
+		<description>
+			Title of the current episode. Falls back to "Episode N" using the episode number if no episode
+			title text
+			is available.
+		</description>
+		<state readOnly="true"/>
+	</channel-type>
+
+	<channel-type id="season">
+		<item-type>Number</item-type>
+		<label>Season</label>
+		<description>Season number of the current episode, when known.</description>
+		<state readOnly="true"/>
+	</channel-type>
+
+	<channel-type id="episode">
+		<item-type>Number</item-type>
+		<label>Episode</label>
+		<description>Episode number of the current episode, when known.</description>
+		<state readOnly="true"/>
+	</channel-type>
+
+	<channel-type id="media-image">
+		<item-type>Image</item-type>
+		<label>Media Image</label>
+		<description>Poster/background image for the current channel, program, VOD title, or recording.</description>
+		<state readOnly="true"/>
+	</channel-type>
+
+	<channel-type id="stop">
+		<item-type>Switch</item-type>
+		<label>Stop</label>
+		<description>Stops the current playback and returns to live TV.</description>
+		<tags>
+			<tag>Switch</tag>
+			<tag>MediaControl</tag>
+		</tags>
+		<autoUpdatePolicy>veto</autoUpdatePolicy>
+	</channel-type>
+
+	<channel-type id="record">
+		<item-type>Switch</item-type>
+		<label>Record</label>
+		<description>Record selected TV program.</description>
+		<tags>
+			<tag>Switch</tag>
+			<tag>MediaControl</tag>
+		</tags>
+		<autoUpdatePolicy>veto</autoUpdatePolicy>
+	</channel-type>
+
+	<channel-type id="channel-up">
+		<item-type>Switch</item-type>
+		<label>Channel Up</label>
+		<description>Moves to the next channel.</description>
+		<tags>
+			<tag>Switch</tag>
+			<tag>Channel</tag>
+		</tags>
+		<autoUpdatePolicy>veto</autoUpdatePolicy>
+	</channel-type>
+
+	<channel-type id="channel-down">
+		<item-type>Switch</item-type>
+		<label>Channel Down</label>
+		<description>Moves to the previous channel.</description>
+		<tags>
+			<tag>Switch</tag>
+			<tag>Channel</tag>
+		</tags>
+		<autoUpdatePolicy>veto</autoUpdatePolicy>
+	</channel-type>
+
+	<channel-type id="arrow-up">
+		<item-type>Switch</item-type>
+		<label>Arrow Up</label>
+		<description>Navigates up in the on-screen menu.</description>
+		<autoUpdatePolicy>veto</autoUpdatePolicy>
+	</channel-type>
+
+	<channel-type id="arrow-down">
+		<item-type>Switch</item-type>
+		<label>Arrow Down</label>
+		<description>Navigates down in the on-screen menu.</description>
+		<autoUpdatePolicy>veto</autoUpdatePolicy>
+	</channel-type>
+
+	<channel-type id="arrow-left">
+		<item-type>Switch</item-type>
+		<label>Arrow Left</label>
+		<description>Navigates left in the on-screen menu.</description>
+		<autoUpdatePolicy>veto</autoUpdatePolicy>
+	</channel-type>
+
+	<channel-type id="arrow-right">
+		<item-type>Switch</item-type>
+		<label>Arrow Right</label>
+		<description>Navigates right in the on-screen menu.</description>
+		<autoUpdatePolicy>veto</autoUpdatePolicy>
+	</channel-type>
+
+	<channel-type id="top-menu">
+		<item-type>Switch</item-type>
+		<label>Home</label>
+		<description>Opens the main menu, or jumps back to the top of the screen from anywhere.</description>
+		<autoUpdatePolicy>veto</autoUpdatePolicy>
+	</channel-type>
+
+	<channel-type id="info">
+		<item-type>Switch</item-type>
+		<label>Info</label>
+		<description>Shows information about the current program.</description>
+		<autoUpdatePolicy>veto</autoUpdatePolicy>
+	</channel-type>
+
+	<channel-type id="context-menu">
+		<item-type>Switch</item-type>
+		<label>Context Menu</label>
+		<description>
+			Opens the context menu for extra actions (e.g. quickly enabling subtitles, adding the
+			current
+			channel/program to favorites or the watchlist).
+		</description>
+		<autoUpdatePolicy>veto</autoUpdatePolicy>
+	</channel-type>
+
+	<channel-type id="tv">
+		<item-type>Switch</item-type>
+		<label>TV</label>
+		<description> Switch to live TV.</description>
+		<autoUpdatePolicy>veto</autoUpdatePolicy>
+	</channel-type>
+
+	<channel-type id="enter">
+		<item-type>Switch</item-type>
+		<label>Enter / OK</label>
+		<description>Confirms the current selection, or opens the channel zap bar during live TV.</description>
+		<autoUpdatePolicy>veto</autoUpdatePolicy>
+	</channel-type>
+
+	<channel-type id="escape">
+		<item-type>Switch</item-type>
+		<label>Back / Escape</label>
+		<description>Goes back to the previous menu, or stops playback and returns to live TV.</description>
+		<autoUpdatePolicy>veto</autoUpdatePolicy>
+	</channel-type>
+
+	<channel-type id="key-code" advanced="true">
+		<item-type>String</item-type>
+		<label>Send Key</label>
+		<description>
+			Send any remote-control key (W3C key name, e.g. "ArrowUp", "Guide", "Red", "MediaRecord") to the box.
+		</description>
+	</channel-type>
+
+</thing:thing-descriptions>

--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -1,21 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
-
   <modelVersion>4.0.0</modelVersion>
-
   <parent>
     <groupId>org.openhab.addons</groupId>
     <artifactId>org.openhab.addons.reactor</artifactId>
     <version>5.3.0-SNAPSHOT</version>
   </parent>
-
   <groupId>org.openhab.addons.bundles</groupId>
   <artifactId>org.openhab.addons.reactor.bundles</artifactId>
   <packaging>pom</packaging>
-
   <name>openHAB Add-ons :: Bundles</name>
-
   <modules>
     <!-- automation -->
     <module>org.openhab.automation.groovyscripting</module>
@@ -248,6 +243,7 @@
     <module>org.openhab.binding.lcn</module>
     <module>org.openhab.binding.leapmotion</module>
     <module>org.openhab.binding.lghombot</module>
+    <module>org.openhab.binding.lghorizon</module>
     <module>org.openhab.binding.lgtvserial</module>
     <module>org.openhab.binding.lgthinq</module>
     <module>org.openhab.binding.lgwebos</module>
@@ -534,13 +530,11 @@
     <module>org.openhab.voice.watsonstt</module>
     <module>org.openhab.voice.whisperstt</module>
   </modules>
-
   <properties>
     <m2e.jdt.annotationpath>target/dependency</m2e.jdt.annotationpath>
     <dep.noembedding/>
     <markdownlint.skip>false</markdownlint.skip>
   </properties>
-
   <dependencies>
     <dependency>
       <groupId>org.lastnpe.eea</groupId>
@@ -596,7 +590,6 @@
       <scope>provided</scope>
     </dependency>
   </dependencies>
-
   <build>
     <pluginManagement>
       <plugins>
@@ -697,7 +690,6 @@
         </plugin>
       </plugins>
     </pluginManagement>
-
     <plugins>
       <plugin>
         <groupId>biz.aQute.bnd</groupId>
@@ -782,7 +774,6 @@
               </target>
             </configuration>
           </execution>
-
           <!-- 2. Generate catalog dynamically -->
           <execution>
             <id>generate-catalog</id>
@@ -793,17 +784,16 @@
             <configuration>
               <target>
                 <mkdir dir="${maven.multiModuleProjectDirectory}/target/schemas"/>
-                <echo file="${maven.multiModuleProjectDirectory}/target/schemas/thing-type-xml-validation-catalog.xml"><![CDATA[<?xml version="1.0" encoding="UTF-8"?>
-<catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
-    <uri name="https://openhab.org/schemas/thing-description-1.0.0.xsd"
-         uri="file:///${maven.multiModuleProjectDirectory}/target/schemas/thing-description-1.0.0.xsd"/>
-</catalog>]]></echo>
+                <echo file="${maven.multiModuleProjectDirectory}/target/schemas/thing-type-xml-validation-catalog.xml">&lt;?xml version="1.0" encoding="UTF-8"?&gt;
+&lt;catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog"&gt;
+    &lt;uri name="https://openhab.org/schemas/thing-description-1.0.0.xsd"
+         uri="file:///${maven.multiModuleProjectDirectory}/target/schemas/thing-description-1.0.0.xsd"/&gt;
+&lt;/catalog&gt;</echo>
               </target>
             </configuration>
           </execution>
         </executions>
       </plugin>
-
       <!-- 3. XML validation plugin -->
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
@@ -828,10 +818,8 @@
           </execution>
         </executions>
       </plugin>
-
     </plugins>
   </build>
-
   <profiles>
     <profile>
       <id>skipXmlValidation</id>
@@ -875,7 +863,6 @@
         </plugins>
       </build>
     </profile>
-
     <profile>
       <id>markdownlint</id>
       <activation>
@@ -913,5 +900,4 @@
       </build>
     </profile>
   </profiles>
-
 </project>


### PR DESCRIPTION
This binding adds support for TV set-top boxes from providers in the Liberty Global Group. This includes providers such as Ziggo (NL), Telenet (BE), Virgin Media (UK, Ireland), UPC Sunrise (CH) and UPC (Poland).

The binding makes it possible to control the set-top box from openHAB.

It features:
- full remote control, matching the remote
- channel selection from a pre-populated list
- visualisation of program being played

This binding uses MQTT over a websocket. The MQTT transport has a limitation that needed to be lifted to be able to use it. I opted to create a small core PR to solve it, rather than coding the logic of the transport in the binding again. Therefore this PR depends on https://github.com/openhab/openhab-core/pull/5830.

This PR is based on work from @Sholofly: https://github.com/Sholofly/lghorizon. It is fully recoded to Java for openHAB. The conversion and adaptation has had some AI help.